### PR TITLE
fix(deps): consume the Remote Compose players at 1.57.0

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -781,7 +781,7 @@ env:
   # the same players at. Renovate keeps the two in step (`.github/renovate.json`).
   RC_PLAYERS_REPO: yschimke/rc-players
   # renovate: datasource=github-tags depName=yschimke/rc-players
-  RC_PLAYERS_PIN: v1.56.1
+  RC_PLAYERS_PIN: v1.57.0
 
 jobs:
   # Resolve, ONCE PER RUN, which compose-ai-tools commit this run's export driver

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -395,7 +395,7 @@ composeai-preview-serve = "2.15.0"
 #
 # During the move these were briefly split across two refs, so that three unpublished coordinates
 # could not pin the five that were already on Central. That is over: one ref again.
-rcplayers = "1.56.1"
+rcplayers = "1.57.0"
 
 [libraries]
 


### PR DESCRIPTION
Moves the two literals that have to agree, so `remote-m3` can finally publish its `androidx-embedded` column.

## The two halves

| where | what it is | 1.56.1 → 1.57.0 |
| --- | --- | --- |
| `rcplayers` in `gradle/libs.versions.toml` | the Maven coordinate nine modules resolve the players through | ✔ |
| `RC_PLAYERS_PIN` in `design-artifacts-reusable.yml` | the git tag the embedded player harnesses are checked out at | ✔ |

They move **together** because `Check the rc-players pin against the consumed player version` skips the vendored-Android and cmp-jvm columns on any mismatch, in either direction — a harness rendering through a different player build than the capture makes every number on the wall unattributable. Bumping one alone would lose two columns rather than gain one.

## What this unblocks

1.57.0 is the first release carrying yschimke/rc-players#30, which enables AndroidX's embedded player behind `RemoteComposePlayerFlags.isEmbeddedPlayerEnabled`. Until that fix, every document the harness was handed threw:

```
IllegalStateException: Embedded player is disabled.
Set RemoteComposePlayerFlags.isEmbeddedPlayerEnabled = true to enable.
```

so it wrote one `.error` per document and no PNGs, and `design-artifacts/remote-m3` carried `rc-androidx-embedded/` with **0** files against its siblings' 476. The fix was released but not consumed — this repo still pinned v1.56.1, so a `remote-m3` run today would still check out the old harness and still drop the column.

## Test plan

**This repository does not build in my sandbox**, so CI is the first real build of this change, and I would rather say that than imply a green local run. `com.android.application` / `com.android.library` plugin 9.4.0 does not resolve there — I confirmed the identical failure on unmodified `main`, so it is the environment (no reachable Google Maven), not this diff.

What I could check, and did:

- Every artifact `rcplayers` feeds resolves at 1.57.0 on Maven Central: the four `rc-player-*` modules, both `third-party-rc-embedded-player*` modules, `remote-compose-player-js-dist`, and `rc-player-wasm-dist`.
- Both `dist` classifier zips the root build pulls exist by exact filename — `rc-player-wasm-dist-1.57.0-dist.zip` and `remote-compose-player-js-dist-1.57.0-dist.zip` — since those are the coordinates a plain version check would not have covered.
- The workflow still parses, and the only other `1.56.1` strings left in the tree are historical prose in comments, correctly untouched.

## Note on Renovate

Renovate maintains `rcplayers` as an ordinary Maven dependency but knows nothing about the `RC_PLAYERS_PIN` literal beside it — that pairing is exactly the "pin BEHIND driver" case the gate's own comment calls an editing mistake needing a manual bump. Left to itself, Renovate would bump `rcplayers` alone and silently drop two columns until someone noticed. Worth considering a custom manager for the workflow literal so the pair can never split; happy to open that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UM3YjextgtTcc7mD7QNQ3p

---
_Generated by [Claude Code](https://claude.ai/code/session_01UM3YjextgtTcc7mD7QNQ3p)_