### PR TITLE
feat(render): say what each --exclude-preview-id pattern matched, and warn at zero

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -716,6 +716,13 @@ private class PackSubcommand(private val args: List<String>) {
     // — see #2965) and simply carry no semantics/layout/figma-svg sidecar, exactly as they carry no
     // PNG.
     val captureIds = PackPreviewIdExclusions.retain(rawIds, excludePreviewIds)
+    // One line per pattern, before the totals (issue #5064). The totals below say how much was
+    // skipped; they cannot say which of three patterns did nothing, and a pattern at zero is
+    // almost always a typo whose cost is a whole capture pass spent on previews the caller meant
+    // to drop.
+    for (match in PackPreviewIdExclusions.matches(rawIds, excludePreviewIds)) {
+      System.err.println("bundle pack: ${match.line}")
+    }
     val excludedFromCapture = rawIds.size - captureIds.size
     if (excludedFromCapture > 0) {
       System.err.println(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusions.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusions.kt
@@ -163,6 +163,43 @@ internal object PackPreviewIdExclusions {
     return raw.flatMap { it.split(',') }.map { it.trim() }.filter { it.isNotEmpty() }
   }
 
+  /**
+   * What one pattern matched, so the pack can attribute its exclusions to the pattern that caused
+   * them (issue #5064). Mirrors the plugin's `PreviewIdExclusionMatch`, deliberately — the two
+   * lanes report the same shape because a reader comparing a pack log against a render log is
+   * reading about the same patterns. [matched] is per-pattern and patterns may overlap, so the
+   * counts need not sum to the number actually dropped.
+   */
+  data class Match(val pattern: String, val matched: Int, val total: Int) {
+    val line: String
+      get() =
+        "--exclude-preview-id '$pattern' matched $matched of $total preview(s)" +
+          if (matched == 0)
+            " — nothing excluded. Check the pattern: preview ids keep spaces where render " +
+              "filenames use underscores, and a plain pattern matches on substring."
+          else ""
+  }
+
+  /**
+   * Per-pattern match counts over [ids], in the order [patterns] were given.
+   *
+   * Separate from [retain] because they answer different questions: that one yields the ids to
+   * capture (overlap irrelevant), this one says which pattern did the work — and, crucially, which
+   * did none. A pattern at zero is almost always a typo, and the pack used to say only how many
+   * previews it skipped in total, which cannot tell three patterns apart.
+   */
+  fun matches(ids: List<String>, patterns: List<String>): List<Match> =
+    patterns
+      .map { it.trim() }
+      .filter { it.isNotEmpty() }
+      .map { pattern ->
+        Match(
+          pattern = pattern,
+          matched = ids.count { matches(pattern, it) },
+          total = ids.size,
+        )
+      }
+
   /** [ids] with every entry matching [patterns] removed. An empty pattern list keeps everything. */
   fun retain(ids: List<String>, patterns: List<String>): List<String> {
     val cleaned = patterns.map { it.trim() }.filter { it.isNotEmpty() }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusionsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusionsTest.kt
@@ -360,4 +360,45 @@ class PackPreviewIdExclusionsTest {
     val f = fileWith(listOf("", "   ", commaBearingIds[0], ""))
     assertEquals(listOf(commaBearingIds[0]), PackPreviewIdExclusions.linesOf(f))
   }
+
+  // --- per-pattern match reporting (issue #5064) ------------------------------------------------
+
+  @Test
+  fun `matches reports one entry per pattern, in order, with per-pattern counts`() {
+    val ids = listOf("Foo_Light", "Foo_Dark", "Bar_Light")
+
+    val matches = PackPreviewIdExclusions.matches(ids, listOf("*_Dark", "Foo*"))
+
+    assertEquals(listOf("*_Dark", "Foo*"), matches.map { it.pattern })
+    assertEquals(listOf(1, 2), matches.map { it.matched })
+    assertEquals(listOf(3, 3), matches.map { it.total })
+  }
+
+  @Test
+  fun `a pattern matching nothing reports zero and says why that usually happens`() {
+    val line =
+      PackPreviewIdExclusions.matches(listOf("Foo Content with dialog"), listOf("*Foo_Content*"))
+        .single()
+        .line
+
+    assertEquals(true, line.contains("matched 0 of 1 preview(s)"))
+    assertEquals(true, line.contains("preview ids keep spaces"))
+  }
+
+  @Test
+  fun `blank patterns are neither applied nor reported`() {
+    assertEquals(emptyList(), PackPreviewIdExclusions.matches(listOf("Foo"), listOf(" ", "")))
+  }
+
+  @Test
+  fun `the reported count agrees with what retain actually drops for a single pattern`() {
+    // One pattern, so overlap cannot explain a difference: if these two disagree, the log is lying.
+    val ids = listOf("Foo_Light", "Foo_Dark", "Bar_Dark")
+    val pattern = "*_Dark"
+
+    val reported = PackPreviewIdExclusions.matches(ids, listOf(pattern)).single().matched
+    val dropped = ids.size - PackPreviewIdExclusions.retain(ids, listOf(pattern)).size
+
+    assertEquals(dropped, reported)
+  }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -353,16 +353,29 @@ abstract class RenderPreviewsTask : DefaultTask() {
     // filter kept, which is the granularity a catalog's per-theme `modePriority` needs to skip the
     // renders it isn't going to publish. Runs immediately after the name filter so both are applied
     // before tier/kind/catalog filtering, and so `--preview Foo --preview-id *_Light` composes.
-    val idFiltered =
-      excludePreviewIds(
-        selectPreviewIds(
-          nameFiltered,
-          previewIdFilters.getOrElse(emptyList()),
-          previewsJson.get().asFile.absolutePath,
-          rawManifest.previews,
-        ),
-        previewIdExcludes.getOrElse(emptyList()),
+    val idSelected =
+      selectPreviewIds(
+        nameFiltered,
+        previewIdFilters.getOrElse(emptyList()),
+        previewsJson.get().asFile.absolutePath,
+        rawManifest.previews,
       )
+    // Say what each exclusion pattern actually matched, BEFORE the render starts (issue #5064).
+    // Exclusion fails safe — a pattern matching nothing renders more than intended, never less —
+    // and that is the right default; saying nothing about it is not. A pattern at zero is almost
+    // always a typo or a wrong guess about id shape, and staying quiet turns that into a wasted
+    // ~30-minute render instead of a one-line diagnosis. The counts are also what makes the
+    // arithmetic of a partial exclusion visible: `*_ja → 28` next to a 62-preview total is how you
+    // see that the bare and `_en` arms of a locale fan-out still collide.
+    val exclusionMatches =
+      previewIdExclusionMatches(idSelected, previewIdExcludes.getOrElse(emptyList()))
+    for (match in exclusionMatches) {
+      // `warn`, not `lifecycle`, for a pattern that matched nothing: it is the one line here that
+      // reports a probable mistake rather than progress.
+      if (match.matched == 0) logger.warn("composePreviewRender: ${match.line}")
+      else logger.lifecycle("composePreviewRender: ${match.line}")
+    }
+    val idFiltered = excludePreviewIds(idSelected, previewIdExcludes.getOrElse(emptyList()))
 
     val permutationValues = permutations.getOrElse(emptyList())
     val permuted = PreviewPermutations.expand(idFiltered, permutationValues)
@@ -1248,6 +1261,54 @@ private fun StringBuilder.appendManifestContext(
 }
 
 /**
+ * What one `--exclude-preview-id` pattern matched, so a run can say so before it renders.
+ *
+ * [matched] counts the previews THIS pattern would drop, independent of the others — patterns may
+ * overlap, so the counts do not sum to the number actually excluded. Per-pattern is the whole
+ * point: the total was already reported ("skipping 28 excluded preview(s)"), and a total cannot
+ * tell you which of three patterns did nothing.
+ */
+internal data class PreviewIdExclusionMatch(
+  val pattern: String,
+  val matched: Int,
+  val total: Int,
+) {
+  /**
+   * The line a run prints. A zero-match pattern carries the likeliest cause with it: preview ids
+   * keep the spaces that render filenames sanitise to underscores, so a pattern copied off a PNG
+   * name matches nothing — the exact way this cost a 26-minute render (issue #5064).
+   */
+  val line: String
+    get() =
+      "--exclude-preview-id '$pattern' matched $matched of $total preview(s)" +
+        if (matched == 0)
+          " — nothing excluded. Check the pattern: preview ids keep spaces where render filenames " +
+            "use underscores, and a plain pattern matches on substring."
+        else ""
+}
+
+/**
+ * Per-pattern match counts for [excludes] over [previews], in the order the patterns were given.
+ *
+ * Pure, and separate from [excludePreviewIds] rather than folded into it, because the two answer
+ * different questions: that one produces the previews to render (where an overlapping pattern is
+ * irrelevant), this one attributes the exclusion to the pattern that caused it (where overlap is
+ * exactly what a reader needs to see). Blank patterns are dropped the same way [excludePreviewIds]
+ * drops them, so nothing is reported that could not have excluded anything.
+ */
+internal fun previewIdExclusionMatches(
+  previews: List<PreviewInfo>,
+  excludes: List<String>,
+): List<PreviewIdExclusionMatch> =
+  excludes.map(String::trim).filter(String::isNotEmpty).map { pattern ->
+    PreviewIdExclusionMatch(
+      pattern = pattern,
+      matched = previews.count { PreviewNameFilter.matchesId(listOf(pattern), it.id) },
+      total = previews.size,
+    )
+  }
+
+/**
  * Drops previews whose **id** matches [excludes], keeping the rest (issue #2966).
  *
  * The deferral polarity — see [RenderPreviewsTask.previewIdExcludes] for why a positive filter
@@ -1255,9 +1316,11 @@ private fun StringBuilder.appendManifestContext(
  * matchable set, because the untagged primary stickers carry no theme suffix to match on.
  *
  * A pattern matching nothing is a no-op on purpose (it renders more than intended, which the
- * publish catches, rather than less). Excluding *everything* still throws: the render would write
- * no PNGs at all and the pack that follows would produce a catalog of missing stickers, which is
- * precisely the silent failure the select-or-fail policy exists to prevent.
+ * publish catches, rather than less) — but never a SILENT one: [previewIdExclusionMatches] reports
+ * what each pattern matched and the task warns on a zero (issue #5064). Excluding *everything*
+ * still throws: the render would write no PNGs at all and the pack that follows would produce a
+ * catalog of missing stickers, which is precisely the silent failure the select-or-fail policy
+ * exists to prevent.
  */
 internal fun excludePreviewIds(
   previews: List<PreviewInfo>,

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/SelectPreviewIdsTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/SelectPreviewIdsTest.kt
@@ -193,4 +193,50 @@ class SelectPreviewIdsTest {
     assertThat(selectPreviewIds(previews, listOf("=FilledButton_Light")).map { it.id })
       .containsExactly("FilledButton_Light")
   }
+
+  // --- per-pattern exclusion reporting (issue #5064) ---------------------------------------------
+
+  @Test
+  fun `exclusion match counts are reported per pattern, in the order given`() {
+    val matches = previewIdExclusionMatches(all, listOf("*_Dark", "*_HighContrast"))
+
+    assertThat(matches.map { it.pattern }).containsExactly("*_Dark", "*_HighContrast").inOrder()
+    assertThat(matches.map { it.matched }).containsExactly(2, 1).inOrder()
+    assertThat(matches.map { it.total }).containsExactly(5, 5).inOrder()
+  }
+
+  @Test
+  fun `a pattern that matches nothing is reported at zero, with the reason it usually happens`() {
+    // The concrete failure from #5064: a pattern copied off a PNG filename, whose underscores the
+    // id does not have. Silence turned that into a 26-minute render that then failed on exactly
+    // the previews the exclusion was meant to remove.
+    val matches = previewIdExclusionMatches(all, listOf("*_Sepia"))
+
+    assertThat(matches).hasSize(1)
+    assertThat(matches.single().matched).isEqualTo(0)
+    assertThat(matches.single().line).contains("matched 0 of 5 preview(s)")
+    assertThat(matches.single().line).contains("preview ids keep spaces")
+  }
+
+  @Test
+  fun `a matching pattern's line states the count and adds no advice`() {
+    val line = previewIdExclusionMatches(all, listOf("*_Dark")).single().line
+
+    assertThat(line).isEqualTo("--exclude-preview-id '*_Dark' matched 2 of 5 preview(s)")
+  }
+
+  @Test
+  fun `overlapping patterns are each counted in full, so the counts need not sum`() {
+    // Deliberate: the reader is diagnosing which pattern did the work, not reconciling a total.
+    val matches = previewIdExclusionMatches(all, listOf("*_Dark", "FilledButton*"))
+
+    assertThat(matches.map { it.matched }).containsExactly(2, 3).inOrder()
+    assertThat(excludePreviewIds(all, listOf("*_Dark", "FilledButton*"))).hasSize(1)
+  }
+
+  @Test
+  fun `blank patterns are reported no more than they are applied`() {
+    assertThat(previewIdExclusionMatches(all, listOf(" ", ""))).isEmpty()
+    assertThat(previewIdExclusionMatches(all, emptyList())).isEmpty()
+  }
 }


### PR DESCRIPTION
Fixes #5064.

## Failing safe is right; failing silently is not

An `--exclude-preview-id` pattern that matches nothing is deliberately a no-op — a stale pattern renders *more* than intended, never less. That default stays. What changes is that the run now says so, before it renders:

```
composePreviewRender: --exclude-preview-id '*_ja' matched 28 of 62 preview(s)
composePreviewRender: --exclude-preview-id '*.FrontendScreen_Content_with_HTTP_auth_dialog*' matched 0 of 62 preview(s) — nothing excluded. Check the pattern: preview ids keep spaces where render filenames use underscores, and a plain pattern matches on substring.
```

A zero-match line goes through `logger.warn`; the rest are `lifecycle` — the one line that reports a probable mistake reads differently from the ones reporting progress. `bundle pack`'s semantics capture prints the same shape on stderr, ahead of the totals it already printed.

Both failures from the issue are addressed by that:

1. **Wrong id shape** — pattern copied off a PNG filename; filenames sanitise spaces to underscores, ids keep them. Zero matches, 26 minutes of rendering, then a failure on exactly the previews the exclusion was meant to remove. The zero-match line carries that cause as its advice.
2. **Right shape, incomplete coverage** — `*_ja` matched 28 and looked correct, but a three-arm locale fan-out left the bare and `_en` arms colliding. `28 of 62` next to the totals is where that arithmetic becomes visible.

## Shape of the change

- `previewIdExclusionMatches(previews, excludes)` in `RenderPreviewsTask.kt` — pure, per-pattern, in declaration order, blanks dropped exactly as `excludePreviewIds` drops them. `PreviewIdExclusionMatch.line` owns the wording so the message itself is under test.
- `PackPreviewIdExclusions.matches(ids, patterns)` — the CLI twin, deliberately the same shape. These two lanes already restate each other's matching (documented in that file: the plugin's discovery module lives in a separate Gradle build the CLI cannot depend on), and the new test asserts the reported count agrees with what `retain` actually drops.

Counts are **per pattern**, and patterns may overlap, so they need not sum to the number excluded — attribution is the point ("which of these three did nothing?"), not reconciliation. The totals already answered the other question.

No behaviour change: exclusion still fails safe, and excluding every preview still fails the task.

## Relation to #5086 (the `needs-info` question on the issue)

`spec-preflight.mjs` reports an `unmatched-exclusion` finding ahead of every render **in the design-artifacts workflow**, and that stays the earliest warning. This covers the two places the patterns are actually applied — `composePreviewRender` and `bundle pack` — which is what an ad-hoc Gradle or CLI invocation goes through, and what the issue cites (`RenderPreviewsTask.kt:130`).

## Test plan

- ✅ `:gradle-plugin:test --tests '*SelectPreviewIdsTest*'` — 22 tests, 0 failures (5 new: per-pattern counts in order; zero-match reported with its reason; the exact line for a matching pattern; overlapping patterns each counted in full while `excludePreviewIds` still drops the union; blanks neither applied nor reported).
- ✅ `:cli:test --tests '*PackPreviewIdExclusionsTest*'` — 34 tests, 0 failures (4 new, including "the reported count agrees with what `retain` actually drops").
- ✅ `ktfmtFormat` on both modules.

Text-only change (no UI surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TVXDu7t4U61UrTAPJHFky

---
_Generated by [Claude Code](https://claude.ai/code/session_014TVXDu7t4U61UrTAPJHFky)_