### PR TITLE
feat(daemon): declare a preview's parameter knobs to the viewer

### DIFF
--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -139,6 +139,11 @@ dependencies {
   // `renderNow.overrides.namedOverrides` into the `previewOverride*` lookups and produces the
   // `compose/overrides` data product (the preview's declared editable knobs).
   implementation(project(":data-preview-overrides-connector"))
+  // The controller itself, not just the connector that plans it: the render body records a
+  // parameter knob's declaration through `PreviewOverrideController.record` so both override
+  // formats reach `compose/overrides` on one channel. The connector depends on the runtime with
+  // `implementation`, so it isn't on this module's compile classpath transitively.
+  implementation(project(":data-preview-overrides-runtime"))
   // Launcher-widget container-size connector — same shape as `:data-touch-overlay-connector`
   // (single shared JVM module on both backends). `LauncherWidgetExtension` wraps the preview in
   // a sized `Box` matching the clamped whole-cell footprint, driven from

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -704,6 +704,14 @@ class RenderEngine(
                             // wrapper.
                             themeProviderFqn = spec.overrides?.themeProvider,
                             previewArgs = previewArgs,
+                            // The preview's parameter knobs, as the declarations a viewer draws
+                            // its controls from — the one-shot render, which is the lane a
+                            // `data/fetch?kind=compose/overrides` reads after.
+                            knobDeclarations =
+                              PreviewKnobDeclarations.of(
+                                spec.knobs,
+                                spec.overrides?.namedOverrides,
+                              ),
                           )
                         }
                       }
@@ -2911,7 +2919,20 @@ internal fun InvokeWithOptionalWrapper(
   wrapperFqnFromSpec: String?,
   themeProviderFqn: String? = null,
   previewArgs: List<Any?> = emptyList(),
+  knobDeclarations: List<ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration> =
+    emptyList(),
 ) {
+  // `SideEffect`, not a plain call: the around-composable resets this preview's declarations from a
+  // `DisposableEffect`, and Compose runs every `RememberObserver` before any `SideEffect`, so the
+  // clear always precedes these. On this backend the record also forwards across the Robolectric
+  // sandbox boundary through the bridge, which is how the host-side registry sees it at all.
+  if (knobDeclarations.isNotEmpty()) {
+    androidx.compose.runtime.SideEffect {
+      knobDeclarations.forEach {
+        ee.schimke.composeai.overrides.PreviewOverrideController.record(it)
+      }
+    }
+  }
   val wrappers =
     remember(composableMethod, wrapperFqnFromSpec, themeProviderFqn) {
       resolveWrapperStack(composableMethod, wrapperFqnFromSpec, themeProviderFqn)

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidParameterKnobTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidParameterKnobTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.bridge.SandboxPreviewOverridesBridge
 import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import java.io.ByteArrayInputStream
@@ -7,6 +8,10 @@ import java.io.File
 import java.util.Base64
 import javax.imageio.ImageIO
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -106,6 +111,79 @@ class AndroidParameterKnobTest {
     }
   }
 
+  /**
+   * The declaration half, end to end on the backend where it has the furthest to travel: the knob's
+   * **default** is read out of the class file by discovery, encoded into the `knobs=` payload token
+   * by the host, parsed back inside the Robolectric sandbox, recorded as a
+   * `PreviewOverrideDeclaration`, forwarded across the classloader boundary by the bridge, and read
+   * back host-side by the registry that answers `data/fetch?kind=compose/overrides`.
+   *
+   * Every one of those hops is a place a default can quietly become nothing, and none of them
+   * throws when it does — the render still succeeds and the viewer just shows no control. That is
+   * why this asserts the fetched payload rather than any single hop.
+   */
+  @Test
+  fun parameterKnobsReachDataFetchAsDeclarationsAcrossTheSandbox() {
+    val outputDir = tempFolder.newFolder("parameter-knob-declared-renders")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+
+    val host = RobolectricHost(previewSpecResolver = previewSpecResolver())
+    val registry = PreviewOverridesDataProductRegistry()
+    host.start()
+    SandboxPreviewOverridesBridge.resetAll()
+    try {
+      val blue = 0xFF42A5F5L
+      val result =
+        host.submit(
+          RenderRequest.Render(
+            payload =
+              "previewId=$KNOBBED_PREVIEW_ID;overrides=${encodeTextBag("topArgb" to blue.toString())}"
+          ),
+          timeoutMs = 120_000,
+        )
+      assertNotNull("pngPath must be populated", result.pngPath)
+
+      // Hand the result to the registry the way `JsonRpcServer.handleRenderFinished` does.
+      registry.onRender(
+        KNOBBED_PREVIEW_ID,
+        result,
+        overrides = null,
+        previewContext = result.previewContext,
+      )
+      val outcome =
+        registry.fetch(KNOBBED_PREVIEW_ID, "compose/overrides", params = null, inline = true)
+      val ok = outcome as DataProductRegistry.Outcome.Ok
+      val declarations = ok.result.payload!!.jsonObject["declarations"]!!.jsonArray
+
+      assertEquals(
+        listOf("topArgb", "bottomArgb", "label"),
+        declarations.map { it.jsonObject["key"]!!.jsonPrimitive.content },
+      )
+      // `Long` has no declaration type of its own, so both colours ride as text.
+      assertEquals(
+        listOf("string", "string", "string"),
+        declarations.map { it.jsonObject["type"]!!.jsonPrimitive.content },
+      )
+      // The pair a control needs: what the author wrote, and what is in force. The seeded knob's
+      // `current` is the seed; the unseeded one's is its own default, which is also what rendered.
+      val current = declarations.associate { entry ->
+        entry.jsonObject["key"]!!.jsonPrimitive.content to
+          entry.jsonObject["current"]!!.jsonObject["value"]!!.jsonPrimitive.content
+      }
+      val default = declarations.associate { entry ->
+        entry.jsonObject["key"]!!.jsonPrimitive.content to
+          entry.jsonObject["default"]!!.jsonObject["value"]!!.jsonPrimitive.content
+      }
+      assertEquals(blue.toString(), current["topArgb"])
+      assertEquals("4293874512", default["topArgb"])
+      assertEquals("4284922730", current["bottomArgb"])
+      assertEquals("hi", current["label"])
+    } finally {
+      host.shutdown()
+    }
+  }
+
   private fun previewSpecResolver(): (String) -> RenderSpec? = { previewId ->
     when (previewId) {
       KNOBBED_PREVIEW_ID ->
@@ -121,9 +199,9 @@ class AndroidParameterKnobTest {
           // Exactly what `renderSpecFromInfo` reads out of `previews.json` for this preview.
           knobs =
             listOf(
-              PreviewKnobDto("topArgb", 0, "LONG"),
-              PreviewKnobDto("bottomArgb", 1, "LONG"),
-              PreviewKnobDto("label", 2, "STRING"),
+              PreviewKnobDto("topArgb", 0, "LONG", "4293874512"),
+              PreviewKnobDto("bottomArgb", 1, "LONG", "4284922730"),
+              PreviewKnobDto("label", 2, "STRING", "hi"),
             ),
         )
       else -> null

--- a/daemon/core/api/core.api
+++ b/daemon/core/api/core.api
@@ -977,15 +977,23 @@ public final class ee/schimke/composeai/daemon/PreviewInfoDto$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class ee/schimke/composeai/daemon/PreviewKnobDeclarations {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/PreviewKnobDeclarations;
+	public final fun of (Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
+}
+
 public final class ee/schimke/composeai/daemon/PreviewKnobDto {
 	public static final field Companion Lee/schimke/composeai/daemon/PreviewKnobDto$Companion;
-	public fun <init> (Ljava/lang/String;ILjava/lang/String;)V
+	public fun <init> (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()I
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;ILjava/lang/String;)Lee/schimke/composeai/daemon/PreviewKnobDto;
-	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/PreviewKnobDto;Ljava/lang/String;ILjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/PreviewKnobDto;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/PreviewKnobDto;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/PreviewKnobDto;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/PreviewKnobDto;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefault ()Ljava/lang/String;
 	public final fun getIndex ()I
 	public final fun getName ()Ljava/lang/String;
 	public final fun getType ()Ljava/lang/String;

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
@@ -153,7 +153,22 @@ public data class PreviewDataProductDto(val kind: String, val scroll: ScrollCapt
  * knob kind this daemon cannot bind, and an unknown name has to degrade to "not seedable" — the
  * author default renders — instead of failing the whole manifest parse.
  */
-@Serializable public data class PreviewKnobDto(val name: String, val index: Int, val type: String)
+@Serializable
+public data class PreviewKnobDto(
+  val name: String,
+  val index: Int,
+  val type: String,
+  /**
+   * The parameter's **literal** default as discovery recovered it from the compiled body, or null
+   * when it has none a reader could reach (an expression default — `stringResource(...)`,
+   * `Color(0xFF3366FF)`, `itemCount + 1`).
+   *
+   * Carried because a `PreviewOverrideDeclaration` needs it: a viewer's control shows what a field
+   * holds before anyone touches it, and offers "reset" against it. A knob without one is left
+   * undeclared rather than declared with an invented value — see [PreviewKnobDeclarations].
+   */
+  val default: String? = null,
+)
 
 /**
  * Daemon-side mirror of the gradle plugin's `Capture` — one planned render of a preview. Only

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewKnobDeclarations.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewKnobDeclarations.kt
@@ -1,0 +1,121 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
+import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
+import ee.schimke.composeai.data.overrides.PreviewOverrideType
+
+/**
+ * Turns a preview's **parameter knobs** into the `PreviewOverrideDeclaration`s a viewer draws its
+ * controls from — the last seam between the two override formats.
+ *
+ * ### Why declarations, and why through this type
+ *
+ * `previewOverride*` publishes a declaration per knob as a by-product of *reading* it: the lookup
+ * knows the key, the type, the author default and the value in force, and records all four. That is
+ * what fills `previews/<id>.overrides.json` and `data/fetch?kind=compose/overrides`, and what a
+ * viewer's control list, the serve `?knob.<key>=` UI and `serve-lanes.spec.mjs` all read.
+ *
+ * A parameter knob is declared by a signature and read by ordinary argument passing, so nothing in
+ * the composition ever announces it. Building the same declarations here and recording them on the
+ * render puts both formats on one channel: every consumer downstream keeps working unchanged, and
+ * neither has to know which format a given preview used.
+ *
+ * ### What it will not declare
+ *
+ * **A knob whose default this could not recover.** `PreviewOverrideDeclaration.default` is not
+ * nullable, so declaring one means inventing a value — an empty string, a zero — and presenting it
+ * as what the author wrote. A viewer would then show a wrong default and offer a "reset" that
+ * resets to something the preview never said. Leaving the knob undeclared costs its editability and
+ * says nothing false; that is the better trade until the declaration contract can carry an absent
+ * default. Discovery recovers a literal default (`PreviewKnobDefaults`), so this only bites a knob
+ * defaulted to an *expression* — `stringResource(...)`, `Color(0xFF3366FF)`, `itemCount + 1`.
+ *
+ * ### Where `Long` and `Double` go
+ *
+ * [PreviewOverrideType] has `STRING` / `INT` / `FLOAT` / `BOOL` / `COLOR` and no wider numerics, so
+ * a `Long` or `Double` knob is declared as **text**. That is not a downgrade in what can be edited:
+ * a text seed reaches the parameter through the same `PreviewKnobSeeds` path and parses against the
+ * knob's declared kind, so a `Long` seeded as `"4281558783"` binds exactly as it would have. The
+ * viewer draws a text field instead of a number field, which is the whole of the difference — and
+ * it is why an ARGB `Long` (the format's stand-in for an editable colour) gets a text box rather
+ * than a colour picker.
+ */
+public object PreviewKnobDeclarations {
+
+  /**
+   * The declarations for [knobs] under this render's [seeds], skipping the knobs that cannot be
+   * declared honestly. Empty when nothing can be — the overwhelmingly common case, since most
+   * previews declare no knobs at all.
+   *
+   * `current` is the value actually in force: the seed when one bound, the author default
+   * otherwise, resolved by the same rules the renderer binds arguments with. A viewer showing a
+   * `current` that disagreed with the pixels beside it would be worse than showing nothing.
+   */
+  public fun of(
+    knobs: List<PreviewKnobDto>,
+    seeds: Map<String, PreviewOverrideValue>?,
+  ): List<PreviewOverrideDeclaration> {
+    if (knobs.isEmpty()) return emptyList()
+    val bound = PreviewKnobSeeds.bind(knobs, seeds)
+    return knobs.mapNotNull { knob ->
+      val default = knob.default ?: return@mapNotNull null
+      val type = declaredTypeOf(knob.type) ?: return@mapNotNull null
+      // The bound argument for this knob's position, when a seed reached it. `bind` returns an
+      // empty list when nothing bound at all, and null at every position no seed named — the same
+      // "use the author default" signal the renderer acts on, so the two cannot disagree.
+      val seeded = bound.getOrNull(knob.index)
+      PreviewOverrideDeclaration(
+        key = knob.name,
+        type = type,
+        // No author-supplied label exists: a parameter has a name and nothing else. The
+        // `previewOverride*` host does the same, so a viewer renders both formats identically.
+        label = knob.name,
+        default = valueOf(type, default),
+        current = valueOf(type, seeded?.toString() ?: default),
+        // Parameter knobs have no indexed form — a parameter list is fixed-arity, so there is no
+        // per-row value to address. Always the un-indexed seed key.
+        index = null,
+      )
+    }
+  }
+
+  /**
+   * The declaration type for a discovery knob kind, or null when there is none.
+   *
+   * `LONG` and `DOUBLE` map to `STRING` — see the class KDoc for why that costs only the control's
+   * shape, not its reach. A kind this doesn't know is dropped rather than guessed: a newer plugin
+   * naming one must leave the knob undeclared, not declared as something it isn't.
+   */
+  private fun declaredTypeOf(knobType: String): String? =
+    when (knobType) {
+      "STRING",
+      "LONG",
+      "DOUBLE" -> PreviewOverrideType.STRING
+      "BOOLEAN" -> PreviewOverrideType.BOOL
+      "INT" -> PreviewOverrideType.INT
+      "FLOAT" -> PreviewOverrideType.FLOAT
+      else -> null
+    }
+
+  /**
+   * [text] as the declaration value of [type], falling back to a string value when it does not
+   * parse.
+   *
+   * The fallback is reachable only if discovery recovered a constant whose text doesn't round-trip
+   * through its own declared type, which would be a bug upstream — but showing the raw text beats
+   * substituting a zero, because the text is at least what the class file said.
+   */
+  private fun valueOf(type: String, text: String): PreviewOverrideValue =
+    when (type) {
+      PreviewOverrideType.INT ->
+        text.toIntOrNull()?.let { PreviewOverrideValue.IntValue(it) }
+          ?: PreviewOverrideValue.StringValue(text)
+      PreviewOverrideType.FLOAT ->
+        text.toFloatOrNull()?.let { PreviewOverrideValue.FloatValue(it) }
+          ?: PreviewOverrideValue.StringValue(text)
+      PreviewOverrideType.BOOL ->
+        text.toBooleanStrictOrNull()?.let { PreviewOverrideValue.BooleanValue(it) }
+          ?: PreviewOverrideValue.StringValue(text)
+      else -> PreviewOverrideValue.StringValue(text)
+    }
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewKnobToken.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewKnobToken.kt
@@ -1,8 +1,8 @@
 package ee.schimke.composeai.daemon
 
 /**
- * The `knobs=<name>:<index>:<TYPE>,…` render-payload token — how a preview's **parameter knobs**
- * travel on the wire when the spec itself cannot.
+ * The `knobs=<name>:<index>:<TYPE>[:<default>],…` render-payload token — how a preview's
+ * **parameter knobs** travel on the wire when the spec itself cannot.
  *
  * ### Why a token at all
  *
@@ -22,6 +22,16 @@ package ee.schimke.composeai.daemon
  * parameter has to degrade to its author default while the rest of the preview still seeds. Failing
  * the whole render because a knob kind is unfamiliar would turn a forward-compatible wire into a
  * hard version pin.
+ *
+ * ### The fourth field
+ *
+ * A knob's **literal default** rides as an optional fourth field, base64url-encoded. It is not
+ * there for the render — the compiled default runs on its own when a position is unseeded — but for
+ * the declaration a viewer draws its control from, which has to say what the field held before
+ * anyone touched it. Encoding it is not optional: a default is author-written text and may
+ * legitimately contain `:`, `,`, `;` or `=`, all of which are payload delimiters. A knob with no
+ * recoverable default emits three fields, exactly as before, so a preview whose defaults are all
+ * expressions produces the token it always did.
  */
 public object PreviewKnobToken {
 
@@ -48,7 +58,10 @@ public object PreviewKnobToken {
         !knob.type.hasDelimiter()
     }
     if (entries.isEmpty()) return null
-    return entries.joinToString(ENTRY_SEPARATOR.toString()) { "${it.name}:${it.index}:${it.type}" }
+    return entries.joinToString(ENTRY_SEPARATOR.toString()) { knob ->
+      val head = "${knob.name}:${knob.index}:${knob.type}"
+      knob.default?.let { "$head:${encodeDefault(it)}" } ?: head
+    }
   }
 
   /** The knobs [token] names, skipping any entry that is not well formed. */
@@ -56,13 +69,33 @@ public object PreviewKnobToken {
     if (token.isNullOrBlank()) return emptyList()
     return token.split(ENTRY_SEPARATOR).mapNotNull { entry ->
       val parts = entry.split(FIELD_SEPARATOR)
-      if (parts.size != 3) return@mapNotNull null
+      if (parts.size != 3 && parts.size != 4) return@mapNotNull null
       val name = parts[0].trim().takeIf { it.isNotBlank() } ?: return@mapNotNull null
       val index = parts[1].trim().toIntOrNull()?.takeIf { it >= 0 } ?: return@mapNotNull null
       val type = parts[2].trim().takeIf { it.isNotBlank() } ?: return@mapNotNull null
-      PreviewKnobDto(name = name, index = index, type = type)
+      // A fourth field that will not decode drops the *default*, not the knob: the knob still
+      // seeds, it just cannot be declared. Losing the whole entry would cost the seeding too.
+      val default = parts.getOrNull(3)?.let(::decodeDefault)
+      PreviewKnobDto(name = name, index = index, type = type, default = default)
     }
   }
+
+  /**
+   * Base64url without padding — `=` is a payload delimiter, so the padded alphabet cannot be used
+   * here. An empty default encodes to the empty string, which round-trips as an empty default
+   * rather than as none: `title: String = ""` is a real default a viewer should show.
+   */
+  private fun encodeDefault(default: String): String =
+    java.util.Base64.getUrlEncoder()
+      .withoutPadding()
+      .encodeToString(default.toByteArray(Charsets.UTF_8))
+
+  private fun decodeDefault(encoded: String): String? =
+    try {
+      String(java.util.Base64.getUrlDecoder().decode(encoded), Charsets.UTF_8)
+    } catch (_: IllegalArgumentException) {
+      null
+    }
 
   /** `;` too: it separates payload tokens, so a name carrying one truncates the whole token. */
   private fun String.hasDelimiter(): Boolean =

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewKnobDeclarationsTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewKnobDeclarationsTest.kt
@@ -1,0 +1,131 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
+import ee.schimke.composeai.data.overrides.PreviewOverrideType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the mapping from a discovery knob to the declaration a viewer draws its control from — the
+ * seam that puts both override formats on one channel.
+ */
+class PreviewKnobDeclarationsTest {
+
+  @Test
+  fun `each seedable kind maps to the declaration type a viewer can draw`() {
+    val declarations =
+      PreviewKnobDeclarations.of(
+        listOf(
+          PreviewKnobDto("label", 0, "STRING", "Filled"),
+          PreviewKnobDto("enabled", 1, "BOOLEAN", "true"),
+          PreviewKnobDto("count", 2, "INT", "3"),
+          PreviewKnobDto("ratio", 3, "FLOAT", "0.5"),
+        ),
+        seeds = null,
+      )
+
+    assertEquals(
+      listOf(
+        PreviewOverrideType.STRING,
+        PreviewOverrideType.BOOL,
+        PreviewOverrideType.INT,
+        PreviewOverrideType.FLOAT,
+      ),
+      declarations.map { it.type },
+    )
+    assertEquals(
+      listOf(
+        PreviewOverrideValue.StringValue("Filled"),
+        PreviewOverrideValue.BooleanValue(true),
+        PreviewOverrideValue.IntValue(3),
+        PreviewOverrideValue.FloatValue(0.5f),
+      ),
+      declarations.map { it.default },
+    )
+    // A parameter has a name and nothing else to label it with, and no indexed form — a parameter
+    // list is fixed-arity, so there is no per-row value to address.
+    assertEquals(listOf("label", "enabled", "count", "ratio"), declarations.map { it.label })
+    assertEquals(listOf(null, null, null, null), declarations.map { it.index })
+  }
+
+  @Test
+  fun `Long and Double are declared as text because the type set has no wider numerics`() {
+    // Not a downgrade in reach: a text seed reaches the parameter through the same path and parses
+    // against the knob's own kind. The viewer draws a text field instead of a number field, which
+    // is the whole of the difference — and why an ARGB Long gets a text box, not a colour picker.
+    val declarations =
+      PreviewKnobDeclarations.of(
+        listOf(
+          PreviewKnobDto("accentArgb", 0, "LONG", "4281558783"),
+          PreviewKnobDto("precise", 1, "DOUBLE", "1.5"),
+        ),
+        seeds = null,
+      )
+
+    assertEquals(
+      listOf(PreviewOverrideType.STRING, PreviewOverrideType.STRING),
+      declarations.map { it.type },
+    )
+    assertEquals(
+      listOf(
+        PreviewOverrideValue.StringValue("4281558783"),
+        PreviewOverrideValue.StringValue("1.5"),
+      ),
+      declarations.map { it.default },
+    )
+  }
+
+  @Test
+  fun `current is the seeded value where one bound, and the default everywhere else`() {
+    // A `current` that disagreed with the pixels beside it would be worse than showing nothing.
+    val knobs =
+      listOf(
+        PreviewKnobDto("label", 0, "STRING", "Filled"),
+        PreviewKnobDto("count", 1, "INT", "3"),
+      )
+    val declarations =
+      PreviewKnobDeclarations.of(knobs, mapOf("count" to PreviewOverrideValue.IntValue(9)))
+
+    assertEquals(
+      listOf(PreviewOverrideValue.StringValue("Filled"), PreviewOverrideValue.IntValue(9)),
+      declarations.map { it.current },
+    )
+    // …and `default` still reports what the author wrote, so a viewer can offer "reset".
+    assertEquals(
+      listOf(PreviewOverrideValue.StringValue("Filled"), PreviewOverrideValue.IntValue(3)),
+      declarations.map { it.default },
+    )
+  }
+
+  @Test
+  fun `a knob whose default could not be recovered is left undeclared`() {
+    // `PreviewOverrideDeclaration.default` is not nullable, so declaring one means inventing a
+    // value and presenting it as what the author wrote — a wrong default and a "reset" that resets
+    // to something the preview never said. The knob still seeds; it just has no control.
+    val declarations =
+      PreviewKnobDeclarations.of(
+        listOf(
+          PreviewKnobDto("label", 0, "STRING", null), // `stringResource(...)`
+          PreviewKnobDto("count", 1, "INT", "3"),
+        ),
+        seeds = null,
+      )
+
+    assertEquals(listOf("count"), declarations.map { it.key })
+  }
+
+  @Test
+  fun `a kind this daemon does not know is left undeclared rather than guessed at`() {
+    val declarations =
+      PreviewKnobDeclarations.of(
+        listOf(PreviewKnobDto("accent", 0, "SOMETHING_NEWER", "#FF42A5F5")),
+        seeds = null,
+      )
+    assertEquals(emptyList<String>(), declarations.map { it.key })
+  }
+
+  @Test
+  fun `a preview with no knobs declares nothing`() {
+    assertEquals(emptyList<Any>(), PreviewKnobDeclarations.of(emptyList(), null))
+  }
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewKnobTokenTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewKnobTokenTest.kt
@@ -51,6 +51,47 @@ class PreviewKnobTokenTest {
   }
 
   @Test
+  fun `a literal default rides the token base64-encoded`() {
+    // Encoding is not optional: a default is author-written text and may legitimately contain `:`,
+    // `,`, `;` or `=`, every one of which is a payload delimiter.
+    val awkward =
+      listOf(PreviewKnobDto("title", 0, "STRING", "a:b,c;d=e"), PreviewKnobDto("n", 1, "INT", "3"))
+    val token = PreviewKnobToken.encode(awkward)
+    assertEquals(awkward, PreviewKnobToken.parse(token))
+  }
+
+  @Test
+  fun `a knob with no recoverable default emits three fields, as before`() {
+    // So a preview whose defaults are all expressions produces the token it always did.
+    assertEquals(
+      "title:0:STRING",
+      PreviewKnobToken.encode(listOf(PreviewKnobDto("title", 0, "STRING"))),
+    )
+    assertEquals(
+      listOf(PreviewKnobDto("title", 0, "STRING", null)),
+      PreviewKnobToken.parse("title:0:STRING"),
+    )
+  }
+
+  @Test
+  fun `an empty default round-trips as empty, not as none`() {
+    // `title: String = ""` is a real default a viewer should show as an empty field, which is a
+    // different thing from a default nobody could recover.
+    val empty = listOf(PreviewKnobDto("title", 0, "STRING", ""))
+    assertEquals(empty, PreviewKnobToken.parse(PreviewKnobToken.encode(empty)))
+  }
+
+  @Test
+  fun `an undecodable default drops the default, not the knob`() {
+    // The knob still seeds; it just cannot be declared. Losing the whole entry would cost the
+    // seeding too, which is the more useful half.
+    assertEquals(
+      listOf(PreviewKnobDto("title", 0, "STRING", null)),
+      PreviewKnobToken.parse("title:0:STRING:!!!not-base64!!!"),
+    )
+  }
+
+  @Test
   fun `a name carrying a payload delimiter is omitted rather than corrupting its neighbours`() {
     // Reachable only through a backticked Kotlin name (`my, knob`). Emitting it would split into
     // fragments that swallow the entries around it; dropping the one knob is the smaller loss.

--- a/daemon/desktop/build.gradle.kts
+++ b/daemon/desktop/build.gradle.kts
@@ -88,6 +88,11 @@ dependencies {
   // `renderNow.overrides.namedOverrides` into the `previewOverride*` lookups and produces the
   // `compose/overrides` data product (the preview's declared editable knobs).
   implementation(project(":data-preview-overrides-connector"))
+  // The controller itself, not just the connector that plans it: the render body records a
+  // parameter knob's declaration through `PreviewOverrideController.record` so both override
+  // formats reach `compose/overrides` on one channel. The connector depends on the runtime with
+  // `implementation`, so it isn't on this module's compile classpath transitively.
+  implementation(project(":data-preview-overrides-runtime"))
   // Launcher-widget container-size connector — same module Android consumes. The around-composable
   // wraps the preview body in a sized `Box` matching the clamped whole-cell footprint, driven
   // from `renderNow.overrides.launcherWidget`.

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -662,6 +662,15 @@ class RenderEngine(
                       InvokeWithOptionalWrapper(
                         composableMethod!!,
                         spec.wrapperClassName,
+                        // The preview's parameter knobs, as the declarations a viewer draws its
+                        // controls from. Recorded from inside the composition so they land in the
+                        // same window the `previewOverride*` lookups record theirs — after the
+                        // around-composable's `clearDeclarations`, before the registry reads them.
+                        knobDeclarations =
+                          PreviewKnobDeclarations.of(
+                            spec.knobs,
+                            spec.overrides?.namedOverrides,
+                          ),
                         // A `themeProvider` override (an app-declared @ThemeCatalog
                         // `PreviewWrapperProvider` FQN) replaces the preview's own
                         // `@PreviewWrapper`
@@ -2983,7 +2992,20 @@ private fun InvokeWithOptionalWrapper(
   wrapperFqnFromSpec: String?,
   themeProviderFqn: String? = null,
   previewArgs: List<Any?> = emptyList(),
+  knobDeclarations: List<ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration> =
+    emptyList(),
 ) {
+  // `SideEffect`, not a plain call: the around-composable resets this preview's declarations from a
+  // `DisposableEffect`, and Compose runs every `RememberObserver` before any `SideEffect`, so the
+  // clear always precedes these. That ordering is the same one the `previewOverride*` host relies
+  // on, which is why both formats can share the one declaration channel.
+  if (knobDeclarations.isNotEmpty()) {
+    androidx.compose.runtime.SideEffect {
+      knobDeclarations.forEach {
+        ee.schimke.composeai.overrides.PreviewOverrideController.record(it)
+      }
+    }
+  }
   val wrappers =
     remember(composableMethod, wrapperFqnFromSpec, themeProviderFqn) {
       resolveWrapperStack(composableMethod, wrapperFqnFromSpec, themeProviderFqn)

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
@@ -1657,6 +1657,92 @@ class OverrideIntegrationTest {
   }
 
   /**
+   * The other half of the format, and the last thing between a `previewOverride*` preview and a
+   * parameter-knob one: after the render, the preview's knobs are **declared** — through the same
+   * `PreviewOverrideController` channel `previewOverride*` records into, so the bundle sidecar,
+   * `data/fetch?kind=compose/overrides` and a viewer's control list all pick them up with no change
+   * of their own.
+   *
+   * Reading the controller rather than a fetch result is deliberate: it is the point where the two
+   * formats converge, and on this backend it is also what the registry reads (there is no sandbox,
+   * so the in-classloader controller IS the source of truth — see
+   * `PreviewOverridesDataProductRegistry.readDeclarationsAcrossClassloaders`).
+   *
+   * The assertion covers the pair a control needs and a render cannot supply on its own: `default`
+   * is what the author wrote, so a viewer can offer "reset"; `current` is what is in force, so the
+   * field agrees with the pixels beside it.
+   */
+  @Test
+  fun parameterKnobsAreDeclaredForTheViewerAfterTheRender() {
+    val outputDir = tempFolder.newFolder("renders-parameter-knob-declared")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    val baseSpec =
+      RenderSpec(
+        previewId = "knobbed",
+        className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+        functionName = "KnobbedSquare",
+        widthPx = 32,
+        heightPx = 32,
+        density = 1.0f,
+        // Exactly what `renderSpecFromInfo` reads out of `previews.json`, defaults included.
+        knobs =
+          listOf(
+            PreviewKnobDto("topArgb", 0, "LONG", "4293874512"),
+            PreviewKnobDto("bottomArgb", 1, "LONG", "4284922730"),
+            PreviewKnobDto("label", 2, "STRING", "hi"),
+          ),
+      )
+    val host =
+      DesktopHost(
+        engine =
+          RenderEngine(
+            previewOverrideExtensions =
+              PreviewOverrideExtensions(listOf(PreviewOverridesPreviewOverrideExtension()))
+          ),
+        previewSpecResolver = { id -> baseSpec.takeIf { id == "knobbed" } },
+      )
+    host.start()
+    try {
+      val blue = 0xFF42A5F5L
+      host.submit(
+        RenderRequest.Render(
+          payload = "previewId=knobbed;overrides=${encodeTextBag("topArgb" to blue.toString())}"
+        ),
+        timeoutMs = 30_000,
+      )
+
+      val declared =
+        ee.schimke.composeai.overrides.PreviewOverrideController.declarations().associateBy {
+          it.key
+        }
+      assertEquals(
+        "every knob with a recoverable default must be declared",
+        setOf("topArgb", "bottomArgb", "label"),
+        declared.keys,
+      )
+      // `Long` has no declaration type of its own, so it rides as text — the control is a text
+      // field rather than a number field, and nothing else changes.
+      assertEquals(
+        PreviewOverrideValue.StringValue("4293874512"),
+        declared.getValue("topArgb").default,
+      )
+      assertEquals(
+        "the seeded knob's `current` must be the value actually rendered",
+        PreviewOverrideValue.StringValue(blue.toString()),
+        declared.getValue("topArgb").current,
+      )
+      assertEquals(
+        "an unseeded knob's `current` is its author default",
+        PreviewOverrideValue.StringValue("4284922730"),
+        declared.getValue("bottomArgb").current,
+      )
+      assertEquals(PreviewOverrideValue.StringValue("hi"), declared.getValue("label").current)
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  /**
    * The unseeded baseline for [parameterKnobSeedsOneParameter]: with no override bag at all,
    * [KnobbedSquare] renders both compiled defaults. Without this the test above could pass on a
    * renderer that ignored the seed entirely and happened to paint blue for some other reason.

--- a/docs/design/PARAMETER_KNOB_MIGRATION.md
+++ b/docs/design/PARAMETER_KNOB_MIGRATION.md
@@ -12,7 +12,7 @@ The two formats, in one line each:
 | Where the knob is declared | by **executing a lookup in the composable body** | by the **function signature** |
 | How a value is seeded | writing typed values into a process-static controller before composing | ordinary argument passing |
 | What the preview's body contains | a harness call per knob | nothing — no harness dependency at all |
-| Where the declaration is published | `previews/<id>.overrides.json`, `data/fetch?kind=compose/overrides` | *nowhere yet* — see [gap 1](#gap-1) |
+| Where the declaration is published | `previews/<id>.overrides.json`, `data/fetch?kind=compose/overrides` | `data/fetch?kind=compose/overrides` (daemon lanes); not the bundle sidecar yet |
 | Where the default value comes from | the author passes it at the call site | read back out of the compiled body (`PreviewKnobDefaults`) |
 
 The reference pair to read side by side is
@@ -24,10 +24,12 @@ declared each way. That pair is deliberate and must **not** be collapsed by a mi
 
 ## The verdict
 
-**No sample should move today.** Not because the format is wrong, but because a migrated preview
-loses its editor: nothing publishes a parameter knob's declaration, so a viewer has no knob to show.
-That is [gap 1](#gap-1), and it is the one that decides the answer — though the hard half of it,
-recovering a knob's default *value*, is now solved.
+**A preview whose knobs all carry *literal* defaults can now move without losing its editor.** Both
+daemons publish a parameter knob as a `PreviewOverrideDeclaration`, so a viewer draws the same
+control it draws for a `previewOverride*` knob. What still stops the samples in this repository is
+narrower than it was, and specific: most of their defaults are **expressions**
+(`stringResource(...)`, `Color(0xFF3366FF)`), which cannot be recovered and so cannot be declared —
+plus the structural limits below, which no amount of wiring changes.
 
 Everything below is what the investigation found on the way to that.
 
@@ -77,40 +79,39 @@ A `renderNow.overrides.namedOverrides` seed naming a parameter knob was read by 
 
 ## The gaps that remain
 
-### <a id="gap-1"></a>1. A parameter knob is never *declared* to a client
+### <a id="gap-1"></a>1. A knob defaulted to an expression cannot be declared
 
 `previewOverride*` publishes each knob as a `PreviewOverrideDeclaration` — key, type, label, default
-value, current value — through the controller, into `previews/<id>.overrides.json` and
-`data/fetch?kind=compose/overrides`. That is what a viewer renders its controls from and what
-`preview-harness/serve-lanes.spec.mjs` selects on.
+value, current value — as a by-product of *reading* it, because the lookup knows all five. That fills
+`previews/<id>.overrides.json` and `data/fetch?kind=compose/overrides`, and it is what a viewer's
+control list, the serve `?knob.<key>=` UI and `serve-lanes.spec.mjs` read.
 
-A parameter knob publishes nothing. Rendering the two `samples/cmp` twins side by side shows it
-exactly:
+A parameter knob is declared by a signature and read by ordinary argument passing, so nothing in the
+composition announces it. Both daemons now build the same declarations from `previews.json` and
+record them through the same controller channel, so every consumer downstream works unchanged and
+neither has to know which format a preview used. `PreviewKnobDefaults` supplies the default value the
+declaration needs by reading it back out of the compiled body.
 
-```
-$ ls samples/cmp/build/compose-previews/renders/*.overrides.json
-…/OverridableListPreview_Overridable_List-c264a81f.overrides.json
-# and no ParameterKnobListPreview sidecar
-```
+**What is left is the honest hole in that.** `PreviewOverrideDeclaration.default` is not nullable, so
+a knob whose default this could not recover is left *undeclared* rather than declared with an
+invented value — a viewer would otherwise show a wrong default and offer a "reset" that resets to
+something the preview never said. That bites exactly the defaults the catalogs use:
 
-**The blocker underneath is gone.** A declaration needs the default *value*, and Kotlin metadata
-records only that a default exists — the Compose compiler inlines the default expressions into the
-function body behind the `$default` mask. `PreviewKnobDefaults` reads them back out of the compiled
-body, so `previews.json` now carries a knob's literal default where it has one:
+| Default | Declared? |
+| --- | --- |
+| `title: String = "Shopping list"` | yes |
+| `enabled: Boolean = true`, `count: Int = 3` | yes |
+| `label: String = stringResource(Res.string.label)` | **no** |
+| `accent: Color = Color(0xFF3366FF)` | **no** (and `Color` is not a knob kind anyway — gap 2) |
+| `computed: Int = itemCount + 1` | **no** |
 
-```json
-{ "name": "title",      "index": 0, "type": "STRING", "default": "Shopping list" },
-{ "name": "accentArgb", "index": 1, "type": "LONG",   "default": "4281558783" }
-```
+Closing it properly means a declaration that can say "this knob's default is not knowable", which is
+a change to the published `data-preview-overrides-core` contract rather than to this repository.
 
-A default that is an **expression** rather than a literal — `stringResource(...)`,
-`Color(0xFF3366FF)`, `Modifier`, `itemCount + 1` — comes back as no default, deliberately: a viewer
-showing an invented value tells the reader the preview does something it does not, and a control
-with an absent default is still a usable control.
-
-What is left is the publish itself: turning those knobs into `PreviewOverrideDeclaration`s on the
-render, so the sidecar, `compose/overrides` and the viewer's controls pick them up through the
-channel `previewOverride*` already uses.
+`Long` and `Double` knobs are declared as **text**: `PreviewOverrideType` has `STRING` / `INT` /
+`FLOAT` / `BOOL` / `COLOR` and no wider numerics. That costs the control's shape, not its reach — a
+text seed parses against the knob's own kind on the way in — but it is why an ARGB `Long`, the
+format's stand-in for an editable colour, gets a text box rather than a colour picker.
 
 ### 2. `Color` and `Dp` are not seedable kinds
 
@@ -151,12 +152,16 @@ A parameter knob only exists on the preview's own signature, so moving either wo
 every knob of every branch onto every preview that could reach it — and `CatalogComponent(id:
 String)` reports no knobs anyway, since `id` has no default.
 
-### 6. The offline bake lanes do not seed, and neither does the harness router
+### 6. The offline bake lanes, and the harness router
 
 Both **daemons** — `:daemon:desktop` (live / `serve` / VS Code) and `:daemon:android` (Robolectric)
-— resolve a defaulted preview and seed its parameter knobs. `:renderer-desktop`'s standalone bake
-can bind a seed (`PreviewKnobArguments`, and it resolves the defaulted shape), but nothing hands it
-one: the Gradle render task has no seed to pass. `:renderer-android`'s bake has no bind at all.
+— resolve a defaulted preview, seed its parameter knobs and declare them.
+
+The **offline bake** does neither. `:renderer-desktop` can bind a seed (`PreviewKnobArguments`) but
+nothing hands it one, `:renderer-android` has no bind at all, and neither drains parameter knobs into
+the `previews/<id>.overrides.json` sidecar the way it drains `previewOverride*` ones. So the twin
+comparison that opened this document still comes out uneven for a *baked* bundle, and even for it the
+only thing missing is threading the manifest's knobs into the render shard.
 
 The harness-only `PreviewManifestRouter` (`composeai.harness.previewsManifest`) is the third: its
 manifest wire type carries no `knobs`, so a knobbed preview rendered through a harness fixture
@@ -168,7 +173,7 @@ renders its defaults. No fixture declares one today, which is why it is a note r
 | --- | --- | --- |
 | `samples/cmp/.../OverridablePreviews.kt` | 4 (`title`, `accent`, `itemCount`, `density`, indexed `rowLabel`) | **Keep as is** — it is the deliberate twin of `ParameterKnobPreviews.kt`; the comparison is what the sample is for |
 | `samples/cmp/.../ParameterKnobPreviews.kt` | 5 parameter knobs | Already migrated — the reference |
-| `samples/android-live-lane/.../LiveLanePreviews.kt` | 1 (`label`, on the `@Preview` itself) | **Cleanest candidate, blocked by gap 1 alone** now the Robolectric daemon seeds. `serve-lanes.spec.mjs` asserts `overrides[].key == "label"`, which would go empty |
+| `samples/android-live-lane/.../LiveLanePreviews.kt` | 1 (`label`, on the `@Preview` itself) | **Migratable.** Its default is the literal `"Live lane"`, so the knob declares, and `serve-lanes.spec.mjs`'s `overrides[].key == "label"` still finds it. Not done here — worth doing as its own change, with the lane run to prove it |
 | `design-catalog-m3-shared/.../CatalogComponents.kt` + `CatalogOverrides.kt` (+ actuals) | ~15 across a `when (id)` dispatch | **Cannot** — gap 5, plus `catalogOverrideColor` (gap 2) |
 | `design-catalog-m3/.../CatalogTheme.kt` | 5 (font, colors, shapes, typography, fonts) | **Cannot** — gap 5: read inside the theme wrapper every sticker calls |
 | `design-catalog-m3/.../CatalogTemplates.kt` | `title`, `fab` hoistable; `sender`, `preview` indexed | **Partial at best** — gap 3 |


### PR DESCRIPTION
The last seam between the two override formats, and the end of the line that started at [#5089](https://github.com/yschimke/compose-ai-tools/pull/5089).

`previewOverride*` publishes a `PreviewOverrideDeclaration` per knob as a by-product of *reading* it — the lookup knows the key, the type, the author default and the value in force, and records all four. That fills `previews/<id>.overrides.json` and `data/fetch?kind=compose/overrides`, and it is what a viewer's control list, the serve `?knob.<key>=` UI and `serve-lanes.spec.mjs` read.

A parameter knob is declared by a signature and read by ordinary argument passing, so nothing in the composition ever announces it. Both daemons now build the same declarations from the manifest — using the literal defaults [#5093](https://github.com/yschimke/compose-ai-tools/pull/5093) recovers — and record them through the same controller channel. Every consumer downstream keeps working unchanged, and none of them has to know which format a preview used.

## Three choices, not mechanisms

**A knob whose default could not be recovered is left undeclared.** `PreviewOverrideDeclaration.default` is not nullable, so declaring one means inventing a value and presenting it as what the author wrote — a wrong default, and a "reset" that resets to something the preview never said. The knob still seeds; it just has no control. That bites exactly the defaults the catalogs use (`stringResource(...)`, `Color(0xFF3366FF)`), and closing it properly means a declaration that can say "not knowable" — a change to the published `data-preview-overrides-core` contract rather than to this repository.

**`Long` and `Double` are declared as text.** `PreviewOverrideType` has `STRING` / `INT` / `FLOAT` / `BOOL` / `COLOR` and no wider numerics. That costs the control's shape, not its reach — a text seed parses against the knob's own kind on the way in — but it is why an ARGB `Long`, the format's stand-in for an editable colour, gets a text box rather than a colour picker.

**The default rides the payload token base64-encoded.** On the Robolectric backend the token is the only way a knob crosses into the sandbox, and a default is author-written text that may legitimately contain `:`, `,`, `;` or `=` — every one of them a payload delimiter. A knob with no recoverable default still emits three fields, so a preview whose defaults are all expressions produces the token it always did.

## Where the recording happens

From a `SideEffect` inside the invoke seam — the same window the `previewOverride*` host records in. The around-composable clears this preview's declarations from a `DisposableEffect`, and Compose runs every `RememberObserver` before any `SideEffect`, so the clear always precedes these. That ordering is precisely what lets both formats share one channel.

## Test plan

Non-visual — no rendered surface changes.

* `:daemon:core:test`, `:daemon:desktop:test`, `:daemon:android:testDebugUnitTest` — all green on the rebased head, as are `:daemon:core:checkLegacyAbi` and `ktfmtCheck` on every touched module.
* `AndroidParameterKnobTest.parameterKnobsReachDataFetchAsDeclarationsAcrossTheSandbox` follows a default the whole way on the backend where it travels furthest: read from the class file → encoded into the `knobs=` token → parsed inside the Robolectric sandbox → recorded as a declaration → forwarded across the classloader boundary by the bridge → read back host-side by the registry that answers `data/fetch`. Six hops, and none of them throws when it silently drops a default — which is why the assertion is on the fetched payload rather than any single hop. It checks `default` *and* `current`: the seeded knob's current is the seed, the unseeded one's is its own default, which is also what rendered.
* `OverrideIntegrationTest.parameterKnobsAreDeclaredForTheViewerAfterTheRender` is the desktop twin, reading the controller directly — the point where the two formats converge, and on that backend also what the registry reads.
* `PreviewKnobDeclarationsTest` (6 cases) pins the mapping rules including the two refusals; `PreviewKnobTokenTest` gains 4 for the encoded fourth field, among them a default containing every payload delimiter and one that fails to decode (which drops the default, not the knob — the knob still seeds).

## What this does and doesn't unblock

`docs/design/PARAMETER_KNOB_MIGRATION.md` is updated. A preview whose knobs all carry **literal** defaults can now move without losing its editor — `samples/android-live-lane`'s `LiveLaneCard` is the clear case, its default being the literal `"Live lane"`. Worth doing as its own change, with the serve lane actually run to prove it, rather than folded in here.

Still open, and stated there: knobs defaulted to expressions (most of the catalogs), the two offline bake lanes, and the harness-only `PreviewManifestRouter` manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o

---
_Generated by [Claude Code](https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o)_