### PR TITLE
feat(renderer-desktop): record a preview's parameter knobs during a bake

### DIFF
--- a/docs/design/PARAMETER_KNOB_MIGRATION.md
+++ b/docs/design/PARAMETER_KNOB_MIGRATION.md
@@ -24,19 +24,21 @@ declared each way. That pair is deliberate and must **not** be collapsed by a mi
 
 ## The verdict
 
-**No sample should move from this repository yet, but the wiring no longer stops one.** Both
-daemons publish a parameter knob as a `PreviewOverrideDeclaration`, so a *live* viewer draws the
-same control it draws for a `previewOverride*` knob — and the **Android offline bake** now does too,
-recording the manifest's knobs onto the same controller channel before the render so the existing
-drain writes them into `previews/<id>.overrides.json`. That sidecar is what `compose-preview serve`
-reads its knob list from, for a daemon-backed host too (which only uses the daemon to *render*).
+**The wiring no longer stops a sample; what stops one now is the format itself, and one
+verification problem.** Every lane publishes a parameter knob as a `PreviewOverrideDeclaration`:
+both daemons for a live viewer, and both offline bakes into `previews/<id>.overrides.json` — the
+sidecar `compose-preview serve` reads its knob list from, for a daemon-backed host too (which only
+uses the daemon to *render*). [Gap 6](#gap-6) is closed.
 
-Two things still hold a sample back, and they are different in kind. The **desktop** standalone
-renderer still records nothing — it has no manifest to read — so a CMP sample would still bake an
-empty override list ([gap 6](#gap-6)). And the one Android sample that could now move,
-`android-live-lane`, is the fixture for a suite that lives in another repository and *fails* rather
-than skips: migrating it blind would hand `compose-preview-server` a red required e2e with no local
-signal, so that migration belongs in a change where the suite can actually be run.
+What is left is not plumbing. Most catalog defaults are **expressions**
+(`stringResource(...)`, `Color(0xFF3366FF)`), which cannot be recovered and so cannot be declared;
+`Color` and `Dp` are not seedable kinds; and the structural limits below rule out the whole
+design-catalog family whatever the wiring does.
+
+The one sample the wiring did block, `android-live-lane`, is now migratable — but it is the fixture
+for a suite that lives in another repository and *fails* rather than skips, so migrating it blind
+would hand `compose-preview-server` a red required e2e with no local signal. That migration belongs
+in a change where the suite can actually be run.
 
 Two further limits are unaffected by any wiring: most sample defaults are **expressions**
 (`stringResource(...)`, `Color(0xFF3366FF)`), which cannot be recovered and so cannot be declared;
@@ -163,32 +165,38 @@ A parameter knob only exists on the preview's own signature, so moving either wo
 every knob of every branch onto every preview that could reach it — and `CatalogComponent(id:
 String)` reports no knobs anyway, since `id` has no default.
 
-### <a id="gap-6"></a>6. The desktop bake lane does not record a parameter knob
+### <a id="gap-6"></a>6. The offline bake lane does not record a parameter knob — **closed**
 
-**Android: closed.** **Desktop: open**, and it is what keeps a CMP sample from moving.
+Kept here because it is what every earlier version of this document said blocked a migration, and
+because the shape of the fix is the thing to copy if a third lane ever appears.
 
 A bundle carries each preview's editable knobs in `previews/<id>.overrides.json`, written by
-draining `PreviewOverrideController.declarations()` after a standalone render — so it captures
+draining `PreviewOverrideController.declarations()` after a standalone render — so it captured
 whatever the `previewOverride*` lookups recorded *during* that render. A parameter knob is read by
-argument passing and records nothing, so that drain used to come back empty for a migrated preview.
+argument passing and records nothing, so that drain came back empty for a migrated preview.
 `compose-preview serve` reads its knob list from that sidecar (`ServeBundleHost.readOverrides`), and
 so does `/api/previews`; **that holds for a daemon-backed host as well**, because the daemon
-supplies renders and not the declaration list.
+supplies renders and not the declaration list. A migrated preview therefore served no controls at
+all.
 
-On the **Android/Robolectric** lane this is now wired. `RenderPreviewEntry` carries the manifest's
-`knobs` (`previews.json` had the field all along — the renderer was dropping it), and
-`PreviewKnobBake` turns them into declarations recorded onto the controller just after the
-`@OverrideVariant` seed and just after `clearDeclarations()`, so the existing drain publishes them.
-The same object binds a seed that names a knob onto the composable's argument list, with the
-defaults-mask invoke a partial seed needs. No plugin change was involved.
+Both lanes now build the declarations from the knobs discovery recorded and record them on the same
+controller channel the other format publishes through, just after `clearDeclarations()` and just
+after the `@OverrideVariant` seed, so the existing drain writes them and every downstream reader is
+unchanged. Each lane also binds a seed naming a knob onto the composable's argument list, with the
+defaults-mask invoke a partial seed needs.
 
-The **desktop** renderer is the remaining half, and it is more plumbing than idea: it has no
-manifest to read — `DesktopRendererMain` takes positional CLI args plus the per-capture
-`composeai.overrides.seed` system property — so the knobs need a channel of their own. A property
-beside the seed covers the forked lane; the pooled lane needs the same payload on
-`DesktopRenderWorkerPool`'s request frame, because a worker outlives one capture and must not
-inherit the previous preview's knobs. Everything past that is shared with the Android side: build
-the declarations, record them before the render, and the drain fills the sidecar for free.
+The two differ only in **how the knobs reach the renderer**, because the renderers differ in what
+they can read:
+
+* **Android/Robolectric** reads `previews.json` itself, so `RenderPreviewEntry` simply stopped
+  dropping the `knobs` field it had always been sent. No plugin change at all.
+* **Desktop** has no manifest — it takes positional CLI args plus per-capture system properties — so
+  the plugin serializes `previews.json`'s own `knobs` array onto `composeai.preview.knobs` beside
+  the seed it already sets. The pooled lane carries the same payload on its request frame (worker
+  protocol v2): a warm worker outlives a capture, so a knob list left in the environment would be
+  read by whatever it drew next. A worker built from an older renderer answers v1, the handshake
+  refuses it, and that capture forks — which still renders correctly, because the forked lane
+  carries the knobs on the property.
 
 The harness-only `PreviewManifestRouter` (`composeai.harness.previewsManifest`) is a separate, much
 smaller hole: its manifest wire type carries no `knobs`, so a knobbed preview rendered through a
@@ -199,8 +207,8 @@ harness fixture renders its defaults. No fixture declares one today.
 | Sample | Knobs | Verdict |
 | --- | --- | --- |
 | `samples/cmp/.../OverridablePreviews.kt` | 4 (`title`, `accent`, `itemCount`, `density`, indexed `rowLabel`) | **Keep as is** — it is the deliberate twin of `ParameterKnobPreviews.kt`; the comparison is what the sample is for |
-| `samples/cmp/.../ParameterKnobPreviews.kt` | 5 parameter knobs | Already migrated — the reference. Note it bakes on the **desktop** lane, which still records no declarations ([gap 6](#gap-6)) |
-| `samples/android-live-lane/.../LiveLanePreviews.kt` | 1 (`label`, on the `@Preview` itself) | **Migratable, but not from here.** Its default is the literal `"Live lane"`, and the Android bake now records the declaration into the sidecar ([gap 6](#gap-6)), so the wiring that blocked it is gone. What remains is verification: this sample is the fixture for `serve-lanes.spec.mjs` in [`compose-preview-server`](https://github.com/yschimke/compose-preview-server), which selects on `overrides[].key == "label"` read from the bundle sidecar and *fails* rather than skips. That suite needs a daemon-backed serve under Playwright and cannot run in this repository, so the migration belongs in a change that can actually run it |
+| `samples/cmp/.../ParameterKnobPreviews.kt` | 5 parameter knobs | Already migrated — the reference. Its desktop bake now declares the knobs whose defaults are literals; the `Color` one stays undeclarable (gaps 1 and 2) |
+| `samples/android-live-lane/.../LiveLanePreviews.kt` | 1 (`label`, on the `@Preview` itself) | **Migratable, but not from here.** Its default is the literal `"Live lane"`, and the bake now records the declaration into the sidecar ([gap 6](#gap-6)), so the wiring that blocked it is gone. What remains is verification: this sample is the fixture for `serve-lanes.spec.mjs` in [`compose-preview-server`](https://github.com/yschimke/compose-preview-server), which selects on `overrides[].key == "label"` read from the bundle sidecar and *fails* rather than skips. That suite needs a daemon-backed serve under Playwright and cannot run in this repository, so the migration belongs in a change that can actually run it |
 | `design-catalog-m3-shared/.../CatalogComponents.kt` + `CatalogOverrides.kt` (+ actuals) | ~15 across a `when (id)` dispatch | **Cannot** — gap 5, plus `catalogOverrideColor` (gap 2) |
 | `design-catalog-m3/.../CatalogTheme.kt` | 5 (font, colors, shapes, typography, fonts) | **Cannot** — gap 5: read inside the theme wrapper every sticker calls |
 | `design-catalog-m3/.../CatalogTemplates.kt` | `title`, `fab` hoistable; `sender`, `preview` indexed | **Partial at best** — gap 3 |

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DesktopRenderWorkerPool.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DesktopRenderWorkerPool.kt
@@ -130,7 +130,7 @@ internal class DesktopRenderWorkerPool(
     Thread(r, "compose-preview-render-worker-watchdog").apply { isDaemon = true }
   }
 
-  fun render(args: List<String>, overridesSeed: String?): WorkerResult {
+  fun render(args: List<String>, overridesSeed: String?, knobs: String? = null): WorkerResult {
     synchronized(lock) {
       disabledReason?.let {
         return WorkerResult.Unusable(it)
@@ -148,7 +148,13 @@ internal class DesktopRenderWorkerPool(
             is StartOutcome.Failed -> return WorkerResult.Unusable(started.reason)
           }
 
-      val result = worker.render(args, overridesSeed.orEmpty(), requestIds.incrementAndGet())
+      val result =
+        worker.render(
+          args,
+          overridesSeed.orEmpty(),
+          knobs.orEmpty(),
+          requestIds.incrementAndGet(),
+        )
       if (result is WorkerResult.Unusable) {
         discard(worker)
         worker = null
@@ -330,14 +336,20 @@ internal class DesktopRenderWorkerPool(
       }
     }
 
-    fun render(args: List<String>, seed: String, requestId: Int): WorkerResult {
+    fun render(args: List<String>, seed: String, knobs: String, requestId: Int): WorkerResult {
       val guard = armWatchdog(RENDER_GUARD_SECONDS)
       try {
         val seedBytes = seed.toByteArray(Charsets.UTF_8)
+        val knobBytes = knobs.toByteArray(Charsets.UTF_8)
         toWorker.writeInt(MAGIC_REQUEST)
         toWorker.writeInt(requestId)
         toWorker.writeInt(seedBytes.size)
         toWorker.write(seedBytes)
+        // Per-capture, exactly like the seed above and for the same reason: a warm worker that
+        // inherited the previous preview's knob list would declare its controls into this capture's
+        // overrides sidecar.
+        toWorker.writeInt(knobBytes.size)
+        toWorker.write(knobBytes)
         toWorker.writeInt(args.size)
         args.forEach {
           val b = it.toByteArray(Charsets.UTF_8)
@@ -416,7 +428,10 @@ internal class DesktopRenderWorkerPool(
     const val MAGIC_HELLO = 0x43505731
     const val MAGIC_REQUEST = 0x43505131
     const val MAGIC_RESPONSE = 0x43505231
-    const val WORKER_PROTOCOL_VERSION = 1
+    // 2 since the request frame gained the per-capture parameter-knob payload. A worker built from
+    // an older renderer answers 1, the handshake refuses it, and the caller forks that capture —
+    // which still renders correctly, because the forked lane passes the knobs as a system property.
+    const val WORKER_PROTOCOL_VERSION = 2
     const val STATUS_OK = 0
 
     const val HANDSHAKE_TIMEOUT_SECONDS = 120L

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.plugin
 
 import ee.schimke.composeai.discovery.*
 import javax.inject.Inject
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
@@ -693,6 +694,16 @@ abstract class RenderPreviewsTask : DefaultTask() {
       )
     val overridesSeed =
       preview.overrides?.let { OVERRIDES_JSON.encodeToString(OverrideVariantSpec.serializer(), it) }
+    // This preview's editable value parameters, for the renderer to declare into the capture's
+    // `<stem>.overrides.json` sidecar and to bind an `@OverrideVariant` seed onto. The desktop
+    // subprocess has no manifest to read them from — unlike the Android backend, which reads
+    // `previews.json` itself — so they ride a per-capture channel beside the seed.
+    // `previews.json`'s
+    // own `knobs` array, serialized unchanged, so producer and consumer share one shape.
+    val knobsPayload =
+      preview.knobs
+        .takeIf { it.isNotEmpty() }
+        ?.let { OVERRIDES_JSON.encodeToString(ListSerializer(PreviewKnob.serializer()), it) }
 
     // Warm path: a pooled worker draws this on an already-booted JVM instead of paying JVM +
     // Compose Desktop + Skiko startup again for one capture. It calls the renderer's own `main()`,
@@ -700,7 +711,7 @@ abstract class RenderPreviewsTask : DefaultTask() {
     // fork below — a `Failed` is the renderer's real answer about this capture, and re-running it
     // cold would double the cost of every capture that cannot be drawn.
     lane.pool?.let { pool ->
-      when (val pooled = pool.render(rendererArgs, overridesSeed)) {
+      when (val pooled = pool.render(rendererArgs, overridesSeed, knobsPayload)) {
         is DesktopRenderWorkerPool.WorkerResult.Ok -> return
         is DesktopRenderWorkerPool.WorkerResult.Failed ->
           throw GradleException(
@@ -780,6 +791,10 @@ abstract class RenderPreviewsTask : DefaultTask() {
           OVERRIDES_JSON.encodeToString(OverrideVariantSpec.serializer(), it),
         )
       }
+      // The forked lane's half of the knob channel. Set only when the preview declares one, so an
+      // ordinary capture's command line — and therefore every unknobbed run's task inputs — is
+      // exactly as it was.
+      knobsPayload?.let { systemProperty("composeai.preview.knobs", it) }
       args = rendererArgs
     }
   }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DesktopRenderWorkerPoolStub.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DesktopRenderWorkerPoolStub.kt
@@ -21,8 +21,11 @@ import kotlin.system.exitProcess
  * real renderer diagnostics arrive in), `failed` reports a render failure, `hang` never answers,
  * `crash` exits mid-request, and `badVersion` sends an unrecognised protocol version.
  *
- * On success it writes `"<argc>:<seed>#<n>"` into the output file, where `n` counts the requests
- * this process has served — which is how a test tells a reused warm worker from a fresh one.
+ * On success it writes `"<argc>:<seed>:<knobs>#<n>"` into the output file, where `n` counts the
+ * requests this process has served — which is how a test tells a reused warm worker from a fresh
+ * one. Reading the knobs payload is not optional decoration: it is the second length-prefixed field
+ * of the request frame, so a stub that skipped it would desynchronise the stream and every
+ * subsequent assertion would be about a corrupt frame rather than about the pool.
  */
 object DesktopRenderWorkerPoolStub {
 
@@ -51,6 +54,7 @@ object DesktopRenderWorkerPoolStub {
 
       val requestId = input.readInt()
       val seed = String(input.readPayload(), Charsets.UTF_8)
+      val knobs = String(input.readPayload(), Charsets.UTF_8)
       val argc = input.readInt()
       val argv = List(argc) { String(input.readPayload(), Charsets.UTF_8) }
 
@@ -69,7 +73,7 @@ object DesktopRenderWorkerPoolStub {
         message = "stub refused request $requestId"
       } else {
         // Last argv entry is the renderer's output path in the real protocol.
-        argv.lastOrNull()?.let { File(it).writeText("$argc:$seed#$served") }
+        argv.lastOrNull()?.let { File(it).writeText("$argc:$seed:$knobs#$served") }
       }
 
       val payload = message.toByteArray(Charsets.UTF_8)

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DesktopRenderWorkerPoolTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DesktopRenderWorkerPoolTest.kt
@@ -34,8 +34,8 @@ class DesktopRenderWorkerPoolTest {
 
       // `#2` is the point of the pool: the second capture was drawn by the same process, so it
       // paid no JVM boot. A fresh worker would report `#1` again.
-      assertEquals("2:#1", first.readText())
-      assertEquals("2:#2", second.readText())
+      assertEquals("2::#1", first.readText())
+      assertEquals("2::#2", second.readText())
       assertEquals(2, pool.servedWarm.get())
     }
   }
@@ -51,7 +51,24 @@ class DesktopRenderWorkerPoolTest {
       // Same worker, different seeds — the per-capture seed must not stick to the process, or a
       // preview would render with the variant knobs of whatever ran before it.
       assertTrue(seeded.readText(), seeded.readText().contains("""{"name":"v"}"""))
-      assertEquals("2:#2", plain.readText())
+      assertEquals("2::#2", plain.readText())
+    }
+  }
+
+  @Test
+  fun theParameterKnobsRideTheRequestRatherThanTheWorkerEnvironment() {
+    pool().use { pool ->
+      val knobbed = tempFolder.newFile("knobbed.txt")
+      val plain = tempFolder.newFile("plain.txt")
+      val payload = """[{"name":"title","index":0,"type":"STRING","default":"hi"}]"""
+      pool.render(argsFor(knobbed), null, payload)
+      pool.render(argsFor(plain), null)
+
+      // Same worker, different previews. A knob list left in the process would declare one
+      // preview's controls into the NEXT capture's overrides sidecar and bind its seeds to
+      // parameters of a different function — the same hazard the override seed above has.
+      assertTrue(knobbed.readText(), knobbed.readText().contains(payload))
+      assertEquals("2::#2", plain.readText())
     }
   }
 
@@ -127,8 +144,8 @@ class DesktopRenderWorkerPoolTest {
       pool.render(argsFor(first), null)
       pool.render(argsFor(second), null)
       // Both `#1`: the budget of one retired the first worker, bounding any native leak.
-      assertEquals("2:#1", first.readText())
-      assertEquals("2:#1", second.readText())
+      assertEquals("2::#1", first.readText())
+      assertEquals("2::#1", second.readText())
     }
   }
 

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -1284,12 +1284,23 @@ internal fun renderPreview(
   // annotation.
   captureGutter: PreviewCaptureGutter = PreviewCaptureGutter.None,
   fileSystem: FileSystem = SystemFileSystem,
+  knobs: List<PreviewKnobSpec> = PreviewKnobBake.fromSystemProperty(),
 ) {
   val clazz = Class.forName(className)
+  // The seed `main` already applied, read back rather than re-parsed, so the two override formats
+  // cannot disagree about what this capture was asked for: the controller serves `previewOverride*`
+  // from this map and the binder below serves the parameter knobs from the same one.
+  val knobSeeds = ee.schimke.composeai.overrides.PreviewOverrideController.seededValues.value
+  // A `@PreviewParameter` fan-out value and a parameter knob are mutually exclusive by
+  // construction: discovery reports knobs only when EVERY value parameter has a default, and a
+  // `@PreviewParameter` one never does. So a non-empty `previewArgs` is always the provider's row,
+  // and an empty one is the only place a knob seed can bind.
+  val resolvedArgs =
+    if (previewArgs.isEmpty()) PreviewKnobBake.seedArgs(knobs, knobSeeds) else previewArgs
   // `openForInvoke` is what lets a `private fun` preview render here — see that function for why
   // the resolution succeeds but the invoke would not (issue #3873).
   val composableMethod =
-    if (previewArgs.isEmpty()) {
+    if (resolvedArgs.isEmpty()) {
         // `getDeclaredComposableMethod(name)` with no argument types searches for the exact
         // signature `(Composer, int)` — a preview with NO value parameters. A preview whose
         // parameters all declare defaults is a supported shape (`allParametersHaveDefaults` admits
@@ -1304,13 +1315,21 @@ internal fun renderPreview(
               ?: throw failure
           }
       } else {
-        findComposableMethodWithArgs(clazz, functionName, previewArgs)
+        findComposableMethodWithArgs(clazz, functionName, resolvedArgs)
       }
       .openForInvoke()
 
   // Arm the named-override capture for this render: drop any knobs a prior preview declared so this
   // preview's `previewOverride*` lookups accumulate a clean set (drained into the sidecar below).
   ee.schimke.composeai.overrides.PreviewOverrideController.clearDeclarations()
+  // Announce this preview's *parameter* knobs on the same channel. `previewOverride*` records a
+  // declaration as it reads each knob during composition; a parameter knob is read by argument
+  // passing and announces nothing, so without this the sidecar drained below came back empty for a
+  // migrated preview and `serve` served it no controls at all. Recorded here rather than inside the
+  // composition: both inputs are already known, and the clear above has just run.
+  PreviewKnobBake.declarations(knobs, knobSeeds).forEach {
+    ee.schimke.composeai.overrides.PreviewOverrideController.record(it)
+  }
 
   // Second half of applying `localeTag` (the first is the RTL flip below): point the JVM default
   // Locale at the override so CMP `stringResource(...)` — which reads
@@ -1439,7 +1458,7 @@ internal fun renderPreview(
             gutter = captureGutter,
             onMeasured = { w, h -> measured = IntSize(w, h) },
           ) {
-            InvokeComposable(composableMethod, null, previewArgs)
+            InvokeComposable(composableMethod, null, resolvedArgs)
           }
         }
         // `@PreviewWrapper(Provider::class)` — instantiate the provider reflectively

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererWorkerMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererWorkerMain.kt
@@ -44,8 +44,9 @@ import kotlin.system.exitProcess
  * * every `exitProcess` in [main] is on the argument-validation prologue — a *render* failure
  *   writes an `.error.json` sidecar and returns normally, so a broken preview costs a request
  *   rather than a worker;
- * * `@OverrideVariant` seeds are reset per render (see [main]'s `resetForNewSession()` call), so a
- *   capture never inherits the knobs of whatever the worker drew before it.
+ * * `@OverrideVariant` seeds are reset per render (see [main]'s `resetForNewSession()` call) and
+ *   both per-capture properties are cleared after every request, so a capture never inherits the
+ *   seeds or the parameter knobs of whatever the worker drew before it.
  *
  * ## Wire protocol
  *
@@ -61,6 +62,7 @@ import kotlin.system.exitProcess
  * pool -> worker, per request:
  *   int32 MAGIC_REQUEST, int32 requestId,
  *   int32 seedLen, <seedLen bytes UTF-8>,     // `composeai.overrides.seed`, empty for none
+ *   int32 knobsLen, <knobsLen bytes UTF-8>,   // `composeai.preview.knobs`, empty for none (v2+)
  *   int32 argc, argc x (int32 len, <len bytes UTF-8>)
  * worker -> pool, per response:
  *   int32 MAGIC_RESPONSE, int32 requestId, int32 status (0=ok, 1=failed),
@@ -102,6 +104,7 @@ fun desktopRendererWorkerMain() {
 
     val requestId = input.readInt()
     val seed = String(input.readPayload(), Charsets.UTF_8)
+    val knobs = String(input.readPayload(), Charsets.UTF_8)
     val argc = input.readInt()
     if (argc < 0 || argc > MAX_ARGC) {
       System.err.println("compose-preview renderer worker: implausible argc $argc; exiting")
@@ -118,6 +121,11 @@ fun desktopRendererWorkerMain() {
       // property set would make the *next* request look seeded to anything else reading it.
       if (seed.isEmpty()) System.clearProperty(OVERRIDES_SEED_PROPERTY)
       else System.setProperty(OVERRIDES_SEED_PROPERTY, seed)
+      // Same reasoning for the preview's parameter knobs, and the same hazard: a warm worker that
+      // kept the previous capture's knob list would declare another preview's controls into this
+      // one's overrides sidecar, and bind its seeds to parameters of a different function.
+      if (knobs.isEmpty()) System.clearProperty(PreviewKnobBake.KNOBS_PROPERTY)
+      else System.setProperty(PreviewKnobBake.KNOBS_PROPERTY, knobs)
       main(args)
     } catch (e: Exception) {
       // A capture the renderer cannot draw is an ordinary per-request failure. `main()` already
@@ -133,6 +141,7 @@ fun desktopRendererWorkerMain() {
       message = "${t::class.java.simpleName}: ${t.message}"
     } finally {
       System.clearProperty(OVERRIDES_SEED_PROPERTY)
+      System.clearProperty(PreviewKnobBake.KNOBS_PROPERTY)
     }
 
     val payload = message.toByteArray(Charsets.UTF_8)
@@ -177,7 +186,13 @@ private fun DataInputStream.readPayload(): ByteArray {
 internal const val MAGIC_HELLO = 0x43505731 // 'CPW1'
 internal const val MAGIC_REQUEST = 0x43505131 // 'CPQ1'
 internal const val MAGIC_RESPONSE = 0x43505231 // 'CPR1'
-internal const val WORKER_PROTOCOL_VERSION = 1
+// 2 since the request frame gained the per-capture parameter-knob payload. The pool refuses a
+// version it does not recognise and forks per capture instead, which stays correct: the forked lane
+// carries the knobs on `composeai.preview.knobs` like every other per-capture property. Plugin and
+// renderer are resolved at the same version by default
+// (`ee.schimke.composeai:renderer-desktop:<plugin-version>`), so only a deliberately pinned
+// renderer sees the mismatch, and it pays in build time rather than in wrong pixels.
+internal const val WORKER_PROTOCOL_VERSION = 2
 internal const val STATUS_OK = 0
 internal const val STATUS_FAILED = 1
 internal const val OVERRIDES_SEED_PROPERTY = "composeai.overrides.seed"

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/PreviewKnobBake.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/PreviewKnobBake.kt
@@ -1,0 +1,244 @@
+package ee.schimke.composeai.renderer
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
+import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
+import ee.schimke.composeai.data.overrides.PreviewOverrideType
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+
+/**
+ * One editable value parameter of a preview, as the render subprocess receives it.
+ *
+ * Desktop mirror of the plugin's `PreviewKnob`. [type] is carried as the plain enum **name** rather
+ * than an enum of its own: a newer plugin naming a kind this renderer cannot build must cost that
+ * one knob, not fail the whole payload and take the preview's other knobs with it.
+ *
+ * @property name the Kotlin parameter name, and the seed key that addresses it.
+ * @property index the parameter's zero-based position in the function's **full** value-parameter
+ *   list — which may include defaulted parameters that are not knobs (`modifier: Modifier =
+ *   Modifier`), so it is not an index into a knob list.
+ * @property default the parameter's literal default as seed text, or null when discovery could not
+ *   recover one (an expression default — `stringResource(...)`, `itemCount + 1`).
+ */
+public data class PreviewKnobSpec(
+  val name: String,
+  val index: Int,
+  val type: String,
+  val default: String? = null,
+)
+
+/**
+ * Makes a preview's **parameter knobs** count during an offline desktop render — the half of the
+ * knob format the CMP bake lane was missing.
+ *
+ * ### What was missing, and why it mattered off the daemon
+ *
+ * `previewOverride*` publishes a declaration as a by-product of *reading* a knob inside the
+ * composable body, so a bake picks it up for free: [renderPreview] clears the controller before
+ * composing and [writePreviewOverridesSidecar] drains it into `<stem>.overrides.json` afterwards. A
+ * parameter knob is declared by the function signature and read by ordinary argument passing, so
+ * nothing in the composition ever announces it and that drain came back empty.
+ *
+ * That sidecar is not a nicety. `compose-preview serve` reads its override list from the bundled
+ * sidecar — for a daemon-backed host too, since the daemon supplies renders and not declarations —
+ * so a preview migrated to parameter knobs served an empty control list and any consumer selecting
+ * on a knob key found nothing. Recording the declarations here, on the same controller channel the
+ * other format uses, puts both formats in the sidecar and leaves every downstream reader unchanged.
+ *
+ * ### How the knobs get here
+ *
+ * Unlike the Android backend, this renderer has no manifest to read: it takes positional CLI args
+ * plus per-capture system properties. The plugin therefore hands the knobs over as
+ * [KNOBS_PROPERTY], a JSON array beside the `composeai.overrides.seed` it already sets, and the
+ * pooled lane carries the same payload on its request frame — a warm worker outlives one capture,
+ * so a knob list left in the environment would be read by whatever it drew next.
+ *
+ * ### Why this is a renderer-local mirror
+ *
+ * The daemon has the same two mappings (`PreviewKnobSeeds`, `PreviewKnobDeclarations` in
+ * `:daemon:core`), and the Android renderer has its own copy for the same reason this one exists:
+ * each renderer artefact is resolved into a consumer's graph on its own and must stay independently
+ * buildable, which is the trade `PreviewParameterSupport` and `findComposableMethodWithArgs`
+ * already make.
+ */
+internal object PreviewKnobBake {
+
+  /**
+   * The per-capture system property carrying this preview's knobs, as a JSON array of
+   * [PreviewKnobSpec]. Absent or blank on every preview that declares none — which is nearly all of
+   * them.
+   */
+  const val KNOBS_PROPERTY: String = "composeai.preview.knobs"
+
+  /**
+   * The knobs named by [KNOBS_PROPERTY], or empty when it is absent, blank or unreadable.
+   *
+   * Best-effort by design: a malformed payload costs this preview its knob controls and renders
+   * every parameter at its author default, which is what the renderer did before the property
+   * existed. Failing the capture instead would turn a wiring bug into a broken build.
+   */
+  fun fromSystemProperty(): List<PreviewKnobSpec> =
+    System.getProperty(KNOBS_PROPERTY)?.takeIf { it.isNotBlank() }?.let(::parse) ?: emptyList()
+
+  /**
+   * [text] decoded as a knob array, or empty when it does not parse.
+   *
+   * Read off the JSON tree rather than through a generated serializer: this module does not apply
+   * the serialization compiler plugin (nothing here was a wire type before), and adding it to a
+   * published renderer artefact to decode four fields is the larger change. The shape is exactly
+   * `previews.json`'s own `knobs` array, so the plugin serializes its `PreviewKnob` list unchanged.
+   *
+   * An entry missing `name`, `index` or `type` is dropped rather than defaulted: a knob with an
+   * invented name or position would bind a seed to the wrong parameter, which is worse than the
+   * knob not existing.
+   */
+  fun parse(text: String): List<PreviewKnobSpec> = runCatching {
+    Json.parseToJsonElement(text).jsonArray.mapNotNull { element ->
+      val fields = element.jsonObject
+      val name = (fields["name"] as? JsonPrimitive)?.takeIf { it.isString }?.content
+      val index = (fields["index"] as? JsonPrimitive)?.content?.toIntOrNull()
+      val type = (fields["type"] as? JsonPrimitive)?.takeIf { it.isString }?.content
+      if (name == null || index == null || type == null) null
+      else
+        PreviewKnobSpec(
+          name = name,
+          index = index,
+          type = type,
+          default = (fields["default"] as? JsonPrimitive)?.takeIf { it.isString }?.content,
+        )
+    }
+  }
+    .getOrDefault(emptyList())
+
+  /**
+   * The argument array to invoke a preview declaring [knobs] with, given this render's
+   * `@OverrideVariant` seed bag — `null` at every position no seed bound, which is how a partial
+   * seed says "leave this parameter alone" to the defaults mask.
+   *
+   * The binding itself is [PreviewKnobArguments.bind], which already owns the per-kind parsing, the
+   * drop-rather-than-coerce rule and the sizing-by-highest-index rule for this renderer. All this
+   * adds is the two conversions that object cannot do: a typed [PreviewOverrideValue] down to the
+   * verbatim text it parses, and a knob kind carried as a *name* down to the enum — dropping a kind
+   * this renderer does not know rather than guessing at it, so a newer plugin costs one knob and
+   * not the render.
+   */
+  fun seedArgs(
+    knobs: List<PreviewKnobSpec>,
+    seeds: Map<String, PreviewOverrideValue>?,
+  ): List<Any?> {
+    if (knobs.isEmpty() || seeds.isNullOrEmpty()) return emptyList()
+    val bindable = knobs.mapNotNull { knob -> knob.toArgumentKnob() }
+    if (bindable.isEmpty()) return emptyList()
+    val texts = buildMap {
+      for ((key, value) in seeds) {
+        seedText(value)?.let { put(key, it) }
+      }
+    }
+    return PreviewKnobArguments.bind(bindable, texts)
+  }
+
+  /**
+   * This knob as the binder's own shape, or null when its [PreviewKnobSpec.type] names a kind this
+   * renderer cannot build.
+   */
+  private fun PreviewKnobSpec.toArgumentKnob(): PreviewKnobArguments.Knob? = runCatching {
+    PreviewKnobArguments.Type.valueOf(type)
+  }
+    .getOrNull()
+    ?.let { PreviewKnobArguments.Knob(name, index, it) }
+
+  /**
+   * The declarations for [knobs] under this render's [seeds], skipping the knobs that cannot be
+   * declared honestly. Empty when nothing can be — the overwhelmingly common case, since most
+   * previews declare no knobs at all.
+   *
+   * **A knob whose default discovery could not recover is left out.**
+   * `PreviewOverrideDeclaration.default` is not nullable, so declaring one would mean inventing a
+   * value — an empty string, a zero — and presenting it as what the author wrote, giving a viewer a
+   * wrong default and a "reset" that resets to something the preview never said.
+   *
+   * `current` is the value actually in force: the seed where one bound, the author default
+   * otherwise, resolved through [seedArgs] so the control cannot disagree with the pixels beside
+   * it.
+   */
+  fun declarations(
+    knobs: List<PreviewKnobSpec>,
+    seeds: Map<String, PreviewOverrideValue>?,
+  ): List<PreviewOverrideDeclaration> {
+    if (knobs.isEmpty()) return emptyList()
+    val bound = seedArgs(knobs, seeds)
+    return knobs.mapNotNull { knob ->
+      val default = knob.default ?: return@mapNotNull null
+      val type = declaredTypeOf(knob.type) ?: return@mapNotNull null
+      val seeded = bound.getOrNull(knob.index)
+      PreviewOverrideDeclaration(
+        key = knob.name,
+        type = type,
+        // No author-supplied label exists: a parameter has a name and nothing else. The
+        // `previewOverride*` host does the same, so a viewer renders both formats identically.
+        label = knob.name,
+        default = valueOf(type, default),
+        current = valueOf(type, seeded?.toString() ?: default),
+        // A parameter list is fixed-arity, so there is no per-row value to address — always the
+        // un-indexed seed key.
+        index = null,
+      )
+    }
+  }
+
+  /**
+   * The seed text for [value], or null when its kind has no parameter-knob equivalent.
+   *
+   * `ColorValue` is deliberately absent: `Color` is not a seedable parameter kind, so its
+   * `#AARRGGBB` text could only ever fail to parse as one of the numeric kinds. A preview wanting
+   * an editable colour as a parameter takes an ARGB `Long` and gets an ordinary numeric seed.
+   */
+  private fun seedText(value: PreviewOverrideValue): String? =
+    when (value) {
+      is PreviewOverrideValue.StringValue -> value.value
+      is PreviewOverrideValue.IntValue -> value.value.toString()
+      is PreviewOverrideValue.BooleanValue -> value.value.toString()
+      is PreviewOverrideValue.FloatValue -> value.value.toString()
+      is PreviewOverrideValue.ColorValue -> null
+    }
+
+  /**
+   * The declaration type for a knob kind, or null when there is none.
+   *
+   * `LONG` and `DOUBLE` map to `STRING` because [PreviewOverrideType] has no wider numerics. That
+   * costs the control's *shape*, not its reach: a text seed reaches the parameter through the same
+   * path and parses against the knob's own kind, so a `Long` seeded as `"4281558783"` binds exactly
+   * as it would have. A kind this renderer does not know is dropped rather than guessed at.
+   */
+  private fun declaredTypeOf(knobType: String): String? =
+    when (knobType) {
+      "STRING",
+      "LONG",
+      "DOUBLE" -> PreviewOverrideType.STRING
+      "BOOLEAN" -> PreviewOverrideType.BOOL
+      "INT" -> PreviewOverrideType.INT
+      "FLOAT" -> PreviewOverrideType.FLOAT
+      else -> null
+    }
+
+  /**
+   * [text] as the declaration value of [type], falling back to a string value when it does not
+   * parse — reachable only if discovery recovered a constant whose text doesn't round-trip through
+   * its own declared type, where the raw text at least reports what the class file said.
+   */
+  private fun valueOf(type: String, text: String): PreviewOverrideValue =
+    when (type) {
+      PreviewOverrideType.INT ->
+        text.toIntOrNull()?.let { PreviewOverrideValue.IntValue(it) }
+          ?: PreviewOverrideValue.StringValue(text)
+      PreviewOverrideType.FLOAT ->
+        text.toFloatOrNull()?.let { PreviewOverrideValue.FloatValue(it) }
+          ?: PreviewOverrideValue.StringValue(text)
+      PreviewOverrideType.BOOL ->
+        text.toBooleanStrictOrNull()?.let { PreviewOverrideValue.BooleanValue(it) }
+          ?: PreviewOverrideValue.StringValue(text)
+      else -> PreviewOverrideValue.StringValue(text)
+    }
+}

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopKnobBakeSidecarTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopKnobBakeSidecarTest.kt
@@ -1,0 +1,116 @@
+package ee.schimke.composeai.renderer
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
+import java.io.ByteArrayInputStream
+import java.io.File
+import javax.imageio.ImageIO
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * End-to-end proof of the **desktop bake lane** for parameter knobs: a preview written as plain
+ * Compose — no harness call, no controller, no `previewOverride*` — leaves an
+ * `<stem>.overrides.json` beside its PNG describing the controls a viewer should draw.
+ *
+ * That sidecar is what `compose-preview serve` reads its override list from, for a daemon-backed
+ * host too (the daemon supplies renders, not declarations), so before this the whole knob format
+ * was invisible to `serve` for anything baked offline. [DesktopKnobRendererTest] covers the pixels
+ * a seed produces; this covers what the capture *announces*, which is the half that was missing.
+ */
+class DesktopKnobBakeSidecarTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  private val fixtureClass = "ee.schimke.composeai.renderer.KnobRenderTestFixturesKt"
+
+  /** [KnobSticker]'s knobs, exactly as `previews.json` records them — defaults included. */
+  private val stickerKnobs =
+    listOf(
+      PreviewKnobSpec("sizeDp", 0, "INT", "40"),
+      PreviewKnobSpec("dark", 1, "BOOLEAN", "false"),
+    )
+
+  @After
+  fun clearController() {
+    ee.schimke.composeai.overrides.PreviewOverrideController.resetForNewSession()
+  }
+
+  @Test
+  fun `a baked preview publishes its parameter knobs as declarations`() {
+    val (png, sidecar) = bake("unseeded")
+
+    assertTrue("render wrote no PNG", png.isFile && png.length() > 0)
+    assertTrue("no overrides sidecar beside the render: ${sidecar.absolutePath}", sidecar.isFile)
+
+    val json = sidecar.readText()
+    // Both knobs declared, at the literal defaults discovery read out of the compiled body.
+    assertTrue(json, json.contains(""""key":"sizeDp""""))
+    assertTrue(json, json.contains(""""key":"dark""""))
+    // …and nothing seeded, so what is in force is what the author wrote.
+    assertEquals(
+      "a viewer would show a `current` that disagrees with the pixels beside it",
+      2,
+      Regex("\"current\"").findAll(json).count(),
+    )
+    assertTrue(json, json.contains("40"))
+  }
+
+  @Test
+  fun `a seeded knob reaches the pixels and the declaration together`() {
+    ee.schimke.composeai.overrides.PreviewOverrideController.set(
+      mapOf("sizeDp" to PreviewOverrideValue.IntValue(90))
+    )
+    val (png, sidecar) = bake("seeded")
+
+    // The seed bound as an argument — this is the whole path under test: a manifest-shaped knob
+    // list plus a `namedOverrides` seed, with no `previewOverride*` call anywhere in the fixture.
+    val image = ByteArrayInputStream(png.readBytes()).use { ImageIO.read(it) }
+    assertEquals("the seed did not reach the parameter", 90, image.width)
+
+    val json = sidecar.readText()
+    // The unseeded sibling still declares, and still reports its author default — a partial seed
+    // must not blank the knobs it did not name.
+    assertTrue(json, json.contains(""""key":"dark""""))
+    assertTrue("the declaration did not follow the seed: $json", json.contains("90"))
+  }
+
+  @Test
+  fun `a preview with no knobs writes no sidecar, exactly as before`() {
+    val (png, sidecar) = bake("plain", knobs = emptyList())
+    assertTrue("render wrote no PNG", png.isFile && png.length() > 0)
+    assertTrue(
+      "an unknobbed preview must not start emitting an empty override list",
+      !sidecar.exists(),
+    )
+  }
+
+  /** One capture through the real render entry, returning its PNG and the sidecar beside it. */
+  private fun bake(
+    base: String,
+    knobs: List<PreviewKnobSpec> = stickerKnobs,
+  ): Pair<File, File> {
+    val out = File(tempFolder.newFolder(base), "$base.png")
+    renderPreview(
+      className = fixtureClass,
+      functionName = "KnobSticker",
+      widthPx = 400,
+      heightPx = 400,
+      density = 1.0f,
+      showBackground = true,
+      backgroundColor = 0xFFFFFFFF,
+      outputFile = out,
+      wrapperClassName = null,
+      wrapWidth = true,
+      wrapHeight = true,
+      previewArgs = emptyList(),
+      localeTag = null,
+      captureGutter = PreviewCaptureGutter.None,
+      knobs = knobs,
+    )
+    return out to File(out.parentFile, "${out.nameWithoutExtension}.overrides.json")
+  }
+}

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopRendererWorkerProtocolTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopRendererWorkerProtocolTest.kt
@@ -118,12 +118,16 @@ class DesktopRendererWorkerProtocolTest {
     args: List<String>,
     requestId: Int,
     seed: String = "",
+    knobs: String = "",
   ): Int {
     val seedBytes = seed.toByteArray(Charsets.UTF_8)
+    val knobBytes = knobs.toByteArray(Charsets.UTF_8)
     toWorker.writeInt(MAGIC_REQUEST)
     toWorker.writeInt(requestId)
     toWorker.writeInt(seedBytes.size)
     toWorker.write(seedBytes)
+    toWorker.writeInt(knobBytes.size)
+    toWorker.write(knobBytes)
     toWorker.writeInt(args.size)
     args.forEach {
       val b = it.toByteArray(Charsets.UTF_8)

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/PreviewKnobBakeTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/PreviewKnobBakeTest.kt
@@ -1,0 +1,210 @@
+package ee.schimke.composeai.renderer
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
+import ee.schimke.composeai.data.overrides.PreviewOverrideType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins what a desktop bake now publishes for a **parameter knob** — the seam that lets a CMP
+ * preview migrated off `previewOverride*` still fill `<stem>.overrides.json`, which is where
+ * `compose-preview serve` reads its control list from even against a live daemon.
+ */
+class PreviewKnobBakeTest {
+
+  private val knobs =
+    listOf(
+      PreviewKnobSpec("title", 0, "STRING", "Shopping list"),
+      PreviewKnobSpec("count", 1, "INT", "3"),
+      PreviewKnobSpec("enabled", 2, "BOOLEAN", "true"),
+    )
+
+  @Test
+  fun `the payload the plugin sends is previews-json's own knobs array`() {
+    // Serialized plugin-side straight off `PreviewKnob`, so this is the shape discovery writes.
+    val parsed =
+      PreviewKnobBake.parse(
+        """
+        [{"name":"title","index":0,"type":"STRING","default":"Shopping list"},
+         {"name":"count","index":1,"type":"INT","default":"3"},
+         {"name":"enabled","index":2,"type":"BOOLEAN","default":"true"}]
+        """
+          .trimIndent()
+      )
+    assertEquals(knobs, parsed)
+  }
+
+  @Test
+  fun `a knob with no recoverable default still arrives, it just cannot be declared`() {
+    val parsed = PreviewKnobBake.parse("""[{"name":"title","index":0,"type":"STRING"}]""")
+    assertEquals(listOf(PreviewKnobSpec("title", 0, "STRING", null)), parsed)
+    // It still binds a seed…
+    assertEquals(
+      listOf("seeded"),
+      PreviewKnobBake.seedArgs(
+        parsed,
+        mapOf("title" to PreviewOverrideValue.StringValue("seeded")),
+      ),
+    )
+    // …but declaring it would mean inventing an author default and offering a "reset" to a value
+    // the preview never said.
+    assertEquals(emptyList<String>(), PreviewKnobBake.declarations(parsed, null).map { it.key })
+  }
+
+  @Test
+  fun `an entry missing a load-bearing field is dropped rather than defaulted`() {
+    // A knob with an invented name or position would bind a seed to the WRONG parameter, which is
+    // worse than the knob not existing.
+    assertEquals(
+      listOf(PreviewKnobSpec("ok", 1, "INT", null)),
+      PreviewKnobBake.parse(
+        """[{"index":0,"type":"STRING"},{"name":"noIndex","type":"INT"},
+            {"name":"noType","index":9},{"name":"ok","index":1,"type":"INT"}]"""
+      ),
+    )
+  }
+
+  @Test
+  fun `a malformed payload costs this preview its controls, not the capture`() {
+    // Best-effort by design: failing the render would turn a wiring bug into a broken build, and
+    // every parameter still renders at its compiled default.
+    assertEquals(emptyList<PreviewKnobSpec>(), PreviewKnobBake.parse("not json"))
+    assertEquals(emptyList<PreviewKnobSpec>(), PreviewKnobBake.parse("""{"not":"an array"}"""))
+    assertEquals(emptyList<PreviewKnobSpec>(), PreviewKnobBake.parse(""))
+  }
+
+  @Test
+  fun `a preview nobody seeded still declares every knob at its author default`() {
+    val declarations = PreviewKnobBake.declarations(knobs, seeds = null)
+
+    assertEquals(listOf("title", "count", "enabled"), declarations.map { it.key })
+    assertEquals(
+      listOf(PreviewOverrideType.STRING, PreviewOverrideType.INT, PreviewOverrideType.BOOL),
+      declarations.map { it.type },
+    )
+    assertEquals(
+      listOf(
+        PreviewOverrideValue.StringValue("Shopping list"),
+        PreviewOverrideValue.IntValue(3),
+        PreviewOverrideValue.BooleanValue(true),
+      ),
+      declarations.map { it.default },
+    )
+    assertEquals(declarations.map { it.default }, declarations.map { it.current })
+    assertEquals(listOf(null, null, null), declarations.map { it.index })
+  }
+
+  @Test
+  fun `current reports the seeded value so the control cannot disagree with the pixels`() {
+    val declarations =
+      PreviewKnobBake.declarations(knobs, mapOf("count" to PreviewOverrideValue.IntValue(9)))
+
+    assertEquals(PreviewOverrideValue.IntValue(9), declarations[1].current)
+    assertEquals(PreviewOverrideValue.IntValue(3), declarations[1].default)
+  }
+
+  @Test
+  fun `Long and Double are declared as text because the type set has no wider numerics`() {
+    val declarations =
+      PreviewKnobBake.declarations(
+        listOf(
+          PreviewKnobSpec("accentArgb", 0, "LONG", "4281558783"),
+          PreviewKnobSpec("precise", 1, "DOUBLE", "1.5"),
+        ),
+        seeds = null,
+      )
+    assertEquals(
+      listOf(PreviewOverrideType.STRING, PreviewOverrideType.STRING),
+      declarations.map { it.type },
+    )
+    // The reach is unchanged: a text seed parses against the knob's own kind on the way in.
+    assertEquals(
+      listOf(4281558783L, null),
+      PreviewKnobBake.seedArgs(
+        listOf(
+          PreviewKnobSpec("accentArgb", 0, "LONG", "4281558783"),
+          PreviewKnobSpec("precise", 1, "DOUBLE", "1.5"),
+        ),
+        mapOf("accentArgb" to PreviewOverrideValue.StringValue("4281558783")),
+      ),
+    )
+  }
+
+  @Test
+  fun `a kind this renderer does not know is dropped rather than guessed at`() {
+    val newer = listOf(PreviewKnobSpec("accent", 0, "SOMETHING_NEWER", "#FF42A5F5"))
+    assertEquals(emptyList<String>(), PreviewKnobBake.declarations(newer, null).map { it.key })
+    assertEquals(
+      emptyList<Any?>(),
+      PreviewKnobBake.seedArgs(newer, mapOf("accent" to PreviewOverrideValue.StringValue("x"))),
+    )
+  }
+
+  @Test
+  fun `a partial seed leaves every unnamed position null for the defaults mask to fill`() {
+    assertEquals(
+      listOf(null, null, false),
+      PreviewKnobBake.seedArgs(knobs, mapOf("enabled" to PreviewOverrideValue.BooleanValue(false))),
+    )
+  }
+
+  @Test
+  fun `the array is sized by the highest index so a non-knob parameter keeps its slot`() {
+    // `index` is a position in the FULL value-parameter list: a `modifier: Modifier = Modifier`
+    // ahead of the knob is defaulted but not seedable, and its slot must stay null.
+    assertEquals(
+      listOf(null, null, "seeded"),
+      PreviewKnobBake.seedArgs(
+        listOf(PreviewKnobSpec("label", 2, "STRING", "hi")),
+        mapOf("label" to PreviewOverrideValue.StringValue("seeded")),
+      ),
+    )
+  }
+
+  @Test
+  fun `a seed that is not a valid value of its knob kind falls back to the author default`() {
+    // Coercing `"yes"` to `true` would publish a capture that disagrees with what was asked for.
+    assertEquals(
+      emptyList<Any?>(),
+      PreviewKnobBake.seedArgs(knobs, mapOf("enabled" to PreviewOverrideValue.StringValue("yes"))),
+    )
+    // A colour has no parameter-knob equivalent, so it binds nothing rather than half-parsing.
+    assertEquals(
+      emptyList<Any?>(),
+      PreviewKnobBake.seedArgs(
+        knobs,
+        mapOf("title" to PreviewOverrideValue.ColorValue("#FF42A5F5")),
+      ),
+    )
+  }
+
+  @Test
+  fun `nothing to bind keeps the zero-argument invoke a plain preview has always used`() {
+    assertEquals(emptyList<Any?>(), PreviewKnobBake.seedArgs(emptyList(), null))
+    assertEquals(emptyList<Any?>(), PreviewKnobBake.seedArgs(knobs, emptyMap()))
+    // A seed naming no declared parameter is the other format's key — the controller takes it.
+    assertEquals(
+      emptyList<Any?>(),
+      PreviewKnobBake.seedArgs(knobs, mapOf("label" to PreviewOverrideValue.StringValue("x"))),
+    )
+    assertEquals(emptyList<Any?>(), PreviewKnobBake.declarations(emptyList(), null))
+  }
+
+  @Test
+  fun `an absent property means a preview with no knobs`() {
+    System.clearProperty(PreviewKnobBake.KNOBS_PROPERTY)
+    assertEquals(emptyList<PreviewKnobSpec>(), PreviewKnobBake.fromSystemProperty())
+    try {
+      System.setProperty(
+        PreviewKnobBake.KNOBS_PROPERTY,
+        """[{"name":"title","index":0,"type":"STRING","default":"Shopping list"}]""",
+      )
+      assertEquals(
+        listOf(PreviewKnobSpec("title", 0, "STRING", "Shopping list")),
+        PreviewKnobBake.fromSystemProperty(),
+      )
+    } finally {
+      System.clearProperty(PreviewKnobBake.KNOBS_PROPERTY)
+    }
+  }
+}

--- a/samples/android-live-lane/build.gradle.kts
+++ b/samples/android-live-lane/build.gradle.kts
@@ -21,7 +21,7 @@
 //
 // **That knob stays a `previewOverride*` one until someone can run the spec.** The spec reads the
 // override list from the bundle's `previews/<id>.overrides.json` sidecar and FAILS rather than
-// skips when it finds no label-knob preview. The Android bake now records a *parameter* knob into
+// skips when it finds no label-knob preview. Both bake lanes now record a *parameter* knob into
 // that sidecar too, so the format is no longer the blocker — but the spec needs a daemon-backed
 // serve under Playwright and cannot run from this repository, so migrating the knob here would ship
 // an unverified change to another repo's required e2e. See


### PR DESCRIPTION
The second half of the offline-bake gap. [#5099](https://github.com/yschimke/compose-ai-tools/pull/5099) did the Android lane; this does desktop/CMP, and with it **every** lane — both daemons and both bakes — publishes a parameter knob as a `PreviewOverrideDeclaration`. `docs/design/PARAMETER_KNOB_MIGRATION.md` gap 6 is closed.

Why the sidecar is the thing that matters: `compose-preview serve` reads its override list from `previews/<id>.overrides.json` — for a daemon-backed host too, since the daemon supplies renders and not declarations — so a migrated CMP preview served no controls at all.

## What changed

The renderers differ only in **how the knobs reach them**. Android reads `previews.json` itself, so #5099 needed no plugin change. Desktop takes positional argv plus per-capture system properties and has no manifest, so it needs a channel:

* **Forked lane** — the plugin serializes `previews.json`'s own `knobs` array onto `composeai.preview.knobs`, beside the `composeai.overrides.seed` it already sets. Set only for a preview that declares a knob, so an ordinary capture's command line — and therefore every unknobbed run's task inputs — is exactly as it was.
* **Pooled lane** — the same payload rides the request frame, **worker protocol v2**. A warm worker outlives a capture, so a knob list left in the environment would be read by whatever it drew next: the identical hazard the override seed already had, and the reason that seed rides the frame rather than the worker's command line. A worker built from an older renderer answers v1, the handshake refuses it, and that capture forks — which still renders correctly, because the forked lane carries the property. Plugin and renderer resolve at the same version by default (`renderer-desktop:${PluginVersion.value}`), so only a deliberately pinned renderer sees the mismatch, and it pays in build time rather than in wrong pixels.

`PreviewKnobBake` then builds the declarations and records them on the same controller channel `previewOverride*` publishes through, just after `clearDeclarations()` and just after the seed, so the existing drain writes them and every downstream reader is unchanged.

### Reusing the binder that was already here

First pass duplicated the seed→argument binding. It didn't need to: **`PreviewKnobArguments` already exists in this module** and owns the per-kind parsing, the drop-rather-than-coerce rule and the sizing-by-highest-index rule. `seedArgs` now delegates to it and adds only the two conversions that object cannot do — a typed `PreviewOverrideValue` down to the text it parses, and a knob kind carried as a *name* down to the enum, dropping a kind this renderer cannot build rather than guessing at it. All 13 mapping tests pass identically before and after that refactor, which is what says the delegation is behaviour-preserving.

A knob whose literal default discovery could not recover is left **undeclared** rather than declared with an invented default and a "reset" that resets to something the preview never said.

## Test plan

Verified by running, not by inspection. `:renderer-desktop:test` — **206 tests, 0 skipped, 0 failed**; `-p gradle-plugin :test` green; `ktfmtCheckAll` green.

* **`DesktopKnobBakeSidecarTest` (new, 3 tests, 0 skipped — it really renders)** is the end-to-end claim: a fixture written as plain Compose, with no harness call, no controller and no `previewOverride*` anywhere, leaves an `<stem>.overrides.json` beside its PNG declaring both knobs at the literal defaults discovery read out of the compiled body. A seeded run then proves the *same* path binds: `sizeDp = 90` comes back as a 90px-wide image **and** a declaration whose `current` followed it, while the unseeded sibling still declares its author default. A preview with no knobs still writes no sidecar.
* **`PreviewKnobBakeTest` (new, 13 tests)** pins the payload shape (`previews.json`'s array, serialized unchanged), an entry missing `name`/`index`/`type` dropped rather than defaulted — an invented name or position would bind a seed to the *wrong* parameter — a malformed payload costing the controls and not the capture, `LONG`/`DOUBLE` declared as text with their reach intact, an unknown kind dropped, and a partial seed leaving unnamed positions null.
* **`DesktopRenderWorkerPoolTest`** gains `theParameterKnobsRideTheRequestRatherThanTheWorkerEnvironment`, the exact sibling of the existing seed test: same worker, two previews, and the knobbed one's payload must not stick to the process. The stub had to read the new field regardless — skipping it would desynchronise the frame stream and every later assertion would be about a corrupt frame rather than about the pool.
* **`DesktopRendererWorkerProtocolTest` ran (2 tests, 0 skipped)**, so the v2 frame round-trips against the *real* renderer with skiko loaded — that is what checks the two hand-duplicated protocol implementations still agree.

Non-visual: the change is what a capture *declares*, not what it draws, and the pixel assertions above exist to prove the seed path rather than to show a new surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o

---
_Generated by [Claude Code](https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o)_