### PR TITLE
feat(design-artifacts): give the catalog a locale axis so a bilingual fan-out folds

### DIFF
--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -1382,6 +1382,47 @@ The cost is the shard bundles moving through the artifact store — a bundle car
 `libs/` is hundreds of MB, uploaded once and downloaded once per shard. They upload with
 `compression-level: 0` (a bundle is already a zip) and `retention-days: 1`.
 
+### A bilingual catalog: the `locales` axis
+
+A project whose previews fan out by **locale** could not be turned into a catalog
+at all. `@LocalePreviews` on one function mints `LanguageToggleButtonPreview_en`
+and `…_ja`; the spec names the base function, both renders match it, and the
+catalog's axes — `variant` / `state` / `theme` / `size` / `props` — had no place
+for "this is the Japanese one". The two arms folded onto the same output key and
+the build was refused with `duplicate output axes`. Nothing was misconfigured: the
+import, the multipreview, the render and the error were all correct, and the model
+simply had no room for locale (issue #5059).
+
+Declare the locales the sheet covers and the arms become distinct renders:
+
+```jsonc
+"locales": ["en", "ja"]
+```
+
+An id whose trailing segment names a declared locale is tagged with a `locale`
+**props** axis, so it gets its own sticker (`…__locale-ja.png`), its own manifest
+entry, and sits beside its sibling the way a `fontScale` variant does. Matching is
+the same as `modes`: case-insensitive, longest-first, and only at a segment
+boundary, so `ja` inside `Ninja` is not a locale. An id naming no declared locale
+stays untagged and remains the component's primary sticker — the same rule that
+keeps an untagged render out of the theme fan-out.
+
+**Why `props.locale` rather than a top-level `locale` field beside `theme` and
+`size`.** Locale is already spelled that way here: a spec hand-writes
+`{ "state": "rtl", "props": { "locale": "ar-XB" } }`, `bridge-live-preview-ids`
+scores `props.locale` when matching a sticker to a live preview, and
+`catalogImagePath` gives props their own path segment. Adding a second spelling
+would leave two representations of one thing. It would also not survive the trip:
+`buildCatalog` lives in the pinned `@design-parity/catalog-export` package and
+builds each component from an allow-list of fields it has been taught — which is
+exactly how the motion axis went missing once — so a field invented here would be
+dropped on the way out.
+
+Locale is **not** wired into `modePriority`: deferring a whole language to the
+live server is a separate decision from deferring a palette, and nobody has asked
+for it. Declaring `locales` costs nothing for a single-locale catalog, which is
+every catalog that does not write the field.
+
 ### Render priority: deferring the long tail to the live server
 
 A catalog that publishes with a live path — `publish-live-bundle: true` (the bundle

--- a/scripts/design-artifacts/catalog-preview-axes.mjs
+++ b/scripts/design-artifacts/catalog-preview-axes.mjs
@@ -1,3 +1,4 @@
+import { localeOfPreviewId } from "./catalog-priority.mjs";
 import { findPreview } from "./preview-id-alias.mjs";
 
 /**
@@ -18,14 +19,29 @@ import { findPreview } from "./preview-id-alias.mjs";
  *
  * @param {Array<{previewId?: string, componentId: string, functionName?: string, images?: Array<object>}>} candidates
  * @param {Array<{id: string, params?: object, captures?: Array<{params?: object}>}>} previews
+ * A locale fan-out is promoted the same way (issue #5059). A bilingual app renders one function
+ * per locale — `@LocalePreviews` mints `LanguageToggleButtonPreview_en` and `…_ja` — and the
+ * catalog's axes (`variant` / `state` / `theme` / `size` / `props`) had no place for "this is the
+ * Japanese one", so both arms folded onto the same output key and the whole catalog build was
+ * refused. Declaring `locales` in the spec turns the id's trailing segment into `props.locale`,
+ * which is the axis this codebase ALREADY spells locale with: a spec writes
+ * `{ state: "rtl", props: { locale: "ar-XB" } }` by hand, `bridge-live-preview-ids` scores
+ * `props.locale` when matching a sticker to a live preview, and `catalogImagePath` gives it a
+ * `__locale-ja` path segment. A new top-level `image.locale` would have to be understood by
+ * `buildCatalog` in the pinned `@design-parity/catalog-export` package, which drops any field it
+ * has not been taught — the way the motion axis went missing — so it would publish nothing.
+ *
  * @param {Map<string, string>} [aliases] raw preview id → bundle-entry id (see preview-id-alias.mjs)
- * @returns {{fontScales: number, duplicates: number}} applied axis and duplicate counts
+ * @param {string[]} [locales] the locales the spec declares (`spec.locales`); empty tags nothing.
+ * @returns {{fontScales: number, duplicates: number, locales: number}} applied axis and duplicate
+ *   counts
  */
-export function applyCatalogPreviewAxes(candidates, previews, aliases) {
+export function applyCatalogPreviewAxes(candidates, previews, aliases, locales) {
   const previewById = new Map(previews.map((preview) => [preview.id, preview]));
   const seenByFunction = new Map();
   let fontScales = 0;
   let duplicates = 0;
+  let localesTagged = 0;
 
   for (const candidate of candidates) {
     // Raw discovery id vs sanitised bundle-entry id — see preview-id-alias.mjs. Without this the
@@ -36,6 +52,12 @@ export function applyCatalogPreviewAxes(candidates, previews, aliases) {
       aliases,
     );
     if (!preview) continue;
+    // Read off the PREVIEW's own id, not the candidate's: the candidate may carry the sanitised
+    // bundle-entry form, and a locale is resolved against what the annotation actually minted.
+    // Applied to every image of the candidate — a locale is a property of the render, not of one
+    // capture within it — and only when the id names a DECLARED locale, so an untagged render
+    // stays the component's primary sticker.
+    const locale = localeOfPreviewId(preview.id, locales);
     const captures =
       Array.isArray(preview.captures) && preview.captures.length > 0
         ? preview.captures
@@ -49,6 +71,10 @@ export function applyCatalogPreviewAxes(candidates, previews, aliases) {
         ...(preview.params ?? {}),
         ...(captures[index]?.params ?? {}),
       };
+      if (locale) {
+        image.props = { ...(image.props ?? {}), locale };
+        localesTagged += 1;
+      }
       const fontScale = params.fontScale;
       if (typeof fontScale === "number" && Number.isFinite(fontScale) && fontScale !== 1) {
         image.props = { ...(image.props ?? {}), fontScale: formatFontScale(fontScale) };
@@ -74,7 +100,7 @@ export function applyCatalogPreviewAxes(candidates, previews, aliases) {
     });
   }
 
-  return { fontScales, duplicates };
+  return { fontScales, duplicates, locales: localesTagged };
 }
 
 function formatFontScale(value) {

--- a/scripts/design-artifacts/catalog-preview-axes.test.mjs
+++ b/scripts/design-artifacts/catalog-preview-axes.test.mjs
@@ -3,7 +3,8 @@ import assert from "node:assert/strict";
 
 import { applySpecBreakpoints } from "./catalog-breakpoints.mjs";
 import { applyCatalogPreviewAxes } from "./catalog-preview-axes.mjs";
-import { foldVariants } from "./catalog-variants.mjs";
+import { catalogImagePath } from "./catalog-image-path.mjs";
+import { foldVariants, outputAxisKey } from "./catalog-variants.mjs";
 
 const candidate = (id, images = [{}]) => ({
   componentId: "HomePreview",
@@ -25,7 +26,7 @@ test("Wear font-scale previews become distinct catalog props axes", () => {
 
   const result = applyCatalogPreviewAxes(candidates, previews);
 
-  assert.deepEqual(result, { fontScales: 1, duplicates: 0 });
+  assert.deepEqual(result, { fontScales: 1, duplicates: 0, locales: 0 });
   assert.deepEqual(candidates[0].images[0].props, { fontScale: "1.24" });
 });
 
@@ -87,7 +88,7 @@ test("overlapping Wear multi-previews keep scaled/device renders and dedupe only
 
   const result = applyCatalogPreviewAxes(candidates, previews);
 
-  assert.deepEqual(result, { fontScales: 2, duplicates: 1 });
+  assert.deepEqual(result, { fontScales: 2, duplicates: 1, locales: 0 });
   assert.deepEqual(
     candidates.map(({ previewId, images }) => [previewId, images[0]?.props?.fontScale]),
     [
@@ -166,3 +167,79 @@ test("an explicit same-function font-scale variant is not folded twice", () => {
     [undefined, "2.0"],
   );
 });
+
+// --- the locale axis (issue #5059) -------------------------------------------
+
+/** The DroidKaigi shape: one function, one arm per declared locale, identical otherwise. */
+const localeFanOut = () => ({
+  candidates: [
+    { componentId: "LanguageToggleButtonPreview", previewId: "LanguageToggleButtonPreview_en", images: [{}] },
+    { componentId: "LanguageToggleButtonPreview", previewId: "LanguageToggleButtonPreview_ja", images: [{}] },
+  ],
+  previews: [
+    { id: "LanguageToggleButtonPreview_en", params: { locale: "en" } },
+    { id: "LanguageToggleButtonPreview_ja", params: { locale: "ja" } },
+  ],
+});
+
+test("a declared locale suffix becomes a props axis, so the arms stop colliding", () => {
+  const { candidates, previews } = localeFanOut();
+
+  const result = applyCatalogPreviewAxes(candidates, previews, undefined, ["en", "ja"]);
+
+  assert.equal(result.locales, 2);
+  assert.deepEqual(candidates[0].images[0].props, { locale: "en" });
+  assert.deepEqual(candidates[1].images[0].props, { locale: "ja" });
+  // The collision the catalog used to refuse on is exactly key equality, so this is the assertion
+  // that matters: two arms, two output keys.
+  assert.notEqual(
+    outputAxisKey(candidates[0].images[0]),
+    outputAxisKey(candidates[1].images[0]),
+  );
+});
+
+test("without a locales declaration nothing is tagged, and the collision is the old one", () => {
+  const { candidates, previews } = localeFanOut();
+
+  const result = applyCatalogPreviewAxes(candidates, previews);
+
+  assert.equal(result.locales, 0);
+  assert.deepEqual(candidates[0].images[0].props ?? {}, {});
+  assert.equal(
+    outputAxisKey(candidates[0].images[0]),
+    outputAxisKey(candidates[1].images[0]),
+  );
+});
+
+test("an id naming no declared locale stays untagged, so the primary sticker is unchanged", () => {
+  const candidates = [candidate("LanguageToggleButtonPreview")];
+  const previews = [{ id: "LanguageToggleButtonPreview", params: {} }];
+
+  const result = applyCatalogPreviewAxes(candidates, previews, undefined, ["en", "ja"]);
+
+  assert.equal(result.locales, 0);
+  assert.equal(candidates[0].images[0].props, undefined);
+});
+
+test("a locale is not matched mid-word, only at a segment boundary", () => {
+  // `ja` inside `Ninja` is the boundary case `modeOfPreviewId` documents for modes; sharing the
+  // matcher is what keeps the two axes from disagreeing about it.
+  const candidates = [candidate("NinjaPreview_en"), candidate("SomethingNinja")];
+  const previews = [{ id: "NinjaPreview_en", params: {} }, { id: "SomethingNinja", params: {} }];
+
+  applyCatalogPreviewAxes(candidates, previews, undefined, ["en", "ja"]);
+
+  assert.deepEqual(candidates[0].images[0].props, { locale: "en" });
+  assert.equal(candidates[1].images[0].props, undefined);
+});
+
+test("the locale axis rides through to the sticker path, so the arms get separate PNGs", () => {
+  const { candidates, previews } = localeFanOut();
+  applyCatalogPreviewAxes(candidates, previews, undefined, ["en", "ja"]);
+
+  assert.equal(
+    catalogImagePath("language-toggle", candidates[1].images[0]),
+    "images/language-toggle/ideal__default__locale-ja.png",
+  );
+});
+

--- a/scripts/design-artifacts/catalog-priority.mjs
+++ b/scripts/design-artifacts/catalog-priority.mjs
@@ -106,22 +106,50 @@ export function modePriority(spec, mode) {
  * unrelated tail and silently defer a required render.
  */
 export function modeOfPreviewId(id, modes) {
+  return declaredSuffixOfPreviewId(id, modes);
+}
+
+/**
+ * The declared value from [values] that [id] ends with, or null.
+ *
+ * The mechanism [modeOfPreviewId] describes is not specific to themes: any axis whose fan-out lives
+ * inside one `@Preview` function leaves its name as the id's trailing segment, and locale is the
+ * second such axis (`LanguageToggleButtonPreview_en` / `…_ja`, issue #5059). Shared rather than
+ * copied, because the fiddly parts — longest-first so `dark` cannot shadow `highContrastDark`,
+ * case-insensitive so `modes: ["light"]` matches `name = "Light"`, and the segment boundary that
+ * stops a mode named `on` matching `ButtonSwitchOn` — are exactly what a second copy would get
+ * subtly wrong.
+ */
+export function declaredSuffixOfPreviewId(id, values) {
   const text = String(id ?? "");
   if (text.length === 0) return null;
-  const declared = (modes ?? [])
+  const declared = (values ?? [])
     .filter((m) => typeof m === "string" && m.length > 0)
     .sort((a, b) => b.length - a.length);
   const lower = text.toLowerCase();
-  for (const mode of declared) {
-    const suffix = mode.toLowerCase();
+  for (const value of declared) {
+    const suffix = value.toLowerCase();
     if (!lower.endsWith(suffix)) continue;
     const start = text.length - suffix.length;
-    if (start === 0) return mode;
+    if (start === 0) return value;
     const before = text[start - 1];
     const boundary = /[^A-Za-z0-9]/.test(before) || /[A-Z]/.test(text[start]);
-    if (boundary) return mode;
+    if (boundary) return value;
   }
   return null;
+}
+
+/**
+ * The declared locale a **daemon preview id** renders in, or null when the id names none.
+ *
+ * The counterpart of [modeOfPreviewId] for `locales` (issue #5059). A bilingual app fans a preview
+ * out with a locale multipreview — `@LocalePreviews` mints `Foo_en` and `Foo_ja` off one function —
+ * and before this the catalog had no axis those two could differ on, so both folded onto the same
+ * output key and the build was refused. An id naming no declared locale stays untagged, exactly as
+ * an id naming no mode does: the untagged render is the component's primary sticker.
+ */
+export function localeOfPreviewId(id, locales) {
+  return declaredSuffixOfPreviewId(id, locales);
 }
 
 /**

--- a/scripts/design-artifacts/catalog-priority.test.mjs
+++ b/scripts/design-artifacts/catalog-priority.test.mjs
@@ -9,6 +9,7 @@ import {
   entryPriority,
   variantPriority,
   isImageDeferred,
+  localeOfPreviewId,
   modePriority,
   previewForImage,
   previewNamesByPriority,
@@ -339,3 +340,21 @@ test("previewForImage resolves a variant's sticker back to the variant's own @Pr
   // A theme the spec never folded in (a multipreview's own dark render) stays on the component.
   assert.equal(previewForImage({ componentId: "B", preview: "Beta" }, { theme: "dark" }), "Beta");
 });
+
+test("localeOfPreviewId reads a declared locale off an id's trailing segment", () => {
+  assert.equal(localeOfPreviewId("com.a.ToggleKt.TogglePreview_ja", ["en", "ja"]), "ja");
+  assert.equal(localeOfPreviewId("com.a.ToggleKt.TogglePreview_en", ["en", "ja"]), "en");
+  // Undeclared, so untagged: the primary sticker keeps no locale (issue #5059).
+  assert.equal(localeOfPreviewId("com.a.ToggleKt.TogglePreview", ["en", "ja"]), null);
+  assert.equal(localeOfPreviewId("com.a.ToggleKt.TogglePreview_ja", []), null);
+});
+
+test("localeOfPreviewId shares the mode matcher's boundary and longest-first rules", () => {
+  // Mid-word: `ja` inside `Ninja` is not a locale, exactly as `on` inside `SwitchOn` is not a mode.
+  assert.equal(localeOfPreviewId("com.a.NinjaKt.SomethingNinja", ["ja"]), null);
+  // Longest first, so a short tag cannot shadow a longer one that also ends the id.
+  assert.equal(localeOfPreviewId("Foo_pt_BR", ["pt", "pt_BR"]), "pt_BR");
+  // Case-insensitive, like `modes: ["light"]` against `name = "Light"`.
+  assert.equal(localeOfPreviewId("Foo_JA", ["ja"]), "ja");
+});
+

--- a/scripts/design-artifacts/catalog.spec.schema.json
+++ b/scripts/design-artifacts/catalog.spec.schema.json
@@ -33,6 +33,11 @@
       "description": "Informational: the theme modes the sticker sheet covers (e.g. [\"light\", \"dark\"]).",
       "items": { "type": "string" }
     },
+    "locales": {
+      "type": "array",
+      "description": "The locales the sticker sheet covers (e.g. [\"en\", \"ja\"]). Unlike `modes` this is not informational: a preview id ending in a declared locale is tagged with a `locale` props axis, so the arms of a locale multipreview fan-out (`Foo_en` / `Foo_ja`) are distinct renders instead of two images folding onto one output key. Match is case-insensitive and only at a segment boundary, as for `modes`. An id naming no declared locale stays untagged and remains the component's primary sticker. Omit for a single-locale catalog.",
+      "items": { "type": "string" }
+    },
     "modePriority": {
       "type": "object",
       "description": "Per-axis render priority for the theme modes: which palettes must be baked into the published bundle and which the preview server produces on demand. Keys are mode names from `modes` plus the `*` wildcard; values are \"required\" (default) or \"deferred\". e.g. { \"light\": \"required\", \"*\": \"deferred\" } bakes one sticker per component and leaves the rest to the serve host's theme switcher. Only stickers that NAME a theme can be deferred, so a component always keeps its primary render. Requires a live path (publish-live-bundle or a buildable `source`) — the export refuses to publish deferred coverage a serve host could not re-render.",

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -263,7 +263,7 @@ async function listFilesRecursive(dir) {
  * ships to npm and the pin is bumped, this can revert to a plain
  * `loadPreviewBundle(path, resolver)`.
  */
-async function loadCandidates(path, breakpoints) {
+async function loadCandidates(path, breakpoints, locales) {
   const bundle = await readPreviewBundle(path);
   for (const preview of bundle.previews) {
     sanitizeNullSizes(preview.params);
@@ -326,7 +326,22 @@ async function loadCandidates(path, breakpoints) {
   // hands back the raw discovery id, so every preview whose `@Preview(name = …)` contains a space
   // needs the manifest's raw→sanitised mapping to be found at all (see preview-id-alias.mjs).
   const previewAliases = previewIdAliases(bundle.manifest);
-  applyCatalogPreviewAxes(candidates, candidateBundle.previews, previewAliases);
+  // The spec's `locales` are what turn a locale fan-out's id suffix into a `props.locale` axis, so the
+  // arms of a bilingual catalog are distinct renders instead of two images fighting over one
+  // output key (issue #5059). Undeclared ⇒ nothing is tagged, so every existing catalog is
+  // unaffected.
+  const localeAxes = applyCatalogPreviewAxes(
+    candidates,
+    candidateBundle.previews,
+    previewAliases,
+    locales,
+  );
+  if (localeAxes.locales > 0) {
+    console.log(
+      `[${basename(path)}] tagged ${localeAxes.locales} image(s) with a locale axis ` +
+        `(${(locales ?? []).join(", ")})`,
+    );
+  }
   // The published candidate reader classifies every numeric width with Material
   // window classes. Give this catalog's declared names precedence so domain
   // breakpoints such as Wear's 192 dp `smallRound` and 227 dp `largeRound` remain
@@ -835,6 +850,12 @@ function catalogFromCandidates(candidates, spec, opts = {}) {
     ...(opts.renderer ? { renderer: opts.renderer } : {}),
     ...(opts.designParity ? { designParity: opts.designParity } : {}),
     generatedAt: opts.generatedAt ?? new Date().toISOString(),
+    // The locales the sheet covers, when it declares any (issue #5059). Carried onto the manifest
+    // beside `themes` so a consumer can group the arms of a locale fan-out rather than infer the
+    // axis from a `props.locale` it happens to see on some stickers.
+    ...(Array.isArray(spec.locales) && spec.locales.length > 0
+      ? { locales: spec.locales }
+      : {}),
     // Presentation hints the system declares (stage surface + hero preview),
     // carried through onto catalog.json so the preview server reads them instead
     // of inferring — see catalog.spec.schema.json `display`.
@@ -1003,14 +1024,14 @@ if (effectiveBreakpoints !== undefined) spec.breakpoints = effectiveBreakpoints;
 // only by an appended `_<mode>`) onto one component. See `loadCandidates` (which
 // also works around the published null-widthDp crash) and the vendored join.
 const primaryRecord = {
-  ...(await loadCandidates(rendersPath, spec.breakpoints)),
+  ...(await loadCandidates(rendersPath, spec.breakpoints, spec.locales)),
   renderPath: rendersPath,
 };
 const additionalRecords = [];
 for (const path of values["additional-renders"] ?? []) {
   const renderPath = resolve(path);
   additionalRecords.push({
-    ...(await loadCandidates(renderPath, spec.breakpoints)),
+    ...(await loadCandidates(renderPath, spec.breakpoints, spec.locales)),
     renderPath,
   });
 }
@@ -1032,6 +1053,7 @@ if (values["extra-renders"]) {
   const { candidates: extra, bundle: extraRenderBundle } = await loadCandidates(
     resolve(values["extra-renders"]),
     spec.breakpoints,
+    spec.locales,
   );
   extraBundle = extraRenderBundle;
   const overridden = new Set(extra.map(functionOf));

--- a/scripts/design-artifacts/spec-preflight.mjs
+++ b/scripts/design-artifacts/spec-preflight.mjs
@@ -58,7 +58,7 @@ import { readFileSync } from "node:fs";
 import { parseArgs } from "node:util";
 
 import { breakpointMatcher, catalogBreakpoints } from "./catalog-breakpoints.mjs";
-import { modeOfPreviewId } from "./catalog-priority.mjs";
+import { localeOfPreviewId, modeOfPreviewId } from "./catalog-priority.mjs";
 import { selectImages, selectLabel, selectOf } from "./catalog-select.mjs";
 import { imageHasVariantAxes, outputAxisKey } from "./catalog-variants.mjs";
 import { previewsFromJson } from "./deferred-preview-ids.mjs";
@@ -210,7 +210,7 @@ function stableJson(value) {
  * `previewId` rides along for the report — a collision is only actionable if it names the ids that
  * collided — and is ignored by `outputAxisKey`, which reads the axes alone.
  */
-export function previewImages(preview, { modes, sizeOf }) {
+export function previewImages(preview, { modes, locales, sizeOf }) {
   const id = preview?.id;
   const state = variantStateFromId(id);
   return capturesOf(preview).map((capture) => {
@@ -220,6 +220,12 @@ export function previewImages(preview, { modes, sizeOf }) {
       typeof fontScale === "number" && Number.isFinite(fontScale) && fontScale !== 1
         ? { fontScale: Number.isInteger(fontScale) ? fontScale.toFixed(1) : String(fontScale) }
         : {};
+    // The locale axis the join promotes from a declared-locale id suffix (issue #5059). Mirrored
+    // here for the same reason every other axis is: this preflight has to report the collisions the
+    // fold WOULD have, and no others. Without it a bilingual catalog reads as two arms colliding —
+    // which is exactly the false failure the locale axis exists to remove.
+    const locale = localeOfPreviewId(preview?.id, locales);
+    if (locale) props.locale = locale;
     const size = sizeOf ? sizeOf(params) : undefined;
     return {
       previewId: id,
@@ -373,6 +379,7 @@ export function preflightSpec(spec, previews, options = {}) {
 
   const byFunction = imagesByFunction(survivors, {
     modes: spec?.modes ?? [],
+    locales: spec?.locales ?? [],
     sizeOf: breakpointMatcher(catalogBreakpoints(spec)),
   });
   const functionsBefore = new Set(all.map(functionOf));

--- a/scripts/design-artifacts/spec-preflight.test.mjs
+++ b/scripts/design-artifacts/spec-preflight.test.mjs
@@ -381,3 +381,34 @@ test("a spec with no groups and an empty manifest report nothing", () => {
   assert.deepEqual(kinds(preflightSpec({ system: "test" }, [])), []);
   assert.deepEqual(preflightSpec(undefined, undefined).counts.previews, 0);
 });
+
+test("a locale fan-out collides without a locales declaration and is clean with one", () => {
+  // The DroidKaigi shape (issue #5059): one spec component, two arms of a locale multipreview.
+  // Both arms name the same function, so the spec cannot tell them apart and the fold sees two
+  // images on one output key — until `locales` gives them an axis to differ on.
+  const component = {
+    componentId: "language-toggle",
+    preview: "LanguageToggleButtonPreview",
+  };
+  // The arms carry the annotation's own `locale` param, which is what keeps them two renders
+  // rather than one: identical params AND identical axes would be collapsed as the same picture.
+  const previews = [
+    preview("com.a.ToggleKt.LanguageToggleButtonPreview_en", {
+      functionName: "LanguageToggleButtonPreview",
+      params: { locale: "en" },
+    }),
+    preview("com.a.ToggleKt.LanguageToggleButtonPreview_ja", {
+      functionName: "LanguageToggleButtonPreview",
+      params: { locale: "ja" },
+    }),
+  ];
+
+  assert.deepEqual(kinds(preflightSpec(spec([component]), previews)), [
+    "duplicate-output-axes",
+  ]);
+  assert.deepEqual(
+    kinds(preflightSpec(spec([component], { locales: ["en", "ja"] }), previews)),
+    [],
+  );
+});
+


### PR DESCRIPTION
Fixes #5059.

## The gap

A project whose previews fan out by **locale** could not become a catalog. `@LocalePreviews` on one function mints `LanguageToggleButtonPreview_en` and `…_ja`; the spec names the base function, both renders match it, and the catalog's axes (`variant` / `state` / `theme` / `size` / `props`) had no place for "this is the Japanese one" — so both folded onto one output key and the build was refused. Nothing was misconfigured: the import, the multipreview, the render and the error were all correct. DroidKaigi's conference app has **28 preview bases** in that shape, and the standing workaround drops the Japanese half of a Japanese conference app's catalog.

## The change

```jsonc
"locales": ["en", "ja"]
```

An id whose trailing segment names a declared locale gets a `locale` **props** axis, so each arm is its own render, with its own sticker path (`…__locale-ja.png`) and manifest entry. Matching **reuses** the mode matcher (extracted as `declaredSuffixOfPreviewId`) rather than copying it — case-insensitive, longest-first so `pt` can't shadow `pt_BR`, and segment-boundary only so `ja` inside `Ninja` is not a locale. An id naming no declared locale stays untagged and remains the component's primary sticker, the same rule the theme fan-out follows. Declaring nothing tags nothing, so every existing catalog is byte-identical.

`spec-preflight.mjs` learns the same axis, so it keeps reporting exactly the collisions the fold would have — otherwise it would fail every bilingual catalog the fold now accepts. `catalog.json`'s meta carries `locales` beside `themes` so a consumer can group the arms rather than infer the axis from a `props.locale` it happens to see.

## Why `props.locale` and not a field beside `theme` / `size`

The issue suggested a first-class axis. Two pieces of evidence in the tree argue for props instead, and I took them:

1. **This codebase already spells locale that way.** A spec hand-writes `{ "state": "rtl", "props": { "locale": "ar-XB" } }`, `bridge-live-preview-ids` scores `props.locale` when matching a sticker to a live preview, and `catalogImagePath` already gives props their own path segment. A second spelling would leave two representations of one thing, and the bridge would only understand one of them.
2. **A new top-level field would not survive the trip.** `buildCatalog` lives in the pinned `@design-parity/catalog-export` package and builds each component from an allow-list of fields it has been taught — which is exactly how the motion axis went missing once (`motion-carried.mjs`). `image.locale` would be dropped on the way out; `props` is carried today.

Locale is deliberately **not** wired into `modePriority`: deferring a whole language to the live server is a separate decision from deferring a palette, and nothing has asked for it.

## Not in this PR

`imports/droidkaigi-conference-app-2026/import.json`'s provisional `*_ja` exclusion lives in `yschimke/compose-preview-imports`, so it is reverted there once this ships — the issue already marks it provisional.

## Test plan

- ✅ `node --test` over `scripts/design-artifacts` — 1390 pass, 0 fail, 30 skipped.
- New tests: a declared locale suffix becomes a props axis and the two arms get **different** output-axis keys (equal keys are precisely the collision that refused the build); without a `locales` declaration nothing is tagged and the keys still collide; an undeclared id stays untagged; no mid-word match; the axis reaches the sticker path (`images/language-toggle/ideal__default__locale-ja.png`).
- `catalog-priority.test.mjs`: `localeOfPreviewId` boundary, longest-first and case rules.
- `spec-preflight.test.mjs`: the DroidKaigi shape reports `duplicate-output-axes` without `locales` and is clean with it — the preflight and the fold still agree.
- Fixtures carry the annotation's own `locale` param, which is what keeps the two arms two renders rather than one collapsed duplicate.

Text-only change (no UI surface of its own; it un-blocks catalogs that could not be published at all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TVXDu7t4U61UrTAPJHFky

---
_Generated by [Claude Code](https://claude.ai/code/session_014TVXDu7t4U61UrTAPJHFky)_