### PR TITLE
fix(discovery): keep a preview's target when its content lambda captures

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
@@ -119,11 +119,31 @@ object PreviewTargetInference {
   private const val CMP_PREVIEW_FQN = PreviewDiscovery.CMP_PREVIEW_FQN
   private const val COMPOSABLE_FQN = "androidx.compose.runtime.Composable"
 
-  /** Single bytecode call site, as captured from the preview method body. */
+  /**
+   * Single bytecode call site, as captured from the preview method body.
+   *
+   * [viaLambda] marks a call the walk reached by descending into one of the preview's content
+   * lambdas rather than one the preview body makes itself. The distinction has to be recorded here
+   * because the two are indistinguishable afterwards, and because **whether a lambda is even
+   * reachable depends on the Kotlin compiler, not on the preview**: a non-capturing composable
+   * lambda is lifted into a `ComposableSingletons$…` class (walked, narrowly, by
+   * [extractComposeSingletonLambdaCalls]), while one that captures compiles to a
+   * `<preview>$lambda$N` method of the preview's own class, which the nested-method walk follows
+   * wholesale. Adding a single defaulted parameter to a preview flips it from the first shape to
+   * the second, so without this flag `infer`'s "how many project composables did this preview
+   * call?" count — and with it the target — changes for a preview whose body did not.
+   *
+   * Only the nested-method descent is tagged. [extractComposeSingletonLambdaCalls]'s results are
+   * lambda contents by the same argument and arguably belong here too, but tagging them changes the
+   * target of previews that have nothing to do with this bug — a `Theme { … }` sticker whose
+   * candidates were all suppressed by the survivor penalty starts reporting the frame it wraps — so
+   * that half is deliberately left alone rather than settled as a side effect of this fix.
+   */
   internal data class Invocation(
     val ownerFqn: String,
     val methodName: String,
     val descriptor: String,
+    val viaLambda: Boolean = false,
   )
 
   private data class Candidate(
@@ -290,7 +310,26 @@ object PreviewTargetInference {
 
     if (candidates.isEmpty()) return emptyList()
 
-    val survivors = candidates.size
+    // Count the composables the preview body calls ITSELF, and fall back to the lambda-reached
+    // ones only when it calls none directly — the `Theme { Screen() }` shape, where the wrapper is
+    // filtered out and the subject is only reachable through the lambda.
+    //
+    // A call reached by descending into a content lambda is not evidence that the preview renders
+    // several things side by side; it is the inside of the one thing it wraps. Counting both
+    // together made the penalty below depend on whether that lambda captured — a Kotlin compiler
+    // decision that a single defaulted parameter flips, silently changing the target of a preview
+    // whose body did not change. See [Invocation.viaLambda].
+    val directCallKeys =
+      calls
+        .asSequence()
+        .filterNot { it.viaLambda }
+        .mapTo(mutableSetOf()) { it.ownerFqn to it.methodName }
+    fun key(candidate: ResolvedCandidate) = candidate.ownerFqn to candidate.method.name
+    val directCandidates = candidates.filter { (candidate, _) -> key(candidate) in directCallKeys }
+    // The candidates the count is taken over. Anything outside it is still allowed to win, but on
+    // its own merits (name match, cross-file, …) rather than by being "the only call".
+    val counted = (directCandidates.ifEmpty { candidates }).mapTo(mutableSetOf()) { key(it.first) }
+    val survivors = counted.size
     // Keep each candidate paired with its score so the winner's resolved metadata is in hand below
     // rather than read a second time.
     val scored = candidates.map { (candidate, signature) ->
@@ -315,6 +354,7 @@ object PreviewTargetInference {
             } == true,
           wrapperUnwrapped = candidate.ownerFqn to candidate.method.name in unwrappedTargets,
           totalSurvivors = survivors,
+          counted = key(candidate) in counted,
           resolveSourceFile = resolveSourceFile,
         )
     }
@@ -443,7 +483,9 @@ object PreviewTargetInference {
       val key = pending.removeFirst()
       if (!visited.add(key)) continue
       val body = bodies[key] ?: continue
-      collected += body.calls
+      // Only a root body's calls are the preview's own; everything a followed nested method calls
+      // was reached by descending into a lambda. See [Invocation.viaLambda].
+      collected += if (isRoot(key)) body.calls else body.calls.map { it.copy(viaLambda = true) }
       pending.addAll(body.nestedMethods.filter(shouldFollow))
     }
     return collected
@@ -639,16 +681,20 @@ object PreviewTargetInference {
     callerMethodHasComposableParam: Boolean,
     wrapperUnwrapped: Boolean,
     totalSurvivors: Int,
+    counted: Boolean,
     resolveSourceFile: (String) -> String?,
   ): ScoredCandidate {
     var score = 0
     val signals = mutableListOf<TargetSignal>()
 
-    // +3 if this is the only project-local non-wrapper composable left after filtering.
-    if (totalSurvivors == 1) {
+    // +3 if this is the only project-local non-wrapper composable left after filtering. Only a
+    // candidate inside the counted set can earn it: when a preview calls one composable directly
+    // and that composable's lambda calls others, "the only call" describes the direct one, and
+    // handing the bonus to a lambda-reached sibling would let it tie and win on call order.
+    if (totalSurvivors == 1 && counted) {
       score += 3
       signals += TargetSignal.SINGLE_PROJECT_COMPOSABLE_CALL
-    } else {
+    } else if (totalSurvivors > 1) {
       // Multiple survivors penalise *each* candidate by (n-1) so the top one still has a
       // chance to clear the threshold when it independently matches by name.
       score -= (totalSurvivors - 1)

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -3967,6 +3967,89 @@ class DiscoveryFunctionalTest {
   }
 
   @Test
+  fun `a capturing content lambda does not cost a preview its target`() {
+    // Mirrors the shape a parameter knob produces: the preview calls ONE project composable (a
+    // sticker wrapper), and the wrapper's content lambda calls several more from the same file.
+    //
+    // A lambda capturing nothing is lifted into a `ComposableSingletons$...` class; one that
+    // captures compiles to a `<preview>$lambda$N` method of the preview's OWN class, which the
+    // nested-method walk follows. Adding a single defaulted parameter flips a preview from the
+    // first shape to the second — so everything inside the lambda joined the preview's own call
+    // set, inflated the "how many project composables did this call?" count, and penalised every
+    // candidate below the emit threshold. The preview reported no target at all, for a body that
+    // had not changed.
+    //
+    // **This test guards the invariant; it does not reproduce the bug.** The Compose compiler does
+    // not lift this small a lambda into the same-class `$lambda$N` shape, so it passes with and
+    // without the fix. The reproduction is a real catalog — `m3-catalog`'s
+    // `ListDetailPaneScaffoldSticker`, whose target went from `AdaptiveSticker`/HIGH to nothing on
+    // the commit that gave it a `twoPanesOnMedium` knob, and came back with this change. Keep this
+    // test as the statement of what must hold; reach for a real project to see it fail.
+    val projectDir = createCmpTestProject()
+
+    val srcDir = File(projectDir, "src/main/kotlin/test")
+    File(srcDir, "Previews.kt").delete()
+
+    File(srcDir, "Previews.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.material3.Text
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.tooling.preview.Preview
+
+        @Composable
+        fun Sticker(content: @Composable (Int) -> Unit) {
+            content(1)
+        }
+
+        @Composable
+        fun Pane(count: Int) {
+            Text("pane ${'$'}count")
+        }
+
+        @Composable
+        fun Caption(count: Int) {
+            Text("caption ${'$'}count")
+        }
+
+        @Preview
+        @Composable
+        fun ScaffoldSticker(doubled: Boolean = false) = Sticker { count ->
+            val scaled = if (doubled) count * 2 else count
+            Pane(scaled)
+            Caption(scaled)
+        }
+        """
+          .trimIndent()
+      )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewDiscover", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+
+    assertThat(result.task(":composePreviewDiscover")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+    val preview = manifest.previews.single { it.functionName == "ScaffoldSticker" }
+    // The knob is what makes the lambda capture, so this really is the shape under test.
+    assertThat(preview.knobs.map { it.name }).containsExactly("doubled")
+
+    // `Sticker` is the one composable the preview calls itself. `Pane` and `Caption` are the inside
+    // of that one thing, not two more subjects beside it.
+    val target = preview.targets.single()
+    assertThat(target.functionName).isEqualTo("Sticker")
+    assertThat(target.signals).contains(TargetSignal.SINGLE_PROJECT_COMPOSABLE_CALL)
+  }
+
+  @Test
   fun `composePreviewDiscover looks through theme and catalog lambdas and names mangled targets`() {
     val projectDir = createCmpTestProject()
 


### PR DESCRIPTION
Found while migrating [`m3-catalog`](https://github.com/yschimke/m3-catalog/pull/284) to parameter knobs: giving a preview a knob silently cost it its inferred target.

## The bug

A preview's content lambda compiles one of two ways, and which one is the Kotlin compiler's decision rather than the author's:

- captures nothing → lifted into a `ComposableSingletons$…` class, which the walk sees into only through `extractComposeSingletonLambdaCalls`
- captures something → a `<preview>$lambda$N` method of the preview's **own** class, which the nested-method walk follows wholesale

Adding a single defaulted parameter flips a preview from the first shape to the second. Everything inside the lambda then joined the preview's own call set, inflated `infer`'s survivor count, and penalised every candidate by `(n-1)` until none cleared `MIN_EMIT_SCORE`.

Concretely, on m3-catalog's `ListDetailPaneScaffoldSticker`, before and after it gained a `twoPanesOnMedium` knob:

| | targets |
| --- | --- |
| no knob | `AdaptiveSticker` — HIGH — `[SINGLE_PROJECT_COMPOSABLE_CALL, NON_SHIPPING_SOURCE_SET]` |
| with knob | *(empty)* |

Same body, same wrapper, no target.

## The fix

`Invocation` records whether the walk reached a call by descending into a lambda. The survivor count is then taken over the calls the preview body makes **itself**, falling back to the lambda-reached ones when it makes none — the `Theme { Screen() }` shape, where the wrapper is filtered out and the subject is only reachable through the lambda. The `SINGLE_PROJECT_COMPOSABLE_CALL` bonus is confined to that same counted set, so a lambda-reached sibling cannot tie with the direct call and win on call order.

**Deliberately narrow.** `extractComposeSingletonLambdaCalls`'s results are lambda contents by the same argument and arguably belong on the same footing — but tagging them too changes previews this bug never touched (a `Theme { … }` sticker whose candidates were all suppressed by the penalty starts reporting the frame it wraps; 6 → 80 changed previews in m3-catalog when I tried it). That half is left for a change that can weigh it on its own merits. I also tried excluding composable *value getters* (`currentScheme(): ColorScheme`) from `infer`, as `inferComponents` already does — same story, so it is not in this PR either.

## Test plan

* `:gradle-plugin:preview-discovery:test` — green.
* `:gradle-plugin:test` — green.
* `:gradle-plugin:functionalTest --tests "*DiscoveryFunctionalTest*"` (whole class, including the four existing target-inference tests) — green.
* **Blast radius on real projects**, discovery run before/after and the manifests diffed whole:
  * `:samples:design-catalog-m3` — 55 previews, **byte-identical**
  * `:samples:cmp` — 75 previews, **byte-identical**
  * `m3-catalog` — 4149 previews, ids identical including order; `ListDetailPaneScaffoldSticker` / `SupportingPaneScaffoldSticker` regain exactly their pre-knob target (`AdaptiveSticker`, HIGH, same signals) while keeping the richer `componentTargets` the lambda descent found. The only other change is six `ColorRoleGridSticker` captures — capture-shape previews that now score on their direct call and report a LOW-confidence `currentScheme` where the blanket penalty previously suppressed everything.

One caveat, stated plainly because it matters for review: **the added functional test guards the invariant but does not reproduce the failure.** The Compose compiler will not lift a lambda that small into the same-class `$lambda$N` shape, so it passes with and without the fix; the comment on the test says so and points at the real reproduction. The evidence that this fixes anything is the m3-catalog manifest diff above, run against a locally published plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STv5Vor6hnPnhMSNuFMqqn

---
_Generated by [Claude Code](https://claude.ai/code/session_01STv5Vor6hnPnhMSNuFMqqn)_