### PR TITLE
ci(layers): fail the build when a server artifact reaches this repo

### DIFF
--- a/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/CheckLayerBoundary.kt
+++ b/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/CheckLayerBoundary.kt
@@ -1,0 +1,100 @@
+package ee.schimke.composeai.buildlogic
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Fails when a module from a strictly higher layer reaches this project's runtime classpath.
+ *
+ * The layer rule lives in `docs/design/REPOSITORY_LAYERS.md`: contracts is shape, this repository
+ * is offline behaviour, compose-preview-server is HTTP and the surfaces over it, and a dependency
+ * may only point down. compose-preview-server has enforced its own floor since the split
+ * (`checkServeModuleBoundary`); this repository enforced nothing at all, so the edge that created
+ * yschimke/compose-preview-server#180 could be re-added by one `api(...)` line with CI green.
+ *
+ * **A positive allowlist, not a list of banned coordinates**, for the reason the server's task
+ * learned the hard way: a denylist names the artifacts that exist today and says nothing about the
+ * next one. Any `ee.schimke.composeai:compose-preview-*` coordinate that is not named below is a
+ * failure, including one that arrives transitively.
+ *
+ * **Resolved identity, not declared dependencies.** A layer-2 artifact pulled in through another
+ * dependency's POM is exactly the case a scan of build files misses, and exactly the case that
+ * matters — `:cli` resolves `compose-preview-render-host` transitively through
+ * `compose-preview-serve` as well as directly.
+ *
+ * Scope, stated because it is not total: this runs on projects with a `runtimeClasspath`, which is
+ * every JVM module. Android modules resolve per-variant classpaths (`debugRuntimeClasspath` and
+ * friends) and are not covered. That is a real gap rather than a claim that they are safe — it is
+ * narrow because no Android module here consumes a server artifact, and widening it means paying
+ * to resolve every variant on `check`.
+ */
+abstract class CheckLayerBoundary : DefaultTask() {
+
+  /**
+   * Every component on the resolved runtime classpath as a `<group>:<name>` string, transitives
+   * included.
+   */
+  @get:Input abstract val resolvedModules: SetProperty<String>
+
+  /** The `compose-preview-*` coordinates permitted on any classpath in this build. */
+  @get:Input abstract val allowedPreviewModules: SetProperty<String>
+
+  @TaskAction
+  fun checkBoundary() {
+    val hits =
+      resolvedModules
+        .get()
+        .filter { it.startsWith("$COMPOSE_AI_GROUP:$PREVIEW_PREFIX") }
+        .filterNot { it in allowedPreviewModules.get() }
+        .sorted()
+
+    check(hits.isEmpty()) {
+      "A compose-preview-server artifact reached ${path.substringBeforeLast(':')}'s runtime " +
+        "classpath. compose-ai-tools is layer 1 and the server is layer 2, so this dependency " +
+        "points the wrong way — see docs/design/REPOSITORY_LAYERS.md. Found: " +
+        hits.joinToString(", ") +
+        ". If the coordinate is published by this repository, add it to `ownPreviewModules`; if it " +
+        "is a new edge into the server, it needs the layer rule changed first."
+    }
+  }
+
+  companion object {
+    const val COMPOSE_AI_GROUP: String = "ee.schimke.composeai"
+
+    private const val PREVIEW_PREFIX = "compose-preview-"
+
+    /**
+     * `compose-preview-*` coordinates this repository publishes itself. Same-layer, so they are not
+     * the rule's target; they share the prefix only because the prefix names the product, not the
+     * repository.
+     */
+    val ownPreviewModules: List<String> =
+      listOf("$COMPOSE_AI_GROUP:compose-preview-config", "$COMPOSE_AI_GROUP:compose-preview-plugin")
+
+    /**
+     * The layer-2 coordinates `:cli` resolves today, allowed under protest.
+     *
+     * These **are** the cycle. `compose-preview-render-host` is offline behaviour filed in the
+     * wrong repository (step 2 of #180's order moves it here); `compose-preview-serve` is reached
+     * from `ServeCommand.kt` alone and goes when `serve` becomes a launcher over the published
+     * binary (steps 3-4). This list shrinks to empty as those land, and the gate's value in the
+     * meantime is that it is exactly three entries long: a fourth cannot be added by accident.
+     *
+     * `compose-preview-ui-builder-runtime` is the one nobody had counted, and it is why this task
+     * reads resolved identity rather than build files. It is declared **nowhere** in this
+     * repository — no `cli/build.gradle.kts` line, no version-catalog alias. It arrives because
+     * the server publishes its three modules in lockstep and `compose-preview-serve`'s POM names
+     * all of them, so depending on the server drags the UI-builder runtime onto the CLI's runtime
+     * classpath. The published analysis on #180 counts two coordinates crossing this edge; there
+     * are three, and it goes when `compose-preview-serve` does.
+     */
+    val knownLayerTwoEdges: List<String> =
+      listOf(
+        "$COMPOSE_AI_GROUP:compose-preview-render-host",
+        "$COMPOSE_AI_GROUP:compose-preview-serve",
+        "$COMPOSE_AI_GROUP:compose-preview-ui-builder-runtime",
+      )
+  }
+}

--- a/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiBaseConventionsPlugin.kt
+++ b/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiBaseConventionsPlugin.kt
@@ -3,8 +3,10 @@ package ee.schimke.composeai.buildlogic
 import com.ncorti.ktfmt.gradle.KtfmtExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
@@ -59,6 +61,50 @@ class ComposeAiBaseConventionsPlugin : Plugin<Project> {
     val cacheSalt = project.providers.gradleProperty("composeai.cacheSalt").orElse("0")
     project.tasks.withType<KotlinCompilationTask<*>>().configureEach {
       inputs.property("composeai.cacheSalt", cacheSalt)
+    }
+
+    registerLayerBoundaryCheck(project)
+  }
+
+  /**
+   * Wires [CheckLayerBoundary] onto every project that has a `runtimeClasspath`, and onto `check`
+   * so it runs where CI already looks rather than needing its own job.
+   *
+   * Registered from base-conventions for the same reason the cache salt is: this is the plugin
+   * every module applies. `plugins.withId("org.gradle.java")` is the guard because the java plugin
+   * is what creates `runtimeClasspath` — a project without one (the Android modules, the artwork
+   * and fixture projects) silently gets no task rather than a configuration failure.
+   */
+  private fun registerLayerBoundaryCheck(project: Project) {
+    project.plugins.withId("org.gradle.java") {
+      val task =
+        project.tasks.register<CheckLayerBoundary>("checkLayerBoundary") {
+          description =
+            "Fails if a compose-preview-server artifact reaches this project's runtime classpath."
+          group = "verification"
+
+          // Resolved identity rather than declared dependencies: a layer-2 artifact arriving
+          // through another POM is the case that matters and the case a build-file scan misses.
+          resolvedModules.set(
+            project.configurations.named("runtimeClasspath").flatMap { configuration ->
+              configuration.incoming.artifacts.resolvedArtifacts.map { artifacts ->
+                artifacts
+                  .mapNotNull { artifact ->
+                    (artifact.id.componentIdentifier as? ModuleComponentIdentifier)?.let {
+                      "${it.group}:${it.module}"
+                    }
+                  }
+                  .toSet()
+              }
+            }
+          )
+
+          allowedPreviewModules.set(
+            CheckLayerBoundary.ownPreviewModules + CheckLayerBoundary.knownLayerTwoEdges
+          )
+        }
+
+      project.tasks.named("check") { dependsOn(task) }
     }
   }
 }

--- a/docs/design/REPOSITORY_LAYERS.md
+++ b/docs/design/REPOSITORY_LAYERS.md
@@ -82,11 +82,29 @@ convenience rather than a layer.
 
 ## What enforces it
 
-Today, partially and from one side only: `checkServeModuleBoundary`,
-`checkRenderHostIsServerFree` and `checkUiBuilderRuntimeBoundary` in compose-preview-server.
-compose-ai-tools rejects no `ee.schimke.composeai:compose-preview-*` coordinate at all, so the edge
-this rule forbids could be re-added by one `api(...)` line with CI green.
+Both sides now, as resolved-classpath positive allowlists.
 
-The gate that finishes the job is a resolved-classpath check in each repository that fails on a
-coordinate from a strictly higher layer — the same shape as `checkServeModuleBoundary`, pointed at
-the table above. Until it exists, this document is a convention and reviewers are the enforcement.
+compose-preview-server has held its floor since the split: `checkServeModuleBoundary`,
+`checkRenderHostIsServerFree` and `checkUiBuilderRuntimeBoundary`.
+
+compose-ai-tools enforced nothing until `checkLayerBoundary` (`build-logic`, registered on every
+project with a `runtimeClasspath` and wired onto `check`). It fails on any
+`ee.schimke.composeai:compose-preview-*` coordinate that is not either published by this repository
+or one of the three known layer-2 edges being removed. A fourth cannot be added by accident.
+
+**Resolved identity, not build files** — and the gate proved why on its first run. It failed on
+`compose-preview-ui-builder-runtime`, which is declared nowhere in this repository: no build-script
+line, no catalog alias. The server publishes its three modules in lockstep and
+`compose-preview-serve`'s POM names all of them, so depending on the server drags the UI-builder
+runtime onto `:cli`'s runtime classpath. The forward edge is three coordinates, not the two the
+analysis on
+[compose-preview-server#180](https://github.com/yschimke/compose-preview-server/issues/180) counted.
+
+The allowlist is the ratchet: it shrinks to empty as `:render-host` moves here and `serve` becomes a
+launcher, and it can only shrink without someone editing `CheckLayerBoundary.kt` and saying why.
+
+Two limits worth stating rather than discovering later. The task covers projects with a
+`runtimeClasspath`, so Android modules — which resolve per-variant classpaths — are not checked;
+none of them consumes a server artifact, and covering them means resolving every variant on every
+`check`. And it has no unit test, because `build-logic` has no test lane that CI runs; what
+exercises it is every module's `check`.


### PR DESCRIPTION
Step 6 of [compose-preview-server#180](https://github.com/yschimke/compose-preview-server/issues/180), on the side that had nothing. Follows [#5129](https://github.com/yschimke/compose-ai-tools/pull/5129), which wrote the layer rule down.

## Why

compose-preview-server has held its own floor since the split — `checkServeModuleBoundary`, `checkRenderHostIsServerFree`, `checkUiBuilderRuntimeBoundary`. This repository enforced **nothing**: no check rejects an `ee.schimke.composeai:compose-preview-*` coordinate, so the edge that created the cycle could be re-added tomorrow by one `api(...)` line with CI green.

## What

`CheckLayerBoundary` in `build-logic`, registered by `composeai.base-conventions` on every project that has a `runtimeClasspath` and wired onto `check`. A **positive allowlist**, not a denylist, for the reason the server's task learned the hard way: a denylist names today's artifacts and says nothing about the next one.

Allowed: the two `compose-preview-*` coordinates this repository publishes itself (`-config`, `-plugin`), plus the known layer-2 edges being removed. Anything else fails.

## It found a third edge on its first run

The task reads **resolved identity**, not build files, and that paid off immediately — the first run failed on:

```
ee.schimke.composeai:compose-preview-ui-builder-runtime
```

which is declared **nowhere** in this repository. No `cli/build.gradle.kts` line, no catalog alias:

```
$ grep -rn "ui-builder-runtime" cli/build.gradle.kts gradle/libs.versions.toml
(no matches)
```

The server publishes its three modules in lockstep and `compose-preview-serve`'s POM names all of them, so depending on the server drags the UI-builder runtime onto `:cli`'s runtime classpath. **The forward edge is three coordinates, not the two** the analysis on #180 counted. A build-file scan would have missed it entirely.

## The allowlist is a ratchet

Three entries today; it shrinks to empty as `:render-host` moves here (step 2) and `serve` becomes a launcher over the published binary (steps 3–4). It cannot grow without someone editing `CheckLayerBoundary.kt` and writing down why, which is the friction this is for.

## Limits, stated rather than left to be discovered

Both are in the task's KDoc and in `REPOSITORY_LAYERS.md`:

- **Android modules are not covered.** They resolve per-variant classpaths (`debugRuntimeClasspath` and friends) rather than `runtimeClasspath`. No Android module here consumes a server artifact, and covering them means resolving every variant on every `check`. That is a real gap, not a claim they are safe.
- **No unit test**, because `build-logic` has no test lane CI runs — adding one that never executes would be worse than none. What exercises the task is every module's `check`.

## Test plan

- `./gradlew :cli:checkLayerBoundary` — **failed** first with the `compose-preview-ui-builder-runtime` hit above, and passes once that coordinate is named. That is the gate demonstrated in both directions on a real dependency rather than a fixture.
- `./gradlew checkLayerBoundary` — BUILD SUCCESSFUL across the modules the fan-out configures.
- `./gradlew :cli:check --dry-run` — lists `:cli:checkLayerBoundary`, confirming the `check` wiring holds where CI actually looks. (Bare `checkLayerBoundary` does not reach every project under Isolated Projects, which is why the wiring is what matters.)
- `./gradlew :cli:ktfmtFormatMain` — clean, no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014NtzoUCr4pou3y1qRDxcpZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014NtzoUCr4pou3y1qRDxcpZ)_