### PR TITLE
feat(discovery): resolve the remember factory a state type ships beside it

### DIFF
--- a/docs/design/COMPONENT_RECORD.md
+++ b/docs/design/COMPONENT_RECORD.md
@@ -923,12 +923,58 @@ gate over the corpora; retire the cleaner for migrated catalogs.
 > gate is what checks it, since `expectedEmitted` names both text fields and the
 > generated wrapper is compiled with exactly the imports the record published.
 >
-> Not taken: `rememberTextFieldState()`. The factory is what a human would write (raw
-> state construction in a composable body does not survive recomposition), but it is a
-> *convention*, not something derivable from the parameter's type — taking it would
-> reintroduce the authored name→expression table this design keeps deleting. The
-> snippet's claim is that it type-checks; a snippet meant to render well is a
-> different artifact, and it should say so rather than smuggling a mapping back in.
+> **Then taken, once the objection dissolved.** This paragraph used to read "not
+> taken: `rememberTextFieldState()`", on the grounds that the factory is a
+> *convention* rather than something derivable from the parameter's type, and that
+> taking it would reintroduce the authored name→expression table this design keeps
+> deleting. The first half was right and is still the reason to want it: raw state
+> construction in a composable body does not survive recomposition, so
+> `TextField(state = TextFieldState())` type-checks and still silently drops what the
+> user typed. The second half confused two different things a convention can be.
+>
+> Spelling `remember` + a type's simple name in the generator and emitting it *is* the
+> authored table — a name mapped to an expression nothing verified. But the same
+> convention can be **looked up** instead: `ComposableSignature.noArgFactoryFor` walks
+> the type's own package for a file facade declaring `remember<SimpleName>`, and
+> accepts it only when the scan can see that it returns that type, is `@Composable`,
+> is public and non-generic, takes no receiver or context, has every parameter
+> defaulted, and carries no opt-in marker. What lands on
+> `TargetParameter.noArgFactory` is the fully-qualified callable the classpath
+> actually had. A convention that is looked up is a fact; a convention that is written
+> down in the generator is the table. That distinction, not the convention's
+> existence, was the real objection — and it is the same move `noArgConstructible`
+> already made one paragraph up.
+>
+> Searching only the type's own package is what keeps it a lookup: the name alone
+> would match any `rememberFoo` anywhere on the classpath, and matching a name is
+> precisely the failure mode being avoided. The facade cannot be derived from the type
+> (it follows the *source file*), so the package's classes are walked and the ones
+> carrying package metadata are read.
+>
+> One trap, worth recording because the unit fixtures could not have found it and the
+> compiler could not have either. `@Composable` is a bytecode annotation, so the
+> check crosses from metadata back to the scan — and it has to cross by the JVM name
+> **metadata carries**, not by the source name. `rememberTextFieldState` takes a
+> defaulted `TextRange`, an inline value class, so Kotlin emits it as
+> `rememberTextFieldState-Le-punE`; looking the method up under its source name found
+> nothing and refused a factory that was right there. Nothing failed loudly — the
+> generator simply fell back to `TextFieldState()`, which compiles. What caught it was
+> the functional test asserting on the *emitted text* against the real androidx
+> classpath, because "it compiles" is exactly the property the wrong answer also has.
+> `MangledFactoryState` now pins it in the fixtures.
+>
+> The generator prefers the factory over the constructor wherever both are resolved,
+> and the two are mutually exclusive in the emitted imports — `rememberTextFieldState()`
+> never names `TextFieldState`, so importing it would be an import for something not
+> printed. Both flags still travel on the record, because the record says what is
+> *true* of the type and choosing between them is the generator's job; a record
+> carrying only the current winner would have to be re-resolved the moment that
+> preference changed. A record predating the field carries null and keeps
+> constructing, so nothing that already compiled is retracted.
+>
+> The snippet's claim is still only that it type-checks. The factory does not widen
+> that claim — it is the *same* claim about a better expression, and every clause
+> above is a way `rememberT()` fails to compile rather than a way it renders nicely.
 >
 > The first run of that measurement read 25/30 with five refusals, three of which —
 > `Checkbox`, `RadioButton`, `Switch` — turned out to share one cause: material3

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComposableSignature.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComposableSignature.kt
@@ -330,6 +330,8 @@ internal object ComposableSignature {
   private val OPT_IN_MARKER_ANNOTATIONS =
     setOf("kotlin.RequiresOptIn", "androidx.annotation.RequiresOptIn")
 
+  private const val COMPOSABLE_ANNOTATION = "androidx.compose.runtime.Composable"
+
   /** Match the metadata function to [method] by JVM signature (name + descriptor). */
   private fun matchFunction(functions: List<KmFunction>, method: MethodInfo): KmFunction? {
     val name = method.name
@@ -365,7 +367,95 @@ internal object ComposableSignature {
   private fun TargetParameter.withConstructibility(scanResult: ScanResult?): TargetParameter {
     if (scanResult == null || hasDefault || nullable || composableSlot) return this
     val fqn = typeFqn ?: return this
-    return if (isNoArgConstructible(scanResult, fqn)) copy(noArgConstructible = true) else this
+    val constructible = isNoArgConstructible(scanResult, fqn)
+    val factory = noArgFactoryFor(scanResult, fqn)
+    if (!constructible && factory == null) return this
+    return copy(noArgConstructible = constructible, noArgFactory = factory)
+  }
+
+  /**
+   * [TargetParameter.noArgFactory] resolved against the classpath: the `remember<SimpleName>` a
+   * call site should prefer over the raw constructor.
+   *
+   * Compose states the convention rather than documenting it — a state type that wants remembering
+   * ships `@Composable fun rememberT(…)` **in its own package**, every parameter defaulted
+   * (`ScrollState`/`rememberScrollState`, `LazyListState`/`rememberLazyListState`,
+   * `TextFieldState`/`rememberTextFieldState`). Searching that one package is what makes this a
+   * lookup instead of a guess: the name alone would match any `rememberFoo` anywhere on the
+   * classpath, so the returned callable is one this scan actually saw, declared beside the type,
+   * and returning the type.
+   *
+   * Top-level functions live in a file facade whose name follows the *source file*, not the type,
+   * so the facade cannot be derived from [fqn] — the package's classes are walked and the ones
+   * carrying package metadata are read. Every refusal below is a way `rememberT()` fails to
+   * compile, mirroring [isNoArgConstructible]:
+   * - **wrong shape** — non-public, generic, an extension, or context-requiring, none of which is
+   *   callable as a bare `rememberT()`;
+   * - **a required parameter** — the point is a call with no arguments;
+   * - **a different return type** — a `rememberFoo` that returns something else is a name
+   *   collision, not the convention;
+   * - **not `@Composable`** — the convention is about remembering across recomposition, and a plain
+   *   function named `rememberT` is not it;
+   * - **opt-in gated** — the same refusal [isNoArgConstructible] makes, for the same reason: the
+   *   generated wrapper carries no marker for it.
+   *
+   * Unlike the constructor, the factory does not put the type's own name in the emitted source, so
+   * a gated *type* does not disqualify its ungated factory — only a marker on the factory itself
+   * does.
+   */
+  internal fun noArgFactoryFor(scanResult: ScanResult, fqn: String): String? {
+    return try {
+      val pkg = fqn.substringBeforeLast('.', missingDelimiterValue = "")
+      val simpleName = fqn.substringAfterLast('.')
+      if (pkg.isEmpty() || simpleName.isEmpty()) return null
+      val factoryName = "remember$simpleName"
+      val declaring =
+        scanResult.getPackageInfo(pkg)?.classInfo?.firstOrNull { info ->
+          declaresNoArgComposableFactory(info, factoryName, fqn)
+        }
+      if (declaring == null) null else "$pkg.$factoryName"
+    } catch (_: Throwable) {
+      // Same posture as every other read here: unreadable answers "no factory", which costs the
+      // caller a constructor (or a placeholder) rather than a call site nothing verified.
+      null
+    }
+  }
+
+  /** Whether [info] is a file facade declaring [factoryName] in the shape described above. */
+  private fun declaresNoArgComposableFactory(
+    info: ClassInfo,
+    factoryName: String,
+    returnFqn: String,
+  ): Boolean {
+    val metadata = readClassMetadata(info) ?: return false
+    val functions =
+      when (val parsed = KotlinClassMetadata.readLenient(metadata)) {
+        is KotlinClassMetadata.FileFacade -> parsed.kmPackage.functions
+        is KotlinClassMetadata.MultiFileClassPart -> parsed.kmPackage.functions
+        else -> return false
+      }
+    val declared =
+      functions.firstOrNull { fn ->
+        fn.name == factoryName &&
+          fn.visibility == Visibility.PUBLIC &&
+          fn.typeParameters.isEmpty() &&
+          fn.receiverParameterType == null &&
+          !hasContextRequirement(fn) &&
+          fn.valueParameters.all { it.declaresDefaultValue } &&
+          (fn.returnType.classifier as? KmClassifier.Class)?.name?.replace('/', '.') == returnFqn
+      } ?: return false
+    // `@Composable` is a bytecode annotation on the JVM method, not something metadata records for
+    // a declaration, so the check crosses back to the scan — and it has to cross by the JVM name
+    // METADATA carries, not by the source name. The real `rememberTextFieldState` takes a defaulted
+    // `TextRange`, an inline value class, so Kotlin emits it as `rememberTextFieldState-Le-punE`;
+    // looking it up under its source name finds no method and refuses a factory that is right
+    // there. Matched on the name alone rather than the descriptor, because the Compose compiler
+    // appends a `Composer, Int` and a default mask that no metadata signature accounts for.
+    val jvmName = declared.signature?.name ?: factoryName
+    return info.getMethodInfo(jvmName).any { method ->
+      method.hasAnnotation(COMPOSABLE_ANNOTATION) &&
+        requiredOptInsOf(method, OPT_IN_MARKER_ANNOTATIONS).isEmpty()
+    }
   }
 
   /**

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComponentSnippetsTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComponentSnippetsTest.kt
@@ -45,6 +45,7 @@ class ComponentSnippetsTest {
     nullable: Boolean = false,
     typeFqn: String? = null,
     noArgConstructible: Boolean = false,
+    noArgFactory: String? = null,
   ) =
     TargetParameter(
       name = name,
@@ -54,6 +55,7 @@ class ComponentSnippetsTest {
       composableSlot = composableSlot,
       nullable = nullable,
       noArgConstructible = noArgConstructible,
+      noArgFactory = noArgFactory,
     )
 
   private fun emitted(record: ComponentRecord): ComponentSnippet.Emitted =
@@ -489,5 +491,90 @@ class ComponentSnippetsTest {
 
     assertThat(snippet.code).isEqualTo("TextField(state = Inner())")
     assertThat(snippet.imports).contains("com.example.Outer.Inner")
+  }
+
+  // --- preferring the `remember…` factory discovery resolved (follow-up to #5067) ----------------
+
+  private fun rememberedState(
+    noArgConstructible: Boolean = true,
+    nullable: Boolean = false,
+    type: String = "TextFieldState",
+  ) =
+    parameter(
+      "state",
+      type,
+      typeFqn = "androidx.compose.foundation.text.input.TextFieldState",
+      nullable = nullable,
+      noArgConstructible = noArgConstructible,
+      noArgFactory = "androidx.compose.foundation.text.input.rememberTextFieldState",
+    )
+
+  @Test
+  fun `a parameter whose type has a factory is written as the factory call`() {
+    val snippet = emitted(textFieldRecord(rememberedState()))
+
+    assertThat(snippet.code).isEqualTo("TextField(state = rememberTextFieldState())")
+  }
+
+  @Test
+  fun `the factory wins over the constructor, because raw state loses what the user typed`() {
+    // Both are true of `TextFieldState` and the record carries both. `TextFieldState()` compiles
+    // and is still wrong: it is rebuilt on every recomposition. This is the whole reason the
+    // factory field exists rather than the constructor flag being enough.
+    val snippet = emitted(textFieldRecord(rememberedState(noArgConstructible = true)))
+
+    assertThat(snippet.code).isEqualTo("TextField(state = rememberTextFieldState())")
+    // And the constructor's import goes with it: a bare `TextFieldState` is neither printed nor
+    // pulled in. Asserted on the imports rather than on the code, because
+    // `rememberTextFieldState()`
+    // contains `TextFieldState()` as a substring and a "does not contain" check would pass here for
+    // the wrong reason.
+    assertThat(snippet.imports)
+      .doesNotContain("androidx.compose.foundation.text.input.TextFieldState")
+  }
+
+  @Test
+  fun `the factory is imported and the type it replaces is not`() {
+    // The emitted source never names `TextFieldState`, so importing it would be an import for
+    // something not printed — the exact disagreement the shared gate exists to prevent.
+    val snippet = emitted(textFieldRecord(rememberedState()))
+
+    assertThat(snippet.imports)
+      .containsExactly(
+        "androidx.compose.material3.TextField",
+        "androidx.compose.foundation.text.input.rememberTextFieldState",
+      )
+      .inOrder()
+  }
+
+  @Test
+  fun `a factory with no constructor behind it is still enough to emit a call`() {
+    // The two are resolved independently: a type that refuses `Type()` (abstract, internal,
+    // generic) can still have a public factory, and that is a call site the constructor path
+    // could never have written.
+    val snippet = emitted(textFieldRecord(rememberedState(noArgConstructible = false)))
+
+    assertThat(snippet.code).isEqualTo("TextField(state = rememberTextFieldState())")
+    assertThat(snippet.imports)
+      .contains("androidx.compose.foundation.text.input.rememberTextFieldState")
+  }
+
+  @Test
+  fun `a nullable parameter still takes null, whatever its package offers`() {
+    val snippet =
+      emitted(textFieldRecord(rememberedState(nullable = true, type = "TextFieldState?")))
+
+    assertThat(snippet.code).isEqualTo("TextField(state = null)")
+    assertThat(snippet.imports).containsExactly("androidx.compose.material3.TextField")
+  }
+
+  @Test
+  fun `a record predating the factory field behaves exactly as it did`() {
+    // Defaulted to null, so an older `components.json` keeps constructing — no silent retraction
+    // of a call site that already compiled.
+    val snippet = emitted(textFieldRecord())
+
+    assertThat(snippet.code).isEqualTo("TextField(state = TextFieldState())")
+    assertThat(snippet.imports).contains("androidx.compose.foundation.text.input.TextFieldState")
   }
 }

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComposableSignatureTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComposableSignatureTest.kt
@@ -286,6 +286,73 @@ class ComposableSignatureTest {
     assertThat(constructible("NoSuchStateAnywhere")).isFalse()
   }
 
+  // --- the `remember…` factory convention -------------------------------------------------------
+
+  /** `noArgFactoryFor` over a real scan, asked of the TYPE for the same reason as above. */
+  private fun factoryFor(simpleName: String): String? {
+    ClassGraph()
+      .enableClassInfo()
+      .enableMethodInfo()
+      .enableAnnotationInfo()
+      .acceptPackages("ee.schimke.composeai.discovery")
+      .scan()
+      .use { scan ->
+        return ComposableSignature.noArgFactoryFor(
+          scan,
+          "ee.schimke.composeai.discovery.$simpleName",
+        )
+      }
+  }
+
+  @Test
+  fun `a composable, fully defaulted factory beside the type resolves to its callable`() {
+    // The whole claim: the callable came off the classpath. Nothing spelled `remember` + the type
+    // name and hoped — the scan found this function, in this package, returning this type.
+    assertThat(factoryFor("DefaultedState"))
+      .isEqualTo("ee.schimke.composeai.discovery.rememberDefaultedState")
+  }
+
+  @Test
+  fun `a type whose package ships no factory resolves to none`() {
+    assertThat(factoryFor("FactorylessState")).isNull()
+  }
+
+  @Test
+  fun `a factory that is not composable is not the convention`() {
+    // Named and shaped exactly right. A resolver matching on the name would take it.
+    assertThat(factoryFor("PlainFactoryState")).isNull()
+  }
+
+  @Test
+  fun `a factory with a required parameter refuses, since the point is a call with none`() {
+    assertThat(factoryFor("RequiredFactoryState")).isNull()
+  }
+
+  @Test
+  fun `a same-named factory returning another type is a collision, not a factory`() {
+    assertThat(factoryFor("MismatchedFactoryState")).isNull()
+  }
+
+  @Test
+  fun `an opt-in-gated factory refuses, because its marker cannot travel either`() {
+    assertThat(factoryFor("GatedFactoryState")).isNull()
+  }
+
+  @Test
+  fun `a factory whose JVM name is mangled still resolves, under the name metadata carries`() {
+    // `rememberMangledFactoryState` takes an inline value class, so the emitted method is
+    // `rememberMangledFactoryState-…`. The source name is what a call site prints and what
+    // metadata records; the mangled one is what the scan can find. Confusing the two is what made
+    // the real `rememberTextFieldState` invisible.
+    assertThat(factoryFor("MangledFactoryState"))
+      .isEqualTo("ee.schimke.composeai.discovery.rememberMangledFactoryState")
+  }
+
+  @Test
+  fun `a type that is not on the scanned classpath has no factory`() {
+    assertThat(factoryFor("NoSuchStateAnywhere")).isNull()
+  }
+
   /** Resolve a fixture function's single parameter through the full `signatureOf` path. */
   private fun parameterWithScan(simpleName: String): TargetParameter {
     ClassGraph()
@@ -311,6 +378,23 @@ class ComposableSignatureTest {
 
     assertThat(parameter.noArgConstructible).isTrue()
     assertThat(parameter.typeFqn).isEqualTo("ee.schimke.composeai.discovery.DefaultedState")
+  }
+
+  @Test
+  fun `a required parameter also carries the factory its package declares`() {
+    // Both travel: the record says what is TRUE of the type, and choosing between them is the
+    // generator's job (`ComponentSnippets` prefers the factory). A record that carried only the
+    // winner would have to be re-resolved the moment that preference changed.
+    val parameter = parameterWithScan("factoryStateComponent")
+
+    assertThat(parameter.noArgConstructible).isTrue()
+    assertThat(parameter.noArgFactory)
+      .isEqualTo("ee.schimke.composeai.discovery.rememberDefaultedState")
+  }
+
+  @Test
+  fun `a defaulted parameter is not asked about the factory either`() {
+    assertThat(parameterWithScan("defaultedParameterComponent").noArgFactory).isNull()
   }
 
   @Test

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/SignatureFixtures.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/SignatureFixtures.kt
@@ -197,3 +197,64 @@ annotation class ExperimentalStateApi
 /** A defaulted parameter is omitted from the call, so nothing is constructed for it. */
 @Suppress("unused", "UNUSED_PARAMETER")
 fun defaultedParameterComponent(state: DefaultedState = DefaultedState()) {}
+
+// --- the `remember…` factory convention ---------------------------------------------------------
+// Each names one clause of `ComposableSignature.noArgFactoryFor`. The convention is Compose's, but
+// what is under test is that it is LOOKED UP rather than spelled from a type name: every fixture
+// below is a real `remember…` the scan can either accept or reject on its declared shape, and a
+// resolver that matched on the name alone would accept all of them.
+
+/** The `rememberTextFieldState` shape: `@Composable`, fully defaulted, returning its type. */
+@Suppress("unused")
+@Composable
+fun rememberDefaultedState(text: String = "", cursor: Int = 0): DefaultedState =
+  DefaultedState(text, cursor)
+
+/** A type whose package ships no factory at all. Its constructor is the only answer. */
+@Suppress("unused") class FactorylessState(val text: String = "")
+
+/** Named right and shaped right, but not `@Composable` — so it is not the convention. */
+@Suppress("unused") class PlainFactoryState(val text: String = "")
+
+@Suppress("unused")
+fun rememberPlainFactoryState(text: String = ""): PlainFactoryState = PlainFactoryState(text)
+
+/** Named right, but takes a value nothing here can supply, so `remember…()` does not compile. */
+@Suppress("unused") class RequiredFactoryState(val text: String = "")
+
+@Suppress("unused")
+@Composable
+fun rememberRequiredFactoryState(text: String): RequiredFactoryState = RequiredFactoryState(text)
+
+/** Named right, returns something else: a name collision, not a factory for this type. */
+@Suppress("unused") class MismatchedFactoryState(val text: String = "")
+
+@Suppress("unused")
+@Composable
+fun rememberMismatchedFactoryState(): DefaultedState = DefaultedState()
+
+/** Named right, but gated: emitting the call would need a marker the wrapper cannot carry. */
+@Suppress("unused") class GatedFactoryState(val text: String = "")
+
+@Suppress("unused")
+@Composable
+@ExperimentalFixtureApi
+fun rememberGatedFactoryState(): GatedFactoryState = GatedFactoryState()
+
+/** The wiring case: a required parameter whose type has a factory, read through `signatureOf`. */
+@Suppress("unused", "UNUSED_PARAMETER") fun factoryStateComponent(state: DefaultedState) {}
+
+/**
+ * A factory whose JVM name is **mangled**, because it takes an inline value class parameter.
+ *
+ * The case the real classpath had and the fixtures above did not: `rememberTextFieldState` takes a
+ * defaulted `TextRange`, so Kotlin emits it as `rememberTextFieldState-Le-punE`. A resolver that
+ * looks the method up under its source name finds nothing and refuses a factory that exists — which
+ * is what the functional test caught, and what this pins.
+ */
+@Suppress("unused") class MangledFactoryState(val text: String = "")
+
+@Suppress("unused")
+@Composable
+fun rememberMangledFactoryState(range: ValueState = ValueState()): MangledFactoryState =
+  MangledFactoryState(range.text)

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ComponentCallSiteCompileFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ComponentCallSiteCompileFunctionalTest.kt
@@ -54,6 +54,12 @@ class ComponentCallSiteCompileFunctionalTest {
    * DefaultConstructorMarker)` bridge — which is exactly why the claim has to be settled by the
    * compiler here rather than by a hand-written record. They also cover the invariant that moved:
    * these are the first snippets that emit an import beyond the callable.
+   *
+   * Those two now carry a second claim as well: that discovery found `rememberTextFieldState` on
+   * the real androidx classpath and the generator preferred it over the constructor. Compiling is
+   * necessary but not sufficient for that one — `TextFieldState()` compiles too — so
+   * [assertPrefersTheRememberFactory] checks the emitted text, and this build checks that the text
+   * the compiler accepted is the text that was checked.
    */
   private val expectedEmitted =
     setOf("Text", "Button", "Card", "Checkbox", "Switch", "TextField", "OutlinedTextField")
@@ -211,6 +217,8 @@ class ComponentCallSiteCompileFunctionalTest {
       .that(emitted.keys)
       .containsAtLeastElementsIn(expectedEmitted)
 
+    assertPrefersTheRememberFactory(emitted)
+
     writeGeneratedCallSites(projectDir, emitted)
 
     // `GradleRunner.build()` throws on a failed build, so reaching this line *is* the gate: the
@@ -220,6 +228,26 @@ class ComponentCallSiteCompileFunctionalTest {
     val compile = runGradle(projectDir, "compileKotlin")
     assertThat(compile.task(":compileKotlin")?.outcome)
       .isIn(listOf(TaskOutcome.SUCCESS, TaskOutcome.FROM_CACHE))
+  }
+
+  /**
+   * The two text fields must be written with `rememberTextFieldState()`, not `TextFieldState()`.
+   *
+   * Asserted on the emitted text because the compiler cannot tell them apart: both type-check, and
+   * only one of them survives recomposition. This is the only place the *preference* is checked
+   * against a real classpath — the unit tests build a `TargetParameter` by hand and so can only
+   * prove the generator honours a factory it was handed, never that discovery resolved one.
+   */
+  private fun assertPrefersTheRememberFactory(emitted: Map<String, ComponentCode>) {
+    for (name in listOf("TextField", "OutlinedTextField")) {
+      val code = emitted.getValue(name)
+      assertWithMessage("%s call site", name)
+        .that(code.call)
+        .contains("state = rememberTextFieldState()")
+      assertWithMessage("%s imports", name)
+        .that(code.imports)
+        .contains("androidx.compose.foundation.text.input.rememberTextFieldState")
+    }
   }
 
   /**

--- a/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ComponentSnippets.kt
+++ b/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ComponentSnippets.kt
@@ -29,8 +29,14 @@ package ee.schimke.composeai.discovery
  *   no-arg-constructible type (issue #5067) breaks that on purpose — `TextField(state =
  *   TextFieldState())` needs `TextFieldState` imported — so the invariant moved rather than
  *   loosened: an import is emitted only for a type DISCOVERY resolved on the classpath and marked
- *   [TargetParameter.noArgConstructible], never for a name read off the rendered spelling. The
- *   compile gate is what checks it.
+ *   [TargetParameter.noArgConstructible], or for a factory callable it resolved into
+ *   [TargetParameter.noArgFactory] — never for a name read off the rendered spelling. The compile
+ *   gate is what checks it.
+ * - **No convention applied from its own name.** Compose's `rememberT` pairing is used, but only as
+ *   something discovery LOOKED UP: `rememberTextFieldState()` is printed because the scan found
+ *   that function beside `TextFieldState`, returning it, `@Composable` and fully defaulted. Nothing
+ *   here spells a factory name from a type name, which would be the authored table
+ *   `docs/design/COMPONENT_RECORD.md` keeps deleting.
  * - **No scope synthesis.** A composable declared on a receiver is refused rather than wrapped in a
  *   guessed `Column { … }`, because the wrapper is a rendering decision this object has no basis to
  *   make.
@@ -93,10 +99,11 @@ object ComponentSnippets {
     }
 
     val arguments = mutableListOf<String>()
-    // Types a constructed placeholder names, in the order they were needed. A `Type()` placeholder
-    // is the one thing this object writes that does not resolve on its own, so its import is
-    // collected here rather than left to the caller to notice (see the object KDoc).
-    val constructedTypes = mutableListOf<String>()
+    // What a constructed or remembered placeholder names, in the order they were needed — a
+    // `Type()` or `rememberType()` placeholder is the one thing this object writes that does not
+    // resolve on its own, so its import is collected here rather than left to the caller to notice
+    // (see the object KDoc).
+    val placeholderImports = mutableListOf<String>()
     // Defaulted parameters are omitted rather than filled: omitting one is legal by definition,
     // whereas restating a default means guessing at an expression the metadata does not carry.
     for (parameter in record.parameters.filterNot { it.hasDefault }) {
@@ -106,12 +113,13 @@ object ComponentSnippets {
             "no placeholder can be written for required parameter " +
               "`${parameter.name}: ${parameter.type}`"
           )
-      constructedTypeOf(parameter)?.let(constructedTypes::add)
+      constructedTypeOf(parameter)?.let(placeholderImports::add)
+      factoryCallableOf(parameter)?.let(placeholderImports::add)
       arguments += "${escapeIfKeyword(parameter.name)} = $placeholder"
     }
     return ComponentSnippet.Emitted(
       imports =
-        (listOf(record.symbol.callable) + constructedTypes).distinct().map {
+        (listOf(record.symbol.callable) + placeholderImports).distinct().map {
           escapeCallableIfKeyword(it)
         },
       code = "${escapeIfKeyword(record.symbol.name)}(${arguments.joinToString(", ")})",
@@ -246,6 +254,33 @@ object ComponentSnippets {
     if (constructsItsType(parameter)) parameter.typeFqn else null
 
   /**
+   * The qualified callable a `rememberT()` placeholder for [parameter] names, or null when its
+   * placeholder is not a factory call.
+   *
+   * The same contract [constructedTypeOf] has, for the other of the two placeholders that need an
+   * import — and the two are mutually exclusive by construction, so a parameter never imports both
+   * a type it does not print and a factory it does.
+   */
+  internal fun factoryCallableOf(parameter: TargetParameter): String? =
+    if (remembersItsValue(parameter)) parameter.noArgFactory else null
+
+  /**
+   * Whether [parameter] is answered by calling the `remember…` factory discovery found beside its
+   * type.
+   *
+   * Preferred over [constructsItsType] wherever both are available, because the two do not compile
+   * to the same thing: a raw `TextFieldState()` in a composable body is rebuilt on every
+   * recomposition and silently loses what the user typed, while `rememberTextFieldState()` is the
+   * expression a human would write. The gate is otherwise identical — a nullable parameter still
+   * takes `null` and a slot still takes `{}`, both shorter answers than any call.
+   */
+  private fun remembersItsValue(parameter: TargetParameter): Boolean =
+    parameter.noArgFactory != null &&
+      !parameter.nullable &&
+      !parameter.composableSlot &&
+      !parameter.type.contains("->")
+
+  /**
    * Whether [parameter] is answered by constructing its type rather than by a literal.
    *
    * The nullable and slot tests come first for the same reason they do in [placeholderFor]: a
@@ -255,7 +290,8 @@ object ComponentSnippets {
    * one carrying the flag without a qualified name could not be imported.
    */
   private fun constructsItsType(parameter: TargetParameter): Boolean =
-    parameter.noArgConstructible &&
+    !remembersItsValue(parameter) &&
+      parameter.noArgConstructible &&
       parameter.typeFqn != null &&
       !parameter.nullable &&
       !parameter.composableSlot &&
@@ -288,8 +324,14 @@ object ComponentSnippets {
       // .isNoArgConstructible`): public, non-generic, non-value, non-inner, plain class, with a
       // public constructor whose parameters all default. The simple name is safe to print here
       // because the import above is the qualified one it resolves through.
+      // A type whose package ships a `remember…` factory is answered by calling it. Discovery
+      // resolved the callable on the classpath (`ComposableSignature.noArgFactoryFor`) rather than
+      // spelling it from the type's name, and it wins over the constructor below because raw state
+      // construction in a composable body does not survive recomposition.
       else ->
-        if (constructsItsType(parameter))
+        if (remembersItsValue(parameter))
+          "${escapeIfKeyword(parameter.noArgFactory!!.substringAfterLast('.'))}()"
+        else if (constructsItsType(parameter))
           "${escapeIfKeyword(parameter.typeFqn!!.substringAfterLast('.'))}()"
         // Everything else — `Modifier`, `ImageVector`, an enum, a domain type — has no literal
         // that is correct without knowing the type, and inventing one is how generated code stops

--- a/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/TargetParameter.kt
+++ b/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/TargetParameter.kt
@@ -63,4 +63,23 @@ data class TargetParameter(
    * True implies [typeFqn] is set, because a call site emitting `Type()` also has to import it.
    */
   val noArgConstructible: Boolean = false,
+  /**
+   * The **fully-qualified callable** of a no-argument factory for this parameter's type —
+   * `androidx.compose.foundation.text.input.rememberTextFieldState` for a `TextFieldState` — or
+   * null when the classpath offers none.
+   *
+   * Compose has a naming convention for exactly this: a state type `T` that wants remembering ships
+   * a `@Composable fun rememberT(…)` beside it, every parameter defaulted (`rememberScrollState`,
+   * `rememberLazyListState`, `rememberCoroutineScope`, `rememberTextFieldState`). A generated call
+   * site should prefer it over the raw constructor, because raw state construction in a composable
+   * body does not survive recomposition and the factory is what a human would write.
+   *
+   * Resolved on the classpath at discovery time, never assumed from the name: the record carries
+   * the callable it actually found. A convention that is looked up is a fact; a convention that is
+   * written down in the generator is the authored table `docs/design/COMPONENT_RECORD.md` keeps
+   * deleting. Null when no such function exists, when it is not `@Composable`, when any parameter
+   * lacks a default, or when it is gated behind an opt-in marker the call site cannot carry — every
+   * one of those being a way `rememberT()` fails to compile.
+   */
+  val noArgFactory: String? = null,
 )


### PR DESCRIPTION
Follow-up to #5067.

## What

After #5067, a required `state: TextFieldState` was answered with `TextFieldState()`. That type-checks and is still wrong: raw state construction in a composable body is rebuilt on every recomposition and silently drops what the user typed. `rememberTextFieldState()` is what a human writes.

`docs/design/COMPONENT_RECORD.md` recorded that as **not taken**, on the grounds that the `rememberT` pairing is a *convention* rather than something derivable from a type, so taking it would reintroduce the authored name→expression table this design keeps deleting.

That conflated two different things a convention can be. Spelling `remember` + a simple name **in the generator** and emitting it *is* the table — a name mapped to an expression nothing verified. Looking the convention up is not.

`ComposableSignature.noArgFactoryFor` walks the type's **own package** for a file facade declaring `remember<SimpleName>`, and accepts it only when the scan can see that it:

- returns that type,
- is `@Composable`,
- is public, non-generic, and takes no receiver or context parameter,
- has every parameter defaulted,
- carries no opt-in marker.

What lands on `TargetParameter.noArgFactory` is the fully-qualified callable the classpath actually had. Searching one package is what keeps it a lookup rather than a guess: the name alone would match any `rememberFoo` anywhere on the classpath, and matching a name is precisely the failure mode being avoided.

The generator prefers the factory over the constructor, and the two are mutually exclusive in the emitted imports — `rememberTextFieldState()` never names `TextFieldState`, so importing it would be an import for something not printed. Both flags still travel on the record, because the record says what is *true* of the type and choosing between them is the generator's job. A record predating the field carries null and keeps constructing, so nothing that already compiled is retracted.

## The bug the compiler could not have caught

Worth calling out, because it is the reason the functional-test assertion in this PR is shaped the way it is.

The first version of the resolver **refused** `rememberTextFieldState` against the real androidx classpath. `@Composable` is a bytecode annotation, so the check has to cross from metadata back to the scan — and it has to cross by the JVM name metadata carries, not by the source name. `rememberTextFieldState` takes a defaulted `TextRange`, an inline value class, so Kotlin emits it as `rememberTextFieldState-Le-punE`. Looking it up under its source name found nothing and refused a factory that was right there.

Nothing failed loudly. The generator fell back to `TextFieldState()` — **which compiles**. Every compile-based gate stays green while emitting the expression that loses user input.

It was caught only because `assertPrefersTheRememberFactory` asserts on the emitted *text*. For a choice between two expressions that both type-check, "it compiles" is not a gate. `MangledFactoryState` now pins the mangling case in the fixtures.

## Test plan

- `:gradle-plugin:preview-discovery:test` — green. Seven new `ComposableSignatureTest` cases over a real ClassGraph scan of compiled fixtures. Six of them each fail exactly one clause — a `remember…` that is not `@Composable`, one taking a required argument, one returning another type, one opt-in gated, a type whose package ships none, a type not on the classpath — so a name-matching resolver would accept them all and this one accepts none. The seventh is the mangled-name case.
- Six new `ComponentSnippetsTest` cases: the factory is emitted, it wins over the constructor, the constructor's import goes with it, a factory resolves even where no constructor does, a nullable parameter still takes `null`, and a record predating the field is unchanged.
- `:gradle-plugin:functionalTest --tests '*ComponentCallSiteCompileFunctionalTest*'` — green. This is the only place the *preference* is checked against a real classpath; the unit tests hand-build a `TargetParameter` and can prove the generator honours a factory it was handed, never that discovery resolved one.
- `ktfmtFormat` run on the touched modules.

## Notes

`docs/design/COMPONENT_RECORD.md` is updated in place rather than appended to: the "not taken" paragraph now records why the objection was right about the risk and wrong about this case, since the reasoning is the reusable part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TVXDu7t4U61UrTAPJHFky

---
_Generated by [Claude Code](https://claude.ai/code/session_014TVXDu7t4U61UrTAPJHFky)_