### PR TITLE
feat(renderer-android): record a preview's parameter knobs during a bake

### DIFF
--- a/docs/design/PARAMETER_KNOB_MIGRATION.md
+++ b/docs/design/PARAMETER_KNOB_MIGRATION.md
@@ -24,13 +24,19 @@ declared each way. That pair is deliberate and must **not** be collapsed by a mi
 
 ## The verdict
 
-**Still no sample should move — but the reason has changed, and it is now one thing.** Both daemons
-publish a parameter knob as a `PreviewOverrideDeclaration`, so a *live* viewer draws the same
-control it draws for a `previewOverride*` knob. The **offline bake** does not: a bundle's
-`previews/<id>.overrides.json` sidecar is written by draining the controller after a standalone
-render, and the standalone renderers were never taught to record a parameter knob. That sidecar is
-what `compose-preview serve` reads its knob list from — for a daemon-backed host too, which only
-uses the daemon to *render* — so a migrated preview would serve an empty override list.
+**No sample should move from this repository yet, but the wiring no longer stops one.** Both
+daemons publish a parameter knob as a `PreviewOverrideDeclaration`, so a *live* viewer draws the
+same control it draws for a `previewOverride*` knob — and the **Android offline bake** now does too,
+recording the manifest's knobs onto the same controller channel before the render so the existing
+drain writes them into `previews/<id>.overrides.json`. That sidecar is what `compose-preview serve`
+reads its knob list from, for a daemon-backed host too (which only uses the daemon to *render*).
+
+Two things still hold a sample back, and they are different in kind. The **desktop** standalone
+renderer still records nothing — it has no manifest to read — so a CMP sample would still bake an
+empty override list ([gap 6](#gap-6)). And the one Android sample that could now move,
+`android-live-lane`, is the fixture for a suite that lives in another repository and *fails* rather
+than skips: migrating it blind would hand `compose-preview-server` a red required e2e with no local
+signal, so that migration belongs in a change where the suite can actually be run.
 
 Two further limits are unaffected by any wiring: most sample defaults are **expressions**
 (`stringResource(...)`, `Color(0xFF3366FF)`), which cannot be recovered and so cannot be declared;
@@ -157,27 +163,32 @@ A parameter knob only exists on the preview's own signature, so moving either wo
 every knob of every branch onto every preview that could reach it — and `CatalogComponent(id:
 String)` reports no knobs anyway, since `id` has no default.
 
-### <a id="gap-6"></a>6. The offline bake lane does not record a parameter knob
+### <a id="gap-6"></a>6. The desktop bake lane does not record a parameter knob
 
-This is now the gap that decides whether a sample can move, so it is worth being exact about.
+**Android: closed.** **Desktop: open**, and it is what keeps a CMP sample from moving.
 
-A bundle carries each preview's editable knobs in `previews/<id>.overrides.json`. That sidecar is
-written by `DesktopRendererMain.writePreviewOverridesSidecar`, which drains
-`PreviewOverrideController.declarations()` after a standalone render — so it captures whatever the
-`previewOverride*` lookups recorded *during* that render, and nothing else. The standalone renderers
-were never taught that a preview's parameter knobs are declarations too.
-
+A bundle carries each preview's editable knobs in `previews/<id>.overrides.json`, written by
+draining `PreviewOverrideController.declarations()` after a standalone render — so it captures
+whatever the `previewOverride*` lookups recorded *during* that render. A parameter knob is read by
+argument passing and records nothing, so that drain used to come back empty for a migrated preview.
 `compose-preview serve` reads its knob list from that sidecar (`ServeBundleHost.readOverrides`), and
-so does `/api/previews`. **That holds for a daemon-backed host as well** — the daemon supplies
-renders, not the declaration list. So a migrated preview serves an empty override list even though
-the live daemon would happily seed and declare it.
+so does `/api/previews`; **that holds for a daemon-backed host as well**, because the daemon
+supplies renders and not the declaration list.
 
-The fix is small in shape and unglamorous in plumbing: hand the standalone renderers the knobs
-discovery already recorded, and record them into the controller before the render, exactly as both
-daemons now do. The desktop renderer takes positional CLI args plus a `composeai.overrides.seed`
-system property, so the knobs would ride a property beside it; the Android renderer has a manifest
-entry (`RenderPreviewEntry`) and would carry a field. Both then fill the sidecar for free, because
-the drain already exists.
+On the **Android/Robolectric** lane this is now wired. `RenderPreviewEntry` carries the manifest's
+`knobs` (`previews.json` had the field all along — the renderer was dropping it), and
+`PreviewKnobBake` turns them into declarations recorded onto the controller just after the
+`@OverrideVariant` seed and just after `clearDeclarations()`, so the existing drain publishes them.
+The same object binds a seed that names a knob onto the composable's argument list, with the
+defaults-mask invoke a partial seed needs. No plugin change was involved.
+
+The **desktop** renderer is the remaining half, and it is more plumbing than idea: it has no
+manifest to read — `DesktopRendererMain` takes positional CLI args plus the per-capture
+`composeai.overrides.seed` system property — so the knobs need a channel of their own. A property
+beside the seed covers the forked lane; the pooled lane needs the same payload on
+`DesktopRenderWorkerPool`'s request frame, because a worker outlives one capture and must not
+inherit the previous preview's knobs. Everything past that is shared with the Android side: build
+the declarations, record them before the render, and the drain fills the sidecar for free.
 
 The harness-only `PreviewManifestRouter` (`composeai.harness.previewsManifest`) is a separate, much
 smaller hole: its manifest wire type carries no `knobs`, so a knobbed preview rendered through a
@@ -188,8 +199,8 @@ harness fixture renders its defaults. No fixture declares one today.
 | Sample | Knobs | Verdict |
 | --- | --- | --- |
 | `samples/cmp/.../OverridablePreviews.kt` | 4 (`title`, `accent`, `itemCount`, `density`, indexed `rowLabel`) | **Keep as is** — it is the deliberate twin of `ParameterKnobPreviews.kt`; the comparison is what the sample is for |
-| `samples/cmp/.../ParameterKnobPreviews.kt` | 5 parameter knobs | Already migrated — the reference |
-| `samples/android-live-lane/.../LiveLanePreviews.kt` | 1 (`label`, on the `@Preview` itself) | **Blocked by gap 6, not gap 1.** Its default is the literal `"Live lane"`, so the knob would declare on a live daemon — but this sample is the fixture for `serve-lanes.spec.mjs` in [`compose-preview-server`](https://github.com/yschimke/compose-preview-server), which selects on `overrides[].key == "label"` read from the **bundle sidecar** and *fails* rather than skips when no such preview is found. Migrating it before the bake lane records parameter knobs breaks that e2e |
+| `samples/cmp/.../ParameterKnobPreviews.kt` | 5 parameter knobs | Already migrated — the reference. Note it bakes on the **desktop** lane, which still records no declarations ([gap 6](#gap-6)) |
+| `samples/android-live-lane/.../LiveLanePreviews.kt` | 1 (`label`, on the `@Preview` itself) | **Migratable, but not from here.** Its default is the literal `"Live lane"`, and the Android bake now records the declaration into the sidecar ([gap 6](#gap-6)), so the wiring that blocked it is gone. What remains is verification: this sample is the fixture for `serve-lanes.spec.mjs` in [`compose-preview-server`](https://github.com/yschimke/compose-preview-server), which selects on `overrides[].key == "label"` read from the bundle sidecar and *fails* rather than skips. That suite needs a daemon-backed serve under Playwright and cannot run in this repository, so the migration belongs in a change that can actually run it |
 | `design-catalog-m3-shared/.../CatalogComponents.kt` + `CatalogOverrides.kt` (+ actuals) | ~15 across a `when (id)` dispatch | **Cannot** — gap 5, plus `catalogOverrideColor` (gap 2) |
 | `design-catalog-m3/.../CatalogTheme.kt` | 5 (font, colors, shapes, typography, fonts) | **Cannot** — gap 5: read inside the theme wrapper every sticker calls |
 | `design-catalog-m3/.../CatalogTemplates.kt` | `title`, `fab` hoistable; `sender`, `preview` indexed | **Partial at best** — gap 3 |

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewKnobBake.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewKnobBake.kt
@@ -1,0 +1,177 @@
+package ee.schimke.composeai.renderer
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
+import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
+import ee.schimke.composeai.data.overrides.PreviewOverrideType
+
+/**
+ * Makes a preview's **parameter knobs** count during an offline render — the half of the knob
+ * format the bake lane was missing.
+ *
+ * ### What was missing, and why it mattered off the daemon
+ *
+ * `previewOverride*` publishes a declaration as a by-product of *reading* a knob inside the
+ * composable body, so a bake picks it up for free: [RobolectricRenderTestBase] clears the
+ * controller before composing and drains it into `renders/<stem>.overrides.json` afterwards. A
+ * parameter knob is declared by the function signature and read by ordinary argument passing, so
+ * nothing in the composition ever announces it and that drain came back empty.
+ *
+ * That sidecar is not a nicety. `compose-preview serve` reads its override list from the bundled
+ * sidecar — for a daemon-backed host too, since the daemon supplies renders and not declarations —
+ * so a preview migrated to parameter knobs served an empty control list and any consumer selecting
+ * on a knob key found nothing. Recording the declarations here, on the same controller channel the
+ * other format uses, puts both formats in the sidecar and leaves every downstream reader unchanged.
+ *
+ * ### Why this is a renderer-local mirror
+ *
+ * The daemon has the same two mappings (`PreviewKnobSeeds`, `PreviewKnobDeclarations` in
+ * `:daemon:core`). This renderer cannot reach them: it is published as `renderer-android` and
+ * injected into a consumer's Robolectric test classpath, and `daemon-core` would drag the JSON-RPC
+ * server and the in-process compile service along with it. Same trade the manifest DTOs already
+ * make — see [RenderPreviewKnob] and its siblings, each "a renderer-side mirror of the plugin's …".
+ */
+internal object PreviewKnobBake {
+
+  /**
+   * The argument array to invoke a preview declaring [knobs] with, given this render's
+   * `@OverrideVariant` seed bag — `null` at every position no seed bound, which is how a partial
+   * seed says "leave this parameter alone" to [PreviewParameterSupport.invokeWithDefaultMask].
+   *
+   * Empty when nothing binds, so a preview nobody seeded keeps the zero-argument invoke it has
+   * always used rather than an all-null array meaning the same thing.
+   *
+   * Sized by the highest knob index plus one rather than by [knobs].size: an index is a position in
+   * the *full* value-parameter list, which may include defaulted parameters that are not knobs
+   * (`modifier: Modifier = Modifier`). Those positions stay null and take their compiled defaults.
+   */
+  fun seedArgs(
+    knobs: List<RenderPreviewKnob>,
+    seeds: Map<String, PreviewOverrideValue>?,
+  ): List<Any?> {
+    if (knobs.isEmpty() || seeds.isNullOrEmpty()) return emptyList()
+    val byName = knobs.associateBy { it.name }
+    val bound = seeds.mapNotNull { (name, value) ->
+      val knob = byName[name] ?: return@mapNotNull null
+      val text = seedText(value) ?: return@mapNotNull null
+      parse(knob.type, text)?.let { knob.index to it }
+    }
+    if (bound.isEmpty()) return emptyList()
+    val size = knobs.maxOf { it.index } + 1
+    val args = arrayOfNulls<Any?>(size)
+    bound.forEach { (index, value) -> if (index in 0 until size) args[index] = value }
+    return args.toList()
+  }
+
+  /**
+   * The declarations for [knobs] under this render's [seeds], skipping the knobs that cannot be
+   * declared honestly. Empty when nothing can be — the overwhelmingly common case, since most
+   * previews declare no knobs at all.
+   *
+   * **A knob whose default discovery could not recover is left out.**
+   * `PreviewOverrideDeclaration.default` is not nullable, so declaring one would mean inventing a
+   * value — an empty string, a zero — and presenting it as what the author wrote, giving a viewer a
+   * wrong default and a "reset" that resets to something the preview never said.
+   *
+   * `current` is the value actually in force: the seed where one bound, the author default
+   * otherwise, resolved through [seedArgs] so the control cannot disagree with the pixels beside
+   * it.
+   */
+  fun declarations(
+    knobs: List<RenderPreviewKnob>,
+    seeds: Map<String, PreviewOverrideValue>?,
+  ): List<PreviewOverrideDeclaration> {
+    if (knobs.isEmpty()) return emptyList()
+    val bound = seedArgs(knobs, seeds)
+    return knobs.mapNotNull { knob ->
+      val default = knob.default ?: return@mapNotNull null
+      val type = declaredTypeOf(knob.type) ?: return@mapNotNull null
+      val seeded = bound.getOrNull(knob.index)
+      PreviewOverrideDeclaration(
+        key = knob.name,
+        type = type,
+        // No author-supplied label exists: a parameter has a name and nothing else. The
+        // `previewOverride*` host does the same, so a viewer renders both formats identically.
+        label = knob.name,
+        default = valueOf(type, default),
+        current = valueOf(type, seeded?.toString() ?: default),
+        // A parameter list is fixed-arity, so there is no per-row value to address — always the
+        // un-indexed seed key.
+        index = null,
+      )
+    }
+  }
+
+  /**
+   * The seed text for [value], or null when its kind has no parameter-knob equivalent.
+   *
+   * `ColorValue` is deliberately absent: `Color` is not a seedable parameter kind, so its
+   * `#AARRGGBB` text could only ever fail to parse as one of the numeric kinds. A preview wanting
+   * an editable colour as a parameter takes an ARGB `Long` and gets an ordinary numeric seed.
+   */
+  private fun seedText(value: PreviewOverrideValue): String? =
+    when (value) {
+      is PreviewOverrideValue.StringValue -> value.value
+      is PreviewOverrideValue.IntValue -> value.value.toString()
+      is PreviewOverrideValue.BooleanValue -> value.value.toString()
+      is PreviewOverrideValue.FloatValue -> value.value.toString()
+      is PreviewOverrideValue.ColorValue -> null
+    }
+
+  /**
+   * The typed value for [raw] under the kind [type] names, or null when this renderer cannot build
+   * that kind or [raw] is not a valid value of it.
+   *
+   * `toBooleanStrictOrNull` rather than `toBoolean`: the lenient form maps every non-`"true"`
+   * string to `false`, so a malformed seed would render the opposite of a `true` default instead of
+   * the default itself. A seed dropped here falls back to the author default, which is always a
+   * value the preview actually names — unlike a coerced one.
+   */
+  private fun parse(type: String, raw: String): Any? =
+    when (type) {
+      "STRING" -> raw
+      "BOOLEAN" -> raw.toBooleanStrictOrNull()
+      "INT" -> raw.toIntOrNull()
+      "LONG" -> raw.toLongOrNull()
+      "FLOAT" -> raw.toFloatOrNull()
+      "DOUBLE" -> raw.toDoubleOrNull()
+      else -> null
+    }
+
+  /**
+   * The declaration type for a knob kind, or null when there is none.
+   *
+   * `LONG` and `DOUBLE` map to `STRING` because [PreviewOverrideType] has no wider numerics. That
+   * costs the control's *shape*, not its reach: a text seed reaches the parameter through the same
+   * path and parses against the knob's own kind, so a `Long` seeded as `"4281558783"` binds exactly
+   * as it would have. A kind this renderer does not know is dropped rather than guessed at.
+   */
+  private fun declaredTypeOf(knobType: String): String? =
+    when (knobType) {
+      "STRING",
+      "LONG",
+      "DOUBLE" -> PreviewOverrideType.STRING
+      "BOOLEAN" -> PreviewOverrideType.BOOL
+      "INT" -> PreviewOverrideType.INT
+      "FLOAT" -> PreviewOverrideType.FLOAT
+      else -> null
+    }
+
+  /**
+   * [text] as the declaration value of [type], falling back to a string value when it does not
+   * parse — reachable only if discovery recovered a constant whose text doesn't round-trip through
+   * its own declared type, where the raw text at least reports what the class file said.
+   */
+  private fun valueOf(type: String, text: String): PreviewOverrideValue =
+    when (type) {
+      PreviewOverrideType.INT ->
+        text.toIntOrNull()?.let { PreviewOverrideValue.IntValue(it) }
+          ?: PreviewOverrideValue.StringValue(text)
+      PreviewOverrideType.FLOAT ->
+        text.toFloatOrNull()?.let { PreviewOverrideValue.FloatValue(it) }
+          ?: PreviewOverrideValue.StringValue(text)
+      PreviewOverrideType.BOOL ->
+        text.toBooleanStrictOrNull()?.let { PreviewOverrideValue.BooleanValue(it) }
+          ?: PreviewOverrideValue.StringValue(text)
+      else -> PreviewOverrideValue.StringValue(text)
+    }
+}

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
@@ -163,7 +163,21 @@ private object ComposePreviewStrategy : PreviewRenderStrategy {
     // constructor, else fall back to null for static methods.
     val receiver = resolvePreviewReceiver(clazz)
     val body: @Composable () -> Unit = {
-      composableMethod.invoke(currentComposer, receiver, *previewArgs.toTypedArray())
+      // A parameter-knob seed leaves a null at every position it did not name, and
+      // `ComposableMethod.invoke` forwards those nulls verbatim — straight into an
+      // `IllegalArgumentException` when one lands on a primitive. `invokeWithDefaultMask` drives
+      // the defaults-mask overload itself for exactly that shape and returns false for every other,
+      // where the ordinary invoke below is already correct.
+      if (
+        !PreviewParameterSupport.invokeWithDefaultMask(
+          composableMethod,
+          receiver,
+          previewArgs,
+          currentComposer,
+        )
+      ) {
+        composableMethod.invoke(currentComposer, receiver, *previewArgs.toTypedArray())
+      }
     }
     val wrapperFqn = preview.params.wrapperClassName
     if (wrapperFqn != null) {

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -404,6 +404,17 @@ data class RenderPreviewEntry(
    * [RenderPreviewArtifact]. The wire field name stays `dataProducts` for back-compat.
    */
   val dataProducts: List<RenderPreviewArtifact> = emptyList(),
+  /**
+   * Editable knobs this preview declares as its own defaulted value parameters — the parameter-knob
+   * override format, the sibling of the `previewOverride*` lookups [overrides] seeds. Empty for
+   * every preview that declares none, so an older manifest and an unmigrated module are unchanged.
+   *
+   * Read here so a **bake** carries them: [PreviewKnobBake] turns them into the declarations the
+   * `renders/<stem>.overrides.json` sidecar publishes, and binds any `@OverrideVariant` seed that
+   * names one onto the composable's argument list. Without this field a migrated preview rendered
+   * offline announced no knobs at all, which is what kept every sample on `previewOverride*`.
+   */
+  val knobs: List<RenderPreviewKnob> = emptyList(),
 ) {
   /**
    * Concise, stable label — the (already-unique, fan-out-suffixed) preview [id]. This is
@@ -416,6 +427,31 @@ data class RenderPreviewEntry(
    */
   override fun toString(): String = id
 }
+
+/**
+ * Renderer-side mirror of the plugin's `PreviewKnob` — one editable value parameter of a preview.
+ *
+ * [type] is carried as the plain enum **name** rather than a renderer-side enum, deliberately: a
+ * newer plugin naming a kind this renderer does not know would otherwise fail to deserialise the
+ * whole manifest, taking every preview in the module down with it. As a string it reaches
+ * [PreviewKnobBake], which drops the one knob it cannot build and renders the rest.
+ *
+ * @property name the Kotlin parameter name, and the seed key that addresses it.
+ * @property index the parameter's zero-based position in the function's **full** value-parameter
+ *   list — which may include defaulted parameters that are not knobs (`modifier: Modifier =
+ *   Modifier`), so it is not an index into a knob list.
+ * @property type the plugin's `PreviewKnobType` name: `STRING`, `BOOLEAN`, `INT`, `LONG`, `FLOAT`
+ *   or `DOUBLE`.
+ * @property default the parameter's literal default as seed text, or null when discovery could not
+ *   recover one (an expression default — `stringResource(...)`, `itemCount + 1`).
+ */
+@Serializable
+data class RenderPreviewKnob(
+  val name: String,
+  val index: Int,
+  val type: String,
+  val default: String? = null,
+)
 
 @Serializable
 data class RenderPreviewCapture(

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -506,7 +506,13 @@ object PreviewManifestLoader {
   internal fun expandParameterProvider(entry: RenderPreviewEntry): List<PreviewRow> {
     val providerFqn =
       entry.params.previewParameterProviderClassName
-        ?: return listOf(PreviewRow(entry, emptyList()))
+        // No provider fan-out: the only arguments a preview can take here are its own parameter
+        // knobs, bound from this entry's `@OverrideVariant` seed. Empty for everything that
+        // declares no knob or that nothing seeded, which is the zero-argument invoke every plain
+        // preview has always used.
+        ?: return listOf(
+          PreviewRow(entry, PreviewKnobBake.seedArgs(entry.knobs, overrideSeedMap(entry)))
+        )
     val limit = entry.params.previewParameterLimit.coerceAtLeast(0)
     if (limit == 0) return emptyList()
     val values =
@@ -993,6 +999,15 @@ abstract class RobolectricRenderTestBase(
     // `renderNow.overrides`
     // lane feeds; here the batch render owns the controller lifecycle directly.
     ee.schimke.composeai.overrides.PreviewOverrideController.set(overrideSeedMap(preview))
+    // Announce this preview's *parameter* knobs on the same channel. `previewOverride*` records a
+    // declaration as it reads each knob during composition; a parameter knob is read by argument
+    // passing and announces nothing, so without this the overrides sidecar drained below came back
+    // empty for a migrated preview and `serve` served it no controls at all. Recorded before the
+    // render rather than inside it: the declarations are derived from the manifest and the seed,
+    // both of which are already known here, and `clearDeclarations()` above has just run.
+    PreviewKnobBake.declarations(preview.knobs, overrideSeedMap(preview)).forEach {
+      ee.schimke.composeai.overrides.PreviewOverrideController.record(it)
+    }
     // Arm the per-preview downloadable-font tracker so a face that falls back to Roboto during THIS
     // render is attributed to this preview (drained right after the render below).
     FontResolutionDiagnostics.beginPreview()

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewKnobBakeTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewKnobBakeTest.kt
@@ -1,0 +1,181 @@
+package ee.schimke.composeai.renderer
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
+import ee.schimke.composeai.data.overrides.PreviewOverrideType
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins what a bake now publishes for a **parameter knob** — the seam that lets a preview migrated
+ * off `previewOverride*` still fill `renders/<stem>.overrides.json`, which is where
+ * `compose-preview serve` reads its control list from even against a live daemon.
+ */
+class PreviewKnobBakeTest {
+
+  private val knobs =
+    listOf(
+      RenderPreviewKnob("title", 0, "STRING", "Shopping list"),
+      RenderPreviewKnob("count", 1, "INT", "3"),
+      RenderPreviewKnob("enabled", 2, "BOOLEAN", "true"),
+    )
+
+  @Test
+  fun `a preview nobody seeded still declares every knob at its author default`() {
+    // The case that unblocks a migrated sample: no seed at all, and the sidecar must still carry
+    // the controls. Before this the drain came back empty and `serve` showed nothing.
+    val declarations = PreviewKnobBake.declarations(knobs, seeds = null)
+
+    assertEquals(listOf("title", "count", "enabled"), declarations.map { it.key })
+    assertEquals(
+      listOf(PreviewOverrideType.STRING, PreviewOverrideType.INT, PreviewOverrideType.BOOL),
+      declarations.map { it.type },
+    )
+    assertEquals(
+      listOf(
+        PreviewOverrideValue.StringValue("Shopping list"),
+        PreviewOverrideValue.IntValue(3),
+        PreviewOverrideValue.BooleanValue(true),
+      ),
+      declarations.map { it.default },
+    )
+    // Nothing seeded, so what is in force is what the author wrote.
+    assertEquals(declarations.map { it.default }, declarations.map { it.current })
+    // A parameter has a name and nothing else to label it with, and no per-row indexed form.
+    assertEquals(listOf("title", "count", "enabled"), declarations.map { it.label })
+    assertEquals(listOf(null, null, null), declarations.map { it.index })
+  }
+
+  @Test
+  fun `current reports the seeded value so the control cannot disagree with the pixels`() {
+    val declarations =
+      PreviewKnobBake.declarations(knobs, mapOf("count" to PreviewOverrideValue.IntValue(9)))
+
+    assertEquals(
+      listOf(
+        PreviewOverrideValue.StringValue("Shopping list"),
+        PreviewOverrideValue.IntValue(9),
+        PreviewOverrideValue.BooleanValue(true),
+      ),
+      declarations.map { it.current },
+    )
+    // …and `default` still reports what the author wrote, so a viewer can offer "reset".
+    assertEquals(PreviewOverrideValue.IntValue(3), declarations[1].default)
+  }
+
+  @Test
+  fun `a knob whose default discovery could not recover is left undeclared`() {
+    // `PreviewOverrideDeclaration.default` is not nullable, so declaring one would mean inventing a
+    // value and presenting it as the author's — a wrong default and a "reset" to something the
+    // preview never said. The knob still seeds; it just gets no control.
+    val declarations =
+      PreviewKnobBake.declarations(
+        listOf(
+          RenderPreviewKnob("title", 0, "STRING", null), // `stringResource(...)`
+          RenderPreviewKnob("count", 1, "INT", "3"),
+        ),
+        seeds = null,
+      )
+
+    assertEquals(listOf("count"), declarations.map { it.key })
+  }
+
+  @Test
+  fun `Long and Double are declared as text because the type set has no wider numerics`() {
+    val declarations =
+      PreviewKnobBake.declarations(
+        listOf(
+          RenderPreviewKnob("accentArgb", 0, "LONG", "4281558783"),
+          RenderPreviewKnob("precise", 1, "DOUBLE", "1.5"),
+        ),
+        seeds = null,
+      )
+
+    assertEquals(
+      listOf(PreviewOverrideType.STRING, PreviewOverrideType.STRING),
+      declarations.map { it.type },
+    )
+  }
+
+  @Test
+  fun `a kind this renderer does not know is dropped rather than guessed at`() {
+    val newer = listOf(RenderPreviewKnob("accent", 0, "SOMETHING_NEWER", "#FF42A5F5"))
+    assertEquals(emptyList<String>(), PreviewKnobBake.declarations(newer, null).map { it.key })
+    assertEquals(
+      emptyList<Any?>(),
+      PreviewKnobBake.seedArgs(newer, mapOf("accent" to PreviewOverrideValue.StringValue("x"))),
+    )
+  }
+
+  @Test
+  fun `a partial seed leaves every unnamed position null for the defaults mask to fill`() {
+    val args =
+      PreviewKnobBake.seedArgs(knobs, mapOf("enabled" to PreviewOverrideValue.BooleanValue(false)))
+    assertEquals(listOf(null, null, false), args)
+  }
+
+  @Test
+  fun `the array is sized by the highest index so a non-knob parameter keeps its slot`() {
+    // `index` is a position in the FULL value-parameter list: a `modifier: Modifier = Modifier`
+    // ahead of the knob is defaulted but not seedable, and its slot must stay null.
+    val args =
+      PreviewKnobBake.seedArgs(
+        listOf(RenderPreviewKnob("label", 2, "STRING", "hi")),
+        mapOf("label" to PreviewOverrideValue.StringValue("seeded")),
+      )
+    assertEquals(listOf(null, null, "seeded"), args)
+  }
+
+  @Test
+  fun `a seed that is not a valid value of its knob kind falls back to the author default`() {
+    // Coercing `"yes"` to `true` would publish a capture that silently disagrees with the request.
+    assertEquals(
+      emptyList<Any?>(),
+      PreviewKnobBake.seedArgs(knobs, mapOf("enabled" to PreviewOverrideValue.StringValue("yes"))),
+    )
+    // A colour has no parameter-knob equivalent, so it binds nothing rather than half-parsing.
+    assertEquals(
+      emptyList<Any?>(),
+      PreviewKnobBake.seedArgs(
+        knobs,
+        mapOf("title" to PreviewOverrideValue.ColorValue("#FF42A5F5")),
+      ),
+    )
+  }
+
+  @Test
+  fun `nothing to bind keeps the zero-argument invoke a plain preview has always used`() {
+    assertEquals(emptyList<Any?>(), PreviewKnobBake.seedArgs(emptyList(), null))
+    assertEquals(emptyList<Any?>(), PreviewKnobBake.seedArgs(knobs, emptyMap()))
+    // A seed naming no declared parameter is the other format's key — the controller takes it.
+    assertEquals(
+      emptyList<Any?>(),
+      PreviewKnobBake.seedArgs(knobs, mapOf("label" to PreviewOverrideValue.StringValue("x"))),
+    )
+    assertEquals(emptyList<Any?>(), PreviewKnobBake.declarations(emptyList(), null))
+  }
+
+  @Test
+  fun `a manifest entry carries its knobs, and one without them still reads`() {
+    val json = Json { ignoreUnknownKeys = true }
+    val withKnobs =
+      json.decodeFromString(
+        RenderPreviewEntry.serializer(),
+        """
+        {"id":"a","functionName":"Card","className":"C",
+         "knobs":[{"name":"title","index":0,"type":"STRING","default":"Shopping list"}]}
+        """
+          .trimIndent(),
+      )
+    assertEquals(listOf(RenderPreviewKnob("title", 0, "STRING", "Shopping list")), withKnobs.knobs)
+
+    // Additive: every manifest written before this field, and every unmigrated module, is
+    // unchanged.
+    val without =
+      json.decodeFromString(
+        RenderPreviewEntry.serializer(),
+        """{"id":"a","functionName":"Card","className":"C"}""",
+      )
+    assertEquals(emptyList<RenderPreviewKnob>(), without.knobs)
+  }
+}

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewManifestLoaderProviderTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewManifestLoaderProviderTest.kt
@@ -1,5 +1,8 @@
 package ee.schimke.composeai.renderer
 
+import ee.schimke.composeai.data.overrides.OverrideSeed
+import ee.schimke.composeai.data.overrides.OverrideSeedKind
+import ee.schimke.composeai.data.overrides.OverrideVariantSpec
 import java.io.File
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -34,6 +37,54 @@ class PreviewManifestLoaderProviderTest {
       params = RenderPreviewParams(previewParameterProviderClassName = providerFqn),
       captures = listOf(RenderPreviewCapture(renderOutput = "renders/$id.png")),
     )
+
+  @Test
+  fun `a preview with no provider binds its parameter knobs from the variant seed`() {
+    // The bake-lane half of the knob format: with no `@PreviewParameter` fan-out, a preview's only
+    // arguments are its own defaulted parameters, and an `@OverrideVariant` naming one has to reach
+    // it as an argument (the controller seed the same spec feeds serves the *other* format).
+    val rows =
+      PreviewManifestLoader.expandParameterProvider(
+        RenderPreviewEntry(
+          id = "ShoppingCard",
+          functionName = "ShoppingCard",
+          className = "com.example.PreviewsKt",
+          captures = listOf(RenderPreviewCapture(renderOutput = "renders/ShoppingCard.png")),
+          knobs =
+            listOf(
+              RenderPreviewKnob("title", 0, "STRING", "Shopping list"),
+              RenderPreviewKnob("count", 1, "INT", "3"),
+            ),
+          overrides =
+            OverrideVariantSpec(
+              name = "empty",
+              seeds = listOf(OverrideSeed(key = "count", kind = OverrideSeedKind.INT, raw = "0")),
+            ),
+        )
+      )
+
+    // One row, as for any preview without a provider — but now carrying arguments. The unseeded
+    // `title` stays null so `invokeWithDefaultMask` sets its bit and the compiled default runs.
+    assertEquals(1, rows.size)
+    assertEquals(listOf(null, 0), rows.single().previewArgs)
+  }
+
+  @Test
+  fun `a preview whose knobs nothing seeds keeps the zero-argument invoke`() {
+    val rows =
+      PreviewManifestLoader.expandParameterProvider(
+        RenderPreviewEntry(
+          id = "ShoppingCard",
+          functionName = "ShoppingCard",
+          className = "com.example.PreviewsKt",
+          captures = listOf(RenderPreviewCapture(renderOutput = "renders/ShoppingCard.png")),
+          knobs = listOf(RenderPreviewKnob("title", 0, "STRING", "Shopping list")),
+        )
+      )
+
+    assertEquals(1, rows.size)
+    assertEquals(emptyList<Any?>(), rows.single().previewArgs)
+  }
 
   @Test
   fun `private provider is enumerated instead of throwing IllegalAccessException`() {

--- a/samples/android-live-lane/build.gradle.kts
+++ b/samples/android-live-lane/build.gradle.kts
@@ -19,10 +19,12 @@
 // the contract the spec selects on (`overrides[].key == "label"`) — so the Android lane reuses the
 // desktop lane's spec unmodified.
 //
-// **That knob must stay a `previewOverride*` one for now.** The spec reads the override list from
-// the bundle's `previews/<id>.overrides.json` sidecar, which only the `previewOverride*` surface
-// writes; the parameter-knob format is not recorded by the offline bake yet, and the spec FAILS
-// rather than skips when it finds no label-knob preview. See
+// **That knob stays a `previewOverride*` one until someone can run the spec.** The spec reads the
+// override list from the bundle's `previews/<id>.overrides.json` sidecar and FAILS rather than
+// skips when it finds no label-knob preview. The Android bake now records a *parameter* knob into
+// that sidecar too, so the format is no longer the blocker — but the spec needs a daemon-backed
+// serve under Playwright and cannot run from this repository, so migrating the knob here would ship
+// an unverified change to another repo's required e2e. See
 // `docs/design/PARAMETER_KNOB_MIGRATION.md` → gap 6.
 plugins {
   id("composeai.base-conventions")


### PR DESCRIPTION
Closes the gap [#5097](https://github.com/yschimke/compose-ai-tools/pull/5097) documents, on the Android half.

The parameter-knob format was discovered, seeded and declared everywhere except the lane that fills the bundle. An offline render announced nothing, so `previews/<id>.overrides.json` came back **empty** for a migrated preview.

That sidecar is not a nicety:

```kotlin
// ServeBundleHost.readOverrides
val sidecar = File(previewsDir, "$id$OVERRIDES_SUFFIX")   // previews/<id>.overrides.json
```

`/api/previews` serves exactly that list, and it does so for a **daemon-backed** host too — the daemon supplies renders, not declarations. So a preview moved off `previewOverride*` served an empty control list and any consumer selecting on a knob key found nothing. That is why no sample could migrate.

## What changed

Three seams on the Android/Robolectric standalone lane, all additive:

* **`RenderPreviewEntry.knobs`** — the renderer-side mirror of the plugin's `PreviewKnob`, alongside the mirrors already there for captures, catalog tokens and scroll. `previews.json` has carried the field since discovery learned to read it, so **nothing on the plugin side changes**; the renderer simply stopped dropping it as an unknown key.

  `type` is mirrored as the enum **name**, not as a renderer-side enum. A newer plugin naming a kind this renderer cannot build must cost that one knob, not fail to deserialise the manifest and take every preview in the module down with it — the failure mode `AndroidCompatibleOverrideVariantSpecSerializer` already exists to work around.

* **`PreviewKnobBake.declarations(...)`** turns those knobs into `PreviewOverrideDeclaration`s and records them on the same controller channel `previewOverride*` publishes through, so the existing drain writes them and every downstream reader keeps working unchanged. Recorded before the render rather than inside it: both inputs (the manifest and the seed) are known there, and `clearDeclarations()` has just run.

  A knob whose **literal default discovery could not recover** is left undeclared. `PreviewOverrideDeclaration.default` is not nullable, so declaring one means inventing a value and presenting it as the author's — a wrong default and a "reset" that resets to something the preview never said.

* **`PreviewKnobBake.seedArgs(...)`** binds an `@OverrideVariant` seed naming a knob onto the composable's argument list, and `ComposePreviewStrategy` drives the defaults-mask overload for it. Without the mask a partial seed sends a null into a primitive parameter and `Method.invoke` throws — the same defect the daemon lane hit in [#5091](https://github.com/yschimke/compose-ai-tools/pull/5091).

`PreviewKnobBake` is a deliberate renderer-local mirror of `:daemon:core`'s `PreviewKnobSeeds` / `PreviewKnobDeclarations`, and says so. This renderer is published as `renderer-android` and injected into a consumer's Robolectric test classpath; depending on `daemon-core` would drag the JSON-RPC server and the in-process compile service onto it.

## What this does **not** do

The **desktop** standalone renderer still records nothing. It has no manifest to read — `DesktopRendererMain` takes argv plus the per-capture `composeai.overrides.seed` property — so handing it the knobs needs a plugin-side channel *and* a `DesktopRenderWorkerPool` request-frame field (a worker outlives one capture and must not inherit the previous preview's knobs). That is a separate change; gap 6 stays open for CMP.

**No sample is migrated here.** `android-live-lane` now *could* move — the wiring that blocked it is gone — but it is the fixture for `serve-lanes.spec.mjs` in [`compose-preview-server`](https://github.com/yschimke/compose-preview-server), which needs a daemon-backed serve under Playwright and *fails* rather than skips. Migrating it from here would ship an unverified change to another repository's required e2e, so the docs and the sample's own comment now say that plainly instead.

`docs/design/PARAMETER_KNOB_MIGRATION.md` is updated in the second commit, now that #5097 has merged: gap 6 is retitled to the desktop lane, and the verdict separates the two remaining reasons a sample stays put — wiring (desktop) and verification (live-lane) — because they are not the same problem.

## Test plan

Non-visual — the change is what a render *declares*, not what it draws. Verified by running, not by inspection:

* `:renderer-android:testDebugUnitTest` — **full suite green** (`BUILD SUCCESSFUL`), so the `ComposePreviewStrategy` invoke change breaks nothing that renders today.
* `PreviewKnobBakeTest` — 10 tests, 0 failures. Covers the case that unblocks a sample (an unseeded preview still declares every knob at its author default), `current` following the seed, an unrecoverable default left undeclared, `LONG`/`DOUBLE` declared as text, an unknown kind dropped rather than guessed, a partial seed leaving unnamed positions null, sizing by the highest index so a non-knob parameter keeps its slot, an invalid seed falling back to the author default, and that the manifest field round-trips *and* that an entry without it still reads.
* `PreviewManifestLoaderProviderTest` — 6 tests, 0 failures, two of them new and exercising the real loader path: a knobbed preview with an `@OverrideVariant` seed produces `previewArgs = [null, 0]` (unseeded `title` left for the defaults mask), and one nothing seeds keeps the zero-argument invoke.
* `./gradlew ktfmtCheckAll` passes, before and after the doc commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o