### PR TITLE
feat(daemon): seed parameter knobs on the Robolectric backend too

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -808,6 +808,12 @@ internal fun renderSpecFromInfo(info: PreviewInfoDto): RenderSpec {
       // covers held/render paths and keeps both daemon backends symmetric.
       outputBaseName = info.id,
       overrides = bakedOverrides,
+      // The parameter knobs discovery read off the signature. Carried on BOTH the early-return
+      // `defaults` and the fully-resolved spec below — a preview whose `params` block is absent
+      // (the incremental rescan's DTO) declares the same parameters, and dropping them on that
+      // path would make a seeded knob render its author default for as long as the manifest
+      // stayed un-rediscovered.
+      knobs = info.knobs,
       // Explicit LIGHT, not null. A null uiMode emits no `uiMode=` token in the routed payload,
       // and Robolectric qualifiers apply incrementally (`setQualifiers("+…")`), so a token-less
       // render inherits whatever `night` bit the previous render in the session left behind — a
@@ -897,6 +903,7 @@ internal fun renderSpecFromInfo(info: PreviewInfoDto): RenderSpec {
     gutterTopDp = params.captureGutter?.top ?: 0,
     gutterEndDp = params.captureGutter?.end ?: 0,
     gutterBottomDp = params.captureGutter?.bottom ?: 0,
+    knobs = defaults.knobs,
   )
 }
 

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -2832,6 +2832,20 @@ private fun SemanticsNode.descendantCount(): Int = runCatching {
  */
 @Composable
 private fun InvokeComposable(composableMethod: ComposableMethod, previewArgs: List<Any?>) {
+  // A **partial** parameter-knob seed leaves nulls in the list, and `ComposableMethod.invoke`
+  // cannot express that: it forwards a null destined for a primitive parameter verbatim and
+  // `Method.invoke` throws on the null `int`. `invokeWithDefaultMask` drives the defaults-mask
+  // overload itself when it sees one and returns false otherwise, so every shape it can't handle
+  // stays on the path it always took.
+  if (
+    ee.schimke.composeai.renderer.PreviewParameterSupport.invokeWithDefaultMask(
+      composableMethod,
+      null,
+      previewArgs,
+      currentComposer,
+    )
+  )
+    return
   composableMethod.invoke(currentComposer, null, *previewArgs.toTypedArray())
 }
 
@@ -2858,6 +2872,9 @@ private fun resolvePreviewInvocation(
     limit = spec.previewParameterLimit,
     classLoader = clazz.classLoader,
     row = spec.previewParameterRow,
+    // The seeded parameter knobs, which also decide the overload to resolve: a preview whose
+    // parameters all declare defaults is invisible to the parameterless lookup either way.
+    previewArgs = PreviewKnobSeeds.bind(spec.knobs, spec.overrides?.namedOverrides),
   )
 
 /**
@@ -3330,6 +3347,19 @@ data class RenderSpec(
    */
   val previewParameterRow: String? = null,
   /**
+   * The **parameter knobs** this preview declares — its own defaulted value parameters, the
+   * secondary override format beside `previewOverride*`. Carried from `previews.json` by
+   * `renderSpecFromInfo`, or from the `knobs=<name>:<index>:<TYPE>,…` payload token by
+   * [parseFromPayload]. Field-for-field identical to `:daemon:desktop`'s twin so one payload string
+   * still drives either backend.
+   *
+   * Empty for every preview that declares none, which is the overwhelming majority: discovery only
+   * reports knobs when **every** value parameter has a default, so a preview cannot acquire one by
+   * accident. A seed in `overrides.namedOverrides` naming one binds to the parameter's position; a
+   * seed naming anything else is left for the `previewOverride*` controller.
+   */
+  val knobs: List<PreviewKnobDto> = emptyList(),
+  /**
    * `@CaptureGutter` edges in **dp** (issue #4443) — field-for-field identical to
    * `:daemon:desktop`'s `RenderSpec`, so one payload string drives either backend. All-zero (the
    * default) is every preview without the annotation, and is what a payload written before the
@@ -3439,12 +3469,22 @@ data class RenderSpec(
         previewParameterLimit =
           map["previewParameterLimit"]?.toIntOrNull() ?: defaults.previewParameterLimit,
         previewParameterRow = map["previewParameterRow"]?.takeIf { it.isNotBlank() },
+        knobs = parseKnobsToken(map["knobs"]),
         gutterStartDp = gutterDp[0],
         gutterTopDp = gutterDp[1],
         gutterEndDp = gutterDp[2],
         gutterBottomDp = gutterDp[3],
       )
     }
+
+    /**
+     * Parses the `knobs=<name>:<index>:<TYPE>,…` payload token into [RenderSpec.knobs]. Delegates
+     * to [PreviewKnobToken], the same codec [RobolectricHost.reshapeRenderPayload] emits with — on
+     * this backend the token is the *only* way a knob crosses into the Robolectric sandbox, so
+     * producer and consumer agreeing is load-bearing rather than tidy.
+     */
+    internal fun parseKnobsToken(token: String?): List<PreviewKnobDto> =
+      PreviewKnobToken.parse(token)
 
     /**
      * The `captureGutter=<start>,<top>,<end>,<bottom>` payload token — four dp edges, in that

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1336,6 +1336,12 @@ open class RobolectricHost(
             ?.takeIf { row -> row.isNotBlank() }
             ?.let { row -> append("previewParameterRow=").append(row).append(';') }
         }
+      // The preview's **parameter knobs**. On this backend the token is the only way they reach
+      // the render: composition happens inside the Robolectric sandbox classloader, which sees the
+      // reshaped payload and never this host-side spec. Dropping it here would leave a seeded knob
+      // silently rendering its author default — the desktop backend has no equivalent emit because
+      // its resolver hands the spec to the render body directly.
+      PreviewKnobToken.encode(base.knobs)?.let { append("knobs=").append(it).append(';') }
       // Key the output PNG on the (unique) previewId, like [PreviewManifestRouter]; the default
       // `className-functionName` stem would collide for the multiple `@Preview` / @WearPreview*
       // variants that share one function, overwriting each other's render.

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidParameterKnobTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidParameterKnobTest.kt
@@ -1,0 +1,187 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.util.Base64
+import javax.imageio.ImageIO
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * End-to-end proof for the **parameter-knob** override format on the Robolectric backend — the
+ * Android counterpart of `:daemon:desktop`'s
+ * `OverrideIntegrationTest.parameterKnobSeedsOneParameter`.
+ *
+ * Two things have to hold, and only one of them is shared with desktop.
+ *
+ * **The preview has to resolve at all.** `getDeclaredComposableMethod(name)` matches only
+ * `(Composer, int)`; [KnobbedSquare] compiles to `(Long, Long, String, Composer, changed,
+ * default)`, so the bare lookup throws `NoSuchMethodException` before composition and the render
+ * produces an `.error.json` rather than a PNG.
+ *
+ * **The knobs have to survive the sandbox boundary.** This backend composes inside a Robolectric
+ * classloader that never sees the host-side `RenderSpec` — it parses the payload string
+ * [RobolectricHost.reshapeRenderPayload] emits. So the host must encode a `knobs=` token and the
+ * sandbox must parse it back, or the render sees a preview with no declared knobs and drops every
+ * seed for one in silence. That round trip is what this test exercises that the desktop twin
+ * cannot.
+ *
+ * Only `topArgb` is seeded, and the assertion checks **both** bands: the top proves the seed bound,
+ * the bottom proves the unseeded position still ran its compiled default expression rather than
+ * being passed a zero. That is the defaults mask doing its job, and it is the whole reason a client
+ * can edit one knob of a preview that declares three without sending the other two.
+ */
+class AndroidParameterKnobTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  @Test
+  fun parameterKnobSeedCrossesTheSandboxAndRepaintsOneBand() {
+    val outputDir = tempFolder.newFolder("parameter-knob-renders")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+
+    val host = RobolectricHost(previewSpecResolver = previewSpecResolver())
+    host.start()
+    try {
+      val blue = 0xFF42A5F5L
+      val result =
+        host.submit(
+          RenderRequest.Render(
+            payload =
+              "previewId=$KNOBBED_PREVIEW_ID;overrides=${encodeTextBag("topArgb" to blue.toString())}"
+          ),
+          timeoutMs = 120_000,
+        )
+      assertNotNull("pngPath must be populated", result.pngPath)
+      val png = decode(File(result.pngPath!!))
+      val bluePct = pixelMatchPct(png, expectedRgb = 0x42A5F5, perChannelTolerance = 8)
+      val greenPct = pixelMatchPct(png, expectedRgb = 0x66BB6A, perChannelTolerance = 8)
+      assertTrue(
+        "the seeded `topArgb` knob must repaint the top band blue; got " +
+          "${"%.2f".format(bluePct * 100)}% blue — if 0, the `knobs=` token didn't reach the " +
+          "sandbox or the seed didn't bind to the parameter",
+        bluePct >= 0.4,
+      )
+      assertTrue(
+        "the unseeded `bottomArgb` knob must keep its compiled default green; got " +
+          "${"%.2f".format(greenPct * 100)}% green — the defaults mask dropped the default",
+        greenPct >= 0.4,
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  /**
+   * The unseeded baseline. Without it the test above could pass on a renderer that ignored the seed
+   * entirely and happened to paint blue for an unrelated reason.
+   */
+  @Test
+  fun parameterKnobPreviewRendersItsDefaultsUnseeded() {
+    val outputDir = tempFolder.newFolder("parameter-knob-default-renders")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+
+    val host = RobolectricHost(previewSpecResolver = previewSpecResolver())
+    host.start()
+    try {
+      val result =
+        host.submit(
+          RenderRequest.Render(payload = "previewId=$KNOBBED_PREVIEW_ID"),
+          timeoutMs = 120_000,
+        )
+      assertNotNull("pngPath must be populated", result.pngPath)
+      val png = decode(File(result.pngPath!!))
+      assertTrue(
+        "an unseeded parameter-knob preview must render its author defaults (red top band)",
+        pixelMatchPct(png, expectedRgb = 0xEF5350, perChannelTolerance = 8) >= 0.4,
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  private fun previewSpecResolver(): (String) -> RenderSpec? = { previewId ->
+    when (previewId) {
+      KNOBBED_PREVIEW_ID ->
+        RenderSpec(
+          previewId = KNOBBED_PREVIEW_ID,
+          className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+          functionName = "KnobbedSquare",
+          widthPx = 32,
+          heightPx = 32,
+          density = 1.0f,
+          showBackground = true,
+          outputBaseName = KNOBBED_PREVIEW_ID,
+          // Exactly what `renderSpecFromInfo` reads out of `previews.json` for this preview.
+          knobs =
+            listOf(
+              PreviewKnobDto("topArgb", 0, "LONG"),
+              PreviewKnobDto("bottomArgb", 1, "LONG"),
+              PreviewKnobDto("label", 2, "STRING"),
+            ),
+        )
+      else -> null
+    }
+  }
+
+  /**
+   * A `namedOverrides` bag of plain **text** values — the shape a parameter-knob seed takes. A
+   * `ColorValue` has no parameter-knob equivalent (`Color` is not a seedable kind), so a colour
+   * seed is deliberately dropped by `PreviewKnobSeeds` and cannot drive one.
+   */
+  private fun encodeTextBag(vararg entries: Pair<String, String>): String {
+    val json = Json { encodeDefaults = false }
+    val bag =
+      PreviewOverrides(
+        namedOverrides = entries.associate { (k, v) -> k to PreviewOverrideValue.StringValue(v) }
+      )
+    return Base64.getUrlEncoder()
+      .withoutPadding()
+      .encodeToString(
+        json.encodeToString(PreviewOverrides.serializer(), bag).toByteArray(Charsets.UTF_8)
+      )
+  }
+
+  private fun decode(file: File): java.awt.image.BufferedImage {
+    require(file.exists()) { "expected capture at ${file.absolutePath}" }
+    return ByteArrayInputStream(file.readBytes()).use { ImageIO.read(it) }
+      ?: error("ImageIO refused to decode capture: ${file.absolutePath}")
+  }
+
+  private fun pixelMatchPct(
+    img: java.awt.image.BufferedImage,
+    expectedRgb: Int,
+    perChannelTolerance: Int,
+  ): Double {
+    val expR = (expectedRgb shr 16) and 0xFF
+    val expG = (expectedRgb shr 8) and 0xFF
+    val expB = expectedRgb and 0xFF
+    var matches = 0L
+    for (y in 0 until img.height) {
+      for (x in 0 until img.width) {
+        val rgb = img.getRGB(x, y)
+        val r = (rgb shr 16) and 0xFF
+        val g = (rgb shr 8) and 0xFF
+        val b = rgb and 0xFF
+        if (
+          kotlin.math.abs(r - expR) <= perChannelTolerance &&
+            kotlin.math.abs(g - expG) <= perChannelTolerance &&
+            kotlin.math.abs(b - expB) <= perChannelTolerance
+        ) {
+          matches++
+        }
+      }
+    }
+    return matches.toDouble() / (img.width * img.height)
+  }
+
+  private companion object {
+    const val KNOBBED_PREVIEW_ID = "knobbed-square"
+  }
+}

--- a/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -234,6 +234,35 @@ fun OverridableSquare() {
 }
 
 /**
+ * The **parameter-knob** twin of [OverridableSquare]: two editable fills and a label declared as
+ * the preview's own defaulted value parameters instead of `previewOverride*` lookups in the body.
+ * Android twin of `:daemon:desktop`'s fixture of the same name.
+ *
+ * Two colours rather than one, on purpose. [AndroidParameterKnobTest] seeds only [topArgb], so one
+ * render proves both halves of the contract: the seeded parameter repaints, and the unseeded
+ * [bottomArgb] runs its **compiled default expression** rather than being handed a zero — which is
+ * the defaults mask doing its job, and the only reason a subset of a preview's knobs can be seeded.
+ *
+ * This backend has a second thing to prove that desktop does not: composition happens inside the
+ * Robolectric sandbox classloader, so the knobs only arrive if the host encoded them into the
+ * reshaped payload and the sandbox parsed them back out.
+ */
+@Composable
+fun KnobbedSquare(
+  topArgb: Long = 0xFFEF5350,
+  bottomArgb: Long = 0xFF66BB6A,
+  label: String = "hi",
+) {
+  // `label` is deliberately never drawn: the assertion is a pixel one and a glyph over either band
+  // would only make the two colours harder to measure. It exists to put a String position into the
+  // same defaults mask as the two Longs, so the test covers a mixed-kind mask and not just Longs.
+  Column(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = Modifier.weight(1f).fillMaxWidth().background(Color(topArgb.toInt())))
+    Box(modifier = Modifier.weight(1f).fillMaxWidth().background(Color(bottomArgb.toInt())))
+  }
+}
+
+/**
  * A clickable square that paints its own **interaction state**: red at rest, blue hovered, orange
  * focused, green pressed. Android twin of `:daemon:desktop`'s fixture of the same name.
  *

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewKnobSeeds.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewKnobSeeds.kt
@@ -41,6 +41,65 @@ public object PreviewKnobSeeds {
       is PreviewOverrideValue.ColorValue -> null
     }
 
+  /**
+   * The argument array to invoke a preview declaring [knobs] with, given this render's typed seed
+   * bag — `null` at every position no seed bound, which is how a partial seed says "leave this
+   * parameter alone".
+   *
+   * Returns an empty list when nothing binds — no knobs, no seed that names one, nothing that
+   * parses — so a caller keeps the zero-argument invoke a plain preview has always used rather than
+   * constructing an all-null array that means the same thing.
+   *
+   * The array is sized by the highest knob index plus one rather than by [knobs].size: a knob's
+   * index is its position in the *full* value-parameter list, which may include parameters that are
+   * defaulted but not seedable (`modifier: Modifier = Modifier`). Those positions stay null and
+   * take their defaults.
+   *
+   * A knob whose declared [PreviewKnobDto.type] this daemon does not know is dropped rather than
+   * guessed at: a newer plugin may name a kind an older daemon cannot build, and degrading that one
+   * parameter to its author default while the rest of the preview still seeds beats failing the
+   * render. A seed whose text is not a valid value for its knob's type is dropped for the same
+   * reason — coercing `"yes"` to `true`, or truncating `"1.5"` to an `Int`, would publish a capture
+   * that silently disagrees with what the client asked for.
+   */
+  public fun bind(
+    knobs: List<PreviewKnobDto>,
+    values: Map<String, PreviewOverrideValue>?,
+  ): List<Any?> {
+    if (knobs.isEmpty()) return emptyList()
+    val seeds = texts(values)
+    if (seeds.isEmpty()) return emptyList()
+    val byName = knobs.associateBy { it.name }
+    val bound = seeds.mapNotNull { (name, raw) ->
+      val knob = byName[name] ?: return@mapNotNull null
+      parse(knob.type, raw)?.let { knob.index to it }
+    }
+    if (bound.isEmpty()) return emptyList()
+    val size = knobs.maxOf { it.index } + 1
+    val args = arrayOfNulls<Any?>(size)
+    bound.forEach { (index, value) -> if (index in 0 until size) args[index] = value }
+    return args.toList()
+  }
+
+  /**
+   * The typed value for [raw] under the knob kind [type] names, or null when [type] is a kind this
+   * daemon cannot build or [raw] is not a valid value of it.
+   *
+   * `toBooleanStrictOrNull` rather than `toBoolean`: the lenient form maps every non-`"true"`
+   * string to `false`, so a malformed seed would silently render the opposite of a `true` default
+   * instead of the default itself.
+   */
+  private fun parse(type: String, raw: String): Any? =
+    when (type) {
+      "STRING" -> raw
+      "BOOLEAN" -> raw.toBooleanStrictOrNull()
+      "INT" -> raw.toIntOrNull()
+      "LONG" -> raw.toLongOrNull()
+      "FLOAT" -> raw.toFloatOrNull()
+      "DOUBLE" -> raw.toDoubleOrNull()
+      else -> null
+    }
+
   /** [text] applied across a whole seed bag, dropping the entries with no equivalent. */
   public fun texts(values: Map<String, PreviewOverrideValue>?): Map<String, String> {
     if (values.isNullOrEmpty()) return emptyMap()

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewKnobToken.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewKnobToken.kt
@@ -1,0 +1,70 @@
+package ee.schimke.composeai.daemon
+
+/**
+ * The `knobs=<name>:<index>:<TYPE>,…` render-payload token — how a preview's **parameter knobs**
+ * travel on the wire when the spec itself cannot.
+ *
+ * ### Why a token at all
+ *
+ * The desktop daemon resolves a `previewId=` render against its `PreviewIndex` and hands the
+ * resulting [RenderSpec][ee.schimke.composeai.daemon.PreviewInfoDto] straight to the render body,
+ * so there the knobs need no encoding. The Android daemon composes inside a Robolectric **sandbox
+ * classloader**: the host reshapes the request into a payload string and the sandbox parses it
+ * back, so anything the sandbox needs has to survive that round trip as text. Without this token an
+ * Android render sees a preview with no declared knobs and every seed for one is dropped, which is
+ * the same silent failure the format had on both backends before it was wired at all.
+ *
+ * ### Why it is forgiving
+ *
+ * An entry that is malformed — wrong arity, a non-numeric or negative index, a blank field — is
+ * **skipped** rather than failing the parse, and an unknown type name is carried through verbatim
+ * for the binder to drop. A newer plugin may name a knob kind an older daemon cannot build; that
+ * parameter has to degrade to its author default while the rest of the preview still seeds. Failing
+ * the whole render because a knob kind is unfamiliar would turn a forward-compatible wire into a
+ * hard version pin.
+ */
+public object PreviewKnobToken {
+
+  private const val ENTRY_SEPARATOR: Char = ','
+  private const val FIELD_SEPARATOR: Char = ':'
+
+  /**
+   * The token for [knobs], or null when there is nothing to say — so a preview that declares none
+   * (the overwhelming majority) produces a payload byte-identical to what it produced before this
+   * token existed.
+   *
+   * A knob whose name carries one of the payload's own delimiters is **omitted**. Kotlin admits
+   * such a name only through backticks (`` `my, knob` ``), so this is vanishingly rare, and
+   * emitting it would corrupt the entries around it rather than just its own — one unseedable knob
+   * is a far smaller loss than a garbled list.
+   */
+  public fun encode(knobs: List<PreviewKnobDto>): String? {
+    if (knobs.isEmpty()) return null
+    val entries = knobs.filter { knob ->
+      knob.index >= 0 &&
+        knob.name.isNotBlank() &&
+        !knob.name.hasDelimiter() &&
+        knob.type.isNotBlank() &&
+        !knob.type.hasDelimiter()
+    }
+    if (entries.isEmpty()) return null
+    return entries.joinToString(ENTRY_SEPARATOR.toString()) { "${it.name}:${it.index}:${it.type}" }
+  }
+
+  /** The knobs [token] names, skipping any entry that is not well formed. */
+  public fun parse(token: String?): List<PreviewKnobDto> {
+    if (token.isNullOrBlank()) return emptyList()
+    return token.split(ENTRY_SEPARATOR).mapNotNull { entry ->
+      val parts = entry.split(FIELD_SEPARATOR)
+      if (parts.size != 3) return@mapNotNull null
+      val name = parts[0].trim().takeIf { it.isNotBlank() } ?: return@mapNotNull null
+      val index = parts[1].trim().toIntOrNull()?.takeIf { it >= 0 } ?: return@mapNotNull null
+      val type = parts[2].trim().takeIf { it.isNotBlank() } ?: return@mapNotNull null
+      PreviewKnobDto(name = name, index = index, type = type)
+    }
+  }
+
+  /** `;` too: it separates payload tokens, so a name carrying one truncates the whole token. */
+  private fun String.hasDelimiter(): Boolean =
+    contains(ENTRY_SEPARATOR) || contains(FIELD_SEPARATOR) || contains(';') || contains('=')
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewKnobSeedsTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewKnobSeedsTest.kt
@@ -37,6 +37,95 @@ class PreviewKnobSeedsTest {
   }
 
   @Test
+  fun aSeedBindsToItsParameterPositionAndLeavesTheRestAlone() {
+    val knobs =
+      listOf(
+        PreviewKnobDto("topArgb", 0, "LONG"),
+        PreviewKnobDto("bottomArgb", 1, "LONG"),
+        PreviewKnobDto("label", 2, "STRING"),
+      )
+    // Only the middle knob is seeded, so the array carries a null on either side of it — which is
+    // how a partial seed says "leave this parameter alone" and lets the compiled default run.
+    assertEquals(
+      listOf(null, 7L, null),
+      PreviewKnobSeeds.bind(
+        knobs,
+        mapOf("bottomArgb" to PreviewOverrideValue.IntValue(7)),
+      ),
+    )
+  }
+
+  @Test
+  fun theArrayIsSizedByTheHighestIndexNotTheKnobCount() {
+    // A knob's index is its position in the FULL value-parameter list, which may skip positions
+    // that are defaulted but not seedable (`modifier: Modifier = Modifier`). Sizing by the count
+    // would place the argument at the wrong parameter.
+    val sparse = listOf(PreviewKnobDto("label", 0, "STRING"), PreviewKnobDto("count", 2, "INT"))
+    assertEquals(
+      listOf("Hi", null, 9),
+      PreviewKnobSeeds.bind(
+        sparse,
+        mapOf(
+          "label" to PreviewOverrideValue.StringValue("Hi"),
+          "count" to PreviewOverrideValue.StringValue("9"),
+        ),
+      ),
+    )
+  }
+
+  @Test
+  fun anUnparseableSeedIsDroppedRatherThanCoerced() {
+    // Coercing "yes" to true, or truncating "1.5" to an Int, would publish a capture that silently
+    // disagrees with the value the client asked for — worse than visibly ignoring it.
+    val knobs = listOf(PreviewKnobDto("enabled", 0, "BOOLEAN"), PreviewKnobDto("count", 1, "INT"))
+    assertEquals(
+      emptyList<Any?>(),
+      PreviewKnobSeeds.bind(knobs, mapOf("enabled" to PreviewOverrideValue.StringValue("yes"))),
+    )
+    assertEquals(
+      listOf(true, null),
+      PreviewKnobSeeds.bind(
+        knobs,
+        mapOf(
+          "enabled" to PreviewOverrideValue.BooleanValue(true),
+          "count" to PreviewOverrideValue.StringValue("1.5"),
+        ),
+      ),
+    )
+  }
+
+  @Test
+  fun aKindThisDaemonCannotBuildIsDropped() {
+    // A newer plugin may name a knob kind an older daemon has never heard of. That parameter takes
+    // its author default; the rest of the preview still seeds.
+    val knobs = listOf(PreviewKnobDto("accent", 0, "COLOR"), PreviewKnobDto("label", 1, "STRING"))
+    assertEquals(
+      listOf(null, "Hi"),
+      PreviewKnobSeeds.bind(
+        knobs,
+        mapOf(
+          "accent" to PreviewOverrideValue.StringValue("#FF42A5F5"),
+          "label" to PreviewOverrideValue.StringValue("Hi"),
+        ),
+      ),
+    )
+  }
+
+  @Test
+  fun nothingToBindIsAnEmptyListNotAnAllNullArray() {
+    // So a caller keeps the zero-argument invoke a plain preview has always used.
+    val knobs = listOf(PreviewKnobDto("label", 0, "STRING"))
+    assertEquals(emptyList<Any?>(), PreviewKnobSeeds.bind(emptyList(), null))
+    assertEquals(emptyList<Any?>(), PreviewKnobSeeds.bind(knobs, null))
+    assertEquals(
+      emptyList<Any?>(),
+      // A seed naming no declared knob — it may be a `previewOverride*` key, which the controller
+      // seeds separately. One seed map serves both formats and each side takes what it recognises.
+      PreviewKnobSeeds.bind(knobs, mapOf("someOverrideKey" to PreviewOverrideValue.IntValue(1))),
+    )
+  }
+
+  @Test
   fun anAbsentOrEmptyBagIsEmpty() {
     assertEquals(emptyMap<String, String>(), PreviewKnobSeeds.texts(null))
     assertEquals(emptyMap<String, String>(), PreviewKnobSeeds.texts(emptyMap()))

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewKnobTokenTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewKnobTokenTest.kt
@@ -1,0 +1,74 @@
+package ee.schimke.composeai.daemon
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pins the `knobs=` payload codec. On the Android backend this token is the **only** way a
+ * preview's parameter knobs cross into the Robolectric sandbox, so producer and consumer agreeing
+ * is load-bearing rather than tidy — hence one object and one test rather than a pair per backend.
+ */
+class PreviewKnobTokenTest {
+
+  private val knobs =
+    listOf(
+      PreviewKnobDto("title", 0, "STRING"),
+      PreviewKnobDto("enabled", 1, "BOOLEAN"),
+      PreviewKnobDto("count", 2, "INT"),
+    )
+
+  @Test
+  fun `a token round-trips`() {
+    val token = PreviewKnobToken.encode(knobs)
+    assertEquals("title:0:STRING,enabled:1:BOOLEAN,count:2:INT", token)
+    assertEquals(knobs, PreviewKnobToken.parse(token))
+  }
+
+  @Test
+  fun `a preview with no knobs emits no token at all`() {
+    // So its payload stays byte-identical to what it was before this token existed.
+    assertNull(PreviewKnobToken.encode(emptyList()))
+    assertEquals(emptyList<PreviewKnobDto>(), PreviewKnobToken.parse(null))
+    assertEquals(emptyList<PreviewKnobDto>(), PreviewKnobToken.parse("   "))
+  }
+
+  @Test
+  fun `an unknown kind survives the round trip and is dropped later by the binder`() {
+    // A newer plugin may name a knob kind this daemon cannot build. That parameter has to degrade
+    // to
+    // its author default; rejecting it here would fail the whole render instead.
+    val future = listOf(PreviewKnobDto("accent", 0, "COLOR"))
+    assertEquals(future, PreviewKnobToken.parse(PreviewKnobToken.encode(future)))
+  }
+
+  @Test
+  fun `malformed entries are skipped rather than failing the parse`() {
+    assertEquals(
+      listOf(PreviewKnobDto("title", 0, "STRING")),
+      PreviewKnobToken.parse("title:0:STRING,noColons,bad:x:INT,:3:INT,negative:-1:INT,two:1:"),
+    )
+  }
+
+  @Test
+  fun `a name carrying a payload delimiter is omitted rather than corrupting its neighbours`() {
+    // Reachable only through a backticked Kotlin name (`my, knob`). Emitting it would split into
+    // fragments that swallow the entries around it; dropping the one knob is the smaller loss.
+    val token =
+      PreviewKnobToken.encode(
+        listOf(
+          PreviewKnobDto("good", 0, "STRING"),
+          PreviewKnobDto("my, knob", 1, "STRING"),
+          PreviewKnobDto("colon:knob", 2, "STRING"),
+          PreviewKnobDto("semi;knob", 3, "STRING"),
+          PreviewKnobDto("eq=knob", 4, "STRING"),
+          PreviewKnobDto("alsoGood", 5, "INT"),
+        )
+      )
+    assertEquals("good:0:STRING,alsoGood:5:INT", token)
+    assertEquals(
+      listOf(PreviewKnobDto("good", 0, "STRING"), PreviewKnobDto("alsoGood", 5, "INT")),
+      PreviewKnobToken.parse(token),
+    )
+  }
+}

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -361,7 +361,7 @@ class RenderEngine(
           // The seeded **parameter knobs**, which also decide the overload to resolve: a preview
           // whose parameters all declare defaults compiles to `(realParams…, Composer, int, int)`
           // and the parameterless lookup cannot see it either way, seeded or not.
-          previewArgs = bindKnobArguments(spec),
+          previewArgs = PreviewKnobSeeds.bind(spec.knobs, spec.overrides?.namedOverrides),
         )
       }
     val composableMethod: ComposableMethod? = resolvedInvocation?.method
@@ -2891,26 +2891,12 @@ data class RenderSpec(
     }
 
     /**
-     * Parses the `knobs=<name>:<index>:<TYPE>,…` payload token into [RenderSpec.knobs].
-     *
-     * A malformed entry — wrong arity, a non-numeric or negative index, a blank name — is
-     * **skipped** rather than failing the render. The type is kept verbatim, including a name this
-     * daemon doesn't know: an unbindable kind has to degrade to "this parameter takes its author
-     * default", which is exactly what a knob the binder skips already does, and failing the whole
-     * render because a newer plugin named a kind an older daemon can't seed would be far worse than
-     * rendering the preview unseeded.
+     * Parses the `knobs=<name>:<index>:<TYPE>,…` payload token into [RenderSpec.knobs]. Delegates
+     * to [PreviewKnobToken] so this backend, `:daemon:android`'s twin, and the Android host-side
+     * producer that emits the token cannot drift apart on what a well-formed entry is.
      */
-    internal fun parseKnobsToken(token: String?): List<PreviewKnobDto> {
-      if (token.isNullOrBlank()) return emptyList()
-      return token.split(',').mapNotNull { entry ->
-        val parts = entry.split(':')
-        if (parts.size != 3) return@mapNotNull null
-        val name = parts[0].trim().takeIf { it.isNotBlank() } ?: return@mapNotNull null
-        val index = parts[1].trim().toIntOrNull()?.takeIf { it >= 0 } ?: return@mapNotNull null
-        val type = parts[2].trim().takeIf { it.isNotBlank() } ?: return@mapNotNull null
-        PreviewKnobDto(name = name, index = index, type = type)
-      }
-    }
+    internal fun parseKnobsToken(token: String?): List<PreviewKnobDto> =
+      PreviewKnobToken.parse(token)
 
     /** Four dp edges, the parsed shape of a `captureGutter=` token. */
     internal data class GutterDp(
@@ -2949,32 +2935,6 @@ data class RenderSpec(
  * composer. Mirrors `:renderer-desktop`'s private `InvokeComposable`; kept private+top-level so the
  * compose-compiler plugin recognises it as a composable function.
  */
-/**
- * The argument array that seeds [RenderSpec.knobs] from this render's `namedOverrides` bag — the
- * **parameter knob** half of the override surface.
- *
- * Returns an empty list whenever nothing binds, so a preview with knobs but no seed keeps invoking
- * through the same zero-argument path it always did. A knob whose declared `type` this daemon does
- * not know is dropped here rather than at parse time (see [RenderSpec.parseKnobsToken]): the
- * parameter then takes its compiled default, which is the only safe reading of "a kind I cannot
- * build".
- */
-private fun bindKnobArguments(spec: RenderSpec): List<Any?> {
-  if (spec.knobs.isEmpty()) return emptyList()
-  val knobs =
-    spec.knobs.mapNotNull { knob ->
-      val type =
-        ee.schimke.composeai.renderer.PreviewKnobArguments.Type.entries.firstOrNull {
-          it.name == knob.type
-        } ?: return@mapNotNull null
-      ee.schimke.composeai.renderer.PreviewKnobArguments.Knob(knob.name, knob.index, type)
-    }
-  return ee.schimke.composeai.renderer.PreviewKnobArguments.bind(
-    knobs,
-    PreviewKnobSeeds.texts(spec.overrides?.namedOverrides),
-  )
-}
-
 @androidx.compose.runtime.Composable
 private fun InvokeComposable(composableMethod: ComposableMethod, previewArgs: List<Any?>) {
   // A **partial** knob seed leaves nulls in the list, and `ComposableMethod.invoke` cannot express

--- a/docs/design/PARAMETER_KNOB_MIGRATION.md
+++ b/docs/design/PARAMETER_KNOB_MIGRATION.md
@@ -53,14 +53,19 @@ Two defects, neither visible from reading the source alone. Both are fixed in th
 document accompanies; both are the reason a migrated preview would have looked broken rather than
 merely un-editable.
 
-**The daemon could not resolve a parameter-knob preview at all.** `getDeclaredComposableMethod(name)`
+**Neither daemon could resolve a parameter-knob preview at all.** `getDeclaredComposableMethod(name)`
 matches only `(Composer, int)` — a preview with no value parameters. One whose parameters all
-declare defaults compiles to `(realParams…, Composer, int changed, int default)`, so the lookup
-threw `NoSuchMethodException` before composition started: no PNG, just an `.error.json`. The
-standalone `:renderer-desktop` bake lane had a fallback for exactly this and the daemon did not,
-which is why `ParameterKnobPreviews.kt` bakes correctly ([render
-evidence](evidence/parameter-knobs/README.md)) and would not have rendered live. The fallback now
-lives in `PreviewParameterSupport`, which both lanes call, instead of privately in one of them.
+declare defaults compiles to `(realParams…, Composer, changed…, default…)`, so the lookup threw
+`NoSuchMethodException` before composition started: no PNG, just an `.error.json`. Both standalone
+bake lanes had a fallback for exactly this and neither daemon did, which is why
+`ParameterKnobPreviews.kt` bakes correctly ([render evidence](evidence/parameter-knobs/README.md))
+and would not have rendered live. The fallback now lives in each renderer's
+`PreviewParameterSupport`, which its daemon already calls, instead of privately in the bake path.
+
+On Android there was a third thing missing behind those two. Composition happens inside a
+Robolectric **sandbox classloader** that never sees the host-side spec — it parses the payload string
+the host reshapes — so the knobs need an encoded `knobs=` token to cross at all. `PreviewKnobToken`
+is that codec, and it is the one place producer and consumer agree.
 
 **Nothing bound a seed to a parameter.** `PreviewKnobArguments` — the binder, with its own tests —
 had no caller outside those tests: no producer of the `knobs=` payload token, no consumer in either
@@ -135,18 +140,16 @@ A parameter knob only exists on the preview's own signature, so moving either wo
 every knob of every branch onto every preview that could reach it — and `CatalogComponent(id:
 String)` reports no knobs anyway, since `id` has no default.
 
-### 6. Only the desktop lanes bind a seed
+### 6. The offline bake lanes do not seed, and neither does the harness router
 
-`:renderer-desktop` (the offline bake) and `:daemon:desktop` (live / `serve` / VS Code) both seed a
-parameter knob. The **Android (Robolectric) daemon** does not: it carries the same `previewArgs`
-seam and the same `resolvePreviewInvocation` shape, but neither the `RenderSpec.knobs` field nor the
-bind, so a parameter knob there renders its defaults — and, until the resolution fix is mirrored,
-a defaulted preview fails to resolve at all. That is what blocks `samples/android-live-lane`
-independently of gap 1.
+Both **daemons** — `:daemon:desktop` (live / `serve` / VS Code) and `:daemon:android` (Robolectric)
+— resolve a defaulted preview and seed its parameter knobs. `:renderer-desktop`'s standalone bake
+can bind a seed (`PreviewKnobArguments`, and it resolves the defaulted shape), but nothing hands it
+one: the Gradle render task has no seed to pass. `:renderer-android`'s bake has no bind at all.
 
-There is also no producer of the `knobs=` payload token yet. The daemon's production lane resolves
-knobs off `previews.json` and never needs it; the token exists so a caller driving the
-`className=`/`functionName=` payload directly can name them, and it is parsed but not written.
+The harness-only `PreviewManifestRouter` (`composeai.harness.previewsManifest`) is the third: its
+manifest wire type carries no `knobs`, so a knobbed preview rendered through a harness fixture
+renders its defaults. No fixture declares one today, which is why it is a note rather than a fix.
 
 ## The samples, one by one
 
@@ -154,7 +157,7 @@ knobs off `previews.json` and never needs it; the token exists so a caller drivi
 | --- | --- | --- |
 | `samples/cmp/.../OverridablePreviews.kt` | 4 (`title`, `accent`, `itemCount`, `density`, indexed `rowLabel`) | **Keep as is** — it is the deliberate twin of `ParameterKnobPreviews.kt`; the comparison is what the sample is for |
 | `samples/cmp/.../ParameterKnobPreviews.kt` | 5 parameter knobs | Already migrated — the reference |
-| `samples/android-live-lane/.../LiveLanePreviews.kt` | 1 (`label`, on the `@Preview` itself) | **Cleanest candidate, blocked** by gaps 1 and 6. `serve-lanes.spec.mjs` asserts `overrides[].key == "label"`, which would go empty |
+| `samples/android-live-lane/.../LiveLanePreviews.kt` | 1 (`label`, on the `@Preview` itself) | **Cleanest candidate, blocked by gap 1 alone** now the Robolectric daemon seeds. `serve-lanes.spec.mjs` asserts `overrides[].key == "label"`, which would go empty |
 | `design-catalog-m3-shared/.../CatalogComponents.kt` + `CatalogOverrides.kt` (+ actuals) | ~15 across a `when (id)` dispatch | **Cannot** — gap 5, plus `catalogOverrideColor` (gap 2) |
 | `design-catalog-m3/.../CatalogTheme.kt` | 5 (font, colors, shapes, typography, fonts) | **Cannot** — gap 5: read inside the theme wrapper every sticker calls |
 | `design-catalog-m3/.../CatalogTemplates.kt` | `title`, `fab` hoistable; `sender`, `preview` indexed | **Partial at best** — gap 3 |

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewParameterSupport.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewParameterSupport.kt
@@ -1,7 +1,7 @@
 package ee.schimke.composeai.renderer
 
 import androidx.compose.runtime.reflect.ComposableMethod
-import androidx.compose.runtime.reflect.getDeclaredComposableMethod
+import kotlin.math.ceil
 
 /**
  * Reflective `@PreviewParameter` support shared by the two Android render bodies — `:renderer
@@ -75,6 +75,12 @@ object PreviewParameterSupport {
    * `private fun` previews are idiomatic and resolve fine, but invoking one without that throws
    * `IllegalAccessException`. Doing it here rather than at each call site is what keeps the
    * daemon's scroll / `figma-svg-long` / held-session paths from each having to remember.
+   *
+   * [previewArgs] carries a **parameter knob** seed — a preview's own defaulted value parameters,
+   * the secondary override format — and is meaningful only when there is no provider, since the two
+   * are mutually exclusive: discovery reports knobs only when every value parameter has a default,
+   * which a provider-bound one does not. Empty (the default) resolves the parameterless overload,
+   * falling back to the defaulted shape when the preview has one.
    */
   fun resolve(
     clazz: Class<*>,
@@ -83,9 +89,28 @@ object PreviewParameterSupport {
     limit: Int = Int.MAX_VALUE,
     classLoader: ClassLoader? = null,
     row: String? = null,
+    previewArgs: List<Any?> = emptyList(),
   ): Resolved {
     if (providerClassName.isNullOrBlank()) {
-      return Resolved(clazz.getDeclaredComposableMethod(functionName).openForInvoke(), emptyList())
+      // [resolveNoArgComposableMethod] rather than the bare lookup: a preview whose parameters all
+      // declare defaults — the whole of the **parameter knob** format, and the shape a production
+      // composable annotated `@Preview` in place almost always has (`modifier: Modifier =
+      // Modifier`)
+      // — compiles to `(realParams…, Composer, changed…, default…)`, which
+      // `getDeclaredComposableMethod(name)` cannot see because it matches only `(Composer, int)`.
+      // The standalone bake lane has resolved it that way since the JetLagged renders; the daemon
+      // reached this seam and threw `NoSuchMethodException` before composition, so a defaulted
+      // preview produced an `.error.json` and no PNG.
+      if (previewArgs.isEmpty()) {
+        return Resolved(
+          resolveNoArgComposableMethod(clazz, functionName).openForInvoke(),
+          emptyList(),
+        )
+      }
+      return Resolved(
+        findComposableMethodWithArgs(clazz, functionName, previewArgs).openForInvoke(),
+        previewArgs,
+      )
     }
     if (limit <= 0) {
       throw PreviewParameterLoadException(
@@ -280,6 +305,99 @@ object PreviewParameterSupport {
       throw PreviewParameterLoadException("$providerFqn.getValues() failed", e)
     }
   }
+
+  /**
+   * Invokes [composableMethod]'s defaults-mask overload directly when [previewArgs] leaves a
+   * parameter unseeded, returning true when it did the call — so a caller falls back to the
+   * ordinary `ComposableMethod.invoke` for every shape this cannot safely drive.
+   *
+   * `ComposableMethod.invoke` cannot express a **partial** seed. It derives the mask from which
+   * arguments are null *and* forwards those same nulls as the parameter values, so a null destined
+   * for a primitive parameter reaches `Method.invoke` as a null `int` and throws
+   * `IllegalArgumentException`. Trailing arguments it never receives are fine — those it pads by
+   * type — so the failure appears exactly when something *after* an unseeded parameter is seeded,
+   * which is precisely the shape a partial parameter-knob seed produces (`Button(label = …, enabled
+   * = <default>, size = …)`).
+   *
+   * Doing it here keeps the semantics the knob format needs: an unseeded position contributes a set
+   * bit to the mask *and* a type-appropriate zero as its placeholder, so the compiled default
+   * expression runs and the author's default is what renders.
+   *
+   * The synthetic tail is reconstructed from the calling convention rather than assumed to be three
+   * ints: a composable with more than [SLOTS_PER_COMPOSABLE_INT] real parameters carries a second
+   * `changed` int, and one with more than [BITS_PER_DEFAULT_INT] carries a second `default` int.
+   * Assuming the small shape would make this abstain on exactly the wide previews whose partial
+   * seed then throws.
+   *
+   * Returns false for an instance method, for a method with no defaults mask, for a tail that does
+   * not match the convention, and when there is no null to place — the shapes where the ordinary
+   * invoke is already correct.
+   */
+  fun invokeWithDefaultMask(
+    composableMethod: ComposableMethod,
+    instance: Any?,
+    previewArgs: List<Any?>,
+    composer: androidx.compose.runtime.Composer,
+  ): Boolean {
+    if (instance != null) return false
+    // Any null at all, not just an interior one: `ComposableMethod.invoke` pads only positions past
+    // `previewArgs.size`, so a null *inside* the list — trailing or not — is forwarded verbatim.
+    if (previewArgs.none { it == null }) return false
+    val method = composableMethod.asMethod()
+    if (!java.lang.reflect.Modifier.isStatic(method.modifiers)) return false
+    if (!method.hasComposableDefaults()) return false
+    val types = method.parameterTypes
+    val realParams = types.indexOfLast { it == androidx.compose.runtime.Composer::class.java }
+    if (realParams <= 0 || previewArgs.size > realParams) return false
+    val changedInts =
+      ceil(realParams.toDouble() / SLOTS_PER_COMPOSABLE_INT).toInt().coerceAtLeast(1)
+    val defaultInts = ceil(realParams.toDouble() / BITS_PER_DEFAULT_INT).toInt().coerceAtLeast(1)
+    if (types.size != realParams + 1 + changedInts + defaultInts) return false
+
+    val masks = IntArray(defaultInts)
+    val arguments = arrayOfNulls<Any?>(types.size)
+    for (i in 0 until realParams) {
+      val seeded = previewArgs.getOrNull(i)
+      if (seeded == null) {
+        masks[i / BITS_PER_DEFAULT_INT] =
+          masks[i / BITS_PER_DEFAULT_INT] or (1 shl (i % BITS_PER_DEFAULT_INT))
+        arguments[i] = zeroValueForComposableParameter(types[i])
+      } else {
+        arguments[i] = seeded
+      }
+    }
+    arguments[realParams] = composer
+    for (c in 0 until changedInts) arguments[realParams + 1 + c] = 0
+    for (d in 0 until defaultInts) arguments[realParams + 1 + changedInts + d] = masks[d]
+    method.isAccessible = true
+    method.invoke(null, *arguments)
+    return true
+  }
+
+  /**
+   * The placeholder an unseeded parameter is passed alongside its set mask bit. The compiled
+   * default expression overwrites it, so the value never reaches the body — but the JVM still
+   * requires one of the right type, which is the whole reason a null cannot be used here.
+   */
+  private fun zeroValueForComposableParameter(type: Class<*>): Any? =
+    when (type) {
+      Int::class.javaPrimitiveType -> 0
+      Boolean::class.javaPrimitiveType -> false
+      Long::class.javaPrimitiveType -> 0L
+      Float::class.javaPrimitiveType -> 0f
+      Double::class.javaPrimitiveType -> 0.0
+      Short::class.javaPrimitiveType -> 0.toShort()
+      Byte::class.javaPrimitiveType -> 0.toByte()
+      Char::class.javaPrimitiveType -> '\u0000'
+      else -> null
+    }
+
+  /**
+   * Real parameters encoded per synthetic `default` int. The Compose compiler's `defaultParamCount`
+   * packs 31 parameters per int (one bit each, the top bit unused), which is *not* the same rate as
+   * the `changed` ints above — mixing the two silently corrupts the mask on a wide preview.
+   */
+  private const val BITS_PER_DEFAULT_INT = 31
 }
 
 /**

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
@@ -195,7 +195,7 @@ private object ComposePreviewStrategy : PreviewRenderStrategy {
  * have the zero values passed through as real arguments (a null `Modifier`, straight into an NPE),
  * which is worse than reporting the miss.
  */
-private fun resolveNoArgComposableMethod(clazz: Class<*>, functionName: String): ComposableMethod {
+internal fun resolveNoArgComposableMethod(clazz: Class<*>, functionName: String): ComposableMethod {
   runCatching { clazz.getDeclaredComposableMethod(functionName) }
     .getOrNull()
     ?.let {
@@ -267,7 +267,7 @@ internal fun findDefaultedComposableMethod(
  * Callers must have established that the method IS composable (`asComposableMethod() != null`)
  * before asking; the arithmetic assumes the synthetic tail is well-formed.
  */
-private fun java.lang.reflect.Method.hasComposableDefaults(): Boolean {
+internal fun java.lang.reflect.Method.hasComposableDefaults(): Boolean {
   val realParams = parameterTypes.indexOfLast {
     it == androidx.compose.runtime.Composer::class.java
   }
@@ -284,7 +284,7 @@ private fun java.lang.reflect.Method.hasComposableDefaults(): Boolean {
  * compiled calling convention (every composable ever compiled encodes it), which is what makes
  * restating it safe: `getDeclaredComposableMethod` depends on the same constant.
  */
-private const val SLOTS_PER_COMPOSABLE_INT = 10
+internal const val SLOTS_PER_COMPOSABLE_INT = 10
 
 /**
  * Resolves the `ComposableMethod` for a preview function that declares `@PreviewParameter`
@@ -321,12 +321,18 @@ internal fun findComposableMethodWithArgs(
 }
 
 private fun argsMatch(method: java.lang.reflect.Method, previewArgs: List<Any?>): Boolean {
+  // A defaults mask changes what a null MEANS. Without one it is a value being passed, so it can't
+  // land on a primitive; with one it is a **parameter knob** left unseeded — "leave this parameter
+  // alone" — which is exactly how a partial seed sets one knob of a preview without disturbing its
+  // primitive siblings. See [hasComposableDefaults] and [invokeWithDefaultMask].
+  val carriesDefaultMask = method.hasComposableDefaults()
   for ((i, arg) in previewArgs.withIndex()) {
     val expected = method.parameterTypes[i]
     if (arg == null) {
       // A null argument can satisfy any reference parameter; a primitive
-      // JVM parameter can't accept null, so it's an immediate mismatch.
-      if (expected.isPrimitive) return false
+      // JVM parameter can't accept null unless the defaults mask can carry
+      // the intent instead.
+      if (expected.isPrimitive && !carriesDefaultMask) return false
       continue
     }
     val actual = arg.javaClass


### PR DESCRIPTION
Follow-up to [#5089](https://github.com/yschimke/compose-ai-tools/pull/5089), which wired parameter knobs on the desktop daemon. The Robolectric daemon could not render a parameter-knob preview at all, for the same first cause: `getDeclaredComposableMethod(name)` matches only `(Composer, int)`, so a preview whose parameters all declare defaults threw `NoSuchMethodException` before composition started. Same fix — the bake lane's defaulted-shape fallback moves into `PreviewParameterSupport`, which the daemon already calls.

## The piece desktop didn't need

Composition on this backend happens inside a **Robolectric sandbox classloader** that never sees the host-side `RenderSpec` — it parses the payload string `RobolectricHost.reshapeRenderPayload` emits. So a knob only reaches the render if it survives a round trip as text.

`PreviewKnobToken` is that codec: one object in `:daemon:core`, encoded by the host and parsed by both backends. Producer and consumer disagreeing here doesn't throw, it silently renders defaults, which is exactly the failure mode this whole line of work has been about — hence one shared codec rather than a pair. A knob whose name carries a payload delimiter (reachable only through a backticked Kotlin name) is dropped rather than emitted: it would corrupt the entries around it, and one unseedable knob beats a garbled list.

The bind moves to `:daemon:core` (`PreviewKnobSeeds.bind`) so both backends share it — `:daemon:android` cannot see `:renderer-desktop`, where the desktop daemon's binder lived. The renderers keep their own binder for the bake lanes; that split is the module layering (the two renderer artefacts are deliberately independently buildable) and both sides now say so in KDoc.

## Two defects the port turned up

* **`renderer-android`'s `argsMatch` rejected a null for a primitive parameter unconditionally.** With a defaults mask a null isn't a value being passed, it's a knob left unseeded — which is what makes a partial seed possible at all.
* **The masked invoke assumed a three-int synthetic tail.** A composable with more than ten real parameters carries a second `changed` int, and more than thirty-one a second `default` int. Assuming the small shape made it abstain on exactly the wide previews whose partial seed then throws. It now reconstructs the tail from the calling convention.

## Test plan

Non-visual — no rendered surface changes; the new render test asserts pixels but nothing a user sees moves.

* `:daemon:android:testDebugUnitTest`, `:daemon:core:test`, `:daemon:desktop:test`, `:renderer-android:testDebugUnitTest` — **1516 tests, 0 failures**. The full Android daemon suite matters here: the `InvokeComposable` change is on the path of every render on that backend.
* `AndroidParameterKnobTest` renders through the production `previewSpecResolver` lane — the one that goes through `reshapeRenderPayload` — and asserts **both** bands of the fixture: seeding only `topArgb` repaints the top blue while the unseeded `bottomArgb` still runs its compiled default green. That is the sandbox round trip and the defaults mask proven in pixels, and it fails on `NoSuchMethodException` without the resolution fix. A second test pins the unseeded baseline so the first can't pass for the wrong reason.
* `PreviewKnobTokenTest` and the widened `PreviewKnobSeedsTest` cover the codec and the bind directly.
* `ktfmtFormat` run on every touched module.

## Still open

Recorded in `docs/design/PARAMETER_KNOB_MIGRATION.md`, updated here:

* **Gap 1 — a parameter knob still publishes no declaration.** Unchanged by this PR, and still the reason no sample should migrate: a viewer has no control to draw and no default to show in it.
* Neither offline bake lane is handed a seed (`:renderer-desktop` can bind one, `:renderer-android` has no bind), and the harness-only `PreviewManifestRouter` manifest carries no `knobs` field — no fixture declares one today, which is why that is a note rather than a fix.

With this landed, `samples/android-live-lane` is blocked by gap 1 alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o

---
_Generated by [Claude Code](https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o)_