### PR TITLE
fix(daemon): refresh the daemon-core ABI dump

### DIFF
--- a/daemon/core/api/core.api
+++ b/daemon/core/api/core.api
@@ -931,10 +931,11 @@ public final class ee/schimke/composeai/daemon/PreviewIndexKt {
 
 public final class ee/schimke/composeai/daemon/PreviewInfoDto {
 	public static final field Companion Lee/schimke/composeai/daemon/PreviewInfoDto$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/PreviewParamsDto;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/data/overrides/OverrideVariantSpec;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/PreviewParamsDto;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/data/overrides/OverrideVariantSpec;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/PreviewParamsDto;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/data/overrides/OverrideVariantSpec;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/PreviewParamsDto;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/data/overrides/OverrideVariantSpec;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component10 ()Lee/schimke/composeai/data/overrides/OverrideVariantSpec;
+	public final fun component10 ()Ljava/util/List;
+	public final fun component11 ()Lee/schimke/composeai/data/overrides/OverrideVariantSpec;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
@@ -943,8 +944,8 @@ public final class ee/schimke/composeai/daemon/PreviewInfoDto {
 	public final fun component7 ()Lee/schimke/composeai/daemon/PreviewParamsDto;
 	public final fun component8 ()Ljava/util/List;
 	public final fun component9 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/PreviewParamsDto;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/data/overrides/OverrideVariantSpec;)Lee/schimke/composeai/daemon/PreviewInfoDto;
-	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/PreviewInfoDto;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/PreviewParamsDto;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/data/overrides/OverrideVariantSpec;ILjava/lang/Object;)Lee/schimke/composeai/daemon/PreviewInfoDto;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/PreviewParamsDto;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/data/overrides/OverrideVariantSpec;)Lee/schimke/composeai/daemon/PreviewInfoDto;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/PreviewInfoDto;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/PreviewParamsDto;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/data/overrides/OverrideVariantSpec;ILjava/lang/Object;)Lee/schimke/composeai/daemon/PreviewInfoDto;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCaptures ()Ljava/util/List;
 	public final fun getClassName ()Ljava/lang/String;
@@ -952,6 +953,7 @@ public final class ee/schimke/composeai/daemon/PreviewInfoDto {
 	public final fun getDisplayName ()Ljava/lang/String;
 	public final fun getGroup ()Ljava/lang/String;
 	public final fun getId ()Ljava/lang/String;
+	public final fun getKnobs ()Ljava/util/List;
 	public final fun getMethodName ()Ljava/lang/String;
 	public final fun getOverrides ()Lee/schimke/composeai/data/overrides/OverrideVariantSpec;
 	public final fun getParams ()Lee/schimke/composeai/daemon/PreviewParamsDto;
@@ -973,6 +975,50 @@ public final synthetic class ee/schimke/composeai/daemon/PreviewInfoDto$$seriali
 
 public final class ee/schimke/composeai/daemon/PreviewInfoDto$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/PreviewKnobDto {
+	public static final field Companion Lee/schimke/composeai/daemon/PreviewKnobDto$Companion;
+	public fun <init> (Ljava/lang/String;ILjava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;ILjava/lang/String;)Lee/schimke/composeai/daemon/PreviewKnobDto;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/PreviewKnobDto;Ljava/lang/String;ILjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/PreviewKnobDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndex ()I
+	public final fun getName ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/PreviewKnobDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/PreviewKnobDto$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/PreviewKnobDto;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/PreviewKnobDto;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/PreviewKnobDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/PreviewKnobSeeds {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/PreviewKnobSeeds;
+	public final fun bind (Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
+	public final fun text (Lee/schimke/composeai/daemon/protocol/PreviewOverrideValue;)Ljava/lang/String;
+	public final fun texts (Ljava/util/Map;)Ljava/util/Map;
+}
+
+public final class ee/schimke/composeai/daemon/PreviewKnobToken {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/PreviewKnobToken;
+	public final fun encode (Ljava/util/List;)Ljava/lang/String;
+	public final fun parse (Ljava/lang/String;)Ljava/util/List;
 }
 
 public final class ee/schimke/composeai/daemon/PreviewOverrideBaseSpec {


### PR DESCRIPTION
**`main` is red and this is the fix.** `:daemon:core:checkKotlinAbi` has been failing since [#5089](https://github.com/yschimke/compose-ai-tools/pull/5089) — mine — added public API to that module without regenerating the reference dump: `PreviewKnobDto`, `PreviewKnobSeeds`, `PreviewKnobToken`, and a `knobs` component on `PreviewInfoDto`. [#5091](https://github.com/yschimke/compose-ai-tools/pull/5091) widened the same surface and didn't regenerate it either.

Both merged because `Module Unit Tests` is not a required check for auto-merge, so the failure landed on `main` rather than blocking the PR that caused it. It surfaced on [#5093](https://github.com/yschimke/compose-ai-tools/pull/5093), which touches none of that code.

Confirmed against `main` itself rather than inferred:

```
$ git checkout --detach origin/main
$ ./gradlew :daemon:core:checkLegacyAbi
> Task :daemon:core:checkKotlinAbi FAILED
  +public final class ee/schimke/composeai/daemon/PreviewKnobDto { …
```

## What changed

`daemon/core/api/core.api` only — regenerated with `:daemon:core:updateLegacyAbi`. No source change.

## Test plan

* `:daemon:core:checkLegacyAbi` — was FAILED on `origin/main`, passes with this commit.
* `checkLegacyAbi` across the whole build (`--continue`) — `:daemon:core` was the only stale dump; the renderer modules touched by the same work have no ABI dump at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o

---
_Generated by [Claude Code](https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o)_