### PR TITLE
fix(design-artifacts): report every duplicate-output-axes collision in one pass

### DIFF
--- a/scripts/design-artifacts/catalog-variants.mjs
+++ b/scripts/design-artifacts/catalog-variants.mjs
@@ -35,21 +35,35 @@ import { selectImages, selectLabel, selectOf } from "./catalog-select.mjs";
  *   the spec component (its `variants` drive the fold).
  * @param {Map<string, {images: Array<object>}>} byFunction rendered candidates
  *   keyed by `@Preview` function name.
- * @returns {{ideal: Array<object>, missing: string[], noSticker: string[]}} the
- *   merged image list, any variant previews that produced no render (as
+ * @returns {{ideal: Array<object>, missing: string[], noSticker: string[],
+ *   duplicateAxes: Array<{componentId: string, axes: string}>}}
+ *   the merged image list, any variant previews that produced no render (as
  *   `"<componentId> [<label>]"` where the label is the variant's state and/or
  *   `k=v` props), so the caller's completeness gate can still refuse a
- *   half-rendered sticker, and — reported separately, NOT as missing — the
+ *   half-rendered sticker, then — reported separately, NOT as missing — the
  *   render-less variants that declared `"capture": "none"` (see
- *   capture-mode.mjs).
+ *   capture-mode.mjs), and any images that collide on effective output axes (as
+ *   `{componentId, axes}`, which [duplicateAxesFailure] turns into the caller's one refusal).
+ *
+ *   `duplicateAxes` is a REPORT, not a throw, and that is the point (issue #5065). This fold used
+ *   to abort on the first colliding component, so a spec with two of them cost one full render
+ *   cycle — roughly half an hour on a real import — to learn about the second. Every other problem
+ *   here is already accumulated and reported together; a collision is now no different. The fold
+ *   deliberately keeps going and appends the colliding image, so the report covers the whole spec:
+ *   the caller (`catalogFromCandidates`) refuses the build once, naming every collision, before
+ *   `buildCatalog` writes a single PNG. Refusing stays non-negotiable — a collision means
+ *   last-write-wins pixels paired with stale manifest metadata, a correctness problem rather than
+ *   a coverage one, so it is never folded under `--allow-incomplete`. What changed is only when
+ *   the refusal happens and how much it says.
  */
 export function foldVariants(defaultImages, component, byFunction) {
   const ideal = [...defaultImages];
   const missing = [];
   const noSticker = [];
+  const duplicateAxes = [];
   const outputKeys = new Set();
   for (const image of defaultImages) {
-    recordOutputKey(outputKeys, image, component.componentId);
+    recordOutputKey(outputKeys, image, component.componentId, duplicateAxes);
   }
   for (const variant of component.variants ?? []) {
     const candidate = byFunction.get(variant.preview);
@@ -88,11 +102,11 @@ export function foldVariants(defaultImages, component, byFunction) {
       if (variant.state !== undefined) tagged.state = variant.state;
       if (variant.props) tagged.props = { ...image.props, ...variant.props };
       if (variant.theme !== undefined) tagged.theme = variant.theme;
-      recordOutputKey(outputKeys, tagged, component.componentId);
+      recordOutputKey(outputKeys, tagged, component.componentId, duplicateAxes);
       ideal.push(tagged);
     }
   }
-  return { ideal, missing, noSticker };
+  return { ideal, missing, noSticker, duplicateAxes };
 }
 
 /**
@@ -164,19 +178,44 @@ export function outputAxisKey(image) {
 }
 
 /**
- * Refuse two images that the exporter would name from the same effective variant axes. Catching
- * this before `buildCatalog` writes either PNG prevents last-write-wins pixels paired with stale
- * manifest metadata.
+ * Record two images that the exporter would name from the same effective variant axes. Reporting
+ * this before `buildCatalog` writes either PNG is what prevents last-write-wins pixels paired with
+ * stale manifest metadata; see [foldVariants] on why the refusal is the caller's and not a throw
+ * from here.
  */
-function recordOutputKey(seen, image, componentId) {
+function recordOutputKey(seen, image, componentId, duplicateAxes) {
   const key = outputAxisKey(image);
   if (seen.has(key)) {
-    throw new Error(
-      `catalog component "${componentId}" produces duplicate output axes ${key}; ` +
-        "each variant must have a unique state, theme, size, or props value",
-    );
+    duplicateAxes.push({ componentId, axes: key });
+    return;
   }
   seen.add(key);
+}
+
+/**
+ * The failure for a whole spec's worth of collisions, or `null` when there are none.
+ *
+ * The message lives here rather than at the throw site so it is unit-testable: `catalogFromCandidates`
+ * is a CLI script that parses argv at import time, so nothing can import it to assert on what it
+ * says. Entries stay STRUCTURED (`{componentId, axes}`) all the way to this function for the same
+ * reason the count is not parsed back out of a formatted line — the shape of the message is a
+ * presentation decision, and re-deriving data from it is how a message starts lying.
+ *
+ * @param {Array<{componentId: string, axes: string}>} entries every collision the fold recorded.
+ * @returns {Error|null}
+ */
+export function duplicateAxesFailure(entries) {
+  if (entries.length === 0) return null;
+  const components = new Set(entries.map((entry) => entry.componentId));
+  const subject =
+    components.size === 1 ? "component produces" : "components produce";
+  return new Error(
+    `${components.size} catalog ${subject} duplicate output axes; each variant must have ` +
+      "a unique state, theme, size, or props value:\n" +
+      entries
+        .map((entry) => `  - ${entry.componentId} ${entry.axes}`)
+        .join("\n"),
+  );
 }
 
 /** A short label for a variant, for the missing-render report: its state, props and/or theme. */

--- a/scripts/design-artifacts/catalog-variants.test.mjs
+++ b/scripts/design-artifacts/catalog-variants.test.mjs
@@ -1,7 +1,12 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { foldVariants, variantLabel } from "./catalog-variants.mjs";
+import {
+  duplicateAxesFailure,
+  foldVariants,
+  outputAxisKey,
+  variantLabel,
+} from "./catalog-variants.mjs";
 import { renderIndexHtml } from "./render-index-html.mjs";
 
 const img = (state, theme) => ({ state, theme, uri: "x", width: 100, height: 40 });
@@ -151,22 +156,82 @@ test("foldVariants reports a theme variant that did not render, labelled by its 
   assert.deepEqual(missing, ["Screen/Foo [dark]"]);
 });
 
-test("foldVariants refuses duplicate effective output axes before export", () => {
+test("foldVariants reports duplicate effective output axes instead of throwing", () => {
   const byFunction = new Map([
     ["SecondDark", { images: [img("default", "light")] }],
   ]);
-  assert.throws(
-    () =>
-      foldVariants(
-        [img("default", "dark")],
-        {
-          componentId: "Screen/Foo",
-          variants: [{ theme: "dark", preview: "SecondDark" }],
-        },
-        byFunction,
-      ),
-    /produces duplicate output axes/,
+  const { duplicateAxes } = foldVariants(
+    [img("default", "dark")],
+    {
+      componentId: "Screen/Foo",
+      variants: [{ theme: "dark", preview: "SecondDark" }],
+    },
+    byFunction,
   );
+  assert.deepEqual(duplicateAxes, [
+    {
+      componentId: "Screen/Foo",
+      axes: outputAxisKey({ state: "default", theme: "dark" }),
+    },
+  ]);
+});
+
+test("foldVariants keeps folding after a collision, so one pass reports them all", () => {
+  // The point of issue #5065: aborting on the first collision cost a full render cycle to learn
+  // about the second. Two variants collide here and both are named.
+  const byFunction = new Map([
+    ["SecondDark", { images: [img("default", "light")] }],
+    ["ThirdDark", { images: [img("default", "light")] }],
+  ]);
+  const { duplicateAxes } = foldVariants(
+    [img("default", "dark")],
+    {
+      componentId: "Screen/Foo",
+      variants: [
+        { theme: "dark", preview: "SecondDark" },
+        { theme: "dark", preview: "ThirdDark" },
+      ],
+    },
+    byFunction,
+  );
+  assert.equal(duplicateAxes.length, 2);
+});
+
+test("duplicateAxesFailure names every colliding component in one refusal", () => {
+  const failure = duplicateAxesFailure([
+    { componentId: "language-toggle", axes: outputAxisKey({}) },
+    { componentId: "back-button", axes: outputAxisKey({}) },
+  ]);
+  assert.match(failure.message, /^2 catalog components produce duplicate output axes/);
+  assert.match(failure.message, /- language-toggle \{/);
+  assert.match(failure.message, /- back-button \{/);
+});
+
+test("duplicateAxesFailure counts components, not collisions, and stays singular for one", () => {
+  // Two collisions from one component is one component's problem, and saying "2 components" would
+  // send someone looking for a second spec entry that does not exist.
+  const failure = duplicateAxesFailure([
+    { componentId: "language-toggle", axes: outputAxisKey({ state: "a" }) },
+    { componentId: "language-toggle", axes: outputAxisKey({ state: "b" }) },
+  ]);
+  assert.match(failure.message, /^1 catalog component produces duplicate/);
+});
+
+test("duplicateAxesFailure is null when nothing collided, so the build proceeds", () => {
+  assert.equal(duplicateAxesFailure([]), null);
+});
+
+test("foldVariants reports no duplicates for a component whose variants are distinct", () => {
+  const byFunction = new Map([["FooDark", { images: [img("default")] }]]);
+  const { duplicateAxes } = foldVariants(
+    [img("default", "light")],
+    {
+      componentId: "Screen/Foo",
+      variants: [{ theme: "dark", preview: "FooDark" }],
+    },
+    byFunction,
+  );
+  assert.deepEqual(duplicateAxes, []);
 });
 
 // --- index.html: default in the grid, states in the zoom view -----------------

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -44,7 +44,11 @@ import {
 } from "@design-parity/candidate";
 import { buildCatalog, writeCatalog } from "@design-parity/catalog-export";
 
-import { foldVariants, variantLabel } from "./catalog-variants.mjs";
+import {
+  duplicateAxesFailure,
+  foldVariants,
+  variantLabel,
+} from "./catalog-variants.mjs";
 import {
   foldMotion,
   motionArtifactsFor,
@@ -576,6 +580,13 @@ function catalogFromCandidates(candidates, spec, opts = {}) {
   const missing = [];
   const noSticker = [];
   const withoutSemantics = [];
+  // Components whose images collide on effective output axes, accumulated across the whole spec and
+  // refused once below (issue #5065). The fold used to throw on the first one, so a spec with two
+  // colliding components — the common shape, since one cause (a bare `@Preview` beside a locale
+  // multipreview) hits every component that carries it — cost one render cycle per collision to
+  // discover. Unlike `missing` / `noSticker` this is never gated by `--allow-incomplete`: see the
+  // refusal below.
+  const duplicateAxes = [];
   // The motion axis, kept BESIDE the sources as well as on them, so the written manifest can be
   // checked against what the join actually resolved. `buildCatalog` builds its components from an
   // allow-list and drops any field it hasn't been taught — which is precisely how this axis went
@@ -688,9 +699,11 @@ function catalogFromCandidates(candidates, spec, opts = {}) {
         ideal,
         missing: missingVariants,
         noSticker: noStickerVariants,
+        duplicateAxes: collidingAxes,
       } = foldVariants(selected, component, byFunction);
       missing.push(...missingVariants);
       noSticker.push(...noStickerVariants);
+      duplicateAxes.push(...collidingAxes);
       // Thin the palette fan-out per `modePriority`: a themed sticker whose mode is deferred is
       // dropped from the baked set (so no PNG is written and the Figma/static kit stays lean) and
       // recorded live-only. Only stickers that NAME a theme are eligible, so every component keeps
@@ -827,6 +840,15 @@ function catalogFromCandidates(candidates, spec, opts = {}) {
       sources.push(source);
     }
   }
+
+  // Refuse the whole build once, naming every collision. Deliberately a `throw` rather than another
+  // entry in the returned report: two images sharing an output path mean last-write-wins pixels
+  // paired with stale manifest metadata, which is a correctness failure and not the coverage gap
+  // `--allow-incomplete` exists to wave through. It fires before `buildCatalog`, so nothing is
+  // written either way — the only thing that changed is that one run now names every colliding
+  // component instead of the first.
+  const duplicateAxesError = duplicateAxesFailure(duplicateAxes);
+  if (duplicateAxesError) throw duplicateAxesError;
 
   const meta = {
     system: spec.system,

--- a/scripts/design-artifacts/spec-preflight.test.mjs
+++ b/scripts/design-artifacts/spec-preflight.test.mjs
@@ -293,13 +293,14 @@ test("the preflight key agrees with the fold's own duplicate guard", () => {
     ],
   };
   const image = (state) => ({ variant: "ideal", state, props: {} });
-  assert.throws(
-    () =>
-      foldVariants([image("default")], component, {
-        get: (fn) => ({ images: [image("default")] }),
-      }),
-    /produces duplicate output axes/,
-  );
+  // The fold REPORTS rather than throws since #5065 (so one pass names every collision), but what
+  // it reports still has to be exactly what this preflight reports — that pairing is the point.
+  const { duplicateAxes } = foldVariants([image("default")], component, {
+    get: (fn) => ({ images: [image("default")] }),
+  });
+  assert.equal(duplicateAxes.length, 1);
+  assert.equal(duplicateAxes[0].componentId, "Home");
+  assert.equal(duplicateAxes[0].axes, outputAxisKey(image("off")));
   assert.equal(outputAxisKey(image("off")), outputAxisKey({ state: "off" }));
 });
 


### PR DESCRIPTION
Fixes #5065.

## The inconsistency

`recordOutputKey` threw on the **first** component whose images collide on effective output axes, and it was the only `throw` in the catalog path — `missing`, `noSticker` and `withoutSemantics` are all accumulated across every component and reported together. So a spec with two colliding components cost one full render cycle (~30 min on a real import) to learn about the second, and on `DroidKaigi/conference-app-2026` both collisions came from the *same* cause (a bare `@Preview` beside a locale multipreview) — one fix, but only if you knew both existed. The second was found by grepping `renderFinished` lines out of a job log.

## The change

- `foldVariants` records collisions as `{componentId, axes}` and **keeps folding**, so one pass sees the whole spec.
- `catalogFromCandidates` accumulates them across all components and refuses **once**, naming each:

```
Error: 2 catalog components produce duplicate output axes; each variant must have a unique state, theme, size, or props value:
  - language-toggle {"variant":"ideal","state":"default","theme":null,"size":null,"props":{}}
  - back-button {"variant":"ideal","state":"default","theme":null,"size":null,"props":{}}
```

Two things deliberately did **not** change, per the issue:

- **It stays a hard failure**, not something `--allow-incomplete` waves through. A collision is last-write-wins pixels paired with stale manifest metadata — a correctness problem, not a coverage gap.
- **It still fires before `buildCatalog`**, so no PNG is written either way. Only *when* the refusal happens and *how much it says* changed.

## Why the message moved into `catalog-variants.mjs`

`duplicateAxesFailure(entries)` builds the Error (and returns `null` for none) rather than the throw site assembling it, because `generate-design-catalog.mjs` parses argv at import time and so cannot be imported by a test. Keeping the message in the pure, unit-tested module is what puts *what the run actually says* under test; the CLI keeps two lines of wiring. Entries stay structured all the way there, so the component count is counted rather than parsed back out of formatted text.

## Relation to #5086 (the `needs-info` question on the issue)

`spec-preflight.mjs` already collects every collision ahead of the render for the design-artifacts workflow, and that remains the early warning. It is explicitly an advisory layer in front of the render — its own comments name `foldVariants` as "the gate" — so the fold itself still aborted on the first collision for any direct invocation. This closes that half; the two now report the same set, which the existing pairing test in `spec-preflight.test.mjs` continues to assert (updated to compare the fold's reported entry rather than its throw).

## Test plan

- ✅ `node --test` over `scripts/design-artifacts` — 1387 pass, 0 fail, 30 skipped (after `npm ci`; without it 8 files fail on missing deps, unrelated).
- New tests in `catalog-variants.test.mjs`: a collision is reported rather than thrown; the fold keeps going so two collisions are both named; a non-colliding component reports none; `duplicateAxesFailure` names every component, counts components rather than collisions (singular for one), and is `null` for an empty list.
- `spec-preflight.test.mjs`'s "the preflight key agrees with the fold's own duplicate guard" updated to the reported entry — same assertion, same pairing.

Text-only change (no UI surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TVXDu7t4U61UrTAPJHFky

---
_Generated by [Claude Code](https://claude.ai/code/session_014TVXDu7t4U61UrTAPJHFky)_