### PR TITLE
fix(render): name the merged unit-test R.jar when a preview cannot load an R class

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -1993,6 +1993,58 @@ internal object ComposePreviewTasks {
    */
   internal const val CASCADE_DIAGNOSIS_PREFIX = "Cascade of the first native-load failure"
 
+  /** The two ways a JVM reports a class that is not on the classpath. */
+  private val CLASS_LOADING_EXCEPTIONS = setOf("ClassNotFoundException", "NoClassDefFoundError")
+
+  /**
+   * A class name of the shape AGP generates for Android resources — `<package>.R`, or one of its
+   * `R$id` / `R$style` nested tables — in either the dotted form `ClassNotFoundException` reports
+   * or the slashed form `NoClassDefFoundError` reports.
+   */
+  private val AGP_R_CLASS = Regex("""\b\w+(?:[./]\w+)*[./]R(?:\$\w+)?\b""")
+
+  /**
+   * The missing AGP resource table behind a class-loading failure, or null when the failure is
+   * something else.
+   *
+   * Worth singling out because it is never a broken preview and never looks like a classpath
+   * problem in the report: compose-ui reads `androidx.customview.poolingcontainer.R.id.*` from
+   * `PoolingContainer.<clinit>`, so on a library module whose merged unit-test `R.jar` is missing
+   * EVERY preview dies at class-init with the same `NoClassDefFoundError` and the per-preview list
+   * reads as if a thousand previews were each independently broken
+   * (yschimke/compose-preview-imports element-x, compose-ai-tools#5026).
+   */
+  internal fun missingAgpRClass(insight: RenderErrorInsight): String? {
+    val classLoadingFailure =
+      insight.exception.substringAfterLast('.') in CLASS_LOADING_EXCEPTIONS ||
+        insight.chain.split(" \u2192 ").any { it in CLASS_LOADING_EXCEPTIONS }
+    if (!classLoadingFailure) return null
+    return AGP_R_CLASS.find(insight.message)?.value?.replace('/', '.')
+  }
+
+  /**
+   * What to check when [missingAgpRClass] fired. The mechanism is the one [AndroidPreviewSupport]
+   * relies on (issue #136) and it is invisible from the outside: the jar is a raw file dependency
+   * on `<variant>UnitTestRuntimeClasspath` with no `artifactType`, so the render's attribute-
+   * filtered artifact view drops it and only AGP's own `test<Variant>UnitTest` task classpath
+   * carries it.
+   */
+  internal fun missingRClassHint(rClass: String): String =
+    "`$rClass` is an AGP-generated resource table, not preview code, so this is a classpath " +
+      "fault rather than a preview that is individually broken. On an Android library every " +
+      "Compose preview fails the same way when the merged unit-test R.jar is missing, because " +
+      "compose-ui reads androidx.customview.poolingcontainer.R.id.* from " +
+      "PoolingContainer.<clinit> at class-init." +
+      "\n  That jar is `build/intermediates/compile_and_runtime_r_class_jar/<variant>UnitTest/" +
+      "process<Variant>UnitTestResources/R.jar`. It reaches the render only through AGP's own " +
+      "`test<Variant>UnitTest` task classpath — it is a raw file dependency with no " +
+      "`artifactType`, so the render's filtered view of `<variant>UnitTestRuntimeClasspath` " +
+      "never sees it (issue #136)." +
+      "\n  Check, in order: that `test<Variant>UnitTest` exists for the rendered variant (run " +
+      "`composePreviewDoctor` to see which variant that is); that " +
+      "`process<Variant>UnitTestResources` ran; and that the jar it wrote actually contains " +
+      "$rClass."
+
   /**
    * Per-preview error-sidecar payload as the gradle plugin reads it. We mirror only the fields used
    * by [formatMissingPreviewsMessage]; the sidecar schema itself lives next to the renderer that
@@ -2190,6 +2242,12 @@ internal object ComposePreviewTasks {
         if (withSidecar.size > shown) {
           sb.append("\n  (+").append(withSidecar.size - shown).append(" more with sidecars)")
         }
+        // One line of the list above says `NoClassDefFoundError: androidx/customview/
+        // poolingcontainer/R$id` and the reader has no way to tell that from a broken preview.
+        // Name the mechanism once, for the first such failure — the rest are the same one.
+        insights.values
+          .firstNotNullOfOrNull { missingAgpRClass(it) }
+          ?.let { sb.append("\n\n").append(missingRClassHint(it)) }
       }
       if (withoutSidecar.isNotEmpty()) {
         sb

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/MissingPreviewMessageTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/MissingPreviewMessageTest.kt
@@ -431,4 +431,109 @@ class MissingPreviewMessageTest {
     assertThat(frame?.file).isEqualTo("AmbientAwareActivity.kt")
     assertThat(frame?.line).isEqualTo(76)
   }
+
+  @Test
+  fun `formatMissingPreviewsMessage names the merged unit-test R jar behind a missing R class`() {
+    // The shape element-x renders with: every preview in the module dies at class-init because
+    // compose-ui's PoolingContainer reads an R table that is not on the render classpath. Without
+    // the hint the list below reads as 321 independently broken previews.
+    val manifest =
+      PreviewManifest(
+        module = "designsystem",
+        variant = "debug",
+        previews =
+          listOf(
+            previewWithCapture("A", "renders/A.png"),
+            previewWithCapture("B", "renders/B.png"),
+          ),
+      )
+    val sidecar =
+      ComposePreviewTasks.ErrorSidecar(
+        exception = "java.lang.NoClassDefFoundError",
+        message = "androidx/customview/poolingcontainer/R\$id",
+      )
+
+    val msg =
+      ComposePreviewTasks.formatMissingPreviewsMessage(
+        manifest = manifest,
+        missingIds = listOf("A", "B"),
+        sidecars = mapOf("A" to sidecar, "B" to sidecar),
+      )
+
+    // Reported once, in dotted form, whatever the slashed form the JVM used.
+    assertThat(msg).contains("androidx.customview.poolingcontainer.R\$id")
+    assertThat(msg).contains("is an AGP-generated resource table")
+    assertThat(msg).contains("compile_and_runtime_r_class_jar")
+    assertThat(msg).contains("test<Variant>UnitTest")
+  }
+
+  @Test
+  fun `the R-jar hint stays out of an ordinary preview failure`() {
+    val manifest =
+      PreviewManifest(
+        module = "app",
+        variant = "debug",
+        previews = listOf(previewWithCapture("A", "renders/A.png")),
+      )
+
+    val msg =
+      ComposePreviewTasks.formatMissingPreviewsMessage(
+        manifest = manifest,
+        missingIds = listOf("A"),
+        sidecars =
+          mapOf(
+            "A" to
+              ComposePreviewTasks.ErrorSidecar(
+                exception = "java.lang.IllegalStateException",
+                message = "missing state",
+              )
+          ),
+      )
+
+    assertThat(msg).doesNotContain("compile_and_runtime_r_class_jar")
+  }
+
+  @Test
+  fun `missingAgpRClass only fires on a class-loading failure over an R table`() {
+    fun insight(exception: String, message: String, chain: String = "") =
+      ComposePreviewTasks.RenderErrorInsight(
+        exception = exception,
+        message = message,
+        frame = null,
+        chain = chain,
+      )
+
+    assertThat(
+        ComposePreviewTasks.missingAgpRClass(
+          insight("java.lang.ClassNotFoundException", "androidx.customview.poolingcontainer.R\$id")
+        )
+      )
+      .isEqualTo("androidx.customview.poolingcontainer.R\$id")
+    // The cascade every other preview reports: the wrapper is an initialiser error and only the
+    // chain names the class-loading failure.
+    assertThat(
+        ComposePreviewTasks.missingAgpRClass(
+          insight(
+            "java.lang.ExceptionInInitializerError",
+            "androidx/customview/poolingcontainer/R\$id",
+            chain = "ExceptionInInitializerError \u2192 NoClassDefFoundError",
+          )
+        )
+      )
+      .isEqualTo("androidx.customview.poolingcontainer.R\$id")
+    // A class-loading failure over something that is not a resource table.
+    assertThat(
+        ComposePreviewTasks.missingAgpRClass(
+          insight("java.lang.ClassNotFoundException", "com.example.PreviewsKt")
+        )
+      )
+      .isNull()
+    // An R table named by a failure that is not about loading a class.
+    assertThat(
+        ComposePreviewTasks.missingAgpRClass(
+          insight("java.lang.IllegalStateException", "androidx.customview.poolingcontainer.R\$id")
+        )
+      )
+      .isNull()
+  }
 }


### PR DESCRIPTION
## What

When a missing preview's root cause is a class-loading failure over a class of the AGP resource-table shape — `<package>.R`, or an `R$id` / `R$style` table, in either the dotted form `ClassNotFoundException` reports or the slashed form `NoClassDefFoundError` reports — `composePreviewRenderAll`'s report now says so once and points at the jar that supplies it.

## Why

`element-hq/element-x-android`'s `:libraries:designsystem` fails all 321 previews at class-init on `androidx/customview/poolingcontainer/R$id`, and the per-preview list renders that as 321 separately broken previews. It is one classpath fault: compose-ui reads `androidx.customview.poolingcontainer.R.id.*` from `PoolingContainer.<clinit>`, so a module whose merged unit-test `R.jar` is off the render classpath loses every preview the same way.

That jar is invisible from the outside. It is a raw file dependency on `<variant>UnitTestRuntimeClasspath` with no `artifactType`, so the render's attribute-filtered artifact view drops it and only AGP's own `test<Variant>UnitTest` task classpath carries it (issue #136) — and nothing in the failure names any of that. The hint names the jar, the task that writes it, and what to check.

This does **not** fix the element-x render. It turns that render's opaque failure into a named one, so the next import run says whether this is the branch at fault. Tracked in #5026.

## What this is not

Not a behaviour change to any render: the hint is appended inside `formatMissingPreviewsMessage`, which only runs on a render that has already failed its missing-output post-condition. An ordinary preview throw that happens to mention an R class does not trigger it — the failure has to be a class-loading one, directly or through its cause chain.

## Test plan

`./gradlew :gradle-plugin:test --tests '*MissingPreviewMessageTest*'` — 15 tests, green. Three are new:

- the element-x shape (`NoClassDefFoundError` on the slashed name, cascading across previews) produces the hint once, with the class in dotted form
- an ordinary `IllegalStateException` failure does not mention the jar
- `missingAgpRClass` fires on `ClassNotFoundException` over an R table and on an `ExceptionInInitializerError` whose chain names `NoClassDefFoundError`; it stays null for a class-loading failure over a non-R class, and for a non-class-loading failure that names an R class

`./gradlew :gradle-plugin:ktfmtFormatMain :gradle-plugin:ktfmtFormatTest` — no changes. Text-only change, so no visual evidence applies; the existing `RenderFunctionalTest` assertions on this message are `contains` checks and are unaffected by an appended paragraph.

## Background: what was ruled out while chasing #5026

The previous investigation could not reproduce element-x at all (its build resolves `matrix-analytics-events` from jitpack, which the sandbox blocks). I built a synthetic AGP 9.3.2 / Gradle 9.7.1 Android library instead and probed the mechanism directly. It works: `androidx/customview/poolingcontainer/R$id.class` is in `compile_and_runtime_r_class_jar/debugUnitTest/processDebugUnitTestResources/R.jar`, it survives `buildAgpClasspathExtras`'s `minus()`, and `composePreviewRenderAll` renders — with each of these layered on:

- element-x's full `gradle.properties` (configuration cache + parallel + configure-on-demand + `nonTransitiveRClass=true` + `enableTestFixtures` + `enableBuildConfigAsBytecode`)
- its module shape (`buildConfig=true`, core-library desugaring, `vectorDrawables { generatedDensities() }`, `isReturnDefaultValues`, consumer proguard files, Robolectric 4.16.1 on `testImplementation`)
- an Android-library **project** dependency carrying its own resources
- `com.autonomousapps.dependency-analysis` 3.19.1, which is element-x's one unique trait among the 15 imports

Also ruled out by comparison across imports: AGP 9 (bitwarden and twine are on 9.3.2 and publish), Gradle 9.7.1 (home-assistant, horologist), compileSdk 37 (bitwarden), and library-vs-application modules generally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pu78hmRSSLNxeH5QRWYftq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pu78hmRSSLNxeH5QRWYftq)_