### PR TITLE
feat(discovery): recover a parameter knob's literal default from the class file

### DIFF
--- a/daemon/core/api/core.api
+++ b/daemon/core/api/core.api
@@ -931,10 +931,11 @@ public final class ee/schimke/composeai/daemon/PreviewIndexKt {
 
 public final class ee/schimke/composeai/daemon/PreviewInfoDto {
 	public static final field Companion Lee/schimke/composeai/daemon/PreviewInfoDto$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/PreviewParamsDto;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/data/overrides/OverrideVariantSpec;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/PreviewParamsDto;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/data/overrides/OverrideVariantSpec;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/PreviewParamsDto;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/data/overrides/OverrideVariantSpec;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/PreviewParamsDto;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/data/overrides/OverrideVariantSpec;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component10 ()Lee/schimke/composeai/data/overrides/OverrideVariantSpec;
+	public final fun component10 ()Ljava/util/List;
+	public final fun component11 ()Lee/schimke/composeai/data/overrides/OverrideVariantSpec;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
@@ -943,8 +944,8 @@ public final class ee/schimke/composeai/daemon/PreviewInfoDto {
 	public final fun component7 ()Lee/schimke/composeai/daemon/PreviewParamsDto;
 	public final fun component8 ()Ljava/util/List;
 	public final fun component9 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/PreviewParamsDto;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/data/overrides/OverrideVariantSpec;)Lee/schimke/composeai/daemon/PreviewInfoDto;
-	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/PreviewInfoDto;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/PreviewParamsDto;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/data/overrides/OverrideVariantSpec;ILjava/lang/Object;)Lee/schimke/composeai/daemon/PreviewInfoDto;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/PreviewParamsDto;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/data/overrides/OverrideVariantSpec;)Lee/schimke/composeai/daemon/PreviewInfoDto;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/PreviewInfoDto;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/PreviewParamsDto;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/data/overrides/OverrideVariantSpec;ILjava/lang/Object;)Lee/schimke/composeai/daemon/PreviewInfoDto;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCaptures ()Ljava/util/List;
 	public final fun getClassName ()Ljava/lang/String;
@@ -952,6 +953,7 @@ public final class ee/schimke/composeai/daemon/PreviewInfoDto {
 	public final fun getDisplayName ()Ljava/lang/String;
 	public final fun getGroup ()Ljava/lang/String;
 	public final fun getId ()Ljava/lang/String;
+	public final fun getKnobs ()Ljava/util/List;
 	public final fun getMethodName ()Ljava/lang/String;
 	public final fun getOverrides ()Lee/schimke/composeai/data/overrides/OverrideVariantSpec;
 	public final fun getParams ()Lee/schimke/composeai/daemon/PreviewParamsDto;
@@ -973,6 +975,50 @@ public final synthetic class ee/schimke/composeai/daemon/PreviewInfoDto$$seriali
 
 public final class ee/schimke/composeai/daemon/PreviewInfoDto$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/PreviewKnobDto {
+	public static final field Companion Lee/schimke/composeai/daemon/PreviewKnobDto$Companion;
+	public fun <init> (Ljava/lang/String;ILjava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;ILjava/lang/String;)Lee/schimke/composeai/daemon/PreviewKnobDto;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/PreviewKnobDto;Ljava/lang/String;ILjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/PreviewKnobDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndex ()I
+	public final fun getName ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/PreviewKnobDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/PreviewKnobDto$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/PreviewKnobDto;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/PreviewKnobDto;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/PreviewKnobDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/PreviewKnobSeeds {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/PreviewKnobSeeds;
+	public final fun bind (Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
+	public final fun text (Lee/schimke/composeai/daemon/protocol/PreviewOverrideValue;)Ljava/lang/String;
+	public final fun texts (Ljava/util/Map;)Ljava/util/Map;
+}
+
+public final class ee/schimke/composeai/daemon/PreviewKnobToken {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/PreviewKnobToken;
+	public final fun encode (Ljava/util/List;)Ljava/lang/String;
+	public final fun parse (Ljava/lang/String;)Ljava/util/List;
 }
 
 public final class ee/schimke/composeai/daemon/PreviewOverrideBaseSpec {

--- a/docs/design/PARAMETER_KNOB_MIGRATION.md
+++ b/docs/design/PARAMETER_KNOB_MIGRATION.md
@@ -13,6 +13,7 @@ The two formats, in one line each:
 | How a value is seeded | writing typed values into a process-static controller before composing | ordinary argument passing |
 | What the preview's body contains | a harness call per knob | nothing — no harness dependency at all |
 | Where the declaration is published | `previews/<id>.overrides.json`, `data/fetch?kind=compose/overrides` | *nowhere yet* — see [gap 1](#gap-1) |
+| Where the default value comes from | the author passes it at the call site | read back out of the compiled body (`PreviewKnobDefaults`) |
 
 The reference pair to read side by side is
 [`samples/cmp/.../OverridablePreviews.kt`](../../samples/cmp/src/main/kotlin/com/example/samplecmp/OverridablePreviews.kt)
@@ -24,8 +25,9 @@ declared each way. That pair is deliberate and must **not** be collapsed by a mi
 ## The verdict
 
 **No sample should move today.** Not because the format is wrong, but because a migrated preview
-loses its editor: nothing publishes a parameter knob's declaration, so a viewer has no knob to show
-and no default to show in it. That is [gap 1](#gap-1), and it is the one that decides the answer.
+loses its editor: nothing publishes a parameter knob's declaration, so a viewer has no knob to show.
+That is [gap 1](#gap-1), and it is the one that decides the answer — though the hard half of it,
+recovering a knob's default *value*, is now solved.
 
 Everything below is what the investigation found on the way to that.
 
@@ -91,15 +93,24 @@ $ ls samples/cmp/build/compose-previews/renders/*.overrides.json
 # and no ParameterKnobListPreview sidecar
 ```
 
-The blocker underneath is that **discovery records that a default exists, not what it is**. A
-declaration needs the default *value*, and the Compose compiler leaves default expressions inside
-the function body guarded by the synthetic `$default` mask rather than in a readable constant pool
-entry — recovering a literal one means walking the method's bytecode, and a non-literal one
-(`stringResource(...)`, which most of this repository's samples use) cannot be recovered at all.
+**The blocker underneath is gone.** A declaration needs the default *value*, and Kotlin metadata
+records only that a default exists — the Compose compiler inlines the default expressions into the
+function body behind the `$default` mask. `PreviewKnobDefaults` reads them back out of the compiled
+body, so `previews.json` now carries a knob's literal default where it has one:
 
-So closing this gap means: read constant defaults from the class file where they are literals, and
-publish a declaration with **no** default where they are not. Until then a migrated preview is
-editable only by a client that already knows the knob's name from `previews.json`.
+```json
+{ "name": "title",      "index": 0, "type": "STRING", "default": "Shopping list" },
+{ "name": "accentArgb", "index": 1, "type": "LONG",   "default": "4281558783" }
+```
+
+A default that is an **expression** rather than a literal — `stringResource(...)`,
+`Color(0xFF3366FF)`, `Modifier`, `itemCount + 1` — comes back as no default, deliberately: a viewer
+showing an invented value tells the reader the preview does something it does not, and a control
+with an absent default is still a usable control.
+
+What is left is the publish itself: turning those knobs into `PreviewOverrideDeclaration`s on the
+render, so the sidecar, `compose/overrides` and the viewer's controls pick them up through the
+channel `previewOverride*` already uses.
 
 ### 2. `Color` and `Dp` are not seedable kinds
 

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComposableSignature.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComposableSignature.kt
@@ -198,8 +198,13 @@ internal object ComposableSignature {
       }
     if (parameters.isEmpty()) return emptyList()
     if (!parameters.all { it.declaresDefaultValue }) return emptyList()
+    // Read the compiled body only when there is a knob to attach a default to. Most previews have
+    // none, and this is the one place discovery reads a method body rather than its signature.
+    val hasKnob = parameters.any { knobType(it.type) != null }
+    val defaults =
+      if (hasKnob) PreviewKnobDefaults.readFrom(classInfo, method, parameters.size) else emptyMap()
     return parameters.mapIndexedNotNull { index, parameter ->
-      knobType(parameter.type)?.let { PreviewKnob(parameter.name, index, it) }
+      knobType(parameter.type)?.let { PreviewKnob(parameter.name, index, it, defaults[index]) }
     }
   }
 

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -1161,7 +1161,26 @@ data class CatalogEntry(
  * @property index the parameter's zero-based position in the function's value-parameter list.
  * @property type which seed kind can be bound to it.
  */
-@Serializable data class PreviewKnob(val name: String, val index: Int, val type: PreviewKnobType)
+@Serializable
+data class PreviewKnob(
+  val name: String,
+  val index: Int,
+  val type: PreviewKnobType,
+  /**
+   * The parameter's **literal** default, as the text a seed would carry, or null when it has none a
+   * reader can recover.
+   *
+   * A knob without this is a control an editor cannot fully draw: a declaration carries `default`
+   * and `current`, which is how a viewer shows what a field holds before anyone touches it and how
+   * it offers "reset". Kotlin metadata records only *that* a default exists, so this is read out of
+   * the compiled body — see `PreviewKnobDefaults`, which also says why only a lone constant counts.
+   *
+   * Null is the honest answer for `stringResource(...)`, `Color(0xFF3366FF)`, `Modifier` and every
+   * other default that is an expression rather than a literal. A viewer should show no default
+   * rather than an invented one.
+   */
+  val default: String? = null,
+)
 
 /** The value kinds a [PreviewKnob] can carry — the types the harness can build from a seed. */
 @Serializable

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewKnobDefaults.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewKnobDefaults.kt
@@ -1,0 +1,347 @@
+package ee.schimke.composeai.discovery
+
+import io.github.classgraph.ClassInfo
+import io.github.classgraph.MethodInfo
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.Label
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.Type
+
+/**
+ * Reads the **literal default value** of a preview's value parameters out of its compiled body.
+ *
+ * ### Why this has to read bytecode
+ *
+ * Kotlin metadata records *that* a parameter declares a default, never what the default is, and the
+ * Compose compiler does not emit a separate `$default` bridge whose constant pool could be read
+ * either — it compiles the default expressions **inline** into the function, each guarded by a bit
+ * of the synthetic `$default` mask:
+ * ```
+ * iload  <mask>          // the trailing `int $default` parameter
+ * iconst_1               // 1 shl <parameter index>
+ * iand
+ * ifeq   L1              // caller supplied this one — skip the default
+ * ldc    "Shopping list"
+ * astore_0               // …otherwise assign it
+ * L1:
+ * ```
+ *
+ * So the value is there, in the one place a reader can reach it, and nowhere else.
+ *
+ * ### Why it matters
+ *
+ * A knob without its default is a control a viewer cannot draw: `PreviewOverrideDeclaration`
+ * carries `default` and `current`, which is how an editor shows what a field holds before anyone
+ * touches it and how it offers "reset". The `previewOverride*` surface gets both for free because
+ * the author passes the default at the call site; a parameter knob's is compiled away. That
+ * asymmetry is the single reason a preview cannot yet move from one format to the other — see
+ * [`docs/design/PARAMETER_KNOB_MIGRATION.md`](../../../../../../../../docs/design/PARAMETER_KNOB_MIGRATION.md).
+ *
+ * ### What it deliberately refuses
+ *
+ * **Only a lone constant push counts.** `title: String = "Shopping list"` is one `LDC` and a store;
+ * `label: String = stringResource(Res.string.label)` is a call, `accent: Color = Color(0xFF3366FF)`
+ * is a call, `modifier: Modifier = Modifier` is a field read. Each of those is reported as *no
+ * constant default* rather than guessed at, because a wrong default is worse than a missing one: a
+ * viewer showing an absent default knows to say nothing, while one showing an invented value tells
+ * the reader the preview does something it does not.
+ *
+ * The refusal is structural, not a heuristic — the pattern matched is exactly the six-instruction
+ * shape above, with the guard bit and the store slot both checked against the parameter's own
+ * position. Anything else falls out.
+ */
+internal object PreviewKnobDefaults {
+
+  /**
+   * The literal default of each value parameter of [method] on [classInfo], keyed by the
+   * parameter's index in the full value-parameter list, rendered as the text a seed would carry.
+   *
+   * Absent from the map means "no constant default" — either the parameter has none, or its default
+   * is an expression this cannot read. [valueParameterCount] is the count Kotlin metadata reported,
+   * used to pick the right overload and to reconstruct the synthetic tail.
+   */
+  fun readFrom(
+    classInfo: ClassInfo,
+    method: MethodInfo,
+    valueParameterCount: Int,
+  ): Map<Int, String> {
+    val resource = classInfo.resource ?: return emptyMap()
+    return try {
+      resource.open().use { stream -> readFrom(stream, method.name, valueParameterCount) }
+    } catch (_: Throwable) {
+      // A class file this can't read is a preview with no known defaults, not a failed discovery.
+      emptyMap()
+    }
+  }
+
+  /**
+   * [readFrom] against raw class bytes. Split out so a test can drive the matcher with a method it
+   * built instruction by instruction: the shape this reads is one the *Compose compiler* emits, so
+   * a fixture written in Kotlin in this module — which has no Compose plugin — would compile to the
+   * ordinary `name$default` bridge instead and prove nothing about the pattern.
+   */
+  fun readFrom(
+    classBytes: java.io.InputStream,
+    methodName: String,
+    valueParameterCount: Int,
+  ): Map<Int, String> {
+    if (valueParameterCount !in 1..BITS_PER_DEFAULT_INT) return emptyMap()
+    val reader = DefaultsReader(methodName, valueParameterCount)
+    ClassReader(classBytes).accept(reader, ClassReader.SKIP_FRAMES or ClassReader.SKIP_DEBUG)
+    return reader.defaults()
+  }
+
+  /**
+   * Compose packs 31 parameters per `$default` int (one bit each). A preview with more than that
+   * carries a second mask word and the single-guard pattern below no longer describes it — a shape
+   * rare enough that refusing it is cheaper than supporting it.
+   */
+  private const val BITS_PER_DEFAULT_INT = 31
+
+  /** Compose's `changed` ints encode this many parameters each — a *different* rate to the mask. */
+  private const val SLOTS_PER_CHANGED_INT = 10
+
+  private class DefaultsReader(
+    private val methodName: String,
+    private val valueParameterCount: Int,
+  ) : ClassVisitor(Opcodes.ASM9) {
+
+    /** Null until a matching overload is seen; set to the empty map on a second, ambiguous one. */
+    private var found: Map<Int, String>? = null
+    private var ambiguous = false
+
+    fun defaults(): Map<Int, String> = if (ambiguous) emptyMap() else found.orEmpty()
+
+    override fun visitMethod(
+      access: Int,
+      name: String,
+      descriptor: String,
+      signature: String?,
+      exceptions: Array<out String>?,
+    ): MethodVisitor? {
+      if (name != methodName) return null
+      // Static only: an instance method shifts every local slot by the receiver, and a `@Preview`
+      // on
+      // a member function is resolved through a receiver the renderer constructs rather than the
+      // defaults path this reads.
+      if (access and Opcodes.ACC_STATIC == 0) return null
+      val argumentTypes = Type.getArgumentTypes(descriptor)
+      val layout = layoutOf(argumentTypes) ?: return null
+      if (found != null) {
+        // Two overloads of one name with the same defaulted shape. Discovery records the function
+        // name only, so nothing here can tell which one carries the `@Preview`; reading either
+        // one's defaults would be a coin flip presented as fact.
+        ambiguous = true
+        return null
+      }
+      val visitor = DefaultsMethodVisitor(layout)
+      found = emptyMap()
+      return object : MethodVisitor(Opcodes.ASM9, visitor) {
+        override fun visitEnd() {
+          found = visitor.harvest()
+          super.visitEnd()
+        }
+      }
+    }
+
+    /**
+     * The local-slot layout of a defaulted composable overload, or null when [argumentTypes] is not
+     * one: `(realParams…, Composer, changed…, default)`, with the counts the calling convention
+     * fixes. Checking the whole shape — not merely "ends in two ints" — is what stops this reading
+     * an unrelated overload's body and reporting its constants as this preview's defaults.
+     */
+    private fun layoutOf(argumentTypes: Array<Type>): SlotLayout? {
+      val changedInts =
+        ((valueParameterCount + SLOTS_PER_CHANGED_INT - 1) / SLOTS_PER_CHANGED_INT).coerceAtLeast(1)
+      if (argumentTypes.size != valueParameterCount + 1 + changedInts + 1) return null
+      if (argumentTypes[valueParameterCount].className != COMPOSER_FQN) return null
+      for (i in valueParameterCount + 1 until argumentTypes.size) {
+        if (argumentTypes[i].sort != Type.INT) return null
+      }
+      var slot = 0
+      val parameterSlots = IntArray(valueParameterCount)
+      for (i in 0 until valueParameterCount) {
+        parameterSlots[i] = slot
+        slot += argumentTypes[i].size
+      }
+      // Past the real parameters: the Composer (one slot) then the ints, the last of which is the
+      // `$default` mask this reads the guard bits from.
+      var tail = slot + 1
+      repeat(changedInts) { tail += 1 }
+      return SlotLayout(
+        parameterSlots = parameterSlots,
+        parameterTypes = argumentTypes.copyOfRange(0, valueParameterCount),
+        maskSlot = tail,
+      )
+    }
+  }
+
+  private const val COMPOSER_FQN = "androidx.compose.runtime.Composer"
+
+  private class SlotLayout(
+    val parameterSlots: IntArray,
+    val parameterTypes: Array<Type>,
+    val maskSlot: Int,
+  )
+
+  /**
+   * Walks a method body looking for the guarded-assignment shape, one parameter at a time.
+   *
+   * Labels, frames and line numbers are ignored rather than recorded, so "the instruction after the
+   * branch" means the next *real* instruction — a jump target label sitting between them would
+   * otherwise break the adjacency the match depends on.
+   */
+  private class DefaultsMethodVisitor(private val layout: SlotLayout) :
+    MethodVisitor(Opcodes.ASM9) {
+
+    private val insns = mutableListOf<Insn>()
+
+    override fun visitInsn(opcode: Int) {
+      insns +=
+        when (opcode) {
+          Opcodes.ICONST_M1 -> Insn.Const(-1)
+          Opcodes.ICONST_0 -> Insn.Const(0)
+          Opcodes.ICONST_1 -> Insn.Const(1)
+          Opcodes.ICONST_2 -> Insn.Const(2)
+          Opcodes.ICONST_3 -> Insn.Const(3)
+          Opcodes.ICONST_4 -> Insn.Const(4)
+          Opcodes.ICONST_5 -> Insn.Const(5)
+          Opcodes.LCONST_0 -> Insn.Const(0L)
+          Opcodes.LCONST_1 -> Insn.Const(1L)
+          Opcodes.FCONST_0 -> Insn.Const(0f)
+          Opcodes.FCONST_1 -> Insn.Const(1f)
+          Opcodes.FCONST_2 -> Insn.Const(2f)
+          Opcodes.DCONST_0 -> Insn.Const(0.0)
+          Opcodes.DCONST_1 -> Insn.Const(1.0)
+          Opcodes.IAND -> Insn.And
+          else -> Insn.Other
+        }
+    }
+
+    override fun visitIntInsn(opcode: Int, operand: Int) {
+      insns +=
+        if (opcode == Opcodes.BIPUSH || opcode == Opcodes.SIPUSH) Insn.Const(operand)
+        else Insn.Other
+    }
+
+    override fun visitLdcInsn(value: Any?) {
+      insns += if (value is String || value is Number) Insn.Const(value) else Insn.Other
+    }
+
+    override fun visitVarInsn(opcode: Int, varIndex: Int) {
+      insns +=
+        when (opcode) {
+          Opcodes.ILOAD -> Insn.Load(varIndex)
+          Opcodes.ISTORE,
+          Opcodes.LSTORE,
+          Opcodes.FSTORE,
+          Opcodes.DSTORE,
+          Opcodes.ASTORE -> Insn.Store(varIndex, opcode)
+          else -> Insn.Other
+        }
+    }
+
+    override fun visitJumpInsn(opcode: Int, label: Label) {
+      insns += if (opcode == Opcodes.IFEQ) Insn.IfZero else Insn.Other
+    }
+
+    override fun visitMethodInsn(
+      opcode: Int,
+      owner: String,
+      name: String,
+      descriptor: String,
+      isInterface: Boolean,
+    ) {
+      insns += Insn.Other
+    }
+
+    override fun visitFieldInsn(opcode: Int, owner: String, name: String, descriptor: String) {
+      insns += Insn.Other
+    }
+
+    override fun visitTypeInsn(opcode: Int, type: String) {
+      insns += Insn.Other
+    }
+
+    override fun visitIincInsn(varIndex: Int, increment: Int) {
+      insns += Insn.Other
+    }
+
+    /**
+     * The constant defaults this body assigns, keyed by parameter index.
+     *
+     * The shape matched is `iload <mask>; push (1 shl i); iand; ifeq …; push <constant>; store
+     * <slot of parameter i>`. Both the guard bit and the store slot are checked against the
+     * parameter's own position, so the *other* place a body reads the mask — the "dirty bits"
+     * computation, which is `iload <mask>; push bit; iand; ifeq …; iload <dirty>; …` — cannot
+     * match: a load, not a constant, follows its branch.
+     */
+    fun harvest(): Map<Int, String> {
+      val defaults = mutableMapOf<Int, String>()
+      for (i in insns.indices) {
+        if (i + 5 >= insns.size) break
+        val load = insns[i] as? Insn.Load ?: continue
+        if (load.slot != layout.maskSlot) continue
+        val bit = (insns[i + 1] as? Insn.Const)?.value as? Int ?: continue
+        if (insns[i + 2] !is Insn.And) continue
+        if (insns[i + 3] !is Insn.IfZero) continue
+        val constant = (insns[i + 4] as? Insn.Const)?.value ?: continue
+        val store = insns[i + 5] as? Insn.Store ?: continue
+        val parameter = layout.parameterSlots.indexOfFirst { it == store.slot }
+        if (parameter < 0) continue
+        if (bit != (1 shl parameter)) continue
+        if (store.opcode != storeOpcodeFor(layout.parameterTypes[parameter])) continue
+        renderConstant(constant, layout.parameterTypes[parameter])?.let { defaults[parameter] = it }
+      }
+      return defaults
+    }
+
+    /**
+     * The seed text for [constant] when it is a valid value of [type], or null when the two
+     * disagree.
+     *
+     * The type check is what turns `iconst_1` into `"true"` for a `Boolean` and `"1"` for an `Int`:
+     * both compile to the same instruction, and the parameter's declared type is the only thing
+     * that says which the author wrote. A constant whose Java type doesn't match the parameter's is
+     * dropped — that means the pattern matched something this doesn't understand, and a default it
+     * doesn't understand is one it must not report.
+     */
+    private fun renderConstant(constant: Any, type: Type): String? =
+      when (type.sort) {
+        Type.BOOLEAN -> (constant as? Int)?.let { (it != 0).toString() }
+        Type.INT -> (constant as? Int)?.toString()
+        Type.LONG -> (constant as? Long)?.toString()
+        Type.FLOAT -> (constant as? Float)?.toString()
+        Type.DOUBLE -> (constant as? Double)?.toString()
+        Type.OBJECT -> if (type.className == "java.lang.String") constant as? String else null
+        else -> null
+      }
+
+    private fun storeOpcodeFor(type: Type): Int =
+      when (type.sort) {
+        Type.LONG -> Opcodes.LSTORE
+        Type.FLOAT -> Opcodes.FSTORE
+        Type.DOUBLE -> Opcodes.DSTORE
+        Type.OBJECT,
+        Type.ARRAY -> Opcodes.ASTORE
+        else -> Opcodes.ISTORE
+      }
+  }
+
+  /** The handful of instruction shapes the match cares about; everything else is [Insn.Other]. */
+  private sealed interface Insn {
+    data class Load(val slot: Int) : Insn
+
+    data class Const(val value: Any) : Insn
+
+    data class Store(val slot: Int, val opcode: Int) : Insn
+
+    data object And : Insn
+
+    data object IfZero : Insn
+
+    data object Other : Insn
+  }
+}

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewKnobDefaultsTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewKnobDefaultsTest.kt
@@ -1,0 +1,321 @@
+package ee.schimke.composeai.discovery
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Label
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.Type
+
+/**
+ * Pins the bytecode matcher that recovers a parameter knob's **literal default**.
+ *
+ * The fixtures are assembled here rather than written in Kotlin because the shape being matched is
+ * one the **Compose compiler** emits: defaults inlined into the function behind a `$default` mask,
+ * with no `name$default` bridge. This module has no Compose plugin, so a Kotlin fixture would
+ * compile to the ordinary bridge and prove nothing about the pattern. Assembling it also lets the
+ * decoys be exact — in particular the "dirty bits" block, which reads the same mask with the same
+ * guard and is the one thing a looser matcher would swallow.
+ *
+ * The end-to-end proof that this shape is the one `kotlinc` + the Compose plugin actually produce
+ * lives in the gradle-plugin's functional tests, which compile a real `@Preview`.
+ */
+class PreviewKnobDefaultsTest {
+
+  @Test
+  fun `a literal default is recovered for every seedable kind`() {
+    val defaults =
+      readDefaults(
+        parameterTypes =
+          listOf(
+            STRING,
+            Type.BOOLEAN_TYPE,
+            Type.INT_TYPE,
+            Type.LONG_TYPE,
+            Type.FLOAT_TYPE,
+            Type.DOUBLE_TYPE,
+          )
+      ) { mv, layout ->
+        layout.assignConstant(mv, parameter = 0) { it.visitLdcInsn("Shopping list") }
+        layout.assignConstant(mv, parameter = 1) { it.visitInsn(Opcodes.ICONST_1) }
+        layout.assignConstant(mv, parameter = 2) { it.visitInsn(Opcodes.ICONST_3) }
+        layout.assignConstant(mv, parameter = 3) { it.visitLdcInsn(4281563647L) }
+        layout.assignConstant(mv, parameter = 4) { it.visitLdcInsn(0.5f) }
+        layout.assignConstant(mv, parameter = 5) { it.visitLdcInsn(1.5) }
+      }
+
+    assertThat(defaults)
+      .containsExactlyEntriesIn(
+        mapOf(
+          0 to "Shopping list",
+          // `iconst_1` for a Boolean is `true`; for an Int it is `1`. The instruction is identical
+          // and the declared type is the only thing that says which the author wrote.
+          1 to "true",
+          2 to "3",
+          3 to "4281563647",
+          4 to "0.5",
+          5 to "1.5",
+        )
+      )
+  }
+
+  @Test
+  fun `the dirty-bits block that reads the same mask is not mistaken for a default`() {
+    // The decoy, and the reason the matcher requires a *constant* immediately after the branch:
+    // Compose emits `iload mask; push bit; iand; ifeq …; iload dirty; push …; ior; istore dirty`
+    // near the top of every defaulted composable. It reads the same mask under the same guard, and
+    // a matcher that only looked for "mask, bit, and, ifeq" would report the dirty-bit constant as
+    // the parameter's default.
+    val defaults =
+      readDefaults(parameterTypes = listOf(Type.INT_TYPE)) { mv, layout ->
+        val skip = Label()
+        mv.visitVarInsn(Opcodes.ILOAD, layout.maskSlot)
+        mv.visitInsn(Opcodes.ICONST_1)
+        mv.visitInsn(Opcodes.IAND)
+        mv.visitJumpInsn(Opcodes.IFEQ, skip)
+        mv.visitVarInsn(Opcodes.ILOAD, layout.maskSlot + 1)
+        mv.visitIntInsn(Opcodes.BIPUSH, 6)
+        mv.visitInsn(Opcodes.IOR)
+        mv.visitVarInsn(Opcodes.ISTORE, layout.maskSlot + 1)
+        mv.visitLabel(skip)
+      }
+
+    assertThat(defaults).isEmpty()
+  }
+
+  @Test
+  fun `a default that is an expression rather than a literal is reported as none`() {
+    // `label: String = stringResource(...)` is a call, `modifier: Modifier = Modifier` a field
+    // read.
+    // Both are the overwhelmingly common shape in this repository's own samples, and both must come
+    // back as "no default" — a viewer showing an invented value tells the reader the preview does
+    // something it does not.
+    val defaults =
+      readDefaults(parameterTypes = listOf(STRING, STRING)) { mv, layout ->
+        layout.guard(mv, parameter = 0) {
+          it.visitMethodInsn(
+            Opcodes.INVOKESTATIC,
+            "com/example/Strings",
+            "label",
+            "()Ljava/lang/String;",
+            false,
+          )
+          it.visitVarInsn(Opcodes.ASTORE, layout.slotOf(0))
+        }
+        layout.guard(mv, parameter = 1) {
+          it.visitFieldInsn(
+            Opcodes.GETSTATIC,
+            "com/example/Strings",
+            "FALLBACK",
+            "Ljava/lang/String;",
+          )
+          it.visitVarInsn(Opcodes.ASTORE, layout.slotOf(1))
+        }
+      }
+
+    assertThat(defaults).isEmpty()
+  }
+
+  @Test
+  fun `a literal alongside an expression still yields the literal`() {
+    // The realistic mixed case: one knob a viewer can show a default for, one it cannot. Recovering
+    // only what is recoverable beats reporting nothing because a sibling was unreadable.
+    val defaults =
+      readDefaults(parameterTypes = listOf(STRING, Type.INT_TYPE)) { mv, layout ->
+        layout.guard(mv, parameter = 0) {
+          it.visitMethodInsn(
+            Opcodes.INVOKESTATIC,
+            "com/example/Strings",
+            "label",
+            "()Ljava/lang/String;",
+            false,
+          )
+          it.visitVarInsn(Opcodes.ASTORE, layout.slotOf(0))
+        }
+        layout.assignConstant(mv, parameter = 1) { it.visitIntInsn(Opcodes.BIPUSH, 12) }
+      }
+
+    assertThat(defaults).containsExactlyEntriesIn(mapOf(1 to "12"))
+  }
+
+  @Test
+  fun `a guard bit that does not match the parameter it stores into is refused`() {
+    // Not a shape the compiler emits — which is the point. The bit and the slot are checked against
+    // each other, so a body this doesn't actually understand cannot be read as if it did.
+    val defaults =
+      readDefaults(parameterTypes = listOf(Type.INT_TYPE, Type.INT_TYPE)) { mv, layout ->
+        val skip = Label()
+        mv.visitVarInsn(Opcodes.ILOAD, layout.maskSlot)
+        mv.visitInsn(Opcodes.ICONST_1) // bit for parameter 0…
+        mv.visitInsn(Opcodes.IAND)
+        mv.visitJumpInsn(Opcodes.IFEQ, skip)
+        mv.visitInsn(Opcodes.ICONST_5)
+        mv.visitVarInsn(Opcodes.ISTORE, layout.slotOf(1)) // …storing into parameter 1
+        mv.visitLabel(skip)
+      }
+
+    assertThat(defaults).isEmpty()
+  }
+
+  @Test
+  fun `a method with no Compose tail is not read at all`() {
+    // An ordinary Kotlin function with defaults gets a `name$default` bridge instead, and its
+    // locals
+    // are laid out differently. Matching on the whole shape — not merely "ends in ints" — is what
+    // keeps this from reading an unrelated overload's constants as a preview's defaults.
+    val writer = ClassWriter(0)
+    writer.visit(Opcodes.V17, Opcodes.ACC_PUBLIC, OWNER, null, "java/lang/Object", null)
+    val mv =
+      writer.visitMethod(
+        Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC,
+        METHOD,
+        "(Ljava/lang/String;II)V",
+        null,
+        null,
+      )
+    mv.visitCode()
+    val skip = Label()
+    mv.visitVarInsn(Opcodes.ILOAD, 2)
+    mv.visitInsn(Opcodes.ICONST_1)
+    mv.visitInsn(Opcodes.IAND)
+    mv.visitJumpInsn(Opcodes.IFEQ, skip)
+    mv.visitLdcInsn("nope")
+    mv.visitVarInsn(Opcodes.ASTORE, 0)
+    mv.visitLabel(skip)
+    mv.visitInsn(Opcodes.RETURN)
+    mv.visitMaxs(2, 3)
+    mv.visitEnd()
+    writer.visitEnd()
+
+    assertThat(PreviewKnobDefaults.readFrom(writer.toByteArray().inputStream(), METHOD, 1))
+      .isEmpty()
+  }
+
+  @Test
+  fun `two defaulted overloads of one name are refused rather than guessed between`() {
+    // Discovery records the function name only, so nothing here can tell which one carries the
+    // `@Preview`. Reading either one's defaults would be a coin flip presented as fact.
+    val writer = ClassWriter(0)
+    writer.visit(Opcodes.V17, Opcodes.ACC_PUBLIC, OWNER, null, "java/lang/Object", null)
+    repeat(2) {
+      emitComposableMethod(writer, listOf(Type.INT_TYPE)) { mv, layout ->
+        layout.assignConstant(mv, parameter = 0) { it.visitInsn(Opcodes.ICONST_2) }
+      }
+    }
+    writer.visitEnd()
+
+    assertThat(PreviewKnobDefaults.readFrom(writer.toByteArray().inputStream(), METHOD, 1))
+      .isEmpty()
+  }
+
+  // --- assembly helpers -------------------------------------------------------------------------
+
+  private fun readDefaults(
+    parameterTypes: List<Type>,
+    body: (MethodVisitor, ComposableLayout) -> Unit,
+  ): Map<Int, String> {
+    val writer = ClassWriter(0)
+    writer.visit(Opcodes.V17, Opcodes.ACC_PUBLIC, OWNER, null, "java/lang/Object", null)
+    emitComposableMethod(writer, parameterTypes, body)
+    writer.visitEnd()
+    return PreviewKnobDefaults.readFrom(
+      writer.toByteArray().inputStream(),
+      METHOD,
+      parameterTypes.size,
+    )
+  }
+
+  /**
+   * Emits `METHOD(realParams…, Composer, int changed, int default)` — the exact shape the Compose
+   * compiler gives a composable whose parameters all declare defaults — with [body] filling in the
+   * default assignments.
+   */
+  private fun emitComposableMethod(
+    writer: ClassWriter,
+    parameterTypes: List<Type>,
+    body: (MethodVisitor, ComposableLayout) -> Unit,
+  ) {
+    val changedInts = ((parameterTypes.size + 9) / 10).coerceAtLeast(1)
+    val descriptor =
+      Type.getMethodDescriptor(
+        Type.VOID_TYPE,
+        *(parameterTypes + COMPOSER + List(changedInts + 1) { Type.INT_TYPE }).toTypedArray(),
+      )
+    val mv =
+      writer.visitMethod(
+        Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC,
+        METHOD,
+        descriptor,
+        null,
+        null,
+      )
+    mv.visitCode()
+    body(mv, ComposableLayout(parameterTypes, changedInts))
+    mv.visitInsn(Opcodes.RETURN)
+    mv.visitMaxs(4, 16)
+    mv.visitEnd()
+  }
+
+  /** Local-slot arithmetic for the emitted method, so a fixture can name a parameter by index. */
+  private class ComposableLayout(val parameterTypes: List<Type>, changedInts: Int) {
+    private val slots = IntArray(parameterTypes.size)
+
+    val maskSlot: Int
+
+    init {
+      var slot = 0
+      parameterTypes.forEachIndexed { i, type ->
+        slots[i] = slot
+        slot += type.size
+      }
+      maskSlot = slot + 1 + changedInts
+    }
+
+    fun slotOf(parameter: Int): Int = slots[parameter]
+
+    /** The `iload mask; push (1 shl i); iand; ifeq …` guard, with [assign] as its body. */
+    fun guard(mv: MethodVisitor, parameter: Int, assign: (MethodVisitor) -> Unit) {
+      val skip = Label()
+      mv.visitVarInsn(Opcodes.ILOAD, maskSlot)
+      pushBit(mv, 1 shl parameter)
+      mv.visitInsn(Opcodes.IAND)
+      mv.visitJumpInsn(Opcodes.IFEQ, skip)
+      assign(mv)
+      mv.visitLabel(skip)
+    }
+
+    /** [guard] whose body is a single constant push and the matching store. */
+    fun assignConstant(mv: MethodVisitor, parameter: Int, push: (MethodVisitor) -> Unit) {
+      guard(mv, parameter) {
+        push(it)
+        it.visitVarInsn(storeOpcode(parameterTypes[parameter]), slots[parameter])
+      }
+    }
+
+    private fun pushBit(mv: MethodVisitor, bit: Int) {
+      when {
+        bit <= 5 -> mv.visitInsn(Opcodes.ICONST_0 + bit)
+        bit <= Byte.MAX_VALUE -> mv.visitIntInsn(Opcodes.BIPUSH, bit)
+        else -> mv.visitIntInsn(Opcodes.SIPUSH, bit)
+      }
+    }
+
+    private fun storeOpcode(type: Type): Int =
+      when (type.sort) {
+        Type.LONG -> Opcodes.LSTORE
+        Type.FLOAT -> Opcodes.FSTORE
+        Type.DOUBLE -> Opcodes.DSTORE
+        Type.OBJECT,
+        Type.ARRAY -> Opcodes.ASTORE
+        else -> Opcodes.ISTORE
+      }
+  }
+
+  private companion object {
+    const val OWNER = "com/example/FixtureKt"
+    const val METHOD = "KnobbedPreview"
+    val STRING: Type = Type.getObjectType("java/lang/String")
+    val COMPOSER: Type = Type.getObjectType("androidx/compose/runtime/Composer")
+  }
+}

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -169,6 +169,79 @@ class DiscoveryFunctionalTest {
   }
 
   @Test
+  fun `composePreviewDiscover records a parameter knob's literal default`() {
+    // The one place the knob-default reader is checked against bytecode the **Compose compiler**
+    // actually emitted. `PreviewKnobDefaultsTest` assembles the instruction shape by hand —
+    // precise,
+    // and worthless if the compiler stops emitting that shape. This compiles a real `@Preview` with
+    // the plugin CI resolves and reads the manifest back, so a compiler change that moves the
+    // defaults out of the function body turns this red instead of silently emptying every default.
+    val projectDir = createCmpTestProject()
+    File(projectDir, "src/main/kotlin/test/Previews.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.ui.tooling.preview.Preview
+        import androidx.compose.foundation.background
+        import androidx.compose.foundation.layout.Box
+        import androidx.compose.foundation.layout.size
+        import androidx.compose.material3.Text
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+        import androidx.compose.ui.graphics.Color
+        import androidx.compose.ui.unit.dp
+
+        @Preview
+        @Composable
+        fun KnobbedPreview(
+            title: String = "Shopping list",
+            accentArgb: Long = 0xFF3366FF,
+            itemCount: Int = 3,
+            ratio: Float = 0.5f,
+            enabled: Boolean = true,
+            // A default that is an *expression*, not a literal: recorded as no default rather than
+            // guessed at, because a viewer showing an invented value misreports the preview.
+            computed: Int = itemCount + 1,
+        ) {
+            Box(modifier = Modifier.size((100 * ratio).dp).background(Color(accentArgb.toInt()))) {
+                Text(if (enabled) "${'$'}title ${'$'}itemCount ${'$'}computed" else "off")
+            }
+        }
+        """
+          .trimIndent()
+      )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewDiscover", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+    assertThat(result.task(":composePreviewDiscover")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+    val knobs = manifest.previews.single { it.functionName == "KnobbedPreview" }.knobs
+
+    assertThat(knobs.map { it.name to it.default })
+      .containsExactly(
+        "title" to "Shopping list",
+        // 0xFF3366FF as the Long the author wrote — the format has no Color kind, so an editable
+        // colour rides an ARGB Long and its default has to survive as that same number.
+        "accentArgb" to 0xFF3366FF.toString(),
+        "itemCount" to "3",
+        "ratio" to "0.5",
+        // `iconst_1` for a Boolean is `true`; the declared type is the only thing that says so.
+        "enabled" to "true",
+        "computed" to null,
+      )
+      .inOrder()
+  }
+
+  @Test
   fun `composePreviewDiscover expands @OverrideVariant into synthetic seeded previews`() {
     val projectDir = createCmpTestProject()
 


### PR DESCRIPTION
The half of the declaration gap that looked hardest, and turned out to be tractable.

A parameter knob has never carried its **default value**, and that is what stops a migrated preview from being editable: `PreviewOverrideDeclaration` holds `default` and `current`, which is how a viewer shows what a field contains before anyone touches it and how it offers "reset". The `previewOverride*` surface gets both free because the author passes the default at the call site. A parameter knob's is compiled away — Kotlin metadata records only *that* a default exists.

## It isn't gone, it's inlined

The Compose compiler emits no `name$default` bridge whose constant pool could be read. It inlines each default expression into the function body, behind a bit of the synthetic `$default` mask. Straight from `samples/cmp`'s reference preview:

```
307: iload         8              // the $default mask
309: iconst_1                     // 1 shl 0
310: iand
311: ifeq          317
314: ldc           #53            // String Shopping list
316: astore_0                     // title
317: iload         8
319: iconst_2                     // 1 shl 1
320: iand
321: ifeq          328
324: ldc2_w        #54            // long 4281558783l
327: lstore_1                     // accentArgb
```

`PreviewKnobDefaults` matches exactly that six-instruction shape, checking **both** the guard bit and the store slot against the parameter's own position. `previews.json` now carries the value:

```json
{ "name": "title",      "index": 0, "type": "STRING", "default": "Shopping list" },
{ "name": "accentArgb", "index": 1, "type": "LONG",   "default": "4281558783" },
{ "name": "itemCount",  "index": 2, "type": "INT",    "default": "3" }
```

## What it refuses, and why that's the point

**Only a lone constant push counts.** `stringResource(...)`, `Color(0xFF3366FF)`, `Modifier` and `itemCount + 1` all come back as *no default* rather than a guess — a viewer showing an absent default knows to say nothing, while one showing an invented value tells the reader the preview does something it does not. The refusal is structural: the same check that recognises the shape rejects everything else, so it isn't a list of expressions someone has to remember to extend.

Two decoys it has to survive, both pinned by tests:

* **The dirty-bits block.** Compose reads the same mask under the same guard at the top of every defaulted composable (`iload mask; push bit; iand; ifeq …; iload dirty; push 6; ior; istore dirty`). A matcher keyed only on the guard would report `6` as the parameter's default. Requiring a *constant* immediately after the branch is what excludes it.
* **Two defaulted overloads of one name.** Discovery records the function name only, so nothing here can tell which one carries the `@Preview`. Refused outright rather than guessed between — the same posture `renderer-android`'s resolver already takes for the same reason.

`iconst_1` is `"true"` for a `Boolean` and `"1"` for an `Int`; the instruction is identical and the declared type is the only thing that says which the author wrote, so the constant is checked against the parameter's type before it's rendered.

## Test plan

Non-visual — discovery output only, no rendered surface changes.

* `:gradle-plugin:preview-discovery:test` and `:gradle-plugin:test` — **869 tests, 0 failures**.
* `PreviewKnobDefaultsTest` (7 cases) assembles its fixtures with ASM rather than writing them in Kotlin. This module has no Compose plugin, so a Kotlin fixture would compile to the ordinary `name$default` bridge and prove nothing about the pattern — and hand assembly is what lets the dirty-bits decoy be byte-exact. Covers every seedable kind, the decoy, expression defaults, a literal alongside an expression, a bit/slot mismatch, a non-Compose tail, and the ambiguous overload.
* `DiscoveryFunctionalTest.composePreviewDiscover records a parameter knob's literal default` compiles a **real** `@Preview` with the Compose plugin CI resolves and reads the manifest back, including a `computed: Int = itemCount + 1` that must come back null. That is the guard against the unit fixtures being precise about a shape the compiler has stopped emitting.
* Verified end to end against the real sample: `:samples:cmp:composePreviewDiscover --rerun` recovers all five of `ParameterKnobListPreview`'s defaults, matching source exactly.
* `ktfmtFormat` on every touched module.

## What's left of gap 1

The publish itself: turning these knobs into `PreviewOverrideDeclaration`s on the render, so the bundle sidecar, `data/fetch?kind=compose/overrides` and the viewer's controls pick them up through the channel `previewOverride*` already uses. That's the next PR, and it is the last thing between the samples and a real migration. `docs/design/PARAMETER_KNOB_MIGRATION.md` is updated to say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o

---
_Generated by [Claude Code](https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o)_