### PR TITLE
fix(render-session): refuse a daemon-launch descriptor whose schemaVersion is not this module's

### DIFF
--- a/render-session/subprocess/build.gradle.kts
+++ b/render-session/subprocess/build.gradle.kts
@@ -39,6 +39,10 @@ dependencies {
 
   testImplementation(libs.junit)
   testImplementation(libs.truth)
+
+  // `DescriptorSchemaVersionTest` opens a session against a descriptor that only exists in memory,
+  // which is what the defaulted `fileSystem` parameter on `open` is for — see its KDoc.
+  testImplementation(libs.okio.fakefilesystem)
 }
 
 // `NonGradleContractTest` (see src/test/.../subprocess/NonGradleContractTest.kt) synthesises a

--- a/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
+++ b/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
@@ -71,6 +71,7 @@ public object SubprocessRenderSessions : RenderSessionFactory {
           cause = e,
         )
       }
+    checkSchemaVersion(descriptor, descriptorFile.path)
     var effectiveDescriptor =
       if (config.forceEnabled && !descriptor.enabled) descriptor.copy(enabled = true)
       else descriptor
@@ -189,6 +190,55 @@ public object SubprocessRenderSessions : RenderSessionFactory {
     )
   }
 
+  /**
+   * Refuse a descriptor whose [DaemonLaunchDescriptor.schemaVersion] is not the one this module
+   * speaks, before anything acts on its fields.
+   *
+   * The descriptor's own contract says consumers gate on the version and force a fresh descriptor
+   * on mismatch (`DaemonClasspathDescriptor` KDoc, "Schema versioning"), and `compose-preview
+   * doctor` has always reported a mismatch as an error — but the spawn path read the version and
+   * never looked at it. That is a silent-wrong-answer shape rather than a cosmetic gap: the JVM
+   * reader keeps `ignoreUnknownKeys = true` and gives its reader-only fields Kotlin defaults, so a
+   * descriptor from a NEWER writer parses cleanly and the session launches against defaults for
+   * everything the new version added. Post-split this module is a published contract an extracted
+   * preview server links against (#3824), so "the reader is older than the writer" is an ordinary
+   * cross-repo version pairing rather than a same-commit mistake. Filed as #5105, deferred
+   * from #4571.
+   *
+   * Both directions refuse — exact match, the same gate the other two consumers of this descriptor
+   * already apply. VS Code's `daemonProcess.ts` requires the version to equal its own and otherwise
+   * discards the descriptor and forces a re-run, `compose-preview doctor` reports any mismatch as
+   * an error, and `docs/NON_GRADLE_INTEGRATION.md` already told hand-written producers that "the
+   * subprocess factory rejects anything else with a clear error". It is the right shape here too:
+   * the version is a single integer bumped only when the shape changes in a way that could break
+   * older readers, so there is no major/minor split to be lenient about, and unlike a packed bundle
+   * (`docs/VERSIONING.md` § 3's "keep readers tolerant of the older value", which is about
+   * artifacts that outlive their writer) a `daemon-launch.json` is a build output the producer
+   * regenerates on demand. The two messages differ in the remedy, which is the part a caller can
+   * act on: an OLDER descriptor is stale and regenerating it fixes it, while a NEWER one needs the
+   * consumer upgraded (regenerating would rewrite the same unreadable version).
+   *
+   * [openBundleDaemon] needs no such gate: it stamps [DAEMON_DESCRIPTOR_SCHEMA_VERSION] into a
+   * descriptor it constructs in-process, so writer and reader are the same build by construction.
+   */
+  private fun checkSchemaVersion(descriptor: DaemonLaunchDescriptor, path: String) {
+    val found = descriptor.schemaVersion
+    if (found == DAEMON_DESCRIPTOR_SCHEMA_VERSION) return
+    val remedy =
+      if (found < DAEMON_DESCRIPTOR_SCHEMA_VERSION)
+        "The descriptor was written by an older compose-preview plugin. Re-run " +
+          "`:<modulePath>:composePreviewDaemonStart` with the current plugin to regenerate it."
+      else
+        "The descriptor was written by a newer compose-preview plugin than this library " +
+          "understands. Upgrade the consumer (or pin the plugin to the version that matches " +
+          "it) — reading it as v$DAEMON_DESCRIPTOR_SCHEMA_VERSION would launch the daemon " +
+          "against defaults for whatever the newer schema added."
+    throw RenderSessionException(
+      "Daemon launch descriptor at $path declares schemaVersion=$found, but this build of " +
+        "render-session-subprocess speaks version $DAEMON_DESCRIPTOR_SCHEMA_VERSION. $remedy"
+    )
+  }
+
   /** Shared spawn + JSON-RPC initialize + session-wrap path for [open] and [openBundleDaemon]. */
   private fun spawnAndInitialize(
     descriptor: DaemonLaunchDescriptor,
@@ -262,6 +312,8 @@ public object SubprocessRenderSessions : RenderSessionFactory {
    * fails if the two ever disagree, which matters more than usual: this is one of the published
    * contract modules an extracted preview server links against (#3824), so after the split a stale
    * copy here is cross-repo version skew that no compiler sees.
+   *
+   * Also the version [open] gates an on-disk descriptor against — see [checkSchemaVersion].
    */
   private const val DAEMON_DESCRIPTOR_SCHEMA_VERSION = 2
 

--- a/render-session/subprocess/src/test/kotlin/ee/schimke/composeai/render/session/subprocess/DescriptorSchemaVersionTest.kt
+++ b/render-session/subprocess/src/test/kotlin/ee/schimke/composeai/render/session/subprocess/DescriptorSchemaVersionTest.kt
@@ -1,0 +1,105 @@
+package ee.schimke.composeai.render.session.subprocess
+
+import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.daemon.client.DaemonClientFactory
+import ee.schimke.composeai.daemon.protocol.DaemonLaunchDescriptor
+import ee.schimke.composeai.render.session.RenderSessionConfig
+import ee.schimke.composeai.render.session.RenderSessionException
+import java.io.File
+import kotlinx.serialization.json.Json
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.Test
+
+/**
+ * `SubprocessRenderSessions.open` gates the on-disk descriptor's `schemaVersion` before anything
+ * acts on its fields (#5105, deferred from #4571).
+ *
+ * The hazard is specific and silent: the JVM reader tolerates unknown keys and defaults its
+ * reader-only fields, so a descriptor written by a NEWER writer parses cleanly and the daemon
+ * launches against defaults for everything the new version added — no exception, just a session
+ * built from a contract nobody agreed on. Post-split this module is a published contract an
+ * extracted preview server links against (#3824), so an older reader meeting a newer descriptor is
+ * an ordinary cross-repo pairing rather than a same-commit mistake.
+ *
+ * The descriptors below are deliberately skewed off the writer's version — that is the point of the
+ * test, and `check-daemon-launch-schema.py` excludes test sources from its stamp scan for exactly
+ * this case.
+ */
+class DescriptorSchemaVersionTest {
+
+  private val json = Json { encodeDefaults = true }
+
+  private val fileSystem = FakeFileSystem()
+
+  /** Never reached by a refused descriptor; reaching it is how the accept case is proven. */
+  private val spawnMarker = "spawn reached"
+
+  private val factory = DaemonClientFactory { _, _ -> throw IllegalStateException(spawnMarker) }
+
+  @Test
+  fun `a newer descriptor is refused, naming the remedy the caller can act on`() {
+    val e = openWithSchemaVersion(99)
+
+    assertThat(e).hasMessageThat().contains("schemaVersion=99")
+    assertThat(e).hasMessageThat().contains("speaks version 2")
+    assertThat(e).hasMessageThat().contains("newer compose-preview plugin")
+    assertThat(e).hasMessageThat().contains("Upgrade the consumer")
+    // The gate fires before the spawn, so no daemon JVM is forked against an unreadable contract.
+    assertThat(e).hasMessageThat().doesNotContain(spawnMarker)
+  }
+
+  @Test
+  fun `an older descriptor is refused, and its remedy is to regenerate it`() {
+    val e = openWithSchemaVersion(1)
+
+    assertThat(e).hasMessageThat().contains("schemaVersion=1")
+    assertThat(e).hasMessageThat().contains("older compose-preview plugin")
+    assertThat(e).hasMessageThat().contains("composePreviewDaemonStart")
+    assertThat(e).hasMessageThat().doesNotContain(spawnMarker)
+  }
+
+  @Test
+  fun `a matching descriptor passes the gate and reaches the spawn`() {
+    // The injected factory always throws, so `open` cannot return a session here. What the test
+    // asserts is *which* failure it gets: the spawn's, not the gate's.
+    val e = openWithSchemaVersion(2)
+
+    assertThat(e).hasMessageThat().contains("Failed to spawn daemon subprocess")
+    assertThat(e).hasMessageThat().contains(spawnMarker)
+    assertThat(e).hasMessageThat().doesNotContain("schemaVersion")
+  }
+
+  private fun openWithSchemaVersion(schemaVersion: Int): RenderSessionException {
+    val path = "/workspace/module/build/compose-previews/daemon-launch.json"
+    fileSystem.createDirectories(path.toPath().parent!!)
+    fileSystem.write(path.toPath()) { writeUtf8(descriptor(schemaVersion)) }
+
+    return runCatching {
+      SubprocessRenderSessions.open(
+        config = RenderSessionConfig(descriptorPath = File(path)),
+        factory = factory,
+        fileSystem = fileSystem,
+      )
+    }
+      .exceptionOrNull() as? RenderSessionException
+      ?: error("expected a RenderSessionException from open(schemaVersion=$schemaVersion)")
+  }
+
+  private fun descriptor(schemaVersion: Int): String =
+    json.encodeToString(
+      DaemonLaunchDescriptor.serializer(),
+      DaemonLaunchDescriptor(
+        schemaVersion = schemaVersion,
+        modulePath = ":module",
+        variant = "desktop",
+        enabled = true,
+        mainClass = "ee.schimke.composeai.daemon.DaemonMain",
+        classpath = listOf("/lib/daemon.jar"),
+        jvmArgs = listOf("-Xmx512m"),
+        systemProperties = mapOf("composeai.daemon.userClassDirs" to "/workspace/module/classes"),
+        workingDirectory = "/workspace/module",
+        manifestPath = "/workspace/module/build/compose-previews/previews.json",
+      ),
+    )
+}

--- a/render-session/subprocess/src/test/kotlin/ee/schimke/composeai/render/session/subprocess/NonGradleContractTest.kt
+++ b/render-session/subprocess/src/test/kotlin/ee/schimke/composeai/render/session/subprocess/NonGradleContractTest.kt
@@ -255,7 +255,10 @@ class NonGradleContractTest {
     renderOutputDir: File,
     historyDir: File,
   ): JsonObject = buildJsonObject {
-    put("schemaVersion", JsonPrimitive(1))
+    // 2, not the stale 1 this carried: the writer moved to v2 and nothing made the test follow,
+    // because `open` read the version without checking it. It does now (#5105), so a hand-written
+    // producer pinning the wrong version is refused — which is exactly what this descriptor was.
+    put("schemaVersion", JsonPrimitive(2))
     put("modulePath", JsonPrimitive(modulePath))
     put("variant", JsonPrimitive(variant))
     put("enabled", JsonPrimitive(true))

--- a/scripts/daemon-launch-schema-allowlist.json
+++ b/scripts/daemon-launch-schema-allowlist.json
@@ -65,8 +65,8 @@
     {
       "file": "render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt",
       "symbol": "DAEMON_DESCRIPTOR_SCHEMA_VERSION",
-      "role": "second writer",
-      "why": "`:render-session-subprocess` writes its own descriptors for the bundle daemons it spawns, stamping this private copy. It is one of the twelve published contract modules an extracted preview server links against (#3824), so post-split a stale mirror here is cross-repo version skew no compiler sees."
+      "role": "second writer + read gate",
+      "why": "`:render-session-subprocess` writes its own descriptors for the bundle daemons it spawns, stamping this private copy, and since #5105 `SubprocessRenderSessions.open` also refuses an on-disk descriptor whose version is not this one. It is one of the twelve published contract modules an extracted preview server links against (#3824), so post-split a stale mirror here is cross-repo version skew no compiler sees."
     },
     {
       "file": "cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt",


### PR DESCRIPTION
Fixes #5105 — the decision deferred from #4571 ("refuse / warn / refuse-only-on-major-bump"), and its implementation.

## The gap

`SubprocessRenderSessions.open` stamped `schemaVersion` when it *wrote* a bundle descriptor but never looked at the field when it *read* one from disk. That is a silent-wrong-answer shape rather than a cosmetic one: the JVM reader keeps `ignoreUnknownKeys = true` and gives its reader-only fields Kotlin defaults, so a descriptor written by a **newer** plugin parses cleanly and the daemon launches against defaults for everything the new version added — no exception, just a session built on a contract nobody agreed on. Post-split this module is one of the published contract modules an extracted preview server links against (#3824), so "the reader is older than the writer" is an ordinary cross-repo version pairing rather than a same-commit mistake.

## The decision: refuse, in both directions

Exact match, which is what the descriptor's other two consumers already do and what this repo's docs already promised:

- VS Code's `daemonProcess.ts` requires the version to equal its own and otherwise discards the descriptor and forces a re-run (`docs/API_STABILITY.md`).
- `compose-preview doctor` reports any mismatch as an `error` finding (`McpCommand.inspectDescriptor`).
- `docs/NON_GRADLE_INTEGRATION.md` already told hand-written producers to pin `2` because "the subprocess factory rejects anything else with a clear error". That sentence was aspirational until this PR; it is now true.

Warn-and-continue was rejected: the version is a single integer bumped *only* when the shape changes in a way that could break older readers, so there is no major/minor split to be lenient about. `docs/VERSIONING.md` § 3's "keep readers tolerant of the older value" is about artifacts that outlive their writer (a packed bundle); a `daemon-launch.json` is a build output the producer regenerates on demand.

The two messages differ in the remedy, which is the part a caller can act on:

| Descriptor | Message says |
| --- | --- |
| older than the reader | stale — re-run `:<modulePath>:composePreviewDaemonStart` with the current plugin |
| newer than the reader | upgrade the consumer (or pin the plugin to the matching version) — regenerating would rewrite the same unreadable version |

`openBundleDaemon` needs no gate: it stamps `DAEMON_DESCRIPTOR_SCHEMA_VERSION` into a descriptor it constructs in-process, so writer and reader are the same build by construction.

## The gate caught a real stale mirror on its first run

`NonGradleContractTest` hand-wrote `schemaVersion: 1` and rendered against it. The writer moved to v2 and nothing made the test follow, precisely because `open` read the version without checking it. Bumped to `2` with a note.

No public ABI change (the check is a private function), and `scripts/daemon-launch-schema-allowlist.json` records that this site is now a read gate as well as a second writer.

## Test plan

- New `DescriptorSchemaVersionTest` (3 tests, in-memory `FakeFileSystem`, no disk, no daemon): a newer descriptor is refused naming the upgrade remedy; an older one is refused naming the regenerate remedy; a matching one passes the gate and reaches the spawn (proven by which failure the injected factory produces). ✅ `:render-session-subprocess:test --tests '*DescriptorSchemaVersionTest*'` — 3 passed.
- ✅ `python3 scripts/check-daemon-launch-schema.py` (3 sites at v2) and its unit tests (43 passed).
- ✅ `:render-session-subprocess:ktfmtFormatMain/Test`, `:compileTestKotlin`, `:checkKotlinAbi`.
- ⚠️ `NonGradleContractTest` (the end-to-end render, which now opens with `schemaVersion: 2`) fails in this sandbox waiting 60s for `renderFinished` on `AutoDetectDurationAnimatedPreview_Animated`. **Confirmed environmental, not this change:** the same test fails identically on unmodified `main` in a sibling worktree in the same sandbox, at the same assertion, with the same preview. It also gets past `open` on both sides, and nothing on the daemon reads the launch descriptor's `schemaVersion`, so the 1→2 bump cannot change render behaviour. CI is the authority and I'm watching it.

Text-only change (no UI surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TVXDu7t4U61UrTAPJHFky