### PR TITLE
ci: adopt a merge queue for main

### DIFF
--- a/.github/scripts/reap-pr-runs.mjs
+++ b/.github/scripts/reap-pr-runs.mjs
@@ -50,9 +50,9 @@ export async function reapPrRuns({
   // reasoning that a PR cannot target its own base; that conflated head with
   // base, and silently stranded every such PR's leftovers.
   //
-  // What actually protects post-merge CI on the default branch is the run-event
-  // allowlist below: that CI runs on `push`, so it is excluded by kind rather
-  // than by name-matching. That is a stronger guarantee than this check ever
+  // What actually protects the default branch's own CI is the run-event
+  // allowlist below: that CI runs on `merge_group` (and `push`), never on
+  // `pull_request`, so it is excluded by kind rather than by name-matching. That is a stronger guarantee than this check ever
   // was, and unlike this check it does not depend on guessing which branch
   // names matter.
 
@@ -183,9 +183,12 @@ export async function reapPrRuns({
     //    they can be run by hand on any branch for regression work; killing
     //    someone's investigation run mid-flight would be a real cost for no
     //    queue benefit.
-    // 2. Post-merge CI on the default branch is a `push` run, so this
-    //    excludes it *categorically* rather than by heuristic — which is what
-    //    lets a PR whose head is `main` be reaped at all (see below).
+    // 2. The default branch's CI is a `merge_group` run (or, for the lanes
+    //    with a side effect, a `push` run), so this excludes it
+    //    *categorically* rather than by heuristic — which is what lets a PR
+    //    whose head is `main` be reaped at all (see below). Merge-queue runs
+    //    matter here more than push runs ever did: cancelling one does not
+    //    waste a run, it blocks a merge.
     if (!PR_EVENTS.has(run.event)) continue
 
     // The branch filter matches on name alone, not repo. Without this a fork

--- a/.github/workflows/agent-entrypoints.yml
+++ b/.github/workflows/agent-entrypoints.yml
@@ -16,14 +16,19 @@ name: Agent Entrypoints
 # in the repository and expensive on the PR, which is why it gets a gate of its own
 # rather than a comment asking someone to remember.
 #
-# Runs on every PR and every push: the files it guards are markdown, which the
-# path-scoped CI classifier deliberately ignores, so this workflow carries no path
-# filter.
+# Runs on every PR and every merge-queue batch: the files it guards are markdown,
+# which the path-scoped CI classifier deliberately ignores, so this workflow
+# carries no path filter.
 
 on:
   pull_request:
-  push:
-    branches: [main]
+  # Verification of the merge result, replacing `push: [main]` (#5063). A
+  # merge-queue run tests the tree GitHub is about to fast-forward `main` to,
+  # so the push it produces needs no second run of the same suite — and unlike
+  # that push run, it is not cancelled by the next merge landing four minutes
+  # later.
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,36 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
+  # The verification lane, replacing `push: [main]`.
+  #
+  # A merge-queue run tests the REAL merge result — the tree GitHub is about to
+  # fast-forward `main` to — before it becomes `main`, which is the thing PR CI
+  # never tests (it tests the PR head against a base that has usually moved by
+  # the time it lands). Once that run is green the push it produces is by
+  # construction the commit this lane already verified, so re-running the same
+  # suite on `push: [main]` would verify an identical tree a second time.
+  #
+  # It also has to be here rather than on push for the reason `main` had no
+  # working post-merge lane at all: merges land a median 4 min apart against a
+  # 20-25 min pipeline, so 75% of push runs were cancelled by the next merge
+  # before finishing and only ~15% ever completed (#5063). The queue batches, so
+  # verification happens once per batch at the batch's cadence instead of once
+  # per merge at the merge cadence, and nothing supersedes it.
+  #
+  # No `branches:` / `paths:` filter: `merge_group` supports neither the way
+  # `pull_request` does, and every group on this repo targets `main` anyway.
+  merge_group:
+    types: [checks_requested]
   # Nightly full run. The heavy "anti-bit-rot" jobs below (full sample renders,
   # XR composite render, the two bundle E2Es, agent-audit-samples) are drift
   # detectors that rarely
   # fail on an ordinary code PR but cost 6–12 min each and dominate the PR
-  # critical path. They're gated off `pull_request` (see the per-job `if:`s) and
-  # instead run here nightly + on every push to main (i.e. immediately
-  # post-merge), so a regression is still caught within minutes of landing
-  # without making every PR wait on them.
+  # critical path. They're gated off `pull_request` AND off `merge_group` (see
+  # the per-job `if:`s, which allow only `schedule` / `workflow_dispatch`) and
+  # run here nightly instead, so a regression is still caught within a day
+  # without making every PR — or every merge batch — wait on them.
   schedule:
     - cron: "23 4 * * *"
   # Manual full run, including the nightly-only drift detectors above.
@@ -26,12 +44,19 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Superseded verification is worthless, so cancel it — on main as well as on
-  # PRs. This is only safe because CI no longer writes the BuildFetch remote
-  # cache: `buildfetch-cache` below takes `ro-token` only, so these runs keep
-  # their local build cache (`ON_CI` stays false) and are cheap to throw away.
-  # Cache writes live in gradle-cache-seed.yml, which runs uncancelled in its
-  # own concurrency group precisely so this one can stay disposable.
+  # Superseded verification is worthless, so cancel it. This is only safe
+  # because CI no longer writes the BuildFetch remote cache:
+  # `buildfetch-cache` below takes `ro-token` only, so these runs keep their
+  # local build cache (`ON_CI` stays false) and are cheap to throw away. Cache
+  # writes live in gradle-cache-seed.yml, which runs uncancelled in its own
+  # concurrency group precisely so this one can stay disposable.
+  #
+  # This only ever cancels PR runs now. Every merge group gets its own ref
+  # (`refs/heads/gh-readonly-queue/main/pr-<n>-<sha>`), so two queue runs are
+  # never in the same group and one can never supersede the other — which is
+  # what the merge queue needs, since its whole job is to finish. When the
+  # queue re-batches (a PR fails and is dequeued) GitHub cancels the obsolete
+  # group's run itself; that is the merge queue's decision, not this one's.
   cancel-in-progress: true
 
 # Release-please PRs only bump the version manifest / CHANGELOG / version
@@ -51,9 +76,19 @@ concurrency:
 #
 # The guard intentionally lives at job level (not a `branches` filter on the
 # trigger): a workflow that never triggers would leave the required check stuck
-# pending forever. On push events `github.head_ref` is empty and
-# `github.event.pull_request` is null, so pushes to main always run the full
-# suite.
+# pending forever. On `merge_group` (and `schedule` / `workflow_dispatch`)
+# events `github.head_ref` is empty and `github.event.pull_request` is null, so
+# the guard is false and the full suite runs.
+#
+# That is deliberate for release PRs too, and it is a change: a release PR
+# skips every job on the PR lane, then runs the full suite once inside the
+# merge group. There is no way to recognise the release PR from a `merge_group`
+# payload — it carries no `head_ref`, no PR author, and (under squash merge) no
+# stable commit-message shape to key off — and a required check cannot be
+# allowed to guess. Paying one batch of CI per release is the cheap side of
+# that trade, and it is not wasted: `gradle.properties` is one of the files
+# release-please rewrites, and it is a `globalPaths` entry in ci-paths.json
+# precisely because a version bump there can break the build.
 jobs:
   # Deliberately the cheapest job in the workflow: checkout + a path classifier,
   # a few seconds. Every other job is `needs: changes`, and GitHub does not even
@@ -102,11 +137,11 @@ jobs:
   # as the cheap classifier lands.
   #
   # PRs only, and that restriction is the whole point. Only a PR narrows the
-  # suite; on push and schedule the answer is unconditionally `full`. Since
-  # `path-scope.py` enables every group on non-PR events, gating this job on
-  # `module_unit_tests` alone would schedule it on EVERY push to `main` purely
-  # to echo a constant — and because Module Unit Tests `needs:` it, that job
-  # could not enter the runner queue until this one had queued and finished
+  # suite; in the merge queue and on schedule the answer is unconditionally
+  # `full`. Since `path-scope.py` enables every group on non-PR events, gating
+  # this job on `module_unit_tests` alone would schedule it on EVERY merge-queue
+  # run purely to echo a constant — and because Module Unit Tests `needs:` it,
+  # that job could not enter the runner queue until this one had queued and finished
   # too. On a saturated queue that is another 40-70 min in front of post-merge
   # module coverage: the exact cost this split exists to remove. Non-PR events
   # skip the job and the consumer defaults to `full` directly.
@@ -122,7 +157,6 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/buildfetch-cache
         with:
-          rw-token: ${{ github.event_name == 'push' && (secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN) || '' }}
           ro-token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
       - name: Run unit tests
         run: ./gradlew :gradle-plugin:test
@@ -144,7 +178,8 @@ jobs:
     # `pull_request` only. `:renderer-android` is in the root build (settings.gradle.kts),
     # so `module-unit-tests`' `full` branch — the one every non-PR event takes — already runs
     # `:renderer-android:test`, which for an Android library depends on `testDebugUnitTest`.
-    # On push this job was a 3.7-min re-run of work happening in parallel two jobs over.
+    # Off the PR lane this job was a 3.7-min re-run of work happening in parallel two
+    # jobs over.
     # It stays on PRs, where `module-unit-tests` is scoped to affected modules and may not
     # reach `:renderer-android` at all.
     if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.renderer_android_tests == 'true' && !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
@@ -156,7 +191,6 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/buildfetch-cache
         with:
-          rw-token: ${{ github.event_name == 'push' && (secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN) || '' }}
           ro-token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
       - name: Run unit tests
         run: ./gradlew :renderer-android:testDebugUnitTest
@@ -214,7 +248,6 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/buildfetch-cache
         with:
-          rw-token: ${{ github.event_name == 'push' && (secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN) || '' }}
           ro-token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
       # Resolved here rather than in a `needs:` job. As a separate job this cost a
       # second checkout, a second Gradle setup and — because a `needs:` edge is a full
@@ -306,7 +339,6 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/buildfetch-cache
         with:
-          rw-token: ${{ github.event_name == 'push' && (secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN) || '' }}
           ro-token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
       # The PUBLISHED bundle, not one built from source: the player lives in yschimke/rc-players
       # now, and what this repo ships in the CLI's `rc-player-wasm/` sidecar is exactly these bytes.
@@ -359,7 +391,6 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/buildfetch-cache
         with:
-          rw-token: ${{ github.event_name == 'push' && (secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN) || '' }}
           ro-token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
       - name: Run functional tests
         run: ./gradlew :gradle-plugin:functionalTest
@@ -387,7 +418,6 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/buildfetch-cache
         with:
-          rw-token: ${{ github.event_name == 'push' && (secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN) || '' }}
           ro-token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
       - name: Build CMP sample and discover previews
         run: ./gradlew :samples:cmp:composePreviewDiscover
@@ -467,8 +497,8 @@ jobs:
     # These render-heavy checks are valuable anti-bit-rot coverage, but they
     # duplicate the representative Android/CMP build performed by the required
     # smoke job and routinely make Build Samples the slowest CI leg. Run them
-    # on main and nightly instead. Because this is a distinct, new check name it
-    # is not part of the existing branch-protection required-check set.
+    # nightly instead. Because this is a distinct, new check name it is not part
+    # of the existing branch-protection required-check set.
     # Drift detector, not a PR gate. Measured: `main` merges land a median 4 min apart
     # while this workflow takes 20-25 min, so 75% of push runs are cancelled by the next
     # merge before they finish. Running it on push therefore paid a runner slot on 100% of
@@ -476,7 +506,8 @@ jobs:
     # commit that broke anything. The nightly cron already catches the drift these guard
     # against within 24h, which is the cadence they were designed for.
     #
-    # The job stays DEFINED rather than deleted so it keeps reporting `skipped` on PRs:
+    # The job stays DEFINED rather than deleted so it keeps reporting `skipped` on PRs and
+    # on merge-queue runs:
     # `Agent Audit Samples` below is a required check in the `Protect Main` ruleset, and a
     # required check that never reports blocks every PR forever. `workflow_dispatch` is the
     # manual escape hatch for running one on demand.
@@ -489,7 +520,6 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/buildfetch-cache
         with:
-          rw-token: ${{ github.event_name == 'push' && (secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN) || '' }}
           ro-token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
       # Daemon-bench smoke (issue #1586). The full latency benches
       # (benchPreviewLatency / benchCompileStages) are deliberately slow and run on the
@@ -577,7 +607,6 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/buildfetch-cache
         with:
-          rw-token: ${{ github.event_name == 'push' && (secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN) || '' }}
           ro-token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
       # Release builds no longer package the per-OS bundle-viewer binaries. Compile
       # and test its source here so removing that packaging matrix does not also
@@ -602,8 +631,8 @@ jobs:
     # client half of the native boundary, while compose-preview-xr owns the renderer/sample E2E.
     name: Render XR composite (sample)
     # Heavy (Xvfb software-GL render, several minutes). Drift detector, not a PR
-    # gate — runs on push-to-main + nightly, skipped on PRs (a skipped required
-    # check counts as passing for branch protection).
+    # gate — runs nightly, skipped on PRs and on merge-queue runs (a skipped
+    # required check counts as passing for branch protection).
     # Drift detector, not a PR gate. Measured: `main` merges land a median 4 min apart
     # while this workflow takes 20-25 min, so 75% of push runs are cancelled by the next
     # merge before they finish. Running it on push therefore paid a runner slot on 100% of
@@ -611,7 +640,8 @@ jobs:
     # commit that broke anything. The nightly cron already catches the drift these guard
     # against within 24h, which is the cadence they were designed for.
     #
-    # The job stays DEFINED rather than deleted so it keeps reporting `skipped` on PRs:
+    # The job stays DEFINED rather than deleted so it keeps reporting `skipped` on PRs and
+    # on merge-queue runs:
     # `Agent Audit Samples` below is a required check in the `Protect Main` ruleset, and a
     # required check that never reports blocks every PR forever. `workflow_dispatch` is the
     # manual escape hatch for running one on demand.
@@ -624,7 +654,6 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/buildfetch-cache
         with:
-          rw-token: ${{ github.event_name == 'push' && (secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN) || '' }}
           ro-token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
       # Provision the compositor exactly the way `XrCompositeProvision` does: the `xr-composite`
       # pin names the version, Version.kt's XR_COMPOSITE_REPO names the repository, and the asset
@@ -695,8 +724,8 @@ jobs:
   bundle-render:
     name: Bundle Render E2E
     # Heavy E2E (~7 min, cold-starts Compose Desktop per preview). Drift
-    # detector — runs on push-to-main + nightly, skipped on PRs (skipped
-    # required check == passing).
+    # detector — runs nightly, skipped on PRs and on merge-queue runs (a skipped
+    # required check counts as passing).
     # Drift detector, not a PR gate. Measured: `main` merges land a median 4 min apart
     # while this workflow takes 20-25 min, so 75% of push runs are cancelled by the next
     # merge before they finish. Running it on push therefore paid a runner slot on 100% of
@@ -704,7 +733,8 @@ jobs:
     # commit that broke anything. The nightly cron already catches the drift these guard
     # against within 24h, which is the cadence they were designed for.
     #
-    # The job stays DEFINED rather than deleted so it keeps reporting `skipped` on PRs:
+    # The job stays DEFINED rather than deleted so it keeps reporting `skipped` on PRs and
+    # on merge-queue runs:
     # `Agent Audit Samples` below is a required check in the `Protect Main` ruleset, and a
     # required check that never reports blocks every PR forever. `workflow_dispatch` is the
     # manual escape hatch for running one on demand.
@@ -717,7 +747,6 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/buildfetch-cache
         with:
-          rw-token: ${{ github.event_name == 'push' && (secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN) || '' }}
           ro-token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
       # End-to-end: pack a bundle from a synthetic Compose Desktop project, then re-render it
       # outside of any Gradle project by spawning the actual CLI binary against the packed PNG.
@@ -745,8 +774,8 @@ jobs:
   android-bundle-daemon-e2e:
     name: Android Bundle Daemon E2E
     # Heavy E2E (~9 min, cold-starts a daemon JVM per bundle). Drift detector —
-    # runs on push-to-main + nightly, skipped on PRs (skipped required check ==
-    # passing).
+    # runs nightly, skipped on PRs and on merge-queue runs (a skipped required
+    # check counts as passing).
     # Drift detector, not a PR gate. Measured: `main` merges land a median 4 min apart
     # while this workflow takes 20-25 min, so 75% of push runs are cancelled by the next
     # merge before they finish. Running it on push therefore paid a runner slot on 100% of
@@ -754,7 +783,8 @@ jobs:
     # commit that broke anything. The nightly cron already catches the drift these guard
     # against within 24h, which is the cadence they were designed for.
     #
-    # The job stays DEFINED rather than deleted so it keeps reporting `skipped` on PRs:
+    # The job stays DEFINED rather than deleted so it keeps reporting `skipped` on PRs and
+    # on merge-queue runs:
     # `Agent Audit Samples` below is a required check in the `Protect Main` ruleset, and a
     # required check that never reports blocks every PR forever. `workflow_dispatch` is the
     # manual escape hatch for running one on demand.
@@ -767,7 +797,6 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/buildfetch-cache
         with:
-          rw-token: ${{ github.event_name == 'push' && (secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN) || '' }}
           ro-token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
       # End-to-end for the Android path of `bundle daemon`: pack real-sample bundles (Wear tile +
       # Remote Compose IR, plus classic Compose previews), then spawn the actual CLI binary against
@@ -822,8 +851,8 @@ jobs:
   agent-audit-samples:
     name: Agent Audit Samples
     # Longest single job (~12 min; one external-fetched audit script). Drift
-    # detector — runs on push-to-main + nightly, skipped on PRs (skipped
-    # required check == passing).
+    # detector — runs nightly, skipped on PRs and on merge-queue runs (a skipped
+    # required check counts as passing).
     # Drift detector, not a PR gate. Measured: `main` merges land a median 4 min apart
     # while this workflow takes 20-25 min, so 75% of push runs are cancelled by the next
     # merge before they finish. Running it on push therefore paid a runner slot on 100% of
@@ -831,7 +860,8 @@ jobs:
     # commit that broke anything. The nightly cron already catches the drift these guard
     # against within 24h, which is the cadence they were designed for.
     #
-    # The job stays DEFINED rather than deleted so it keeps reporting `skipped` on PRs:
+    # The job stays DEFINED rather than deleted so it keeps reporting `skipped` on PRs and
+    # on merge-queue runs:
     # `Agent Audit Samples` below is a required check in the `Protect Main` ruleset, and a
     # required check that never reports blocks every PR forever. `workflow_dispatch` is the
     # manual escape hatch for running one on demand.

--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -4,6 +4,11 @@ name: Compose Preview
 # push-to-main, sticky diff comments on PRs, manual reruns via dispatch
 # (or the `/rerun previews` PR command — see pr-commands.yml).
 #
+# This is one of the few workflows that KEEPS its `push: [main]` lane under the
+# merge queue, because that lane has a side effect rather than a verdict — see
+# the `concurrency` note below for why the baseline has to come from the real
+# `main` commit and not from the merge group.
+#
 # The four pipelines run as TWO PARALLEL JOBS (compose+resources /
 # a11y+notifications) rather than one serial `apply` invocation. The two
 # jobs are independent — disjoint baseline/PR branches
@@ -65,6 +70,26 @@ concurrency:
   # Queueing instead of cancelling is bounded, not unbounded: GitHub keeps at
   # most one *pending* run per group and cancels the older pending one, so a
   # burst of N merges runs the first and the last, not all N.
+  #
+  # That bound was the flaw, and #5063 is what fixes it — from the other end.
+  # `cancel-in-progress: false` cannot help while merges land a median 4 min
+  # apart and this render takes 20-32: the pending slot is always occupied, so
+  # 64% of main runs were cancelled anyway and the baseline was stale during
+  # exactly the merge bursts where it matters. The merge queue does not change
+  # a line of this workflow; it changes the input. A batch lands its N commits
+  # as ONE push, so the push cadence becomes the batch cadence — the same
+  # 20-25 min the pipeline needs — and the pending slot is free again by the
+  # time the next batch arrives.
+  #
+  # The baseline stays on `push`, and is deliberately NOT moved to
+  # `merge_group`. A merge group's SHA never becomes a commit on `main` (PRs
+  # are squash-merged, so `main` gets a different SHA for the same tree) and a
+  # batch can be dequeued and never land at all. A baseline records a `_base_sha`
+  # that later PR comments diff against and link to, so publishing one from a
+  # speculative, unreachable commit would strand every subsequent diff on a
+  # revision nobody can check out — the same class of bug as #2766/#2765, just
+  # reached from the other side. The resulting `main` commit is the only commit
+  # that is both real and final, so it is the one the baseline is computed for.
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/daemon-harness.yml
+++ b/.github/workflows/daemon-harness.yml
@@ -8,7 +8,8 @@ name: Daemon Harness
 # Android/desktop implementation or baseline change runs only that real
 # renderer. Shared daemon/harness/build inputs run every leg. These are plain
 # jobs, so a scoped skip still reports the historical check as skipped, which
-# branch protection accepts. Pushes to main and classification errors run all.
+# branch protection accepts. Merge-queue batches and classification errors run
+# all — a batch is never scope-skipped, so the merge result is verified whole.
 #
 # Three independently-scoped jobs provide the complete main-branch suite:
 #   * `desktop-fake` — FakeDaemonMain + FakeHost; deterministic-failure
@@ -27,10 +28,15 @@ name: Daemon Harness
 #     `android-real` are required.
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
+  # Verification of the merge result, replacing `push: [main]` (#5063). A
+  # merge-queue run tests the tree GitHub is about to fast-forward `main` to,
+  # so the push it produces needs no second run of the same suite — and unlike
+  # that push run, it is not cancelled by the next merge landing four minutes
+  # later.
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,10 +1,15 @@
 name: Format Check
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
+  # Verification of the merge result, replacing `push: [main]` (#5063). A
+  # merge-queue run tests the tree GitHub is about to fast-forward `main` to,
+  # so the push it produces needs no second run of the same suite — and unlike
+  # that push run, it is not cancelled by the next merge landing four minutes
+  # later.
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,18 +23,19 @@ name: Integration
 # Each external-repo job runs independently (`fail-fast: false`) so one broken
 # consumer does not mask regressions in the others.
 #
-# PRs run ONE cell, everything else runs on `main` + the nightly cron. The
-# matrix cell flagged `pr_blocking: true` — currently just `wear-os-samples
-# (ComposeStarter)` — is the only one that does build/discover/render work on
-# `pull_request`; `agp8-min` is skipped there too. ComposeStarter is both the
-# cheapest real cell and the widest one: measured on recent PR runs it takes
+# PRs and merge-queue batches run ONE cell; the full matrix runs on the nightly
+# cron. The matrix cell flagged `pr_blocking: true` — currently just
+# `wear-os-samples (ComposeStarter)` — is the only one that does
+# build/discover/render work on `pull_request` and in the merge queue;
+# `agp8-min` is skipped there too. ComposeStarter is both the cheapest real
+# cell and the widest one: measured on recent PR runs it takes
 # ~2.6 min (discover 53s + render 23s + daemon round-trip 34s) against
 # androidify ~3.4-4.1 min, nowinandroid ~3.4-3.6 min and agp8-min ~3.3-4.2 min,
 # while covering the full render pipeline, the daemon, and the configuration
 # cache end-to-end. Every other cell still spins up on a PR (so
-# its check reports) but skips the expensive steps. The daily cron and pushes
-# to `main` run the full matrix, so consumer/AGP-floor drift still surfaces
-# within a day — it just doesn't sit on the PR critical path.
+# its check reports) but skips the expensive steps. The daily cron runs the full
+# matrix, so consumer/AGP-floor drift still surfaces within a day — it just
+# doesn't sit on the PR critical path.
 #
 # Change-scoped on PRs (.github/ci/integration-safe-paths.json): the `changes` job
 # classifies the diff first. A PR that touches only paths which provably cannot
@@ -44,18 +45,34 @@ name: Integration
 # — skips the whole `build-plugin` + external matrix, and `integration-scope-
 # gate` re-emits the required `wear-os-samples` legs green so branch protection
 # still clears. Anything touching the plugin / CLI / renderers / daemon / data
-# modules / build wiring runs the full matrix. Fail-open: pushes to main, the
+# modules / build wiring runs the full matrix. Fail-open: merge-queue runs, the
 # nightly cron, manual dispatch, and any diff error all run everything.
+#
+# Scoping is deliberately NOT carried into the merge queue. `merge_group` takes
+# no `paths-ignore` and the classifier resolves `run=true` there, so a batch
+# always builds the plugin and runs the two required legs. A required check that
+# scope-skips itself in the queue is a required check that can be talked out of
+# running by the diff it is meant to judge.
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
     paths-ignore:
       - ".github/workflows/ci.yml"
       - ".github/workflows/integration.yml"
       - ".github/workflows/compose-preview.yml"
+  # The verification lane, replacing `push: [main]` (#5063). A merge-queue run
+  # tests the tree GitHub is about to fast-forward `main` to, before it becomes
+  # `main`; the push it then produces is that same tree, so a push lane here
+  # would only repeat it. It also finishes: 72% of this workflow's push runs
+  # were cancelled by the next merge, because merges landed a median 4 min
+  # apart and this pipeline takes 20-25 min.
+  #
+  # `merge_group` takes no `paths-ignore`, so the two required `wear-os-samples`
+  # legs run on every batch regardless of the diff — which is what a required
+  # check has to do.
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
   schedule:
     # Daily — catches drift when consumer repos bump AGP/Kotlin without us.
@@ -79,9 +96,9 @@ env:
 jobs:
   # Fast PR-diff classifier that decides whether the slow external-repo matrix
   # below needs to run at all. Outputs `run` = true|false; every other job keys
-  # off it. On non-PR events (push / cron / dispatch) and on any classification
-  # error it resolves to `true`, so scoping can only ever trim the PR critical
-  # path — never skip work that could hide a regression.
+  # off it. On non-PR events (merge_group / cron / dispatch) and on any
+  # classification error it resolves to `true`, so scoping can only ever trim the
+  # PR critical path — never skip work that could hide a regression.
   changes:
     name: Determine integration scope
     if: ${{ !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
@@ -132,8 +149,11 @@ jobs:
           persist-credentials: false
 
       # PR code may consume the trusted Gradle cache but must not update it.
-      # Push, schedule, and manual runs execute trusted revisions, so keep their
-      # cache writable; the external-repository matrix configures its own cache.
+      # Merge-queue, schedule, and manual runs execute trusted revisions, so keep
+      # their cache writable; the external-repository matrix configures its own
+      # cache. (A merge-group tree is trusted in exactly the sense that matters
+      # here: it is the merge of PRs that already passed review and the PR gate,
+      # and it is the tree about to become `main`.)
       - uses: ./.github/actions/setup
         with:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
@@ -141,13 +161,15 @@ jobs:
       # This is the one job in this workflow that builds *this* repo's Gradle
       # tasks (the matrix jobs build external consumers, which never see our
       # settings.gradle.kts), so it's the only place the BuildFetch remote cache
-      # applies. Writes on main pushes: the publish/installDist fan-out here is
-      # expensive and shared, and with the local cache now on for pushers (see
-      # settings.gradle.kts) a cancelled run just pushes whatever it finished
-      # rather than paying for a no-cache build.
+      # applies. Writes on merge-queue runs — this workflow's only remaining
+      # trusted non-cron lane, and the one that used to be `push`: the
+      # publish/installDist fan-out here is expensive and shared, and with the
+      # local cache now on for trusted runs (see settings.gradle.kts) a run the
+      # queue cancels on a re-batch just pushes whatever it finished rather than
+      # paying for a no-cache build.
       - uses: ./.github/actions/buildfetch-cache
         with:
-          rw-token: ${{ github.event_name == 'push' && (secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN) || '' }}
+          rw-token: ${{ github.event_name == 'merge_group' && (secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN) || '' }}
           ro-token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
 
       - name: Publish plugin + renderer-android + data-* + daemon-* to mavenLocal
@@ -236,8 +258,13 @@ jobs:
   # does), reporting them green — so the release PR clears branch protection with
   # no bypass. Its `if:` is the exact inverse of the matrix job's guard, so on
   # any given event exactly one of the two posts each context, never both: the
-  # real matrix on normal PRs / pushes / the nightly cron, this gate on release
-  # PRs. Keep the two names in lockstep with the `pr_blocking: true` matrix cells.
+  # real matrix on normal PRs / merge-queue batches / the nightly cron, this gate
+  # on release PRs. Keep the two names in lockstep with the `pr_blocking: true`
+  # matrix cells.
+  #
+  # In the merge queue there is no `head_ref` and no PR author, so this gate's
+  # guard is false and the real matrix reports — a release PR pays one batch of
+  # the two required legs. See the same note in ci.yml.
   release-please-gate:
     if: ${{ startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]' }}
     name: ${{ matrix.name }}
@@ -308,16 +335,20 @@ jobs:
     # checks in the `Protect Main` ruleset, and the others' names are cheap to keep reporting —
     # but a cell that is not active skips every expensive step below and costs ~0.1 min.
     #
-    # PRs already worked this way: only `pr_blocking` cells built anything. What changed is the
-    # push-to-main lane, which used to run the full external matrix on every merge — 8 cells,
-    # ~25 job-min. Measured, 72% of those push runs were cancelled by the next merge before they
-    # finished (`main` merges land a median 4 min apart), so the lane was paying for the full
-    # matrix on every merge and completing it on roughly one in four. These cells guard against
-    # *upstream* drift — an external repo bumping AGP / Kotlin / the Compose BOM — which is
-    # correlated with time, not with our commits, so the nightly cron is the cadence that
+    # PRs already worked this way: only `pr_blocking` cells built anything. What changed first
+    # was the push-to-main lane, which used to run the full external matrix on every merge —
+    # 8 cells, ~25 job-min. Measured, 72% of those push runs were cancelled by the next merge
+    # before they finished (`main` merges land a median 4 min apart), so the lane was paying for
+    # the full matrix on every merge and completing it on roughly one in four. These cells guard
+    # against *upstream* drift — an external repo bumping AGP / Kotlin / the Compose BOM — which
+    # is correlated with time, not with our commits, so the nightly cron is the cadence that
     # actually fits them and the one the workflow header already describes.
     #
-    # The two `pr_blocking` cells stay on push for immediate post-merge signal.
+    # That push lane is now the merge queue (#5063), and `merge_group` is deliberately absent
+    # from the list above: the two `pr_blocking` cells are active there because they are
+    # required checks, and the remaining six stay on the cron. So a batch pays the same ~2 cells
+    # a PR does, and the pre-merge signal it gives is strictly better than the post-merge one it
+    # replaces — it is the merge result, and it is not cancelled.
     env:
       CELL_ACTIVE: ${{ (matrix.pr_blocking || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && '1' || '0' }}
     strategy:
@@ -336,8 +367,8 @@ jobs:
             # `Render` steps below). Every other cell still spins up but skips
             # the expensive gradle steps, so its check still reports
             # (branch-protection-safe) while the rest of the external builds
-            # drop off the PR critical path and run on push-to-main + the
-            # nightly cron instead.
+            # drop off the PR critical path and run on the nightly cron
+            # instead.
             #
             # It earns the slot on both axes: cheapest real cell (~2.6 min
             # measured, vs ~3.4-4.2 for androidify / nowinandroid / agp8-min)
@@ -446,7 +477,7 @@ jobs:
             # ~3.4-4.1 min per run. Its coverage — a big AGP app configuring
             # and discovering against the locally-published plugin — overlaps
             # what the ComposeStarter PR cell already proves, so it rides the
-            # push-to-main + nightly-cron lane instead of the PR critical path.
+            # nightly-cron lane instead of the PR critical path.
             # No opt-outs after #1546's IP-cleanup pass (#1549 tracks the cross-project-metadata
             # follow-up). Re-add specific flags here (with a fresh comment naming the regression)
             # if the consumer's build surfaces a new CC / IP gap.
@@ -488,7 +519,7 @@ jobs:
             # (guards the #1546 variant-matching fix against a large real
             # project), ~3.4-3.6 min per run. The fix itself is pinned by unit
             # tests in the plugin; this cell is the real-project confirmation,
-            # which the push-to-main + nightly lane catches within a day.
+            # which the nightly lane catches within a day.
             # `:app` declares productFlavors `demo` / `prod` with build types
             # `debug` / `release`, so its variants are `demoDebug`, `prodDebug`,
             # `demoRelease`, `prodRelease` — no plain `debug`. `:app-nia-catalog`
@@ -931,7 +962,7 @@ jobs:
         # `git apply` exit 1, which would otherwise block unrelated PRs via a
         # non-representative drift cell. The discover/render steps that consume
         # the patch are already PR-gated the same way, so there's nothing to
-        # patch for on a skipped cell. (Drift still surfaces on cron/push.)
+        # patch for on a skipped cell. (Drift still surfaces on the nightly cron.)
         if: ${{ matrix.patch_file != '' && env.CELL_ACTIVE == '1' }}
         # Runs from the external checkout root so each patch's
         # repo-root-relative paths (e.g. AdaptiveJetStream/jetstream/...)
@@ -1018,10 +1049,10 @@ jobs:
         run: ${{ matrix.pre_gradle_script }}
 
       - name: Discover previews via Gradle
-        # On PRs only `pr_blocking` cells do the expensive gradle work; the rest
-        # are covered by the daily cron + push-to-main. `matrix` is available at
-        # step level (unlike at `jobs.<id>.if`), so the cell still reports its
-        # check — it just skips the build.
+        # On PRs and in the merge queue only `pr_blocking` cells do the expensive
+        # gradle work; the rest are covered by the daily cron. `matrix` is
+        # available at step level (unlike at `jobs.<id>.if`), so the cell still
+        # reports its check — it just skips the build.
         if: ${{ !matrix.use_cli && env.CELL_ACTIVE == '1' }}
         working-directory: external/${{ matrix.workdir }}
         env:
@@ -1163,16 +1194,27 @@ jobs:
         # baselines.json + README gallery) so the rendered previews are
         # browsable on GitHub rather than only living in a 7-day artifact.
         #
-        # Gated to trusted events: on fork PRs the token is read-only and
-        # can't push anyway, and we don't want PR runs racing the shared
-        # branches. Staging runs in THIS job (read-only token) so the
-        # untrusted consumer build never sees a write token; the actual push
-        # is a separate `publish-previews` job that runs no external code.
+        # Gated to the cron and manual dispatch, which is narrower than the
+        # old "any non-PR event". On fork PRs the token is read-only and can't
+        # push anyway, and we don't want PR runs racing the shared branches —
+        # but a MERGE-QUEUE run is excluded for a different reason: its tree is
+        # speculative. A batch can be dequeued and never land, and these
+        # branches are a published artifact, so pushing one from a commit that
+        # may never become `main` would advertise a gallery for a tree nobody
+        # can check out. The queue replaced the push lane that used to refresh
+        # the two `pr_blocking` galleries per merge, and 72% of those runs were
+        # cancelled before reaching the publish job anyway, so the cron is now
+        # the single cadence for every gallery. Staging runs in THIS job
+        # (read-only token) so the untrusted consumer build never sees a write
+        # token; the actual push is a separate `publish-previews` job that runs
+        # no external code.
         #
         # Staged before the daemon round-trip below: that step edits a
         # source file and re-renders, which would otherwise leak into the
         # published gallery.
-        if: matrix.render && github.event_name != 'pull_request' && env.CELL_ACTIVE == '1'
+        if: >-
+          ${{ matrix.render && env.CELL_ACTIVE == '1'
+          && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
         working-directory: external/${{ matrix.workdir }}
         # Matrix-derived strings go through env, not inline `${{ }}` in the
         # script body: `pre_gradle_script` / `notes` are multi-line and
@@ -1242,7 +1284,7 @@ jobs:
 
           # Turn the envelope into the same renders/ + baselines.json +
           # README.md layout the in-repo compose-preview/main branch uses.
-          intro="Auto-rendered by the integration matrix from [\`${MATRIX_REPO}@${MATRIX_REF}\`](https://github.com/${MATRIX_REPO}/tree/${MATRIX_REF}). Updated on every push to \`main\`."
+          intro="Auto-rendered by the integration matrix from [\`${MATRIX_REPO}@${MATRIX_REF}\`](https://github.com/${MATRIX_REPO}/tree/${MATRIX_REF}). Updated by the nightly integration run."
           if ! python3 "$GITHUB_WORKSPACE/bundle/ci/compare-previews.py" generate \
               "$GITHUB_WORKSPACE/_previews.json" \
               --output-dir "$GITHUB_WORKSPACE/_integration_baselines" \
@@ -1516,7 +1558,7 @@ jobs:
     # ~3.3-4.2 min. Skipping it on `pull_request` is safe for branch protection
     # because it is not a required check (nothing needs to re-emit it, unlike
     # the two `wear-os-samples` legs the gate jobs above cover). AGP-floor
-    # drift surfaces on the next push to main / nightly cron.
+    # drift surfaces on the next merge-queue batch / nightly cron.
     #
     # Also consumes build-plugin's bundle, so it rides the same change-scope
     # gate: skipped on out-of-scope PRs too.
@@ -1524,7 +1566,8 @@ jobs:
     # Floor-coverage job for AGP 8.x consumers. Uses the in-repo fixture under
     # `.github/ci/fixtures/agp8-min/` (Gradle 8.13 + AGP 8.13.0 + Kotlin 2.0.21
     # + compileSdk 36) so we exercise the bottom of our publicly-supported
-    # consumer envelope on every push, without cloning a 2 GB external repo.
+    # consumer envelope on every merge-queue batch, without cloning a 2 GB
+    # external repo.
     # Distinct from the `integration` matrix above because it skips the
     # external-checkout / pre-Gradle-patch dance entirely — the fixture is
     # already shaped exactly the way we want it. The plugin still rides in
@@ -1865,11 +1908,15 @@ jobs:
     # the matrix job and `git push` them. The untrusted external builds all
     # ran in the `integration` job under a read-only token.
     #
-    # Cadence note: since the non-`pr_blocking` cells moved to the nightly cron, a push to
-    # main refreshes only the `pr_blocking` cells' gallery branches. The rest refresh on the
-    # nightly run instead of per-merge — in practice fresher than before, because 72% of the
-    # per-merge runs were cancelled before ever reaching this job.
-    if: always() && github.event_name != 'pull_request'
+    # Cadence note: every gallery branch now refreshes on the nightly cron (or a manual
+    # dispatch), and nothing refreshes per-merge. The non-`pr_blocking` cells moved to the cron
+    # first; the two `pr_blocking` ones followed when the push lane became the merge queue,
+    # whose trees are speculative — see the staging step's comment. In practice this is fresher
+    # than the per-merge lane was, because 72% of those runs were cancelled before ever
+    # reaching this job.
+    if: >-
+      ${{ always()
+      && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/no-agent-attribution.yml
+++ b/.github/workflows/no-agent-attribution.yml
@@ -45,15 +45,26 @@ name: No Agent Attribution
 # Untrusted text (title/body) is passed through env: and never interpolated
 # into the shell, per the repo zizmor policy.
 #
-# Two layers, because a check that only *warns* is not a gate:
+# Three layers, because a check that only *warns* is not a gate:
 #   • `scan` runs on the PR and is meant to BLOCK the merge. Make it a required
 #     status check on the "Protect Main" ruleset — without that, a red run is
 #     merely advisory and can be merged straight past (which is exactly what
 #     happened for #2749).
+#   • `scan` ALSO runs on `merge_group`, and that run closes the gap the
+#     paragraph above calls "the honest boundary between the two jobs". On the
+#     PR lane the squash message does not exist yet, so neither the hand-edited
+#     message nor GitHub's auto-added `Co-authored-by:` credits are visible to
+#     it. In the merge queue they are: the merge group holds the commits GitHub
+#     is about to fast-forward `main` to, so scanning
+#     `merge_group.base_sha..head_sha` reads the very text that lands. This is
+#     the layer that turns the trailer described below from a post-mortem into
+#     a blocked merge. It is also why the merge-queue run must be REQUIRED, not
+#     merely present.
 #   • `drift` runs on every push to `main` and fails loudly if attribution got
 #     in anyway — via an unblocked merge, an admin override, or a direct push.
 #     It cannot prevent the commit, but it makes the breach visible instead of
-#     silent, and dates it to a single push.
+#     silent, and dates it to a single push. It stays even with the queue in
+#     place: a queue can be turned off, and a bypass actor can be added.
 #
 # Detection lives in .github/scripts/agent-attribution-scan.sh so both jobs
 # share one implementation. Keep AGENT_NAME / AGENT_EMAIL there in sync with
@@ -62,6 +73,10 @@ name: No Agent Attribution
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
+  # The merge queue is where `scan` gets its last, and best, look. See the
+  # third bullet in the two-layers note above.
+  merge_group:
+    types: [checks_requested]
   push:
     branches: [main]
 
@@ -97,14 +112,22 @@ permissions:
 # put two push events in one group and evict the pending run for the first —
 # leaving that event's commit range scanned by nothing. This workflow exists to
 # handle force-pushed history, so it cannot assume tips are never revisited.
+# Merge-queue runs need neither special case: every merge group has its own
+# ref, so they never share a group and `cancel-in-progress` can never reach
+# one. (The queue cancels its own obsolete groups when it re-batches.)
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.run_id || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   scan:
+    # ONE job for both pre-merge lanes, deliberately, because the required
+    # status check is matched by name: two jobs called "Reject agent
+    # attribution" would be two contexts the ruleset cannot tell apart. What
+    # differs between the lanes is only the range and whether there is PR prose
+    # to scan, and both are handled per-step below.
     name: Reject agent attribution
-    if: github.event_name == 'pull_request'
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -121,7 +144,14 @@ jobs:
       #
       # Writing the file here also keeps untrusted text out of the shell
       # entirely, rather than routing it through env: as before.
+      #
+      # Merge-queue runs skip this step: there is no single PR to read (a batch
+      # can hold several), and there is nothing left to read it FOR — by then
+      # the title and body have already been rendered into the commit messages
+      # the range scan below covers, which is strictly more of the truth than
+      # the PR text was.
       - name: Read the PR's current title and body
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -137,13 +167,30 @@ jobs:
           # The commit range stays on the payload: this check reports against
           # the head SHA of the event that started it, and a push produces its
           # own run. Only the metadata is re-read.
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          #
+          # `merge_group` carries its own base/head, and exactly one of the two
+          # pairs is non-empty on any given run, so the `||` picks the right
+          # one rather than guessing.
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
         run: |
           set -uo pipefail
 
+          # The merge queue's base is not in a shallow clone by default; fetch
+          # it rather than let the scanner fail closed on an unresolvable rev.
+          if ! git rev-parse --quiet --verify "${BASE_SHA}^{commit}" >/dev/null; then
+            git fetch --no-tags --quiet origin "${BASE_SHA}" || true
+          fi
+
+          # `--text-file` only where there is PR prose to scan. In the merge
+          # queue that text is already inside the commit range.
+          text_args=()
+          if [ -f pr_text.txt ]; then
+            text_args=(--text-file pr_text.txt)
+          fi
+
           .github/scripts/agent-attribution-scan.sh \
-            --range "${BASE_SHA}..${HEAD_SHA}" --text-file pr_text.txt
+            --range "${BASE_SHA}..${HEAD_SHA}" "${text_args[@]}"
           status=$?
           # 2 means the scan could not run (unresolvable revision). That is not
           # "clean" and it is not "found" either — say so, rather than printing
@@ -155,7 +202,7 @@ jobs:
             exit 1
           fi
           if [ "$status" -ne 0 ]; then
-            printf '::error::Agent attribution found in this PR\n'
+            printf '::error::Agent attribution found in these commits\n'
             cat >&2 <<'MSG'
 
           ───────────────────────────────────────────────────────────────

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -16,7 +16,7 @@ on:
     types: [opened, edited, synchronize, reopened]
   # Required checks are matched in the merge-group context, so this workflow
   # has to report there too or nothing can leave the queue. What it checks
-  # there is a different question — see the `queue` job.
+  # there is a different question — see the merge_group lane in `lint`.
   merge_group:
     types: [checks_requested]
 
@@ -50,17 +50,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ONE job, two lanes, and that is load-bearing rather than tidy. The required
+  # status check is matched by NAME, and a job whose `if:` is false still posts
+  # a check run — as `skipped`, which branch protection and the merge queue both
+  # count as passing. So two jobs called "Conventional Commit title" would post
+  # two check runs of the same context on every event, one of them always green
+  # by virtue of not having run, and the gate resolves on whichever reported
+  # last. A failing lint could then be masked by its own skipped twin. Splitting
+  # the lanes into steps keeps it one check run that means one thing.
+  #
+  # (This is the mirror image of the asymmetry integration.yml documents: there,
+  # a skipped MATRIX job posts nothing and the required leg hangs; here, a
+  # skipped plain job posts something and the required context doubles.)
   lint:
     name: Conventional Commit title
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
+      # ── pull_request lane ────────────────────────────────────────────────
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        if: github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           # Subset release-please recognises. Keep in sync with any custom
-          # release-please commit-types config (none currently — defaults).
+          # release-please commit-types config (none currently — defaults), and
+          # with the `types` list in the merge-queue step below.
           types: |
             feat
             fix
@@ -75,39 +90,34 @@ jobs:
             revert
           requireScope: false
 
-  # The merge-queue half of the same required context. Only one of `lint` and
-  # `queue` runs on any given event, so the check reports exactly once.
-  #
-  # It does NOT re-run the action above. That action reads the PR title out of
-  # its own event payload, and a merge group has no PR — a batch can hold
-  # several, and the payload names none of them. Nor can the answer be a
-  # pass-through "already checked on the PR": a required check that always
-  # reports green is not a check.
-  #
-  # So it validates what the merge group actually has, which is the thing the
-  # PR title exists to produce: the commit subjects GitHub is about to
-  # fast-forward `main` to. Under squash merge those subjects ARE the PR
-  # titles, and they are what release-please reads to bump the version and
-  # populate the changelog — so this is a more direct statement of the rule
-  # than checking the title ever was.
-  #
-  # GitHub's own plumbing commits are exempt. The queue builds its temp branch
-  # with merge commits of its own ("Merge <sha> into <sha>", "Merge pull
-  # request #n from …", "Merge branch …"), and those are not ours to name.
-  # Failing on them would deadlock every batch, which is the one outcome a
-  # required check must never have.
-  queue:
-    name: Conventional Commit title
-    if: github.event_name == 'merge_group'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
+      # ── merge_group lane ─────────────────────────────────────────────────
+      #
+      # The action above cannot serve this lane: it reads the PR title out of
+      # its own event payload, and a merge group has no PR — a batch can hold
+      # several, and the payload names none of them. Nor can the answer be a
+      # pass-through "already checked on the PR": a required check that always
+      # reports green is not a check.
+      #
+      # So this validates what the merge group actually has, which is the thing
+      # the PR title exists to produce: the commit subjects GitHub is about to
+      # fast-forward `main` to. Under squash merge those subjects ARE the PR
+      # titles, and they are what release-please reads to bump the version and
+      # populate the changelog — a more direct statement of the rule than
+      # checking the title ever was.
+      #
+      # GitHub's own plumbing commits are exempt. The queue builds its temp
+      # branch with merge commits of its own ("Merge <sha> into <sha>", "Merge
+      # pull request #n from …", "Merge branch …"), and those are not ours to
+      # name. Failing on them would deadlock every batch, which is the one
+      # outcome a required check must never have.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: github.event_name == 'merge_group'
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Check the merge group's commit subjects
+        if: github.event_name == 'merge_group'
         env:
           BASE_SHA: ${{ github.event.merge_group.base_sha }}
           HEAD_SHA: ${{ github.event.merge_group.head_sha }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -14,6 +14,11 @@ name: PR Title
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
+  # Required checks are matched in the merge-group context, so this workflow
+  # has to report there too or nothing can leave the queue. What it checks
+  # there is a different question — see the `queue` job.
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read
@@ -47,6 +52,7 @@ concurrency:
 jobs:
   lint:
     name: Conventional Commit title
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
@@ -68,3 +74,94 @@ jobs:
             style
             revert
           requireScope: false
+
+  # The merge-queue half of the same required context. Only one of `lint` and
+  # `queue` runs on any given event, so the check reports exactly once.
+  #
+  # It does NOT re-run the action above. That action reads the PR title out of
+  # its own event payload, and a merge group has no PR — a batch can hold
+  # several, and the payload names none of them. Nor can the answer be a
+  # pass-through "already checked on the PR": a required check that always
+  # reports green is not a check.
+  #
+  # So it validates what the merge group actually has, which is the thing the
+  # PR title exists to produce: the commit subjects GitHub is about to
+  # fast-forward `main` to. Under squash merge those subjects ARE the PR
+  # titles, and they are what release-please reads to bump the version and
+  # populate the changelog — so this is a more direct statement of the rule
+  # than checking the title ever was.
+  #
+  # GitHub's own plumbing commits are exempt. The queue builds its temp branch
+  # with merge commits of its own ("Merge <sha> into <sha>", "Merge pull
+  # request #n from …", "Merge branch …"), and those are not ours to name.
+  # Failing on them would deadlock every batch, which is the one outcome a
+  # required check must never have.
+  queue:
+    name: Conventional Commit title
+    if: github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check the merge group's commit subjects
+        env:
+          BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+        run: |
+          set -uo pipefail
+
+          if ! git rev-parse --quiet --verify "${BASE_SHA}^{commit}" >/dev/null; then
+            git fetch --no-tags --quiet origin "${BASE_SHA}" || true
+          fi
+          if ! git rev-parse --quiet --verify "${BASE_SHA}^{commit}" >/dev/null; then
+            printf '::error::Cannot resolve the merge group base %s\n' "${BASE_SHA}"
+            echo "Refusing to report green on a range this job could not read." >&2
+            exit 1
+          fi
+
+          # Keep in lockstep with the `types:` list on the action above.
+          types='feat|fix|chore|docs|refactor|perf|test|build|ci|style|revert'
+          # `!` marks a breaking change; a scope in parentheses is optional.
+          pattern="^(${types})(\([^)]+\))?!?: .+"
+          # GitHub's own merge-queue plumbing, not authored by anyone here.
+          plumbing='^Merge (pull request |branch |remote-tracking branch |[0-9a-f]{7,40} into )'
+
+          bad=0
+          while IFS= read -r subject; do
+            [ -n "${subject}" ] || continue
+            if printf '%s' "${subject}" | grep -Eq "${plumbing}"; then
+              echo "skip (merge-queue plumbing): ${subject}"
+              continue
+            fi
+            if printf '%s' "${subject}" | grep -Eq "${pattern}"; then
+              echo "ok:   ${subject}"
+            else
+              echo "BAD:  ${subject}"
+              bad=1
+            fi
+          done < <(git log --no-merges --format='%s' "${BASE_SHA}..${HEAD_SHA}")
+
+          if [ "${bad}" -ne 0 ]; then
+            printf '::error::A commit subject in this merge group is not a conventional commit\n'
+            cat >&2 <<MSG
+
+          ───────────────────────────────────────────────────────────────
+          Every commit this merge group would add to main must have a
+          conventional-commit subject:
+
+            <type>(<scope>)?: <subject>
+
+          with type one of: ${types//|/, }
+
+          PRs here are squash-merged, so the subject above is the PR title.
+          Fix the offending PR's title and requeue it — release-please reads
+          these headlines to bump the version and write the changelog, and a
+          non-conforming one is silently dropped from both.
+          ───────────────────────────────────────────────────────────────
+          MSG
+            exit 1
+          fi

--- a/.github/workflows/report-schemas.yml
+++ b/.github/workflows/report-schemas.yml
@@ -1,10 +1,15 @@
 name: Report Schemas
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
+  # Verification of the merge result, replacing `push: [main]` (#5063). A
+  # merge-queue run tests the tree GitHub is about to fast-forward `main` to,
+  # so the push it produces needs no second run of the same suite — and unlike
+  # that push run, it is not cancelled by the next merge landing four minutes
+  # later.
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,14 @@ examples are in [`docs/AGENT_GUIDE.md` → PR workflow](docs/AGENT_GUIDE.md#pr-w
   the repair does not cover are listed in `docs/AGENT_GUIDE.md`.
 - **Wire new visual surfaces into the preview workflow** so the next change to
   them is diffed without anyone remembering to do it.
+- **`main` merges through a merge queue.** Add the PR to the queue rather than
+  pressing merge; the required checks are re-run there against the real merge
+  result, and a red merge-group run *dequeues* the PR instead of marking it red —
+  so when a merge silently does not happen, look at the queue, not the PR's own
+  checks. Verification workflows therefore run on `merge_group`, not
+  `push: [main]`; only workflows with a side effect (baselines, publishing,
+  releases) keep a push lane. Details and the ruleset settings:
+  [`docs/MERGE_QUEUE.md`](docs/MERGE_QUEUE.md).
 - **Don't auto-merge your own PR.** Opening, tracking and fix-up commits are
   automatic; pressing merge on a PR *you* opened is the user's call, and no agent
   approves or merges one. This is about agent-opened PRs. It is not a blanket
@@ -157,6 +165,7 @@ examples are in [`docs/AGENT_GUIDE.md` → PR workflow](docs/AGENT_GUIDE.md#pr-w
 | The contributor doc index | [`docs/README.md`](docs/README.md) |
 | Releasing, versioning | [`docs/RELEASING.md`](docs/RELEASING.md), [`docs/VERSIONING.md`](docs/VERSIONING.md) |
 | Invoking an agent from an issue or PR | [`docs/AGENT_INVOCATION.md`](docs/AGENT_INVOCATION.md) |
+| How `main` merges, and which workflows run where | [`docs/MERGE_QUEUE.md`](docs/MERGE_QUEUE.md) |
 | Which agent reads which file, and what it costs | [`docs/AGENT_ENTRYPOINTS.md`](docs/AGENT_ENTRYPOINTS.md) |
 | Consumer docs for the published plugin and CLI | [`yschimke/skills`](https://github.com/yschimke/skills) |
 | The VS Code extension (split out; consumes this repo's published plugin) | [`yschimke/compose-preview-vscode`](https://github.com/yschimke/compose-preview-vscode) |

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -258,6 +258,17 @@ on UI-affecting PRs, leave injected backticks alone, wire new visual surfaces in
 the preview pipeline, don't auto-merge — is stated once in
 [root `AGENTS.md`](../AGENTS.md#pr-workflow). Below is the detail behind it.
 
+- **Merging goes through the queue.** `main` is behind a GitHub merge queue, so
+  the last step is *add to queue*, not *merge*. Two things follow that trip
+  people up. A merge-group run that fails **dequeues** the PR rather than
+  reporting red on it, so a PR that looks green and did not merge is a queue
+  question, not a checks question — read the merge-group run. And a required
+  check is matched by name in the merge-group context, so a workflow that only
+  triggers on `pull_request` cannot satisfy one: if you add a required check,
+  give it a `merge_group` trigger in the same change. Which workflows run in
+  which lane, and why some kept `push: [main]`, is in
+  [`MERGE_QUEUE.md`](MERGE_QUEUE.md).
+
 - **Finding the existing PR.** Before opening one, check whether the branch already
   has an open PR (`list_pull_requests` or `search_pull_requests` filtered by head)
   and push to it instead of opening a duplicate. A *merged* or *closed* PR does not

--- a/docs/MERGE_QUEUE.md
+++ b/docs/MERGE_QUEUE.md
@@ -1,0 +1,171 @@
+# The merge queue
+
+`main` is merged through a **GitHub merge queue**. This page is the record of
+why, what it changed in the workflows, and the one part of it that lives in
+repository settings rather than in a file.
+
+The rules it implements are in [root AGENTS.md](../AGENTS.md); nothing here
+restates one.
+
+## Why
+
+Merges land a **median 4 minutes apart** — 89% within 25 minutes of the previous
+one — while the pipeline takes 20–25. Post-merge verification therefore could
+not finish before the next merge superseded it. Measured over the last 100
+push-to-`main` runs of each workflow (#5063):
+
+| Workflow | cancelled | success |
+| --- | --- | --- |
+| `ci.yml` | **75%** | 15% |
+| `integration.yml` | 72% | 14% |
+| `codeql.yml` | 72% | 28% |
+| `compose-preview.yml` | 64% | 34% |
+| `daemon-harness.yml` | 62% | 24% |
+
+That is a property of the cadence, not of the job durations: no amount of making
+jobs cheaper closes a 4-minute gap against a 20-minute pipeline. #5062 did the
+mechanical part (~198 → ~110 job-minutes per merge) and moved the ratio not at
+all.
+
+Four things followed from it, and the queue fixes all four:
+
+1. **"`main` is green" was not a statement anyone could make.** Only ~15% of
+   merges were ever verified end to end. A merge-queue run verifies the batch,
+   once, and finishes.
+2. **Cancelled runs still burned the runner pool.** A cancelled `ci.yml` push run
+   lived a median 4.3 minutes holding ~10–16 slots — a direct cause of the p90
+   18–25 minute queue waits on PR jobs. Those runs no longer exist.
+3. **`compose-preview` baselines were stale during merge bursts**, despite
+   `cancel-in-progress: false`, because GitHub keeps at most one *pending* run
+   per concurrency group. A batch lands its N commits as one push, so the push
+   cadence becomes the batch cadence and the pending slot is free again by the
+   time the next batch arrives.
+4. **Nothing tested the actual merge result.** PR CI tests the PR head against a
+   base that has usually moved by the time it lands. A merge group *is* the
+   merge result.
+
+## What the queue runs
+
+Two lanes, and the difference between them is the whole design:
+
+- **`merge_group` — verdicts.** A workflow whose `push: [main]` lane existed to
+  say *yes this is fine* now runs on `merge_group` instead, and its push lane is
+  gone. The tree a merge group holds is the tree GitHub is about to fast-forward
+  `main` to, so a push run of the same suite would verify an identical tree a
+  second time.
+
+  `ci.yml`, `integration.yml`, `no-agent-attribution.yml` (the `scan` job),
+  `pr-title.yml`, `format.yml`, `daemon-harness.yml`, `report-schemas.yml`,
+  `agent-entrypoints.yml`.
+
+- **`push: [main]` — side effects.** A workflow whose main lane *does* something
+  — publishes, tags, deploys, records a baseline — keeps its push trigger. A
+  merge group's SHA never becomes a commit on `main` (PRs are squash-merged, so
+  `main` gets a different SHA for the same tree) and a batch can be dequeued and
+  never land at all, so a side effect fired from one would point at a revision
+  nobody can check out.
+
+  `compose-preview.yml` (baselines), `release-please.yml`, `snapshot.yml`,
+  `pages.yml`, `gradle-cache-seed.yml`, `design-artifacts.yml`,
+  `no-agent-attribution.yml` (the `drift` backstop), `samples-sdk21.yml` and
+  `install-action-test.yml` (both narrowly `paths:`-filtered, and `merge_group`
+  supports no path filter).
+
+Nightly drift detectors are unaffected: they were already gated to `schedule` /
+`workflow_dispatch` and stay there, so a batch never waits on a 12-minute
+anti-bit-rot job. Two of them (`Agent Audit Samples`, and the XR/bundle jobs
+that share the pattern) are *required* checks that report `skipped` in the merge
+group — which counts as passing, exactly as it already does on a release PR.
+That is why those jobs stay defined rather than deleted: a required check that
+never reports at all blocks every batch forever.
+
+### Scope classifiers do not narrow a batch
+
+`path-scope.py` and `change-scope.py` enable every group on any non-`pull_request`
+event, so a merge-group run is always the full suite. That is deliberate and
+worth keeping: a required check that can be talked out of running by the diff it
+is meant to judge is not a gate. It is also why `merge_group` carries no
+`paths-ignore` even where the `pull_request` trigger does.
+
+### Release PRs pay one batch
+
+Release-please PRs skip every job on the PR lane (they only bump the manifest,
+the CHANGELOG and version strings), and then run the full suite once inside the
+merge group. The skip cannot be carried into the queue: a `merge_group` payload
+has no `head_ref`, no PR author, and — under squash merge — no stable
+commit-message shape to key off, and a required check must not guess. It is not
+wasted anyway: `gradle.properties` is one of the files release-please rewrites,
+and it is a `globalPaths` entry in `ci-paths.json` precisely because a version
+bump there can break the build.
+
+## The two required checks that had to be rebuilt
+
+Required checks are matched **by name in the merge-group context**. Six of the
+eight in the `Protect Main` ruleset come from `ci.yml` and `integration.yml` and
+simply needed the trigger. Two are PR-shaped and did not:
+
+- **`Conventional Commit title`** (`pr-title.yml`). The action reads the PR title
+  out of its own event payload, and a merge group has no PR — a batch can hold
+  several, and the payload names none of them. The `queue` job checks the thing
+  the title exists to produce instead: every commit subject in
+  `merge_group.base_sha..head_sha`. Under squash merge those subjects *are* the
+  PR titles, and they are what release-please reads. GitHub's own merge-queue
+  plumbing commits are exempt — failing on those would deadlock every batch.
+
+- **`Reject agent attribution`** (`no-agent-attribution.yml`). This one gets
+  *better* in the queue, and it is the reason to want the queue even without the
+  cadence argument. On the PR lane the squash message does not exist yet, so the
+  `Co-authored-by:` credits GitHub auto-adds for each distinct branch commit
+  author are invisible to it — that is how `5aacb786` got its trailer, and why
+  `drift` had to exist as a post-mortem. In the merge group those commits are
+  real and in range, so the trailer is now a **blocked merge** rather than
+  something `drift` reports after the fact. `drift` stays regardless: a queue can
+  be switched off and a bypass actor can be added.
+
+Both are one job reporting one context, gated by `github.event_name`, rather than
+two jobs sharing a name — the ruleset cannot tell two contexts of the same name
+apart.
+
+## Enabling it: the part that is not in this repository
+
+The queue itself is a setting on the `Protect Main` ruleset. Nothing in a diff
+can turn it on.
+
+**Order matters.** Enable the queue only *after* the workflow changes are on
+`main`. A queue enabled first would demand required checks in a `merge_group`
+context that no workflow on `main` yet produces, and every batch would time out.
+
+1. Merge the workflow changes normally. Between this step and the next, `main`
+   has PR-gate coverage only — which is, in practice, what it had before: the
+   post-merge lane completed on ~15% of merges.
+2. Settings → Rules → `Protect Main` → **Require merge queue**.
+3. Merge method **Squash**, matching the repository's
+   `squash_merge_commit_message=BLANK` setting, on which the `Conventional
+   Commit title` queue job depends.
+4. Maximum PRs to build **5**, minimum **1**; wait to build **5 minutes**;
+   maximum time to merge **60 minutes**. Five is chosen against the measured
+   cadence: it is roughly what accumulates in 20 minutes at 4-minute intervals,
+   so a batch is usually full by the time the previous one finishes, and a batch
+   that fails costs at most five requeues.
+5. Leave the eight required checks as they are — they now report from the
+   merge-group context under the same names.
+
+### Rolling back
+
+Turn off **Require merge queue** and restore `push: [main]` on the workflows
+listed under *verdicts* above. The push lanes were removed, not disabled, so a
+rollback is a revert of this change plus the setting. Nothing else in the
+repository depends on the queue existing.
+
+## Consequences worth knowing
+
+- **A red merge-group run does not mark a PR red.** It dequeues it. Look at the
+  merge queue, not the PR's own checks, when a merge silently does not happen.
+- **A push to `main` is now a batch, not a merge.** Anything reading
+  `github.event.before..github.sha` (the `drift` job, for one) sees N commits
+  where it used to see one. `drift` already handled ranges.
+- **Integration gallery branches refresh on the nightly cron only.** They used to
+  refresh from the push lane for the two `pr_blocking` cells; that lane is gone,
+  and publishing them from a speculative merge group is exactly the mistake the
+  side-effect rule above exists to prevent. 72% of those push runs were cancelled
+  before reaching the publish job anyway, so in practice this is fresher.

--- a/docs/MERGE_QUEUE.md
+++ b/docs/MERGE_QUEUE.md
@@ -122,9 +122,17 @@ simply needed the trigger. Two are PR-shaped and did not:
   something `drift` reports after the fact. `drift` stays regardless: a queue can
   be switched off and a bypass actor can be added.
 
-Both are one job reporting one context, gated by `github.event_name`, rather than
-two jobs sharing a name — the ruleset cannot tell two contexts of the same name
-apart.
+Both are **one job with two step-level lanes**, gated by `github.event_name` —
+not two jobs sharing a name. That distinction is load-bearing, and it was got
+wrong once before it was got right: a job whose `if:` is false still posts a
+check run, as `skipped`, which the gate counts as passing. Two jobs of the same
+name therefore post two check runs of that context on every event, one of them
+always green by virtue of not having run, and the required check resolves on
+whichever reported last — so a failing lane can be masked by its own skipped
+twin. (This is the mirror image of the asymmetry `integration.yml` documents:
+there, a skipped *matrix* job posts nothing and the required leg hangs on
+"Expected — waiting for status"; here, a skipped plain job posts something and
+the required context doubles.)
 
 ## Enabling it: the part that is not in this repository
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,7 @@ this index as the map of everything else.
 - [API_STABILITY.md](API_STABILITY.md) — what counts as a public contract.
 - [AGENT_INVOCATION.md](AGENT_INVOCATION.md) — summoning an agent onto an issue/PR.
 - [AGENT_ENTRYPOINTS.md](AGENT_ENTRYPOINTS.md) — **measurement**: which instruction file each agent (Claude Code, Codex, Gemini, Copilot) actually resolves, why none of them follows a markdown link, what the old layout cost the three non-Claude agents, and the CI gate that keeps every CI-enforced invariant reachable from all four.
+- [MERGE_QUEUE.md](MERGE_QUEUE.md) — `main` merges through a GitHub merge queue: which workflows moved to `merge_group`, which kept `push: [main]` and why, and the ruleset settings that are not in any file.
 - [PR_REVIEW_WORKFLOW.md](PR_REVIEW_WORKFLOW.md) — preview-gated AI PR review.
 - [TOKEN_USAGE.md](TOKEN_USAGE.md) — token-budget reference for agent recipes.
 - Testing the extension in a cloud sandbox — moved with the extension to


### PR DESCRIPTION
Closes #5063.

Post-merge verification on `main` was structurally unreachable: merges land a median 4 minutes apart against a 20–25 minute pipeline, so 75% of `ci.yml` push runs were cancelled by the next merge and only ~15% ever completed. This moves verification into a GitHub merge queue, where it runs once per batch against the real merge result.

**This PR is only half of the change.** The queue itself is a `Protect Main` ruleset setting that no diff can turn on, and the order matters — see [Enabling it](https://github.com/yschimke/compose-ai-tools/blob/agent/merge-queue-5063/docs/MERGE_QUEUE.md#enabling-it-the-part-that-is-not-in-this-repository). Enable it *after* this lands; a queue enabled first would demand required checks in a `merge_group` context that no workflow on `main` yet produces, and every batch would time out.

## Two lanes

**`merge_group` — verdicts.** A workflow whose `push: [main]` lane existed to say *yes this is fine* now runs on `merge_group`, and its push lane is gone. The tree a merge group holds is the tree GitHub is about to fast-forward `main` to, so a push run of the same suite verifies an identical tree a second time.

`ci.yml`, `integration.yml`, `no-agent-attribution.yml` (`scan`), `pr-title.yml`, `format.yml`, `daemon-harness.yml`, `report-schemas.yml`, `agent-entrypoints.yml`.

**`push: [main]` — side effects.** A workflow whose main lane *does* something — publishes, tags, deploys, records a baseline — keeps its push trigger. A merge group's SHA never becomes a commit on `main` (PRs are squash-merged, so `main` gets a different SHA for the same tree) and a batch can be dequeued and never land, so a side effect fired from one would point at a revision nobody can check out.

`compose-preview.yml` (baselines), `release-please.yml`, `snapshot.yml`, `pages.yml`, `gradle-cache-seed.yml`, `design-artifacts.yml`, `no-agent-attribution.yml` (`drift`), plus `samples-sdk21.yml` / `install-action-test.yml` (narrowly `paths:`-filtered, and `merge_group` supports no path filter).

That answers the issue's fourth open question directly: the `compose-preview` baseline is computed for the resulting `main` commit, not the merge group. The queue fixes the staleness from the other end anyway — a batch lands its N commits as **one** push, so the push cadence becomes the batch cadence and `cancel-in-progress: false` finally has a free pending slot when the next batch arrives.

## The two required checks that had to be rebuilt

Six of the eight required checks come from `ci.yml` / `integration.yml` and just needed the trigger. Two are PR-shaped:

- **`Conventional Commit title`** — the action reads the PR title from its own event payload, and a merge group has no PR (a batch can hold several; the payload names none). The new `queue` job checks what the title exists to produce instead: every commit subject in `merge_group.base_sha..head_sha`. Under squash merge those subjects *are* the PR titles, and they are what release-please reads. GitHub's own merge-queue plumbing commits are exempt — failing on those would deadlock every batch, which is the one outcome a required check must never have. A pass-through "already checked on the PR" was rejected: a required check that always reports green is not a check.

- **`Reject agent attribution`** — this one gets *better* in the queue, and is the reason to want it even without the cadence argument. On the PR lane the squash message does not exist yet, so the `Co-authored-by:` credits GitHub auto-adds for each distinct branch commit author are invisible to it; that is how `5aacb786` got its trailer, and why `drift` had to exist as a post-mortem. In the merge group those commits are real and in range, so the trailer becomes a **blocked merge**. `drift` stays regardless — a queue can be switched off and a bypass actor can be added.

Both are one job reporting one context, gated by `github.event_name`, rather than two jobs sharing a name: the ruleset cannot tell two contexts of the same name apart.

## Decisions worth flagging

- **Scope classifiers do not narrow a batch.** `path-scope.py` / `change-scope.py` enable every group on non-`pull_request` events, so a merge-group run is always the full suite, and `merge_group` carries no `paths-ignore` even where `pull_request` does. A required check that can be talked out of running by the diff it is meant to judge is not a gate.
- **Release PRs pay one batch.** They still skip every job on the PR lane. The skip cannot be carried into the queue — a `merge_group` payload has no `head_ref`, no PR author, and no stable commit-message shape to key off, and a required check must not guess. It is not wasted: `gradle.properties` is one of the files release-please rewrites, and it is a `globalPaths` entry in `ci-paths.json` precisely because a version bump there can break the build.
- **Integration gallery branches move to the nightly cron only.** They used to refresh from the push lane for the two `pr_blocking` cells; publishing them from a speculative merge group is the same mistake the side-effect rule above prevents. 72% of those push runs were cancelled before reaching the publish job, so in practice this is fresher.
- **`integration.yml`'s BuildFetch write token moves from `push` to `merge_group`** — that was this workflow's only trusted non-cron writer, and removing the push lane would otherwise have silently removed it.
- **`ci.yml`'s eleven dead `rw-token:` lines are deleted.** They were gated on `github.event_name == 'push'`, which can no longer be true, and the workflow's own `concurrency` comment already claimed CI takes `ro-token` only. That claim is now true.

## Test plan

Nothing here can be exercised end to end before the ruleset setting is flipped — the honest boundary of this PR. What was verified:

- Every workflow parses, and the trigger set of all 39 was diffed before/after.
- `scripts/test-agent-attribution.sh` — 44 passed, 0 failed (the detector self-test the modified `scan` job drives).
- `node --test .github/scripts/reap-pr-runs.test.mjs` — 27 passed (the reaper's event allowlist is what keeps the queue's runs from being cancelled; its comments are updated to say `merge_group` rather than `push`).
- `scripts/check-agent-entrypoints.sh --report` — all invariants reachable; `AGENTS.md` is 10,076 bytes, well inside Codex's 32 KiB.
- The `queue` job's subject matcher was run against a synthetic history covering `feat(x):`, `chore!:`, a `Merge <sha> into <sha>` plumbing commit, and a non-conforming subject: exits 0 on the first three, 1 on the fourth.
- `agent-attribution-scan.sh --range origin/main..HEAD` — clean.

Text-only change; no rendered surface is affected, so there is no visual evidence to embed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMVwBTuu6VXpZ8MjKD2TAT

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMVwBTuu6VXpZ8MjKD2TAT)_