### PR TITLE
fix(daemon): report the cause chain, not just the head throwable

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -1339,7 +1339,7 @@ public class JsonRpcServer(
     } catch (t: Throwable) {
       System.err.println(
         "compose-ai-daemon: data product onRender failed for $previewId " +
-          "(${t.javaClass.simpleName}: ${t.message})"
+          "(${describeThrowable(t)})"
       )
     }
     val tookMs = result.metrics?.get("tookMs") ?: 0L
@@ -1463,7 +1463,7 @@ public class JsonRpcServer(
         } catch (t: Throwable) {
           System.err.println(
             "compose-ai-daemon: history: failed to read PNG bytes for $previewId at $pngPath " +
-              "(${t.javaClass.simpleName}: ${t.message}); skipping history entry"
+              "(${describeThrowable(t)}); skipping history entry"
           )
           return
         }
@@ -1515,7 +1515,7 @@ public class JsonRpcServer(
       } catch (t: Throwable) {
         System.err.println(
           "compose-ai-daemon: history: HistoryManager.recordRender($previewId) threw " +
-            "(${t.javaClass.simpleName}: ${t.message}); continuing"
+            "(${describeThrowable(t)}); continuing"
         )
         return
       }
@@ -1541,7 +1541,7 @@ public class JsonRpcServer(
     } catch (t: Throwable) {
       System.err.println(
         "compose-ai-daemon: history: $kind fetch for $previewId failed " +
-          "(${t.javaClass.simpleName}: ${t.message}); recording entry without it"
+          "(${describeThrowable(t)}); recording entry without it"
       )
       null
     }
@@ -2019,7 +2019,7 @@ public class JsonRpcServer(
     } catch (t: Throwable) {
       System.err.println(
         "compose-ai-daemon: data product onRenderFailed failed for $previewId " +
-          "(${t.javaClass.simpleName}: ${t.message})"
+          "(${describeThrowable(t)})"
       )
     }
     // D3 — wake any data/fetch waiter that queued this render so it can return
@@ -2629,10 +2629,10 @@ public class JsonRpcServer(
           overrides = params.overrides,
         )
       } catch (t: UnsupportedOperationException) {
-        fallbackReason = "${t.javaClass.simpleName}: ${t.message}"
+        fallbackReason = "${describeThrowable(t)}"
         null
       } catch (t: Throwable) {
-        val reason = "${t.javaClass.simpleName}: ${t.message}"
+        val reason = "${describeThrowable(t)}"
         if (host.supportsInteractive) {
           sendErrorResponse(
             id = req.id,
@@ -2753,7 +2753,7 @@ public class JsonRpcServer(
         sendErrorResponse(
           req.id,
           ERR_INTERNAL,
-          "xr/start: render failed: ${t.javaClass.simpleName}: ${t.message}",
+          "xr/start: render failed: ${describeThrowable(t)}",
         )
         return
       }
@@ -2787,7 +2787,7 @@ public class JsonRpcServer(
       } catch (t: Throwable) {
         System.err.println(
           "compose-ai-daemon: xr/updatePanels failed for ${params.frameStreamId}: " +
-            "${t.javaClass.simpleName}: ${t.message}"
+            "${describeThrowable(t)}"
         )
         return
       }
@@ -2820,7 +2820,7 @@ public class JsonRpcServer(
         sendErrorResponse(
           req.id,
           ERR_INTERNAL,
-          "xr/structure failed: ${t.javaClass.simpleName}: ${t.message}",
+          "xr/structure failed: ${describeThrowable(t)}",
         )
         return
       }
@@ -2854,7 +2854,7 @@ public class JsonRpcServer(
       // decoder state this method exists to release.
       System.err.println(
         "compose-ai-daemon: xr/stop close failed for ${params.frameStreamId}: " +
-          "${t.javaClass.simpleName}: ${t.message}; continuing"
+          "${describeThrowable(t)}; continuing"
       )
     }
     if (finalFrame != null) {
@@ -2922,7 +2922,7 @@ public class JsonRpcServer(
           overrides = params.overrides,
         )
       } catch (t: UnsupportedOperationException) {
-        fallbackReason = "${t.javaClass.simpleName}: ${t.message}"
+        fallbackReason = "${describeThrowable(t)}"
         null
       } catch (t: Throwable) {
         // Same policy as interactive/start: if the host claims to support held sessions but
@@ -2933,11 +2933,11 @@ public class JsonRpcServer(
             code = ERR_INTERNAL,
             message =
               "stream/start: host advertises held sessions but failed to acquire one for " +
-                "previewId='${params.previewId}': ${t.javaClass.simpleName}: ${t.message}",
+                "previewId='${params.previewId}': ${describeThrowable(t)}",
           )
           return
         }
-        fallbackReason = "${t.javaClass.simpleName}: ${t.message}"
+        fallbackReason = "${describeThrowable(t)}"
         null
       }
     val codec = streamRegistry.negotiateCodec(params.codec)
@@ -3004,7 +3004,7 @@ public class JsonRpcServer(
       } catch (t: Throwable) {
         System.err.println(
           "compose-ai-daemon: stream/stop: session.close() threw " +
-            "(${t.javaClass.simpleName}: ${t.message}); continuing"
+            "(${describeThrowable(t)}); continuing"
         )
       }
     }
@@ -3049,7 +3049,7 @@ public class JsonRpcServer(
       } catch (t: Throwable) {
         System.err.println(
           "compose-ai-daemon: interactive/stop: session.close() threw " +
-            "(${t.javaClass.simpleName}: ${t.message}); continuing"
+            "(${describeThrowable(t)}); continuing"
         )
       }
     }
@@ -3508,12 +3508,12 @@ public class JsonRpcServer(
       } catch (t: Throwable) {
         System.err.println(
           "compose-ai-daemon: recording/start: acquireRecordingSession failed for " +
-            "previewId='${params.previewId}': ${t.javaClass.simpleName}: ${t.message}"
+            "previewId='${params.previewId}': ${describeThrowable(t)}"
         )
         sendErrorResponse(
           id = req.id,
           code = ERR_INTERNAL,
-          message = "recording/start: ${t.javaClass.simpleName}: ${t.message}",
+          message = "recording/start: ${describeThrowable(t)}",
         )
         return
       }
@@ -3536,7 +3536,7 @@ public class JsonRpcServer(
     } catch (t: Throwable) {
       System.err.println(
         "compose-ai-daemon: recording/script: postScript failed for " +
-          "recordingId='${params.recordingId}': ${t.javaClass.simpleName}: ${t.message}"
+          "recordingId='${params.recordingId}': ${describeThrowable(t)}"
       )
     }
   }
@@ -3556,7 +3556,7 @@ public class JsonRpcServer(
     } catch (t: Throwable) {
       System.err.println(
         "compose-ai-daemon: recording/input: postInput failed for " +
-          "recordingId='${params.recordingId}': ${t.javaClass.simpleName}: ${t.message}"
+          "recordingId='${params.recordingId}': ${describeThrowable(t)}"
       )
     }
   }
@@ -3611,7 +3611,7 @@ public class JsonRpcServer(
             sendErrorResponse(
               id = req.id,
               code = ERR_INTERNAL,
-              message = "recording/stop: ${t.javaClass.simpleName}: ${t.message}",
+              message = "recording/stop: ${describeThrowable(t)}",
             )
           }
         },
@@ -3671,7 +3671,7 @@ public class JsonRpcServer(
       sendErrorResponse(
         id = req.id,
         code = ERR_INTERNAL,
-        message = "recording/generateTest: ${t.javaClass.simpleName}: ${t.message}",
+        message = "recording/generateTest: ${describeThrowable(t)}",
       )
     }
   }
@@ -3722,7 +3722,7 @@ public class JsonRpcServer(
             sendErrorResponse(
               id = req.id,
               code = ERR_INTERNAL,
-              message = "recording/encode: ${t.javaClass.simpleName}: ${t.message}",
+              message = "recording/encode: ${describeThrowable(t)}",
             )
           }
         },
@@ -3985,7 +3985,7 @@ public class JsonRpcServer(
               } catch (t: Throwable) {
                 System.err.println(
                   "compose-ai-daemon: incrementalDiscovery: invalid path '$path' " +
-                    "(${t.javaClass.simpleName}: ${t.message}); skipping"
+                    "(${describeThrowable(t)}); skipping"
                 )
                 return@Thread
               }
@@ -3997,8 +3997,7 @@ public class JsonRpcServer(
             emitDiscoveryUpdated(diff)
           } catch (t: Throwable) {
             System.err.println(
-              "compose-ai-daemon: incrementalDiscovery worker failed " +
-                "(${t.javaClass.simpleName}: ${t.message})"
+              "compose-ai-daemon: incrementalDiscovery worker failed " + "(${describeThrowable(t)})"
             )
             t.printStackTrace(System.err)
           }
@@ -4166,7 +4165,7 @@ public class JsonRpcServer(
       sessions.close()
     } catch (e: Throwable) {
       System.err.println(
-        "compose-ai-daemon: xrSessions.close failed: ${e.javaClass.simpleName}: ${e.message}; " +
+        "compose-ai-daemon: xrSessions.close failed: ${describeThrowable(e)}; " +
           "continuing shutdown"
       )
     }
@@ -4192,7 +4191,7 @@ public class JsonRpcServer(
       } catch (e: Throwable) {
         System.err.println(
           "compose-ai-daemon: closeAllInteractiveSessions: session.close() " +
-            "(${session.previewId}) threw ${e.javaClass.simpleName}: ${e.message}; continuing"
+            "(${session.previewId}) threw ${describeThrowable(e)}; continuing"
         )
       }
     }
@@ -4212,7 +4211,7 @@ public class JsonRpcServer(
       } catch (e: Throwable) {
         System.err.println(
           "compose-ai-daemon: closeAllRecordingSessions: session.close() " +
-            "(${session.previewId}) threw ${e.javaClass.simpleName}: ${e.message}; continuing"
+            "(${session.previewId}) threw ${describeThrowable(e)}; continuing"
         )
       }
     }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/ThrowableDescription.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/ThrowableDescription.kt
@@ -1,0 +1,67 @@
+package ee.schimke.composeai.daemon
+
+/**
+ * Render [t] for a daemon log line or a JSON-RPC error message, **including its cause chain**.
+ *
+ * The daemon used to spell these as `"${t.javaClass.simpleName}: ${t.message}"`. That reads fine
+ * for the throwables which carry their own explanation, and loses the whole failure for the ones
+ * that do not:
+ * ```
+ * recording/start: ExceptionInInitializerError: null
+ * ```
+ *
+ * `ExceptionInInitializerError` has a **null message** by construction — the class that failed to
+ * initialise and the reason it failed both live in its `cause`. So does
+ * `InvocationTargetException`, and so does every wrapper a reflective preview invocation travels
+ * through. The line above names neither the class nor the reason, and the client sees the same
+ * string, so a failure that is perfectly diagnosable inside the JVM arrives as a dead end at both
+ * ends of the wire.
+ *
+ * The chain is what makes it diagnosable, so the chain is what this renders:
+ * ```
+ * ExceptionInInitializerError ← caused by NoClassDefFoundError: kotlinx/coroutines/GlobalScope
+ * ```
+ *
+ * Depth is capped at [MAX_CAUSE_DEPTH] and self-referential chains terminate: a message that lands
+ * in a log line and a protocol field has to stay bounded whatever the JVM hands us.
+ */
+internal fun describeThrowable(t: Throwable): String {
+  val out = StringBuilder()
+  var current: Throwable? = t
+  var depth = 0
+  // Identity, not equality: a cause chain can legitimately repeat an equal-but-distinct throwable,
+  // and only a cycle through the *same* instance would spin here.
+  val seen = java.util.Collections.newSetFromMap(java.util.IdentityHashMap<Throwable, Boolean>())
+  while (current != null && depth <= MAX_CAUSE_DEPTH) {
+    if (!seen.add(current)) {
+      out.append(" ← caused by (cycle)")
+      break
+    }
+    if (depth > 0) out.append(" ← caused by ")
+    out.append(describeOne(current))
+    val next = current.cause
+    if (next != null && depth == MAX_CAUSE_DEPTH) {
+      out.append(" ← caused by …")
+      break
+    }
+    current = next
+    depth++
+  }
+  return out.toString()
+}
+
+/** `SimpleName: message`, or the bare name when there is no message worth printing. */
+private fun describeOne(t: Throwable): String {
+  // `simpleName` is empty for an anonymous class; fall back to the binary name so the line still
+  // names something.
+  val name = t.javaClass.simpleName.ifEmpty { t.javaClass.name }
+  val message = t.message?.trim()
+  return if (message.isNullOrEmpty()) name else "$name: $message"
+}
+
+/**
+ * How many causes deep to walk. Four links past the head covers the wrapper stacks this daemon
+ * actually produces (reflection → class init → linkage) without letting a pathological chain turn
+ * one log line into a page.
+ */
+private const val MAX_CAUSE_DEPTH = 4

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/ThrowableDescriptionTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/ThrowableDescriptionTest.kt
@@ -1,0 +1,88 @@
+package ee.schimke.composeai.daemon
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The property that matters: a throwable whose own message is null must still say what went wrong.
+ * Each test below fails against the old `"${t.javaClass.simpleName}: ${t.message}"` spelling.
+ */
+class ThrowableDescriptionTest {
+
+  @Test
+  fun rendersNameAndMessage() {
+    assertEquals("IllegalStateException: boom", describeThrowable(IllegalStateException("boom")))
+  }
+
+  @Test
+  fun omitsTheColonWhenThereIsNoMessage() {
+    // The old spelling produced "IllegalStateException: null" here.
+    assertEquals("IllegalStateException", describeThrowable(IllegalStateException()))
+  }
+
+  @Test
+  fun blankMessageIsTreatedAsAbsent() {
+    assertEquals("IllegalStateException", describeThrowable(IllegalStateException("   ")))
+  }
+
+  /**
+   * The real case from the field: `recording/start` reported `ExceptionInInitializerError: null`,
+   * which names neither the class that failed to initialise nor why. The cause carries both.
+   */
+  @Test
+  fun carriesTheCauseOfAMessagelessThrowable() {
+    val boom = ExceptionInInitializerError(NoClassDefFoundError("kotlinx/coroutines/GlobalScope"))
+    assertEquals(
+      "ExceptionInInitializerError ← caused by NoClassDefFoundError: kotlinx/coroutines/GlobalScope",
+      describeThrowable(boom),
+    )
+  }
+
+  @Test
+  fun walksSeveralLinks() {
+    val root = IllegalArgumentException("bad arg")
+    val mid = RuntimeException("wrapping", root)
+    val top = IllegalStateException("outer", mid)
+    assertEquals(
+      "IllegalStateException: outer ← caused by RuntimeException: wrapping ← " +
+        "caused by IllegalArgumentException: bad arg",
+      describeThrowable(top),
+    )
+  }
+
+  /** A long chain is truncated rather than allowed to fill a log line or a protocol field. */
+  @Test
+  fun capsDepth() {
+    var t = RuntimeException("level-0")
+    repeat(12) { t = RuntimeException("level-${it + 1}", t) }
+    val described = describeThrowable(t)
+    assertTrue("must mark the truncation: $described", described.endsWith("← caused by …"))
+    // Four rendered causes after the head, then the ellipsis: five separators in total.
+    assertEquals(
+      "head + 4 causes + the truncation marker",
+      5,
+      described.split("← caused by ").size - 1,
+    )
+    assertTrue("head must survive: $described", described.startsWith("RuntimeException: level-12"))
+  }
+
+  /** A cause cycle must terminate rather than spin. */
+  @Test
+  fun terminatesOnACycle() {
+    val a = RuntimeException("a")
+    val b = RuntimeException("b", a)
+    a.initCause(b)
+    val described = describeThrowable(a)
+    assertTrue("must report the cycle: $described", described.contains("(cycle)"))
+  }
+
+  /** An anonymous throwable subclass has an empty `simpleName`; the line must still name it. */
+  @Test
+  fun namesAnAnonymousThrowable() {
+    val anon = object : RuntimeException("anon") {}
+    val described = describeThrowable(anon)
+    assertTrue("must not start with a bare colon: $described", !described.startsWith(":"))
+    assertTrue("must carry the message: $described", described.contains("anon"))
+  }
+}


### PR DESCRIPTION
Driving the live keyboard-navigation lane against m3-catalog, `recording/start` failed with this, on both the daemon's stderr and the JSON-RPC error the client receives:

```
recording/start: ExceptionInInitializerError: null
```

That line names neither the class that failed to initialise nor why. It isn't merely terse — it's structurally empty: `ExceptionInInitializerError` has a **null message by construction**, and the entire failure lives in its `cause`. So does `InvocationTargetException`, and so does every wrapper a reflective preview invocation travels through. Both ends of the wire got the same dead end, so diagnosing it meant calling `recording/start` a *second* time just to make the JVM say `NoClassDefFoundError: Could not initialize class org.jetbrains.skia.Surface` — the linkage error the first attempt had already discarded.

## The change

`describeThrowable` walks the cause chain. Applied at all 28 sites in `JsonRpcServer` that spelled `"${t.javaClass.simpleName}: ${t.message}"` by hand, so the interactive, recording, xr and history lanes gain it together rather than one lane at a time.

Same failure, before and after — this is the actual output, captured from a daemon built at this commit against the same broken environment:

**Before**
```
recording/start: ExceptionInInitializerError: null
```

**After**
```
recording/start: ExceptionInInitializerError
  ← caused by LibraryLoadException: Failed to loade library …/libskiko-linux-x64.so
  ← caused by UnsatisfiedLinkError: …/libskiko-linux-x64.so: /lib/x86_64-linux-gnu/libc.so.6:
    version `GLIBC_ABI_DT_X86_64_PLT' not found (required by …/glibc-2.42-67/lib/libpthread.so.0)
```

The second one says what is wrong: a stale `LD_LIBRARY_PATH` had reached the daemon subprocess and put a nix glibc in front of the system one, so skiko's native library could not link. That was a real environment fault, and it was fully diagnosable inside the JVM the whole time — the daemon was just throwing the evidence away.

A null or blank message now yields the bare class name (`IllegalStateException`) rather than the old `IllegalStateException: null`.

## Bounds

These strings land in log lines *and* in a protocol field, so they stay bounded whatever the JVM hands us:

- depth capped at 4 causes past the head, with the truncation marked `← caused by …`;
- cause cycles terminate and are reported as `(cycle)`, compared by **identity** so a legitimately-repeated equal throwable still renders;
- an anonymous throwable subclass (empty `simpleName`) falls back to the binary name instead of emitting a bare `: message`.

## Test plan

`ThrowableDescriptionTest` — 8 cases, each written against the behaviour the old spelling got wrong: the messageless-throwable case asserts the exact `ExceptionInInitializerError ← caused by NoClassDefFoundError: …` string that the old code rendered as `: null`.

- `:daemon:core:test` — **green**, full suite, forced rerun (`--rerun-tasks`).
- `./gradlew ktfmtCheckAll` — green.
- Rebased onto `bbf60f9` and both re-run green after the rebase.

One note for the record: on the first full-suite run, `JsonRpcServerIntegrationTest.classpath_fingerprint_dirty_emits_classpathDirty_and_exits` failed. It passes on a clean tree, and it also passes on this branch both in isolation and on a forced full rerun — it awaits a 5-second latch on a daemon self-exit, so it's timing-sensitive. I'm flagging it rather than claiming it as mine or silently ignoring it; nothing in this diff touches classpath fingerprinting.

Non-visual — no rendered surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKa4vow5EnyW4mUz2yE4BU

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKa4vow5EnyW4mUz2yE4BU)_