### PR TITLE
feat(daemon): seed a preview's parameter knobs from the override bag

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
@@ -102,6 +102,20 @@ public data class PreviewInfoDto(
    */
   val captures: List<PreviewCaptureDto> = emptyList(),
   /**
+   * The **parameter knobs** this preview declares — its own defaulted value parameters, the
+   * secondary override format beside `previewOverride*`. Mirrors the gradle plugin's `PreviewKnob`
+   * (`:gradle-plugin:preview-discovery`); the renderer binds a seed to the parameter's position
+   * rather than to a controller lookup inside the body.
+   *
+   * Optional and additive — a `previews.json` written before the field existed omits it, and the
+   * incremental class-file rescan ([IncrementalDiscovery.toDto]) leaves it empty because it
+   * rebuilds a DTO from the annotation alone and never reads the signature. [diff] and [applyDiff]
+   * carry it forward exactly as they do [params] and [captures], so a save doesn't silently strip a
+   * preview's knobs (which would make every seeded value fall back to the author default) until the
+   * next full rediscovery.
+   */
+  val knobs: List<PreviewKnobDto> = emptyList(),
+  /**
    * `@OverrideVariant` seed for a synthetic variant preview (same `functionName` as its base, a
    * `_VARIANT_<name>` id). Parsed straight into the canonical
    * [ee.schimke.composeai.data.overrides.OverrideVariantSpec] — the wire shape the plugin emits —
@@ -128,6 +142,18 @@ public data class PreviewInfoDto(
  */
 @Serializable
 public data class PreviewDataProductDto(val kind: String, val scroll: ScrollCaptureDto? = null)
+
+/**
+ * Daemon-side mirror of the gradle plugin's `PreviewKnob` — one editable value parameter of a
+ * preview. [index] is the parameter's position in the **full** value-parameter list (not among the
+ * knobs), because that is the position the renderer has to place the bound argument at; [type] is
+ * the plugin's `PreviewKnobType` name (`STRING` / `BOOLEAN` / `INT` / `LONG` / `FLOAT` / `DOUBLE`).
+ *
+ * The type is carried as a plain [String] rather than an enum on purpose: a newer plugin may name a
+ * knob kind this daemon cannot bind, and an unknown name has to degrade to "not seedable" — the
+ * author default renders — instead of failing the whole manifest parse.
+ */
+@Serializable public data class PreviewKnobDto(val name: String, val index: Int, val type: String)
 
 /**
  * Daemon-side mirror of the gradle plugin's `Capture` — one planned render of a preview. Only
@@ -580,10 +606,13 @@ internal constructor(
         // `captures` is unrecoverable from the class file for the same reason, and carries the
         // `@ScrollingPreview(END)` drive — so it gets the same normalization, or an END sticker
         // would re-report as `changed` on every save.
+        // `knobs` is read off the *signature*, which the annotation-only rescan never looks at,
+        // so it too always comes back empty and gets the same treatment.
         val normalized =
           fresh
             .let { if (it.params == null) it.copy(params = prior.params) else it }
             .let { if (it.captures.isEmpty()) it.copy(captures = prior.captures) else it }
+            .let { if (it.knobs.isEmpty()) it.copy(knobs = prior.knobs) else it }
         normalized != prior
       }
       // Removed scopes to ids whose previous DTO claimed `sourceFile` matches the saved path.
@@ -637,6 +666,12 @@ internal constructor(
             .let {
               if (it.captures.isEmpty() && !prior?.captures.isNullOrEmpty())
                 it.copy(captures = prior.captures)
+              else it
+            }
+            // And for `knobs`: dropping them would leave every seeded parameter knob rendering its
+            // author default after the first save, with no error anywhere to say why.
+            .let {
+              if (it.knobs.isEmpty() && !prior?.knobs.isNullOrEmpty()) it.copy(knobs = prior.knobs)
               else it
             }
       }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewKnobSeeds.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewKnobSeeds.kt
@@ -1,0 +1,53 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
+
+/**
+ * Flattens `renderNow.overrides.namedOverrides` — the typed seed bag both override formats share —
+ * into the `name -> verbatim text` map a **parameter knob** binder takes.
+ *
+ * ### Why one seed map serves both formats
+ *
+ * `previewOverride*` declares a knob by executing a lookup inside the composable body, so it is
+ * seeded by writing typed values into a process-static controller. A parameter knob is declared by
+ * the function signature, so it is seeded by ordinary argument passing. A client shouldn't have to
+ * know which of the two a given preview used, so both read the same `namedOverrides` map and each
+ * side takes only the keys it recognises: the controller ignores a key no `previewOverride*` call
+ * asked for, and the binder ignores a key that names no declared parameter.
+ *
+ * ### Why the text, rather than the typed value
+ *
+ * The binder parses against the knob's *declared* type, which is the only type that can be bound —
+ * a client that sent `IntValue(3)` for a `Long` parameter meant 3, and one that sent
+ * `StringValue("3")` for an `Int` parameter meant 3 as well. Reducing both to `"3"` and parsing
+ * once, at the knob, keeps that decision in a single place and keeps an unparseable seed falling
+ * back to the author default rather than being coerced into a value nobody asked for.
+ *
+ * [ColorValue][PreviewOverrideValue.ColorValue] is deliberately **not** flattened: `Color` is not a
+ * seedable parameter-knob kind, so its `#AARRGGBB` text would only ever fail to parse as one of the
+ * numeric kinds, and returning it would make a colour seed look like a dropped number rather than
+ * an unsupported kind. A preview that wants an editable colour as a parameter takes it as an ARGB
+ * `Long` and gets an ordinary numeric seed.
+ */
+public object PreviewKnobSeeds {
+
+  /** The seed text for [value], or null when its kind has no parameter-knob equivalent. */
+  public fun text(value: PreviewOverrideValue): String? =
+    when (value) {
+      is PreviewOverrideValue.StringValue -> value.value
+      is PreviewOverrideValue.IntValue -> value.value.toString()
+      is PreviewOverrideValue.BooleanValue -> value.value.toString()
+      is PreviewOverrideValue.FloatValue -> value.value.toString()
+      is PreviewOverrideValue.ColorValue -> null
+    }
+
+  /** [text] applied across a whole seed bag, dropping the entries with no equivalent. */
+  public fun texts(values: Map<String, PreviewOverrideValue>?): Map<String, String> {
+    if (values.isNullOrEmpty()) return emptyMap()
+    return buildMap {
+      for ((key, value) in values) {
+        text(value)?.let { put(key, it) }
+      }
+    }
+  }
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewIndexDiffTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewIndexDiffTest.kt
@@ -161,6 +161,36 @@ class PreviewIndexDiffTest {
   }
 
   @Test
+  fun `a knobs-less rescan keeps the preview's parameter knobs`() {
+    // `knobs` is read off the *signature*, which the annotation-only incremental rescan never
+    // looks at, so it always comes back empty. Dropping it on a save would leave every seeded
+    // parameter knob rendering its author default — silently, with nothing anywhere saying why —
+    // until the next full rediscovery.
+    val prior =
+      PreviewInfoDto(
+        id = "Knobbed",
+        className = "com.example.KnobbedKt",
+        methodName = "Knobbed",
+        sourceFile = "Knobbed.kt",
+        knobs = listOf(PreviewKnobDto("title", 0, "STRING")),
+      )
+    val fresh = prior.copy(knobs = emptyList())
+    val index = PreviewIndex.fromMap(path = null, byId = mapOf("Knobbed" to prior))
+    val diff = index.diff(setOf(fresh), Path.of("Knobbed.kt"))
+    assertTrue("a knobs-only empty rescan must not be reported as changed", diff.changed.isEmpty())
+    index.applyDiff(diff)
+    assertEquals(prior.knobs, index.byId("Knobbed")?.knobs)
+
+    // A genuine edit alongside the empty knobs still lands, knobs intact.
+    val renamed = prior.copy(displayName = "Y", knobs = emptyList())
+    val realDiff = index.diff(setOf(renamed), Path.of("Knobbed.kt"))
+    assertEquals(listOf("Knobbed"), realDiff.changed.map { it.id })
+    index.applyDiff(realDiff)
+    assertEquals("Y", index.byId("Knobbed")?.displayName)
+    assertEquals(prior.knobs, index.byId("Knobbed")?.knobs)
+  }
+
+  @Test
   fun `a real field change with null params is still reported and preserves params`() {
     // A genuine change (displayName) alongside the incremental scan's null params IS a change — and
     // applyDiff still carries the prior params forward, so the real edit lands without losing size.

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewIndexTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewIndexTest.kt
@@ -72,6 +72,54 @@ class PreviewIndexTest {
   }
 
   @Test
+  fun `loadFromFile reads the parameter knobs discovery wrote`() {
+    // The plugin has emitted `knobs` since the parameter-knob format landed, but nothing on the
+    // daemon side read it — so a preview declaring editable value parameters resolved to a spec
+    // with none and every seed for one was silently ignored. This pins the parse.
+    val tmp = Files.createTempFile("previews-knobs", ".json")
+    Files.writeString(
+      tmp,
+      """
+      {
+        "previews": [
+          {
+            "id": "Knobbed_1",
+            "className": "com.example.KnobbedKt",
+            "functionName": "Knobbed",
+            "knobs": [
+              { "name": "title", "index": 0, "type": "STRING" },
+              { "name": "accentArgb", "index": 1, "type": "LONG" },
+              { "name": "future", "index": 2, "type": "SOMETHING_NEWER" }
+            ]
+          },
+          {
+            "id": "Plain_1",
+            "className": "com.example.PlainKt",
+            "functionName": "Plain"
+          }
+        ]
+      }
+      """
+        .trimIndent(),
+    )
+    val index = PreviewIndex.loadFromFile(tmp)
+    assertEquals(
+      listOf(
+        PreviewKnobDto("title", 0, "STRING"),
+        PreviewKnobDto("accentArgb", 1, "LONG"),
+        // A kind this daemon cannot bind survives the parse verbatim — the binder drops it and the
+        // parameter takes its compiled default. Rejecting it here would fail the whole manifest
+        // because a newer plugin named a knob kind, which is the one outcome worse than a preview
+        // rendering unseeded.
+        PreviewKnobDto("future", 2, "SOMETHING_NEWER"),
+      ),
+      index.byId("Knobbed_1")?.knobs,
+    )
+    // A preview that declares none — the overwhelming majority — parses to an empty list, not null.
+    assertEquals(emptyList<PreviewKnobDto>(), index.byId("Plain_1")?.knobs)
+  }
+
+  @Test
   fun `loadFromFile happy path indexes previews by id`() {
     val tmp = Files.createTempFile("previews", ".json")
     Files.writeString(

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewKnobSeedsTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewKnobSeedsTest.kt
@@ -1,0 +1,44 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PreviewKnobSeedsTest {
+
+  @Test
+  fun everyNumericAndTextKindFlattensToItsVerbatimText() {
+    assertEquals("hi", PreviewKnobSeeds.text(PreviewOverrideValue.StringValue("hi")))
+    assertEquals("3", PreviewKnobSeeds.text(PreviewOverrideValue.IntValue(3)))
+    assertEquals("true", PreviewKnobSeeds.text(PreviewOverrideValue.BooleanValue(true)))
+    assertEquals("1.5", PreviewKnobSeeds.text(PreviewOverrideValue.FloatValue(1.5f)))
+  }
+
+  /**
+   * `Color` is not a seedable parameter-knob kind. Flattening `#FF42A5F5` would hand the binder a
+   * string that can only fail to parse as one of the numeric kinds — reporting an unsupported kind
+   * as a malformed number. Dropping it here keeps the distinction.
+   */
+  @Test
+  fun aColourSeedHasNoParameterKnobEquivalent() {
+    assertNull(PreviewKnobSeeds.text(PreviewOverrideValue.ColorValue("#FF42A5F5")))
+  }
+
+  @Test
+  fun aBagKeepsWhatItCanAndDropsWhatItCannot() {
+    val bag =
+      mapOf(
+        "label" to PreviewOverrideValue.StringValue("hi"),
+        "count" to PreviewOverrideValue.IntValue(4),
+        "accent" to PreviewOverrideValue.ColorValue("#FF42A5F5"),
+      )
+    assertEquals(mapOf("label" to "hi", "count" to "4"), PreviewKnobSeeds.texts(bag))
+  }
+
+  @Test
+  fun anAbsentOrEmptyBagIsEmpty() {
+    assertEquals(emptyMap<String, String>(), PreviewKnobSeeds.texts(null))
+    assertEquals(emptyMap<String, String>(), PreviewKnobSeeds.texts(emptyMap()))
+  }
+}

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -523,6 +523,12 @@ internal fun renderSpecFromInfo(info: PreviewInfoDto): RenderSpec {
       // PreviewManifestRouter does.
       outputBaseName = info.id,
       overrides = bakedOverrides,
+      // The parameter knobs discovery read off the signature. Carried on BOTH the early-return
+      // `defaults` and the fully-resolved spec below — a preview whose `params` block is absent
+      // (the incremental rescan's DTO) still declares the same parameters, and dropping them on
+      // that path would make a seeded knob render its author default for exactly as long as the
+      // manifest stayed un-rediscovered.
+      knobs = info.knobs,
     )
   // A *missing* params block means "params unknown", NOT "params empty" — the incremental
   // source-change path (IncrementalDiscovery.toDto → PreviewIndex.applyDiff) replaces an edited
@@ -622,6 +628,7 @@ internal fun renderSpecFromInfo(info: PreviewInfoDto): RenderSpec {
     gutterTopDp = params.captureGutter?.top ?: 0,
     gutterEndDp = params.captureGutter?.end ?: 0,
     gutterBottomDp = params.captureGutter?.bottom ?: 0,
+    knobs = defaults.knobs,
   )
 }
 

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -358,9 +358,18 @@ class RenderEngine(
           limit = spec.previewParameterLimit,
           classLoader = classLoader,
           row = spec.previewParameterRow,
+          // The seeded **parameter knobs**, which also decide the overload to resolve: a preview
+          // whose parameters all declare defaults compiles to `(realParams…, Composer, int, int)`
+          // and the parameterless lookup cannot see it either way, seeded or not.
+          previewArgs = bindKnobArguments(spec),
         )
       }
     val composableMethod: ComposableMethod? = resolvedInvocation?.method
+    // Either the `@PreviewParameter` provider's bound value or the seeded parameter knobs — never
+    // both. A preview with a provider is never also a parameter-knob preview: discovery reports
+    // knobs only when EVERY value parameter declares a default, and a provider-bound parameter does
+    // not. An empty list is the plain parameterless preview, and also the knob preview nobody
+    // seeded, which is the same invocation.
     val previewArgs: List<Any?> = resolvedInvocation?.args ?: emptyList()
 
     // Self-diagnostic — surfaces in the VS Code extension's output channel as `[daemon stderr] …`.
@@ -2701,6 +2710,19 @@ data class RenderSpec(
    */
   val previewParameterRow: String? = null,
   /**
+   * The **parameter knobs** this preview declares — its own defaulted value parameters, the
+   * secondary override format beside `previewOverride*` (see
+   * [ee.schimke.composeai.renderer.PreviewKnobArguments]). Carried from `previews.json` by
+   * `renderSpecFromInfo`, or from the `knobs=<name>:<index>:<TYPE>,…` payload token by
+   * [parseFromPayload].
+   *
+   * Empty for every preview that declares none, which is the overwhelming majority: discovery only
+   * reports knobs when **every** value parameter has a default, so a preview cannot acquire one by
+   * accident. A seed in `overrides.namedOverrides` naming one of these binds to the parameter's
+   * position; a seed naming anything else is left for the `previewOverride*` controller.
+   */
+  val knobs: List<PreviewKnobDto> = emptyList(),
+  /**
    * `@CaptureGutter` edges in **dp** (issue #4443). Four flat Ints rather than a nested type
    * because `:daemon:android`'s twin of this class can't see `:preview-data-api`'s
    * `CaptureGutterDp`, and the two RenderSpecs are deliberately kept field-for-field identical so
@@ -2848,6 +2870,7 @@ data class RenderSpec(
         previewParameterLimit =
           map["previewParameterLimit"]?.toIntOrNull() ?: defaults.previewParameterLimit,
         previewParameterRow = map["previewParameterRow"]?.takeIf { it.isNotBlank() },
+        knobs = parseKnobsToken(map["knobs"]),
         gutterStartDp = gutterDp.start,
         gutterTopDp = gutterDp.top,
         gutterEndDp = gutterDp.end,
@@ -2865,6 +2888,28 @@ data class RenderSpec(
       if (parts.size != 4) return GutterDp()
       val edges = parts.map { it.trim().toIntOrNull()?.coerceAtLeast(0) ?: return GutterDp() }
       return GutterDp(edges[0], edges[1], edges[2], edges[3])
+    }
+
+    /**
+     * Parses the `knobs=<name>:<index>:<TYPE>,…` payload token into [RenderSpec.knobs].
+     *
+     * A malformed entry — wrong arity, a non-numeric or negative index, a blank name — is
+     * **skipped** rather than failing the render. The type is kept verbatim, including a name this
+     * daemon doesn't know: an unbindable kind has to degrade to "this parameter takes its author
+     * default", which is exactly what a knob the binder skips already does, and failing the whole
+     * render because a newer plugin named a kind an older daemon can't seed would be far worse than
+     * rendering the preview unseeded.
+     */
+    internal fun parseKnobsToken(token: String?): List<PreviewKnobDto> {
+      if (token.isNullOrBlank()) return emptyList()
+      return token.split(',').mapNotNull { entry ->
+        val parts = entry.split(':')
+        if (parts.size != 3) return@mapNotNull null
+        val name = parts[0].trim().takeIf { it.isNotBlank() } ?: return@mapNotNull null
+        val index = parts[1].trim().toIntOrNull()?.takeIf { it >= 0 } ?: return@mapNotNull null
+        val type = parts[2].trim().takeIf { it.isNotBlank() } ?: return@mapNotNull null
+        PreviewKnobDto(name = name, index = index, type = type)
+      }
     }
 
     /** Four dp edges, the parsed shape of a `captureGutter=` token. */
@@ -2904,8 +2949,47 @@ data class RenderSpec(
  * composer. Mirrors `:renderer-desktop`'s private `InvokeComposable`; kept private+top-level so the
  * compose-compiler plugin recognises it as a composable function.
  */
+/**
+ * The argument array that seeds [RenderSpec.knobs] from this render's `namedOverrides` bag — the
+ * **parameter knob** half of the override surface.
+ *
+ * Returns an empty list whenever nothing binds, so a preview with knobs but no seed keeps invoking
+ * through the same zero-argument path it always did. A knob whose declared `type` this daemon does
+ * not know is dropped here rather than at parse time (see [RenderSpec.parseKnobsToken]): the
+ * parameter then takes its compiled default, which is the only safe reading of "a kind I cannot
+ * build".
+ */
+private fun bindKnobArguments(spec: RenderSpec): List<Any?> {
+  if (spec.knobs.isEmpty()) return emptyList()
+  val knobs =
+    spec.knobs.mapNotNull { knob ->
+      val type =
+        ee.schimke.composeai.renderer.PreviewKnobArguments.Type.entries.firstOrNull {
+          it.name == knob.type
+        } ?: return@mapNotNull null
+      ee.schimke.composeai.renderer.PreviewKnobArguments.Knob(knob.name, knob.index, type)
+    }
+  return ee.schimke.composeai.renderer.PreviewKnobArguments.bind(
+    knobs,
+    PreviewKnobSeeds.texts(spec.overrides?.namedOverrides),
+  )
+}
+
 @androidx.compose.runtime.Composable
 private fun InvokeComposable(composableMethod: ComposableMethod, previewArgs: List<Any?>) {
+  // A **partial** knob seed leaves nulls in the list, and `ComposableMethod.invoke` cannot express
+  // that: it forwards a null destined for a primitive parameter verbatim and `Method.invoke` throws
+  // on the null `int`. `invokeWithDefaultMask` drives the `$default` bridge itself when it sees one
+  // and returns false otherwise, so every shape it can't handle stays on the path it always took.
+  if (
+    ee.schimke.composeai.renderer.PreviewParameterSupport.invokeWithDefaultMask(
+      composableMethod,
+      null,
+      previewArgs,
+      currentComposer,
+    )
+  )
+    return
   composableMethod.invoke(currentComposer, null, *previewArgs.toTypedArray())
 }
 

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
@@ -1589,6 +1589,116 @@ class OverrideIntegrationTest {
   }
 
   /**
+   * End-to-end proof for the **parameter-knob** override format: a seed in
+   * `renderNow.overrides.namedOverrides` reaches a preview's own defaulted value parameter and
+   * changes the rendered pixels. Same wire as the `previewOverride*` test above — one seed map
+   * serves both formats — but the value arrives as an ordinary argument rather than through the
+   * process-static controller, so nothing in [KnobbedSquare]'s body knows a harness exists.
+   *
+   * Only `topArgb` is seeded, and the assertion checks **both** bands. The top proves the seed
+   * bound; the bottom proves the unseeded position still ran its compiled default expression rather
+   * than being passed a zero — that is Kotlin's synthetic `$default` mask doing its job, and it is
+   * the whole reason a client can edit one knob of a preview that declares five without having to
+   * send the other four.
+   */
+  @Test
+  fun parameterKnobSeedsOneParameter() {
+    val outputDir = tempFolder.newFolder("renders-parameter-knob")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    val baseSpec =
+      RenderSpec(
+        previewId = "knobbed",
+        className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+        functionName = "KnobbedSquare",
+        widthPx = 32,
+        heightPx = 32,
+        density = 1.0f,
+        knobs =
+          listOf(
+            PreviewKnobDto("topArgb", 0, "LONG"),
+            PreviewKnobDto("bottomArgb", 1, "LONG"),
+            PreviewKnobDto("label", 2, "STRING"),
+          ),
+      )
+    val host =
+      DesktopHost(
+        engine =
+          RenderEngine(
+            previewOverrideExtensions =
+              PreviewOverrideExtensions(listOf(PreviewOverridesPreviewOverrideExtension()))
+          ),
+        previewSpecResolver = { id -> baseSpec.takeIf { id == "knobbed" } },
+      )
+    host.start()
+    try {
+      val blue = 0xFF42A5F5L
+      val request =
+        RenderRequest.Render(
+          payload = "previewId=knobbed;overrides=${encodeTextBag("topArgb" to blue.toString())}"
+        )
+      val result = host.submit(request, timeoutMs = 30_000)
+      assertNotNull("pngPath must be populated", result.pngPath)
+      val png = ByteArrayInputStream(File(result.pngPath!!).readBytes()).use { ImageIO.read(it) }
+      val bluePct = pixelMatchPct(png, expectedRgb = 0x42A5F5, perChannelTolerance = 8)
+      val greenPct = pixelMatchPct(png, expectedRgb = 0x66BB6A, perChannelTolerance = 8)
+      assertTrue(
+        "the seeded `topArgb` knob must repaint the top band blue; got " +
+          "${"%.2f".format(bluePct * 100)}% blue",
+        bluePct >= 0.4,
+      )
+      assertTrue(
+        "the unseeded `bottomArgb` knob must keep its compiled default green; got " +
+          "${"%.2f".format(greenPct * 100)}% green — the \$default mask dropped the default",
+        greenPct >= 0.4,
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  /**
+   * The unseeded baseline for [parameterKnobSeedsOneParameter]: with no override bag at all,
+   * [KnobbedSquare] renders both compiled defaults. Without this the test above could pass on a
+   * renderer that ignored the seed entirely and happened to paint blue for some other reason.
+   */
+  @Test
+  fun parameterKnobPreviewRendersItsDefaultsUnseeded() {
+    val outputDir = tempFolder.newFolder("renders-parameter-knob-default")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    val baseSpec =
+      RenderSpec(
+        previewId = "knobbed",
+        className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+        functionName = "KnobbedSquare",
+        widthPx = 32,
+        heightPx = 32,
+        density = 1.0f,
+        knobs = listOf(PreviewKnobDto("topArgb", 0, "LONG")),
+      )
+    val host =
+      DesktopHost(
+        engine =
+          RenderEngine(
+            previewOverrideExtensions =
+              PreviewOverrideExtensions(listOf(PreviewOverridesPreviewOverrideExtension()))
+          ),
+        previewSpecResolver = { id -> baseSpec.takeIf { id == "knobbed" } },
+      )
+    host.start()
+    try {
+      val result = host.submit(RenderRequest.Render(payload = "previewId=knobbed"), 30_000)
+      assertNotNull("pngPath must be populated", result.pngPath)
+      val png = ByteArrayInputStream(File(result.pngPath!!).readBytes()).use { ImageIO.read(it) }
+      assertTrue(
+        "an unseeded parameter-knob preview must render its author defaults (red top band)",
+        pixelMatchPct(png, expectedRgb = 0xEF5350, perChannelTolerance = 8) >= 0.4,
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  /**
    * End-to-end proof that a `themeProvider` override wraps an arbitrary preview in an app-declared
    * `@ThemeCatalog` theme (the render side of the serve viewer's declared-theme selector). Renders
    * [WallpaperAwareSquare] — which paints the *ambient* `MaterialTheme.colorScheme.primary` with no
@@ -2093,6 +2203,24 @@ class OverrideIntegrationTest {
   private fun encodeNamedBag(key: String, argb: String): String {
     val json = Json { encodeDefaults = false }
     val bag = PreviewOverrides(namedOverrides = mapOf(key to PreviewOverrideValue.ColorValue(argb)))
+    return Base64.getUrlEncoder()
+      .withoutPadding()
+      .encodeToString(
+        json.encodeToString(PreviewOverrides.serializer(), bag).toByteArray(Charsets.UTF_8)
+      )
+  }
+
+  /**
+   * A `namedOverrides` bag of plain **text** values — the shape a parameter-knob seed takes.
+   * [encodeNamedBag]'s `ColorValue` has no parameter-knob equivalent (`Color` is not a seedable
+   * kind), so a colour seed is deliberately dropped by `PreviewKnobSeeds` and cannot drive one.
+   */
+  private fun encodeTextBag(vararg entries: Pair<String, String>): String {
+    val json = Json { encodeDefaults = false }
+    val bag =
+      PreviewOverrides(
+        namedOverrides = entries.associate { (k, v) -> k to PreviewOverrideValue.StringValue(v) }
+      )
     return Base64.getUrlEncoder()
       .withoutPadding()
       .encodeToString(

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderSpecFromInfoTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderSpecFromInfoTest.kt
@@ -31,6 +31,26 @@ class RenderSpecFromInfoTest {
     PreviewInfoDto(id = "Foo", className = "com.example.FooKt", methodName = "Foo", params = params)
 
   @Test
+  fun `parameter knobs reach the spec on both the params and the no-params path`() {
+    // Both branches of the conversion have to carry them. The early return for a null params block
+    // is the *incremental* rescan's DTO — an edited preview keeps its knobs there via the index's
+    // carry-forward, so dropping them at this seam instead would put the same silent
+    // seed-does-nothing bug one layer down.
+    val knobs = listOf(PreviewKnobDto("title", 0, "STRING"), PreviewKnobDto("count", 1, "INT"))
+    val base =
+      PreviewInfoDto(
+        id = "Foo",
+        className = "com.example.FooKt",
+        methodName = "Foo",
+        knobs = knobs,
+      )
+    assertEquals(knobs, renderSpecFromInfo(base).knobs)
+    assertEquals(knobs, renderSpecFromInfo(base.copy(params = PreviewParamsDto())).knobs)
+    // The overwhelming majority of previews declare none.
+    assertEquals(emptyList<PreviewKnobDto>(), renderSpecFromInfo(info(params = null)).knobs)
+  }
+
+  @Test
   fun `no-size no-device preview wraps to content in the sandbox bound`() {
     // A preview whose (present) params block declares neither an explicit size nor a device (a
     // catalog sticker — it always carries params because it declares showBackground) renders

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderSpecKnobsTokenTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderSpecKnobsTokenTest.kt
@@ -1,0 +1,68 @@
+package ee.schimke.composeai.daemon
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the `knobs=<name>:<index>:<TYPE>,…` payload token — the className-based render path's way of
+ * naming a preview's **parameter knobs** when there is no `previews.json` entry to resolve them
+ * from (the previewId path takes them off the manifest instead, see [renderSpecFromInfo]).
+ *
+ * The parse is deliberately forgiving. A newer plugin can name a knob kind, or a shape, this daemon
+ * has never heard of, and the only sane degradation is that the parameter takes its compiled
+ * default while every other knob in the token still seeds. Failing the render instead would turn a
+ * forward-compatible wire into a hard version pin.
+ */
+class RenderSpecKnobsTokenTest {
+
+  @Test
+  fun `a well-formed token parses every entry in order`() {
+    assertEquals(
+      listOf(
+        PreviewKnobDto("title", 0, "STRING"),
+        PreviewKnobDto("enabled", 1, "BOOLEAN"),
+        PreviewKnobDto("count", 2, "INT"),
+      ),
+      RenderSpec.parseKnobsToken("title:0:STRING,enabled:1:BOOLEAN,count:2:INT"),
+    )
+  }
+
+  @Test
+  fun `an unknown kind survives the parse and is dropped later by the binder`() {
+    assertEquals(
+      listOf(PreviewKnobDto("accent", 0, "COLOR")),
+      RenderSpec.parseKnobsToken("accent:0:COLOR"),
+    )
+  }
+
+  @Test
+  fun `malformed entries are skipped rather than failing the render`() {
+    assertEquals(
+      listOf(PreviewKnobDto("title", 0, "STRING")),
+      RenderSpec.parseKnobsToken("title:0:STRING,noColons,bad:x:INT,:3:INT,negative:-1:INT,two:1:"),
+    )
+  }
+
+  @Test
+  fun `an absent or blank token is no knobs at all`() {
+    assertEquals(emptyList<PreviewKnobDto>(), RenderSpec.parseKnobsToken(null))
+    assertEquals(emptyList<PreviewKnobDto>(), RenderSpec.parseKnobsToken("   "))
+  }
+
+  @Test
+  fun `the token round-trips through parseFromPayload onto the spec`() {
+    val spec =
+      RenderSpec.parseFromPayload(
+        "className=com.example.FooKt;functionName=Foo;knobs=title:0:STRING,count:1:INT"
+      )
+    assertEquals(
+      listOf(PreviewKnobDto("title", 0, "STRING"), PreviewKnobDto("count", 1, "INT")),
+      spec.knobs,
+    )
+    // A payload with no token at all — every client older than this field — decodes to no knobs.
+    assertEquals(
+      emptyList<PreviewKnobDto>(),
+      RenderSpec.parseFromPayload("className=com.example.FooKt;functionName=Foo").knobs,
+    )
+  }
+}

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -120,6 +120,34 @@ fun OverridableSquare() {
 }
 
 /**
+ * The **parameter-knob** twin of [OverridableSquare]: two editable fills and a label, declared as
+ * the preview's own defaulted value parameters instead of `previewOverride*` lookups in the body.
+ * Discovery reports a knob per parameter (`ComposableSignature.knobsOf`) and the renderer binds a
+ * seed to the parameter's *position*, so this fixture contains no harness call at all.
+ *
+ * Two colours rather than one, on purpose. [OverrideIntegrationTest.parameterKnobSeedsOneParameter]
+ * seeds only [topArgb], so the render proves both halves of the contract at once: the seeded
+ * parameter repaints, and the unseeded [bottomArgb] renders its **compiled default** rather than a
+ * zero — which is what Kotlin's synthetic `$default` mask does for the positions the binder leaves
+ * null, and the only reason a subset of a preview's knobs can be seeded at all. [label] is a third
+ * kind left unseeded, so a `String` position sharing the mask is covered too.
+ */
+@Composable
+fun KnobbedSquare(
+  topArgb: Long = 0xFFEF5350,
+  bottomArgb: Long = 0xFF66BB6A,
+  label: String = "hi",
+) {
+  // `label` is deliberately never drawn: the assertion is a pixel one and a glyph over either band
+  // would only make the two colours harder to measure. It exists to put a String position into the
+  // same `$default` mask as the two Longs, so the test covers a mixed-kind mask and not just Longs.
+  Column(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = Modifier.weight(1f).fillMaxWidth().background(Color(topArgb.toInt())))
+    Box(modifier = Modifier.weight(1f).fillMaxWidth().background(Color(bottomArgb.toInt())))
+  }
+}
+
+/**
  * The same `fill` knob as [OverridableSquare], but read **through a keyless `remember`** — the
  * shape every androidx `remember*State` factory has (`rememberTimePickerState`,
  * `rememberDatePickerState`, …), each of which saves through a keyless `rememberSaveable` whose

--- a/docs/design/PARAMETER_KNOB_MIGRATION.md
+++ b/docs/design/PARAMETER_KNOB_MIGRATION.md
@@ -1,0 +1,176 @@
+# Migrating a preview's knobs to the parameter format
+
+Two override formats exist side by side. This is the record of what happened when the repository's
+own samples were tested against the newer one — which of them can move, which cannot, and what has
+to land before "cannot" becomes "can". It is written so the question doesn't have to be
+re-investigated from the source the next time it comes up.
+
+The two formats, in one line each:
+
+| | `previewOverride*` (named overrides) | Parameter knobs |
+| --- | --- | --- |
+| Where the knob is declared | by **executing a lookup in the composable body** | by the **function signature** |
+| How a value is seeded | writing typed values into a process-static controller before composing | ordinary argument passing |
+| What the preview's body contains | a harness call per knob | nothing — no harness dependency at all |
+| Where the declaration is published | `previews/<id>.overrides.json`, `data/fetch?kind=compose/overrides` | *nowhere yet* — see [gap 1](#gap-1) |
+
+The reference pair to read side by side is
+[`samples/cmp/.../OverridablePreviews.kt`](../../samples/cmp/src/main/kotlin/com/example/samplecmp/OverridablePreviews.kt)
+and
+[`ParameterKnobPreviews.kt`](../../samples/cmp/src/main/kotlin/com/example/samplecmp/ParameterKnobPreviews.kt):
+the same list, the same pixels ([render evidence](evidence/parameter-knobs/README.md)), the knobs
+declared each way. That pair is deliberate and must **not** be collapsed by a migration.
+
+## The verdict
+
+**No sample should move today.** Not because the format is wrong, but because a migrated preview
+loses its editor: nothing publishes a parameter knob's declaration, so a viewer has no knob to show
+and no default to show in it. That is [gap 1](#gap-1), and it is the one that decides the answer.
+
+Everything below is what the investigation found on the way to that.
+
+## What discovery already does
+
+`ComposableSignature.knobsOf` reports a knob per value parameter, and only when:
+
+* **every** value parameter declares a default — one non-defaulted parameter and the preview reports
+  no knobs at all, so a preview cannot acquire one by accident;
+* the parameter is **non-nullable** — null is the "use the default" channel on the wire, so it
+  cannot also mean "set this to null"; and
+* its type is one the harness can build from a seed string: `String`, `Boolean`, `Int`, `Long`,
+  `Float`, `Double`, matched on the metadata classifier's FQN so a project's own `Boolean` can't
+  masquerade as `kotlin/Boolean`.
+
+`PreviewKnob.index` is the parameter's position in the **full** value-parameter list, not among the
+knobs, because that is the position an argument has to be placed at. A defaulted-but-not-seedable
+parameter (`modifier: Modifier = Modifier`) keeps its slot and takes its default.
+
+That much has worked since the format landed: `previews.json` carries the knobs today.
+
+## What testing the migration found, and fixed
+
+Two defects, neither visible from reading the source alone. Both are fixed in the change this
+document accompanies; both are the reason a migrated preview would have looked broken rather than
+merely un-editable.
+
+**The daemon could not resolve a parameter-knob preview at all.** `getDeclaredComposableMethod(name)`
+matches only `(Composer, int)` — a preview with no value parameters. One whose parameters all
+declare defaults compiles to `(realParams…, Composer, int changed, int default)`, so the lookup
+threw `NoSuchMethodException` before composition started: no PNG, just an `.error.json`. The
+standalone `:renderer-desktop` bake lane had a fallback for exactly this and the daemon did not,
+which is why `ParameterKnobPreviews.kt` bakes correctly ([render
+evidence](evidence/parameter-knobs/README.md)) and would not have rendered live. The fallback now
+lives in `PreviewParameterSupport`, which both lanes call, instead of privately in one of them.
+
+**Nothing bound a seed to a parameter.** `PreviewKnobArguments` — the binder, with its own tests —
+had no caller outside those tests: no producer of the `knobs=` payload token, no consumer in either
+daemon, and the daemon's `RenderSpec` had no field to carry the knobs `previews.json` already listed.
+A `renderNow.overrides.namedOverrides` seed naming a parameter knob was read by the
+`previewOverride*` controller, matched nothing there, and was dropped in silence.
+
+## The gaps that remain
+
+### <a id="gap-1"></a>1. A parameter knob is never *declared* to a client
+
+`previewOverride*` publishes each knob as a `PreviewOverrideDeclaration` — key, type, label, default
+value, current value — through the controller, into `previews/<id>.overrides.json` and
+`data/fetch?kind=compose/overrides`. That is what a viewer renders its controls from and what
+`preview-harness/serve-lanes.spec.mjs` selects on.
+
+A parameter knob publishes nothing. Rendering the two `samples/cmp` twins side by side shows it
+exactly:
+
+```
+$ ls samples/cmp/build/compose-previews/renders/*.overrides.json
+…/OverridableListPreview_Overridable_List-c264a81f.overrides.json
+# and no ParameterKnobListPreview sidecar
+```
+
+The blocker underneath is that **discovery records that a default exists, not what it is**. A
+declaration needs the default *value*, and the Compose compiler leaves default expressions inside
+the function body guarded by the synthetic `$default` mask rather than in a readable constant pool
+entry — recovering a literal one means walking the method's bytecode, and a non-literal one
+(`stringResource(...)`, which most of this repository's samples use) cannot be recovered at all.
+
+So closing this gap means: read constant defaults from the class file where they are literals, and
+publish a declaration with **no** default where they are not. Until then a migrated preview is
+editable only by a client that already knows the knob's name from `previews.json`.
+
+### 2. `Color` and `Dp` are not seedable kinds
+
+An editable colour is the single most common knob in these samples
+(`previewOverrideColor("accent", …)`, `catalogOverrideColor("iconColor", …)`). The parameter format
+has no `Color` kind, so the workaround is an ARGB `Long` — which is what `ParameterKnobPreviews.kt`
+does, and it costs the viewer its colour picker. `Dp` is the same story with `Int` dp.
+
+A colour seed is deliberately *dropped* rather than coerced on its way to a parameter knob (see
+`PreviewKnobSeeds`): `#FF42A5F5` is not a number, and reporting it as a malformed one would hide
+that the kind is simply unsupported.
+
+### 3. There is no indexed knob
+
+`previewOverrideString("rowLabel", default = "Item ${i + 1}", index = i)` gives every row of a
+repeated component its own editable value. A parameter list is fixed-arity and a per-row value is
+not, so there is no equivalent. Three samples rely on it:
+`samples/cmp/.../OverridablePreviews.kt`, `design-catalog-m3/.../CatalogTemplates.kt` (the message
+list's `sender` / `preview`), and `design-catalog-wear-m3/.../CatalogPreviews.kt` (the pager's
+`page`).
+
+### 4. There is no closed value set
+
+`previewOverrideChoice` declares the values a knob may take, so a viewer draws a picker over the
+declared labels instead of a text field a reader has to already know spells `compact` / `cosy` /
+`comfortable`. A `String` parameter carries no such set. The wear catalog's font knob is the same
+shape with autocomplete over the declared typefaces.
+
+### 5. A knob declared outside the `@Preview` function has no equivalent at all
+
+This is the structural one, and it rules out the whole design-catalog family rather than any single
+knob. `CatalogComponent(id: String)` is *one* dispatch composable holding every component's knobs,
+called by dozens of previews; `CatalogSticker { … }` is a theme wrapper reading the font / palette /
+shapes / typography knobs on behalf of every sticker. Both are the reason those previews stay clean
+one-liners.
+
+A parameter knob only exists on the preview's own signature, so moving either would mean copying
+every knob of every branch onto every preview that could reach it — and `CatalogComponent(id:
+String)` reports no knobs anyway, since `id` has no default.
+
+### 6. Only the desktop lanes bind a seed
+
+`:renderer-desktop` (the offline bake) and `:daemon:desktop` (live / `serve` / VS Code) both seed a
+parameter knob. The **Android (Robolectric) daemon** does not: it carries the same `previewArgs`
+seam and the same `resolvePreviewInvocation` shape, but neither the `RenderSpec.knobs` field nor the
+bind, so a parameter knob there renders its defaults — and, until the resolution fix is mirrored,
+a defaulted preview fails to resolve at all. That is what blocks `samples/android-live-lane`
+independently of gap 1.
+
+There is also no producer of the `knobs=` payload token yet. The daemon's production lane resolves
+knobs off `previews.json` and never needs it; the token exists so a caller driving the
+`className=`/`functionName=` payload directly can name them, and it is parsed but not written.
+
+## The samples, one by one
+
+| Sample | Knobs | Verdict |
+| --- | --- | --- |
+| `samples/cmp/.../OverridablePreviews.kt` | 4 (`title`, `accent`, `itemCount`, `density`, indexed `rowLabel`) | **Keep as is** — it is the deliberate twin of `ParameterKnobPreviews.kt`; the comparison is what the sample is for |
+| `samples/cmp/.../ParameterKnobPreviews.kt` | 5 parameter knobs | Already migrated — the reference |
+| `samples/android-live-lane/.../LiveLanePreviews.kt` | 1 (`label`, on the `@Preview` itself) | **Cleanest candidate, blocked** by gaps 1 and 6. `serve-lanes.spec.mjs` asserts `overrides[].key == "label"`, which would go empty |
+| `design-catalog-m3-shared/.../CatalogComponents.kt` + `CatalogOverrides.kt` (+ actuals) | ~15 across a `when (id)` dispatch | **Cannot** — gap 5, plus `catalogOverrideColor` (gap 2) |
+| `design-catalog-m3/.../CatalogTheme.kt` | 5 (font, colors, shapes, typography, fonts) | **Cannot** — gap 5: read inside the theme wrapper every sticker calls |
+| `design-catalog-m3/.../CatalogTemplates.kt` | `title`, `fab` hoistable; `sender`, `preview` indexed | **Partial at best** — gap 3 |
+| `design-catalog-wear-m3/.../CatalogPreviews.kt` | ~24, most directly on a `@Preview` | **Most migratable, blocked** by gaps 1 and 3 (`index = page`) and the font knob's autocomplete (gap 4) |
+| `design-catalog-wear-m3/.../CatalogTheme.kt` | 4 | **Cannot** — gap 5 |
+| `design-catalog-wear-m3/.../CatalogInteractive.kt` | 1, seeding a state holder | Follows whatever its preview does |
+
+## When to reach for which
+
+Once gap 1 closes, the split is a real design choice rather than a capability gap:
+
+* **Parameter knobs** when the preview is a self-contained composable whose editable values are its
+  own arguments, and you want the body to carry no harness dependency — the shape a preview already
+  has when it is also called by real code.
+* **`previewOverride*`** when the knob is a colour or a dimension, when each item of a repeated
+  component needs its own value, when the value set is closed and a picker is the right control, or
+  when the knob is declared once in a wrapper or dispatch helper on behalf of many previews.
+
+Neither replaces the other, which is why both are supported.

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Composer
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.currentComposer
 import androidx.compose.runtime.reflect.ComposableMethod
@@ -1301,7 +1300,8 @@ internal fun renderPreview(
         // default", which is exactly what a zero-seed render of such a preview wants.
         runCatching { clazz.getDeclaredComposableMethod(functionName) }
           .getOrElse { failure ->
-            findDefaultedComposableMethod(clazz, functionName) ?: throw failure
+            PreviewParameterSupport.findDefaultedComposableMethod(clazz, functionName)
+              ?: throw failure
           }
       } else {
         findComposableMethodWithArgs(clazz, functionName, previewArgs)
@@ -1715,86 +1715,17 @@ private fun InvokeComposable(
   instance: Any?,
   previewArgs: List<Any?>,
 ) {
-  if (invokeWithDefaultMask(composableMethod, instance, previewArgs, currentComposer)) return
+  if (
+    PreviewParameterSupport.invokeWithDefaultMask(
+      composableMethod,
+      instance,
+      previewArgs,
+      currentComposer,
+    )
+  )
+    return
   composableMethod.invoke(currentComposer, instance, *previewArgs.toTypedArray())
 }
-
-/**
- * Invokes [composableMethod]'s `$default` bridge directly when [previewArgs] leaves an **interior**
- * parameter unseeded, returning true when it did the call.
- *
- * `ComposableMethod.invoke` cannot express that. It derives the default mask from which arguments
- * are null *and* forwards those same nulls as the parameter values, so a null destined for a
- * primitive parameter reaches `Method.invoke` as a null `int` and throws
- * `IllegalArgumentException`. Trailing arguments it never receives are fine — those it pads by type
- * — so the failure only appears when something after an unseeded parameter *is* seeded, which is
- * precisely the shape a partial knob seed produces (`Button(label = …, enabled = <default>, size =
- * …)`).
- *
- * Doing it here keeps the semantics the format needs: an unseeded position contributes a set bit to
- * Kotlin's synthetic `$default` mask *and* a type-appropriate zero as its placeholder value, so the
- * compiled default expression runs and the author's default is what renders.
- *
- * Returns false — leaving the caller on the ordinary path — whenever the shape is not one this can
- * safely drive: no null to fix, no `$default` bridge on the method, an instance method, or more
- * than 31 value parameters (past which Kotlin emits a second mask word and the single-int layout
- * below no longer holds).
- */
-private fun invokeWithDefaultMask(
-  composableMethod: ComposableMethod,
-  instance: Any?,
-  previewArgs: List<Any?>,
-  composer: Composer,
-): Boolean {
-  if (instance != null) return false
-  // Any null at all, not just an interior one: `ComposableMethod.invoke` pads only positions past
-  // `args.size`, so a null *inside* the list — trailing or not — is forwarded verbatim.
-  if (previewArgs.none { it == null }) return false
-  val method = composableMethod.asMethod()
-  val realParams = method.parameterCount - 3
-  if (realParams !in 1..31 || previewArgs.size > realParams) return false
-  val types = method.parameterTypes
-  if (types[realParams] != Composer::class.java) return false
-  if (types[realParams + 1] != Int::class.javaPrimitiveType) return false
-  if (types[realParams + 2] != Int::class.javaPrimitiveType) return false
-
-  var mask = 0
-  val arguments = arrayOfNulls<Any?>(method.parameterCount)
-  for (i in 0 until realParams) {
-    val seeded = previewArgs.getOrNull(i)
-    if (seeded == null) {
-      mask = mask or (1 shl i)
-      arguments[i] = zeroValueFor(types[i])
-    } else {
-      arguments[i] = seeded
-    }
-  }
-  arguments[realParams] = composer
-  arguments[realParams + 1] = 0
-  arguments[realParams + 2] = mask
-  method.isAccessible = true
-  method.invoke(null, *arguments)
-  return true
-}
-
-/**
- * The placeholder a defaulted parameter is passed alongside its set mask bit. Kotlin's `$default`
- * bridge overwrites it with the compiled default expression, so the value never reaches the body —
- * but the JVM still requires one of the right type, which is the whole reason a null cannot be
- * used.
- */
-private fun zeroValueFor(type: Class<*>): Any? =
-  when (type) {
-    Int::class.javaPrimitiveType -> 0
-    Boolean::class.javaPrimitiveType -> false
-    Long::class.javaPrimitiveType -> 0L
-    Float::class.javaPrimitiveType -> 0f
-    Double::class.javaPrimitiveType -> 0.0
-    Short::class.javaPrimitiveType -> 0.toShort()
-    Byte::class.javaPrimitiveType -> 0.toByte()
-    Char::class.javaPrimitiveType -> '\u0000'
-    else -> null
-  }
 
 /**
  * Desktop mirror of the Android renderer's lookup for `@PreviewParameter` functions — see
@@ -1817,30 +1748,6 @@ internal fun findComposableMethodWithArgs(
       )
   val declaredTypes = candidate.parameterTypes.take(argCount).toTypedArray()
   return clazz.getDeclaredComposableMethod(name, *declaredTypes)
-}
-
-/**
- * The defaulted-parameter overload of [name] on [clazz], resolved by shape, or null when there
- * isn't one.
- *
- * A `@Composable` function with defaults compiles to `(realParams…, Composer, int changed, int
- * default)`, so a trailing `(Composer, int, int)` is the signal that Kotlin emitted a `$default`
- * bridge and every parameter can therefore be left to its default. Resolution goes through
- * [findComposableMethodWithArgs] with an all-null list so there is one code path deciding what a
- * null argument means.
- */
-private fun findDefaultedComposableMethod(clazz: Class<*>, name: String): ComposableMethod? {
-  val candidate =
-    clazz.declaredMethods.firstOrNull { m ->
-      m.name == name &&
-        m.parameterCount >= 3 &&
-        m.parameterTypes[m.parameterCount - 3] == Composer::class.java &&
-        m.parameterTypes[m.parameterCount - 2] == Int::class.javaPrimitiveType &&
-        m.parameterTypes[m.parameterCount - 1] == Int::class.javaPrimitiveType
-    } ?: return null
-  val realParams = candidate.parameterCount - 3
-  if (realParams <= 0) return null
-  return findComposableMethodWithArgs(clazz, name, List(realParams) { null })
 }
 
 private fun argsMatch(method: java.lang.reflect.Method, previewArgs: List<Any?>): Boolean {

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/PreviewParameterSupport.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/PreviewParameterSupport.kt
@@ -79,6 +79,12 @@ object PreviewParameterSupport {
    * The returned method is always opened for reflective invocation ([openForInvoke]) — Kotlin
    * `private fun` previews are idiomatic and resolve fine, but invoking one without that throws
    * `IllegalAccessException`.
+   *
+   * [previewArgs] carries a **parameter knob** seed — a preview's own defaulted value parameters,
+   * the secondary override format — and is meaningful only when there is no provider, since the two
+   * are mutually exclusive: discovery reports knobs only when every value parameter has a default,
+   * which a provider-bound one does not. Empty (the default) resolves the parameterless overload,
+   * falling back to the defaulted shape when the preview has one.
    */
   fun resolve(
     clazz: Class<*>,
@@ -87,9 +93,32 @@ object PreviewParameterSupport {
     limit: Int = Int.MAX_VALUE,
     classLoader: ClassLoader? = null,
     row: String? = null,
+    previewArgs: List<Any?> = emptyList(),
   ): Resolved {
     if (providerClassName.isNullOrBlank()) {
-      return Resolved(clazz.getDeclaredComposableMethod(functionName).openForInvoke(), emptyList())
+      // A preview whose parameters ALL declare defaults is a supported shape — it is what a
+      // production composable annotated `@Preview` in place almost always looks like
+      // (`modifier: Modifier = Modifier`), and it is the whole of the **parameter knob** format.
+      // It compiles to `(realParams…, Composer, int changed, int default)`, which the parameterless
+      // `getDeclaredComposableMethod(name)` lookup — it matches only `(Composer, int)` — cannot
+      // see. Before this fell back, such a preview threw `NoSuchMethodException` on the daemon
+      // before composition started: no PNG, no semantics, just an `.error.json`, and every knob
+      // seed for it moot. The standalone `:renderer-desktop` bake lane had the fallback and the
+      // daemon did not, which is why a parameter-knob preview baked correctly and would not render
+      // live.
+      if (previewArgs.isEmpty()) {
+        val method = runCatching {
+          clazz.getDeclaredComposableMethod(functionName)
+        }
+          .getOrElse { failure ->
+            findDefaultedComposableMethod(clazz, functionName) ?: throw failure
+          }
+        return Resolved(method.openForInvoke(), emptyList())
+      }
+      return Resolved(
+        findComposableMethodWithArgs(clazz, functionName, previewArgs).openForInvoke(),
+        previewArgs,
+      )
     }
     if (limit <= 0) {
       throw PreviewParameterLoadException(
@@ -300,11 +329,120 @@ object PreviewParameterSupport {
     return clazz.getDeclaredComposableMethod(name, *declaredTypes)
   }
 
+  /**
+   * The defaulted-parameter overload of [name] on [clazz], resolved by shape, or null when there
+   * isn't one.
+   *
+   * A `@Composable` function with defaults compiles to `(realParams…, Composer, int changed, int
+   * default)`, so a trailing `(Composer, int, int)` is the signal that Kotlin emitted a `$default`
+   * bridge and every parameter can therefore be left to its default. Resolution goes through
+   * [findComposableMethodWithArgs] with an all-null list so there is one code path deciding what a
+   * null argument means.
+   */
+  fun findDefaultedComposableMethod(clazz: Class<*>, name: String): ComposableMethod? {
+    val candidate =
+      clazz.declaredMethods.firstOrNull { m ->
+        m.name == name &&
+          m.parameterCount >= 3 &&
+          m.parameterTypes[m.parameterCount - 3] == androidx.compose.runtime.Composer::class.java &&
+          m.parameterTypes[m.parameterCount - 2] == Int::class.javaPrimitiveType &&
+          m.parameterTypes[m.parameterCount - 1] == Int::class.javaPrimitiveType
+      } ?: return null
+    val realParams = candidate.parameterCount - 3
+    if (realParams <= 0) return null
+    return findComposableMethodWithArgs(clazz, name, List(realParams) { null })
+  }
+
+  /**
+   * Invokes [composableMethod]'s `$default` bridge directly when [previewArgs] leaves a parameter
+   * unseeded, returning true when it did the call — so a caller falls back to the ordinary
+   * `ComposableMethod.invoke` only when this cannot safely drive the shape.
+   *
+   * `ComposableMethod.invoke` cannot express a partial seed. It derives the default mask from which
+   * arguments are null *and* forwards those same nulls as the parameter values, so a null destined
+   * for a primitive parameter reaches `Method.invoke` as a null `int` and throws
+   * `IllegalArgumentException`. Trailing arguments it never receives are fine — those it pads by
+   * type — so the failure appears exactly when something *after* an unseeded parameter is seeded,
+   * which is precisely the shape a partial knob seed produces (`Button(label = …, enabled =
+   * <default>, size = …)`).
+   *
+   * Doing it here keeps the semantics the format needs: an unseeded position contributes a set bit
+   * to Kotlin's synthetic `$default` mask *and* a type-appropriate zero as its placeholder, so the
+   * compiled default expression runs and the author's default is what renders.
+   *
+   * Returns false whenever the shape is not one this can drive: no null to fix, no `$default`
+   * bridge, an instance method, or more than 31 value parameters (past which Kotlin emits a second
+   * mask word and the single-int layout below no longer holds).
+   */
+  fun invokeWithDefaultMask(
+    composableMethod: ComposableMethod,
+    instance: Any?,
+    previewArgs: List<Any?>,
+    composer: androidx.compose.runtime.Composer,
+  ): Boolean {
+    if (instance != null) return false
+    // Any null at all, not just an interior one: `ComposableMethod.invoke` pads only positions past
+    // `args.size`, so a null *inside* the list — trailing or not — is forwarded verbatim.
+    if (previewArgs.none { it == null }) return false
+    val method = composableMethod.asMethod()
+    val realParams = method.parameterCount - 3
+    if (realParams !in 1..31 || previewArgs.size > realParams) return false
+    val types = method.parameterTypes
+    if (types[realParams] != androidx.compose.runtime.Composer::class.java) return false
+    if (types[realParams + 1] != Int::class.javaPrimitiveType) return false
+    if (types[realParams + 2] != Int::class.javaPrimitiveType) return false
+
+    var mask = 0
+    val arguments = arrayOfNulls<Any?>(method.parameterCount)
+    for (i in 0 until realParams) {
+      val seeded = previewArgs.getOrNull(i)
+      if (seeded == null) {
+        mask = mask or (1 shl i)
+        arguments[i] = zeroValueFor(types[i])
+      } else {
+        arguments[i] = seeded
+      }
+    }
+    arguments[realParams] = composer
+    arguments[realParams + 1] = 0
+    arguments[realParams + 2] = mask
+    method.isAccessible = true
+    method.invoke(null, *arguments)
+    return true
+  }
+
+  /**
+   * The placeholder a defaulted parameter is passed alongside its set mask bit. Kotlin's `$default`
+   * bridge overwrites it with the compiled default expression, so the value never reaches the body
+   * — but the JVM still requires one of the right type, which is the whole reason a null cannot be
+   * used.
+   */
+  private fun zeroValueFor(type: Class<*>): Any? =
+    when (type) {
+      Int::class.javaPrimitiveType -> 0
+      Boolean::class.javaPrimitiveType -> false
+      Long::class.javaPrimitiveType -> 0L
+      Float::class.javaPrimitiveType -> 0f
+      Double::class.javaPrimitiveType -> 0.0
+      Short::class.javaPrimitiveType -> 0.toShort()
+      Byte::class.javaPrimitiveType -> 0.toByte()
+      Char::class.javaPrimitiveType -> '\u0000'
+      else -> null
+    }
+
   private fun argsMatch(method: java.lang.reflect.Method, previewArgs: List<Any?>): Boolean {
+    // A `@Composable` with defaults ends in `(Composer, int changed, int default)`; without them it
+    // ends in `(Composer, int changed)`. Only the former can honour a null, because that is what
+    // becomes a set bit in Kotlin's synthetic `$default` mask.
+    val carriesDefaultMask = method.parameterCount >= previewArgs.size + 3
     for ((i, arg) in previewArgs.withIndex()) {
       val expected = method.parameterTypes[i]
       if (arg == null) {
-        if (expected.isPrimitive) return false
+        // Without a default mask a null would reach a primitive parameter as 0/false and render a
+        // value the author never wrote, so it still cannot bind there. With one, null is precisely
+        // how a partial seed says "leave this parameter alone" — which is what makes it possible to
+        // seed one knob of a preview without disturbing its primitive siblings.
+        if (expected.isPrimitive && !carriesDefaultMask) return false
         continue
       }
       val actual = arg.javaClass


### PR DESCRIPTION
Testing whether the local samples could migrate to the parameter-knob preview style turned up two defects that made the answer moot, and this fixes both.

## What was broken

**Nothing bound a seed to a parameter.** `PreviewKnobArguments` — the binder, with its own tests — had no caller outside those tests. `previews.json` has carried a preview's `knobs` since the format landed, but the daemon's `RenderSpec` had no field to hold them, no code read them, and nobody produced the `knobs=` payload token. A `renderNow.overrides.namedOverrides` seed naming a parameter knob was offered to the `previewOverride*` controller, matched nothing there, and was dropped in silence.

**The desktop daemon could not resolve such a preview at all.** This one only showed up on running the test. `getDeclaredComposableMethod(name)` matches only `(Composer, int)` — a preview with no value parameters. One whose parameters all declare defaults compiles to `(realParams…, Composer, int changed, int default)`, so the lookup threw `NoSuchMethodException` before composition started: no PNG, just an `.error.json`. The standalone `:renderer-desktop` bake lane had a fallback for exactly this and the daemon did not, which is why `samples/cmp`'s reference preview bakes correctly ([evidence](https://github.com/yschimke/compose-ai-tools/blob/main/docs/design/evidence/parameter-knobs/README.md)) and would not have rendered live.

## What changed

* The defaulted-shape resolution fallback and the `$default`-mask invoke move out of `DesktopRendererMain`'s privates into `PreviewParameterSupport`, which both lanes already call. That removes a copy rather than adding one — and closes real drift: `PreviewParameterSupport.argsMatch` rejected a null for a primitive parameter unconditionally, where `DesktopRendererMain`'s copy admitted it when the method carries a `$default` mask.
* `PreviewInfoDto.knobs` parses the field discovery already writes, with the same rescan carry-forward `params` and `captures` have — the incremental class-file scan never reads a signature, so without it every seeded knob would fall back to its author default after the first save.
* `RenderSpec.knobs` carries them, from the manifest (`renderSpecFromInfo`) or from a new tolerant `knobs=<name>:<index>:<TYPE>,…` payload token.
* `PreviewKnobSeeds` flattens the shared `namedOverrides` bag to the text the binder parses. A `ColorValue` is deliberately dropped: `Color` is not a seedable parameter-knob kind, and reporting `#FF42A5F5` as a malformed number would hide that.
* The daemon binds and invokes. A position left unseeded contributes a set bit to Kotlin's synthetic `$default` mask, so its compiled default expression still runs — that is what lets a client edit one knob of a preview declaring five without sending the other four.

## The migration verdict

`docs/design/PARAMETER_KNOB_MIGRATION.md` records the whole investigation: the sample-by-sample classification, and the five gaps that remain. **No sample should move yet.** The deciding one is that a parameter knob still publishes no `PreviewOverrideDeclaration`, so a viewer has no control to draw and no default to show in it — visible directly in the build output, where `OverridableListPreview` gets an `.overrides.json` sidecar and its parameter-knob twin gets none. Underneath that, discovery records *that* a default exists, not *what it is*; the Compose compiler leaves default expressions inside the function body behind the `$default` mask.

The others: `Color`/`Dp` are not seedable kinds; there is no indexed knob; there is no closed value set (no picker); and a knob declared in a shared dispatch helper or theme wrapper — which is the entire design-catalog architecture — has no parameter equivalent at all.

## Test plan

Non-visual — no rendered surface changes; the two new render tests assert pixels but nothing a user sees moves.

* `:daemon:core:test` and `:daemon:desktop:test` — **849 tests, 0 failures**, including:
  * `OverrideIntegrationTest.parameterKnobSeedsOneParameter` — end-to-end through a real `DesktopHost` on the `previewId=` payload path. Seeds only `topArgb` and asserts both bands: the top repaints blue from the seed, the bottom keeps its compiled default green. Fails on `NoSuchMethodException` without the resolution fix and renders all-default without the bind.
  * `OverrideIntegrationTest.parameterKnobPreviewRendersItsDefaultsUnseeded` — the unseeded baseline, so the above can't pass for the wrong reason.
  * `PreviewIndexTest` / `PreviewIndexDiffTest` / `RenderSpecFromInfoTest` / `RenderSpecKnobsTokenTest` / `PreviewKnobSeedsTest`.
* `:renderer-desktop:test` — green, confirming the standalone bake lane is unaffected by the extraction.
* `ktfmtFormat` run on every touched module.

Not covered here, and stated in the doc: the Android (Robolectric) daemon, which needs the same two fixes mirrored, and a producer for the `knobs=` token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o

---
_Generated by [Claude Code](https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o)_