### PR TITLE
docs: correct which gap blocks the live-lane sample from migrating

### DIFF
--- a/docs/design/PARAMETER_KNOB_MIGRATION.md
+++ b/docs/design/PARAMETER_KNOB_MIGRATION.md
@@ -24,12 +24,17 @@ declared each way. That pair is deliberate and must **not** be collapsed by a mi
 
 ## The verdict
 
-**A preview whose knobs all carry *literal* defaults can now move without losing its editor.** Both
-daemons publish a parameter knob as a `PreviewOverrideDeclaration`, so a viewer draws the same
-control it draws for a `previewOverride*` knob. What still stops the samples in this repository is
-narrower than it was, and specific: most of their defaults are **expressions**
-(`stringResource(...)`, `Color(0xFF3366FF)`), which cannot be recovered and so cannot be declared —
-plus the structural limits below, which no amount of wiring changes.
+**Still no sample should move — but the reason has changed, and it is now one thing.** Both daemons
+publish a parameter knob as a `PreviewOverrideDeclaration`, so a *live* viewer draws the same
+control it draws for a `previewOverride*` knob. The **offline bake** does not: a bundle's
+`previews/<id>.overrides.json` sidecar is written by draining the controller after a standalone
+render, and the standalone renderers were never taught to record a parameter knob. That sidecar is
+what `compose-preview serve` reads its knob list from — for a daemon-backed host too, which only
+uses the daemon to *render* — so a migrated preview would serve an empty override list.
+
+Two further limits are unaffected by any wiring: most sample defaults are **expressions**
+(`stringResource(...)`, `Color(0xFF3366FF)`), which cannot be recovered and so cannot be declared;
+and the structural ones below.
 
 Everything below is what the investigation found on the way to that.
 
@@ -152,20 +157,31 @@ A parameter knob only exists on the preview's own signature, so moving either wo
 every knob of every branch onto every preview that could reach it — and `CatalogComponent(id:
 String)` reports no knobs anyway, since `id` has no default.
 
-### 6. The offline bake lanes, and the harness router
+### <a id="gap-6"></a>6. The offline bake lane does not record a parameter knob
 
-Both **daemons** — `:daemon:desktop` (live / `serve` / VS Code) and `:daemon:android` (Robolectric)
-— resolve a defaulted preview, seed its parameter knobs and declare them.
+This is now the gap that decides whether a sample can move, so it is worth being exact about.
 
-The **offline bake** does neither. `:renderer-desktop` can bind a seed (`PreviewKnobArguments`) but
-nothing hands it one, `:renderer-android` has no bind at all, and neither drains parameter knobs into
-the `previews/<id>.overrides.json` sidecar the way it drains `previewOverride*` ones. So the twin
-comparison that opened this document still comes out uneven for a *baked* bundle, and even for it the
-only thing missing is threading the manifest's knobs into the render shard.
+A bundle carries each preview's editable knobs in `previews/<id>.overrides.json`. That sidecar is
+written by `DesktopRendererMain.writePreviewOverridesSidecar`, which drains
+`PreviewOverrideController.declarations()` after a standalone render — so it captures whatever the
+`previewOverride*` lookups recorded *during* that render, and nothing else. The standalone renderers
+were never taught that a preview's parameter knobs are declarations too.
 
-The harness-only `PreviewManifestRouter` (`composeai.harness.previewsManifest`) is the third: its
-manifest wire type carries no `knobs`, so a knobbed preview rendered through a harness fixture
-renders its defaults. No fixture declares one today, which is why it is a note rather than a fix.
+`compose-preview serve` reads its knob list from that sidecar (`ServeBundleHost.readOverrides`), and
+so does `/api/previews`. **That holds for a daemon-backed host as well** — the daemon supplies
+renders, not the declaration list. So a migrated preview serves an empty override list even though
+the live daemon would happily seed and declare it.
+
+The fix is small in shape and unglamorous in plumbing: hand the standalone renderers the knobs
+discovery already recorded, and record them into the controller before the render, exactly as both
+daemons now do. The desktop renderer takes positional CLI args plus a `composeai.overrides.seed`
+system property, so the knobs would ride a property beside it; the Android renderer has a manifest
+entry (`RenderPreviewEntry`) and would carry a field. Both then fill the sidecar for free, because
+the drain already exists.
+
+The harness-only `PreviewManifestRouter` (`composeai.harness.previewsManifest`) is a separate, much
+smaller hole: its manifest wire type carries no `knobs`, so a knobbed preview rendered through a
+harness fixture renders its defaults. No fixture declares one today.
 
 ## The samples, one by one
 
@@ -173,7 +189,7 @@ renders its defaults. No fixture declares one today, which is why it is a note r
 | --- | --- | --- |
 | `samples/cmp/.../OverridablePreviews.kt` | 4 (`title`, `accent`, `itemCount`, `density`, indexed `rowLabel`) | **Keep as is** — it is the deliberate twin of `ParameterKnobPreviews.kt`; the comparison is what the sample is for |
 | `samples/cmp/.../ParameterKnobPreviews.kt` | 5 parameter knobs | Already migrated — the reference |
-| `samples/android-live-lane/.../LiveLanePreviews.kt` | 1 (`label`, on the `@Preview` itself) | **Migratable.** Its default is the literal `"Live lane"`, so the knob declares, and `serve-lanes.spec.mjs`'s `overrides[].key == "label"` still finds it. Not done here — worth doing as its own change, with the lane run to prove it |
+| `samples/android-live-lane/.../LiveLanePreviews.kt` | 1 (`label`, on the `@Preview` itself) | **Blocked by gap 6, not gap 1.** Its default is the literal `"Live lane"`, so the knob would declare on a live daemon — but this sample is the fixture for `serve-lanes.spec.mjs` in [`compose-preview-server`](https://github.com/yschimke/compose-preview-server), which selects on `overrides[].key == "label"` read from the **bundle sidecar** and *fails* rather than skips when no such preview is found. Migrating it before the bake lane records parameter knobs breaks that e2e |
 | `design-catalog-m3-shared/.../CatalogComponents.kt` + `CatalogOverrides.kt` (+ actuals) | ~15 across a `when (id)` dispatch | **Cannot** — gap 5, plus `catalogOverrideColor` (gap 2) |
 | `design-catalog-m3/.../CatalogTheme.kt` | 5 (font, colors, shapes, typography, fonts) | **Cannot** — gap 5: read inside the theme wrapper every sticker calls |
 | `design-catalog-m3/.../CatalogTemplates.kt` | `title`, `fab` hoistable; `sender`, `preview` indexed | **Partial at best** — gap 3 |

--- a/samples/android-live-lane/build.gradle.kts
+++ b/samples/android-live-lane/build.gradle.kts
@@ -1,5 +1,10 @@
-// `:samples:android-live-lane` — the fixture behind the **Android (Robolectric) serve lane** e2e
-// (`.github/workflows/serve-lanes-e2e.yml`, job `serve-lanes-android`).
+// `:samples:android-live-lane` — the fixture behind the **Android (Robolectric) serve lane** e2e.
+//
+// That e2e lives in the split-out `yschimke/compose-preview-server`
+// (`preview-harness/serve-lanes.spec.mjs`, driven by `serve-lanes-boot.sh`), NOT in this
+// repository — the workflow and spec this comment used to name were moved with the preview server
+// and nothing here builds or runs them. This module is still the fixture they consume, so it is
+// load-bearing for a suite whose failures surface in the other repo.
 //
 // It is packed into a bundle and live-rendered by a daemon-backed `compose-preview serve`,
 // reproducing the shape that let #2669 ship broken: a merged manifest naming an `Application` the
@@ -11,8 +16,14 @@
 //
 // Deliberately tiny (one preview file, no resources, no theme) so the e2e's cold Robolectric start
 // dominates rather than the build. The single `@Preview` declares a `label` string knob, which is
-// the contract `preview-harness/serve-lanes.spec.mjs` looks for — so the Android lane reuses the
+// the contract the spec selects on (`overrides[].key == "label"`) — so the Android lane reuses the
 // desktop lane's spec unmodified.
+//
+// **That knob must stay a `previewOverride*` one for now.** The spec reads the override list from
+// the bundle's `previews/<id>.overrides.json` sidecar, which only the `previewOverride*` surface
+// writes; the parameter-knob format is not recorded by the offline bake yet, and the spec FAILS
+// rather than skips when it finds no label-knob preview. See
+// `docs/design/PARAMETER_KNOB_MIGRATION.md` → gap 6.
 plugins {
   id("composeai.base-conventions")
   id("composeai.android-conventions")

--- a/samples/android-live-lane/src/main/kotlin/com/example/androidlivelane/LiveLanePreviews.kt
+++ b/samples/android-live-lane/src/main/kotlin/com/example/androidlivelane/LiveLanePreviews.kt
@@ -16,10 +16,11 @@ import ee.schimke.composeai.overrides.previewOverrideString
  * The preview the Android serve-lane e2e renders.
  *
  * The declared `label` string knob is the contract `preview-harness/serve-lanes.spec.mjs` selects
- * on (`overrides[].key == "label"`), so this preview drives the same PNG / SVG / Live-WebSocket
- * assertions the desktop `compose-m3` lane runs — only here the render comes from the Robolectric
- * daemon, whose sandbox has to survive this module's deliberately unresolvable manifest
- * `Application` (see `AndroidManifest.xml`).
+ * on (`overrides[].key == "label"`) — that spec lives in the split-out
+ * `yschimke/compose-preview-server`, not here — so this preview drives the same PNG / SVG /
+ * Live-WebSocket assertions the desktop `compose-m3` lane runs — only here the render comes from
+ * the Robolectric daemon, whose sandbox has to survive this module's deliberately unresolvable
+ * manifest `Application` (see `AndroidManifest.xml`).
  *
  * Text-only on purpose: the assertions compare bytes across a knob flip, so the label has to be the
  * dominant thing on screen, and nothing here should need app resources or a theme the bundle would


### PR DESCRIPTION
I set out to migrate `samples/android-live-lane` to the parameter-knob format — the one sample [#5095](https://github.com/yschimke/compose-ai-tools/pull/5095) was supposed to unblock — and found the claim that it was unblocked is wrong. This corrects it rather than shipping the migration.

## What I got wrong

`PARAMETER_KNOB_MIGRATION.md` said the sample was migratable once declarations landed, on the strength of `serve-lanes.spec.mjs` selecting `overrides[].key == "label"`. I carried that from the sample's own KDoc without checking **where the consumer reads its override list from**.

It reads the **bundle sidecar**:

```kotlin
// ServeBundleHost.readOverrides
val sidecar = File(previewsDir, "$id$OVERRIDES_SUFFIX")   // previews/<id>.overrides.json
```

`/api/previews` serves exactly that list, and it does so **for a daemon-backed host too** — the daemon supplies renders, not declarations. The sidecar is written by `DesktopRendererMain.writePreviewOverridesSidecar`, which drains the controller after a *standalone* render, and the standalone renderers still don't record a parameter knob.

So a migrated `LiveLaneCard` would serve an empty override list. The spec then finds no label-knob preview and **fails rather than skips** — that's explicit in its own words:

> `no label-knob preview at /${SYSTEM}/api/previews — the daemon-backed serve isn't exposing the expected catalog; refusing to green-skip the Serve Lanes suite`

I can't run that suite from here — it lives in the split-out [`compose-preview-server`](https://github.com/yschimke/compose-preview-server) and needs a daemon-backed serve under Playwright — so shipping the migration would have handed a red required e2e to the other repo with no local signal.

## What changed

* **Gap 6 rewritten.** It was a short note about the bake lanes among other loose ends; it is now the gap that decides whether any sample can move, so it says exactly what is missing (the standalone renderers never record parameter knobs), why that reaches `serve` (the sidecar is the declaration source even for a live host), and what the fix looks like (hand the renderers the knobs discovery already recorded; the drain into the sidecar already exists).
* **The verdict section** no longer says a literal-defaulted preview can move today. It can move on a *live* viewer; it cannot survive the bake.
* **The sample's row** now reads "blocked by gap 6, not gap 1", with the reason.

## Two stale pointers, fixed while confirming this

`samples/android-live-lane` named `.github/workflows/serve-lanes-e2e.yml` and `preview-harness/serve-lanes.spec.mjs` as if they lived here. Neither exists in this repository — both moved to `compose-preview-server` with the preview-server split, so nothing here builds or runs them. The module is still the fixture that suite consumes, which is worth saying plainly since its failures surface in the other repo, plus a note that the knob has to stay `previewOverride*` until the bake lane records the other format.

## Test plan

Docs and comments only — no source change, nothing to run beyond formatting.

* `:samples:android-live-lane:ktfmtCheckMain` passes.
* The claims above were verified against the actual code rather than inferred: `ServeBundleHost.readOverrides`, `ServeHttpServer`'s `PreviewDto.overrides`, and `serve-lanes.spec.mjs`'s selection and failure text, all read in the `compose-preview-server` checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o

---
_Generated by [Claude Code](https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o)_