### PR TITLE
fix(renderer-desktop): make the focus, motion and scroll lanes honour parameter knobs

### DIFF
--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/ComposableMethodAccess.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/ComposableMethodAccess.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.renderer
 
 import androidx.compose.runtime.reflect.ComposableMethod
+import androidx.compose.runtime.reflect.getDeclaredComposableMethod
 
 /**
  * Opens a resolved preview entrypoint for reflective invocation.
@@ -28,3 +29,30 @@ import androidx.compose.runtime.reflect.ComposableMethod
 internal fun ComposableMethod.openForInvoke(): ComposableMethod = also {
   runCatching { it.asMethod().isAccessible = true }
 }
+
+/**
+ * Resolves a preview that takes no seeded arguments, whether or not its parameters declare
+ * defaults.
+ *
+ * `getDeclaredComposableMethod(name)` searches for the exact signature `(Composer, int)` — a
+ * preview with **no value parameters**. A preview whose parameters all declare defaults is an
+ * equally supported shape: it is what a production composable annotated `@Preview` in place almost
+ * always looks like (`modifier: Modifier = Modifier`), and it is the whole of the **parameter
+ * knob** format. It compiles to `(realParams…, Composer, int changed, int default)`, which that
+ * lookup cannot see, so resolution threw `NoSuchMethodException` before composition started — an
+ * `.error.json` where the capture should be.
+ *
+ * The ordinary render path and both daemons already fell back to
+ * [PreviewParameterSupport.findDefaultedComposableMethod]; the **focus**, **motion** and **scroll**
+ * lanes did not, so a parameter-knob preview baked its resting capture and then failed every
+ * interaction-state, motion and scroll cell built on top of it. In a catalog those cells are the
+ * kit-comparison addresses, so the loss was 222 renders in `m3-catalog` with the manifest still
+ * reporting success. This is the one place all four lanes now agree.
+ */
+internal fun resolveDefaultedOrPlain(clazz: Class<*>, functionName: String): ComposableMethod =
+  runCatching {
+    clazz.getDeclaredComposableMethod(functionName)
+  }
+  .getOrElse { failure ->
+    PreviewParameterSupport.findDefaultedComposableMethod(clazz, functionName) ?: throw failure
+  }

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopFocusRenderer.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopFocusRenderer.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.currentComposer
 import androidx.compose.runtime.reflect.ComposableMethod
-import androidx.compose.runtime.reflect.getDeclaredComposableMethod
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
@@ -205,13 +204,15 @@ fun renderFocusPreview(
   // plus a state — that has to hold for what gets composed, not just for how it is framed.
   // `openForInvoke` keeps `private fun` previews renderable on the focus path too — issue #3873.
   val composableMethod =
-    (if (previewArgs.isEmpty()) clazz.getDeclaredComposableMethod(functionName)
+    (if (previewArgs.isEmpty()) resolveDefaultedOrPlain(clazz, functionName)
       else findComposableMethodWithArgs(clazz, functionName, previewArgs))
       .openForInvoke()
 
   // Arm the named-override capture exactly as [renderPreview] does, so a focused capture ships the
   // same `renders/<stem>.overrides.json` sidecar an ordinary one would.
   ee.schimke.composeai.overrides.PreviewOverrideController.clearDeclarations()
+  // …and announce the parameter knobs, which composition never will. See the KDoc there.
+  PreviewKnobBake.recordAmbientDeclarations()
 
   // The controller is process-static and the renderer worker is pooled — a capture must never
   // inherit the focus target of whatever this JVM drew before it.
@@ -637,6 +638,20 @@ private fun InvokeFocusComposable(
   instance: Any?,
   previewArgs: List<Any?>,
 ) {
+  // A partial knob seed leaves `null` at every unseeded position, which the plain reflective
+  // invoke cannot pass to a primitive parameter (`Cannot invoke "java.lang.Number.intValue()"`).
+  // `invokeWithDefaultMask` is the same masked invoke the ordinary render path uses — see
+  // [InvokeComposable] — so a seed that names one of two knobs leaves the other on its default
+  // instead of failing the capture.
+  if (
+    PreviewParameterSupport.invokeWithDefaultMask(
+      composableMethod,
+      instance,
+      previewArgs,
+      currentComposer,
+    )
+  )
+    return
   composableMethod.invoke(currentComposer, instance, *previewArgs.toTypedArray())
 }
 

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopMotionCapture.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopMotionCapture.kt
@@ -243,7 +243,7 @@ internal fun resolveMotionComposable(
   val clazz =
     if (classLoader != null) Class.forName(className, true, classLoader)
     else Class.forName(className)
-  return (if (previewArgs.isEmpty()) clazz.getDeclaredComposableMethod(functionName)
+  return (if (previewArgs.isEmpty()) resolveDefaultedOrPlain(clazz, functionName)
     else findMotionComposableMethod(clazz, functionName, previewArgs))
     .openForInvoke()
 }
@@ -269,6 +269,20 @@ internal fun InvokeMotionComposable(
   instance: Any?,
   previewArgs: List<Any?>,
 ) {
+  // A partial knob seed leaves `null` at every unseeded position, which the plain reflective
+  // invoke cannot pass to a primitive parameter (`Cannot invoke "java.lang.Number.intValue()"`).
+  // `invokeWithDefaultMask` is the same masked invoke the ordinary render path uses — see
+  // [InvokeComposable] — so a seed that names one of two knobs leaves the other on its default
+  // instead of failing the capture.
+  if (
+    PreviewParameterSupport.invokeWithDefaultMask(
+      composableMethod,
+      instance,
+      previewArgs,
+      currentComposer,
+    )
+  )
+    return
   composableMethod.invoke(currentComposer, instance, *previewArgs.toTypedArray())
 }
 

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -513,7 +513,22 @@ fun main(args: Array<String>) {
   }
   for ((idx, value) in keptValues.withIndex()) {
     val targetFile = targetFiles[idx]
-    val previewArgs = if (value === NO_PARAM) emptyList() else listOf(value)
+    // A `@PreviewParameter` row and a parameter knob are mutually exclusive by construction
+    // (discovery reports knobs only when EVERY value parameter has a default, which a
+    // `@PreviewParameter` one never has), so `NO_PARAM` is the only case a knob seed can bind in.
+    //
+    // Bind it HERE rather than inside `renderPreview`, because the focus, motion and scroll lanes
+    // invoke the composable themselves and never saw the binding: every interaction-state and
+    // scroll cell of a parameter-knob preview rendered the author defaults, so a kit cell seeded
+    // `trailing=true` drew the same pixels as its `false` sibling. `renderPreview` still seeds when
+    // it is handed nothing, so its own path is unchanged.
+    val previewArgs =
+      if (value === NO_PARAM)
+        PreviewKnobBake.seedArgs(
+          PreviewKnobBake.fromSystemProperty(),
+          ee.schimke.composeai.overrides.PreviewOverrideController.seededValues.value,
+        )
+      else listOf(value)
     // Per-value try/catch — the user-facing pain we're addressing is "one
     // broken preview turns the whole panel into 'Build failed'". Catching
     // here lets sibling previews in the same subprocess (i.e. multiple

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopScrollRenderer.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopScrollRenderer.kt
@@ -148,7 +148,7 @@ fun renderScrollPreview(
     else Class.forName(className)
   // `openForInvoke` keeps `private fun` previews renderable on the scroll path too — issue #3873.
   val composableMethod =
-    (if (previewArgs.isEmpty()) clazz.getDeclaredComposableMethod(functionName)
+    (if (previewArgs.isEmpty()) resolveDefaultedOrPlain(clazz, functionName)
       else findComposableMethodForScroll(clazz, functionName, previewArgs))
       .openForInvoke()
 
@@ -163,6 +163,8 @@ fun renderScrollPreview(
   // because END reports `didCapture = true`, the caller skips the fallback that would have written
   // the right one.
   ee.schimke.composeai.overrides.PreviewOverrideController.clearDeclarations()
+  // …and announce the parameter knobs, which composition never will. See the KDoc there.
+  PreviewKnobBake.recordAmbientDeclarations()
 
   val sceneDensity = Density(density, fontScale)
   runSkikoComposeUiTest(
@@ -890,6 +892,20 @@ private fun InvokeScrollComposable(
   instance: Any?,
   previewArgs: List<Any?>,
 ) {
+  // A partial knob seed leaves `null` at every unseeded position, which the plain reflective
+  // invoke cannot pass to a primitive parameter (`Cannot invoke "java.lang.Number.intValue()"`).
+  // `invokeWithDefaultMask` is the same masked invoke the ordinary render path uses — see
+  // [InvokeComposable] — so a seed that names one of two knobs leaves the other on its default
+  // instead of failing the capture.
+  if (
+    PreviewParameterSupport.invokeWithDefaultMask(
+      composableMethod,
+      instance,
+      previewArgs,
+      currentComposer,
+    )
+  )
+    return
   composableMethod.invoke(currentComposer, instance, *previewArgs.toTypedArray())
 }
 

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/PreviewKnobBake.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/PreviewKnobBake.kt
@@ -124,6 +124,27 @@ internal object PreviewKnobBake {
    * this renderer does not know rather than guessing at it, so a newer plugin costs one knob and
    * not the render.
    */
+  /**
+   * Record this render's parameter-knob declarations onto the override controller, reading both the
+   * knob list and the seed from the ambient per-capture channels this subprocess was handed.
+   *
+   * `previewOverride*` records a declaration as a by-product of *reading* each knob during
+   * composition; a parameter knob is read by argument passing and announces nothing, so a lane that
+   * does not do this ships a `<stem>.overrides.json` with the knob missing and `serve` offers no
+   * control for it. [renderPreview] has always done this with the knobs and seed already in hand;
+   * the focus, motion and scroll lanes have neither, which is why they need this ambient form — and
+   * why, before it, an interaction-state capture of a migrated preview served fewer controls than
+   * its own resting capture.
+   *
+   * Call directly after `clearDeclarations()`, which is what makes the set this adds to clean.
+   */
+  fun recordAmbientDeclarations() {
+    val seeds = ee.schimke.composeai.overrides.PreviewOverrideController.seededValues.value
+    declarations(fromSystemProperty(), seeds).forEach {
+      ee.schimke.composeai.overrides.PreviewOverrideController.record(it)
+    }
+  }
+
   fun seedArgs(
     knobs: List<PreviewKnobSpec>,
     seeds: Map<String, PreviewOverrideValue>?,


### PR DESCRIPTION
#5103 taught the **bake** lane the parameter-knob format. The focus, motion and scroll lanes resolve and invoke the composable themselves, and none of them learned any of it.

Found by migrating [`m3-catalog`](https://github.com/yschimke/m3-catalog/pull/284)'s remaining knobs and diffing the render set: **222 of 618 captures came back as `.error.json`, and the survivors lost their controls — with the manifest still reporting success.** Those captures are the interaction-state cells the Figma kit is compared against, so the damage lands on comparison addresses rather than anywhere a reader would notice.

## Four defects, each the twin of one the ordinary path already fixed

| # | Defect | Symptom |
| --- | --- | --- |
| 1 | **Resolution** — `getDeclaredComposableMethod(name)` matches only `(Composer, int)` | `NoSuchMethodException` before composition; no capture |
| 2 | **Seeding** — the lanes got `previewArgs`, never the knob binding | every kit cell drew author defaults; `trailing=true` and `trailing=false` rendered the same pixels |
| 3 | **Invocation** — a partial seed leaves `null` at unseeded positions | `Cannot invoke "java.lang.Number.intValue()"` on a primitive parameter |
| 4 | **Sidecar** — a parameter knob announces nothing during composition | the focused `<stem>.overrides.json` shipped without the knob, so `serve` offered no control |

Each fix routes through the code that already solved it for the render path: `resolveDefaultedOrPlain` joins `openForInvoke` in `ComposableMethodAccess` (the file that exists so the desktop lanes agree on what is renderable), the seed binding moves to the one point in `main` all four lanes read, the lanes call `invokeWithDefaultMask` as `InvokeComposable` does, and `recordAmbientDeclarations` reads the knobs and seed from the per-capture channels the lanes actually have.

Defect 4 is worth calling out: `DesktopFocusRenderer` already *says* it arms the capture "exactly as `renderPreview` does, so a focused capture ships the same `renders/<stem>.overrides.json` sidecar an ordinary one would". It just wasn't true for this format.

## Test plan

`:renderer-desktop:test` and `:renderer-desktop:ktfmtCheckMain` green.

The real evidence is m3-catalog with every eligible knob migrated — 618 captures across 27 stickers, rendered before and after against a locally published renderer, at each stage:

| Stage | Result |
| --- | --- |
| unfixed | 396 PNGs + **222 `.error.json`** |
| + resolution | 618 PNGs, **186 wrong** (distinct kit cells sharing pixels) |
| + seeding | 594 PNGs + **24 `.error.json`** (the primitive NPE) |
| + masked invoke + sidecar | **618 PNGs, 0 errors** |

At the end, both surfaces are provably unchanged by the migration:

* **every one of the 618 renders is byte-identical (md5) to the unmigrated baseline**
* **the override surface — key, type, default, current, index, options — is identical across all 618 previews**, including seeded variants (`LinearProgress_VARIANT_full` reports `progress` default `0.5`, current `1.0`)

Also unchanged in m3-catalog: `previews.json` ids identical including order (4149), `design-map.json` / `design-map-variants.json` regenerate byte-identically, and the six kit/Figma mapping suites pass (`design-map`, `interaction-coverage`, `kit-coverage`, `duplicate-renders`, `import-figma-pages`, `exhaustive-kit-cells`).

No test in this repo reproduces the failure, and I want to be straight about why: it needs a preview whose content lambda captures *and* a focus/motion/scroll lane over it, which is a catalog-shaped fixture rather than a synthetic one. The reproduction is m3-catalog, and the stage table above is what I ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STv5Vor6hnPnhMSNuFMqqn

---
_Generated by [Claude Code](https://claude.ai/code/session_01STv5Vor6hnPnhMSNuFMqqn)_