### PR TITLE
feat(render-host): bring the render host home from the preview server

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -410,6 +410,9 @@ composeai-data-layoutinspector-core = { module = "ee.schimke.composeai:data-layo
 composeai-data-theme-core = { module = "ee.schimke.composeai:data-theme-core", version.ref = "composeai-contracts" }
 composeai-data-preview-overrides-core = { module = "ee.schimke.composeai:data-preview-overrides-core", version.ref = "composeai-contracts" }
 composeai-common-io = { module = "ee.schimke.composeai:common-io", version.ref = "composeai-contracts" }
+# `ServeHost.parityIssues()` — the shape a catalog publishes for component-parity issues. Contracts
+# (layer 0) owns the wire shape; `:render-host` owns validation and storage over it.
+composeai-parity-issues-protocol = { module = "ee.schimke.composeai:parity-issues-protocol", version.ref = "composeai-contracts" }
 
 # The preview server (see `composeai-preview-serve`). `-test-fixtures` rides the same coordinates
 # as a Gradle feature variant, so `testFixtures(libs.composeai.preview.serve)` picks it up without

--- a/render-host/build.gradle.kts
+++ b/render-host/build.gradle.kts
@@ -1,0 +1,186 @@
+// The render host, the bundle daemon and the git-backed preview history — what renders and reads
+// history, with no web server underneath it.
+//
+// **This module came home.** It was written inside the `serve` package, so when the server was
+// extracted to yschimke/compose-preview-server it went along, and `:cli` had to reach back across a
+// repository boundary for it: `bundle render`, `render matrix`, `history manifest` and the
+// missing-render report are OFFLINE commands that opened no socket, yet depended on a published
+// artifact from the repository that owns the web server. That is one of the two edges of the
+// dependency cycle in yschimke/compose-preview-server#180, and the half with no reason to exist —
+// the module has zero project dependencies inside the server, and its entire dependency block is
+// compose-ai-tools and contracts coordinates.
+//
+// `docs/design/REPOSITORY_LAYERS.md` settles where it belongs and the answer is here: layer 1 is
+// behaviour that opens no socket, and this renders. Nothing about the sources changed in the move.
+//
+// Coordinate change, deliberate: it published as `compose-preview-render-host` from the server and
+// publishes as `render-host` from here. Keeping the old coordinate would mean two repositories
+// publishing one artifact on two version lines — a 1.x release that sorts BELOW the 2.x the server
+// already shipped, which is a downgrade to every resolver and to Renovate. A new coordinate in this
+// repository's own naming (`bundle-format`, `daemon-core`, `render-session-api`) has neither
+// problem, and the old one stays resolvable at its final 2.x for anyone pinned to it.
+//
+// Package note: the sources keep `ee.schimke.composeai.cli.serve`, exactly as they did in the
+// server. The rename is a separately reviewed change in both repositories, and keeping it is what
+// makes this move source-compatible — `:cli`'s call sites do not change at all, they just resolve
+// from a module in the right repository.
+//
+// One simplification the move earns for free. In the server this project was named `render-host`
+// but published as `compose-preview-render-host`, so `java-test-fixtures` derived a capability
+// (`…:render-host-test-fixtures`) that did not match what a consumer's `testFixtures(...)` asks for
+// (`…:compose-preview-render-host-test-fixtures`), and the build file carried a block of
+// configuration plus a `checkTestFixturesCapabilities` guard to reconcile them. Here the project
+// name and the artifactId are the same string, so the derived capability is already the right one
+// and all of that goes away.
+plugins {
+  id("composeai.base-conventions")
+  id("composeai.jvm-conventions")
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+  // `FakeRenderSession` — the fake `RenderSession` that drives `ServeRenderHost` without a daemon
+  // subprocess. Shared by this module's own tests, `:cli`'s `BundleRenderKnobTest`, and the
+  // server's live-host and session-registry tests across the repository boundary. A fixture rather
+  // than a `main` source: it must not reach any runtime classpath.
+  `java-test-fixtures`
+}
+
+dependencies {
+  // `api` for everything appearing in this module's own public signatures, because both `:cli` here
+  // and `:server` in the other repository write against those types directly: `ServeRenderHost`
+  // returns products from `:data-*`, `ServeBundleDaemon.materialize` takes a
+  // `DaemonLaunchDescriptor`, and `ServeHost` exposes `PreviewOverrides` and `StreamFrameParams`.
+  //
+  // Project dependencies where the server had to name published coordinates. That substitution is
+  // the point of the move: this module is compiled and tested against the same source tree it ships
+  // beside, instead of against whichever compose-ai-tools release the server happened to pin. The
+  // skew that made #180 worth filing — the render host built against 1.62.0 while running against
+  // main — cannot recur from this side.
+  api(project(":preview-data-api"))
+  api(project(":bundle-format"))
+  api(project(":bundle-coordinates"))
+  api(project(":daemon:core"))
+  api(project(":render-session-api"))
+  api(project(":render-session-subprocess"))
+  api(project(":data-remotecompose-core"))
+
+  // Layer 0. These stay published coordinates in both repositories: contracts is shape-only and
+  // below us, which is exactly the dependency direction the layer rule allows.
+  api(libs.composeai.data.layoutinspector.core)
+  api(libs.composeai.data.theme.core)
+  // `ServeHost.parityIssues()` exposes the shape published by catalogs. The wire contract is
+  // contracts'; this module owns only validation and storage behaviour.
+  api(libs.composeai.parity.issues.protocol)
+  // Both reached by FULLY-QUALIFIED name rather than an import, so they are easy to miss when
+  // reading the sources for what this module needs: `ServePreview.overrides` is declared as
+  // `List<ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration>`. A public signature,
+  // hence `api`.
+  api(libs.composeai.data.preview.overrides.core)
+
+  implementation(libs.composeai.common.io)
+  implementation(project(":common-image-crop"))
+  implementation(libs.kotlinx.serialization.json)
+
+  testImplementation(kotlin("test"))
+  // In-memory FileSystem for the store tests, which assert on-disk output without touching the real
+  // FS. Okio itself is on the compile classpath via `common-io`; the fake ships separately.
+  testImplementation(libs.okio.fakefilesystem)
+
+  testFixturesImplementation(kotlin("test"))
+  // `FakeRenderSession` implements `RenderSession`, so the interface is part of the fixture's own
+  // signature rather than an implementation detail of it.
+  testFixturesApi(project(":render-session-api"))
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "render-host",
+    displayName = "Compose Preview — Render Host",
+    description =
+      "Daemon-backed preview rendering, packed-bundle materialisation and git-backed preview " +
+        "history, without a web server. Backs the offline `bundle render`, `render matrix` and " +
+        "`history manifest` commands, and is consumed by the preview server.",
+  )
+  inceptionYear.set("2026")
+}
+
+tasks.withType<Test>().configureEach {
+  // JUnit 5: the moved tests use the Jupiter `@Test` and `@TempDir`, which is what `kotlin("test")`
+  // resolves once the platform is selected. Without this the platform defaults to JUnit 4 and the
+  // moved test classes do not run.
+  useJUnitPlatform()
+}
+
+// The whole point of the module, asserted against the RESOLVED runtime classpath rather than the
+// `dependencies {}` block above — a transitive Ktor server would not show up in the block, and
+// reading the block back would only re-state what someone just wrote.
+//
+// Ported unchanged in substance from the server, where it was `checkRenderHostIsServerFree`, and it
+// matters more here rather than less: `docs/design/REPOSITORY_LAYERS.md` puts this module in layer
+// 1
+// precisely because it opens no socket, so this task is the layer test for it. It is also narrower
+// than `checkLayerBoundary`, which asks where a coordinate comes from; this asks what kind of thing
+// it is.
+//
+// Scoped to what this module can actually hold out. The Ktor CLIENT and OkHttp arrive through
+// `:bundle-coordinates` (resolving coordinates is an HTTP fetch by nature) and
+// `kotlin-build-tools-api` — the interface, not the compiler — through `:daemon:core`. A check that
+// asserted "no HTTP at all" would fail on the commit introducing it, which is the same as not
+// having one. A client is not a server: `bundle render` opens no listening socket either way.
+abstract class CheckRenderHostIsServerFree : DefaultTask() {
+  @get:Input abstract val resolvedModules: SetProperty<String>
+
+  @get:Input abstract val forbiddenPrefixes: ListProperty<String>
+
+  @TaskAction
+  fun check() {
+    val prefixes = forbiddenPrefixes.get()
+    val offenders =
+      resolvedModules.get().filter { module -> prefixes.any { module.startsWith(it) } }.sorted()
+    check(offenders.isEmpty()) {
+      "`:render-host` resolved artifacts it exists to stay free of: " +
+        offenders.joinToString(", ") +
+        ". This module backs the OFFLINE `bundle render`, `render matrix` and `history manifest` " +
+        "commands and is layer 1 because it opens no socket (docs/design/REPOSITORY_LAYERS.md). " +
+        "Either the new code belongs in the preview server, or the dependency belongs behind an " +
+        "interface this module implements."
+    }
+  }
+}
+
+tasks.register<CheckRenderHostIsServerFree>("checkRenderHostIsServerFree") {
+  description = "Fails if a web server, mDNS or the Kotlin compiler reaches this module."
+  group = "verification"
+
+  resolvedModules.set(
+    configurations.named("runtimeClasspath").flatMap { configuration ->
+      configuration.incoming.artifacts.resolvedArtifacts.map { artifacts ->
+        artifacts
+          .mapNotNull { artifact ->
+            (artifact.id.componentIdentifier as? ModuleComponentIdentifier)?.let {
+              "${it.group}:${it.module}"
+            }
+          }
+          .toSet()
+      }
+    }
+  )
+
+  // Prefixes rather than exact coordinates: `io.ktor:ktor-server-cio` today, but the invariant is
+  // "no web server", and an exact list would pass the first time someone swaps CIO for Netty.
+  forbiddenPrefixes.set(
+    listOf(
+      "io.ktor:ktor-server",
+      "org.jmdns:",
+      // UI-builder service and protocol ownership belongs to the server's own published runtime.
+      // Offline render/history callers must not regain that product surface transitively.
+      "ee.schimke.composeai:ui-builder-protocol",
+      // The Kotlin compiler frontend behind the playground's in-process compile. NOT
+      // `kotlin-build-tools-api`, which is the interface and arrives via `:daemon:core`.
+      "org.jetbrains.kotlin:kotlin-compiler",
+      "org.jetbrains.kotlin:kotlin-build-tools-impl",
+    )
+  )
+}
+
+tasks.named("check") { dependsOn("checkRenderHostIsServerFree") }

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/BundleClasspathGaps.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/BundleClasspathGaps.kt
@@ -1,0 +1,278 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.io.SystemFileSystem
+import java.io.File
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+/**
+ * The coordinates a catalog's bundle recorded that this server could not resolve — written beside
+ * the daemon launch descriptor at materialization time, read back when a render dies of a linkage
+ * error so the failure can name its cause.
+ *
+ * ## Why
+ *
+ * [CoordinateResolver][ee.schimke.composeai.cli.CoordinateResolver] warns and drops a coordinate it
+ * can't find rather than failing, and that is right: most misses are harmless (a dependency no
+ * render path touches), and a slightly-thin classpath still beats no catalog. What it cost was
+ * attribution. `remote-m3` publishes a `coordinates` bundle whose whole Remote Compose runtime is
+ * an androidx.dev snapshot build; the server resolved none of it, logged thirteen separate warnings
+ * at startup, stood the daemon up, and every render then died with `NoClassDefFoundError:
+ * androidx/compose/remote/player/view/RemoteComposePlayer`. That is the text the circuit breaker
+ * latched and the viewer showed, and it names a class, not a cause — so issues #4259 and #4265 were
+ * both filed against the symptom.
+ *
+ * ## The other shape: resolved, but not the recorded bytes
+ *
+ * A coordinate can also come back **wrong** rather than missing.
+ * [CoordinateResolver][ee.schimke.composeai.cli.CoordinateResolver] compares a resolved artifact
+ * against the `sha256` the bundle recorded and, on a mismatch, warns and returns it anyway
+ * ("almost-compatible beats nothing") — which is right for a leaf dependency and fatal for a family
+ * whose artifacts must move together. That is what killed `meshcore-mobile`: its whole Remote
+ * Compose runtime is pinned at `1.0.0-SNAPSHOT` from one androidx.dev build, a stale extraction
+ * served `remote-player-core` from a *different* build, and the resulting classpath carried two
+ * Remote Compose lines. Every IR replay died on `NoSuchFieldError: class
+ * androidx.compose.remote.core.RemoteClock does not have member field … SYSTEM`
+ * (compose-preview-server#187; the resolver-side fix is content-keyed extraction).
+ *
+ * Nothing was *unresolved* there, so the record above stayed silent and the breaker reason named a
+ * class and no cause — the same hole issues #4259 / #4265 opened, reached through a different door.
+ * A version-level skew check would not have found it either: both sides read `1.0.0-SNAPSHOT`. Only
+ * the hash separates them, and the resolver already computed it, so [record] keeps the mismatches
+ * too.
+ *
+ * ## What
+ *
+ * [record] persists the gap as `classpath-gaps.json` next to `daemon-launch.json`.
+ * [linkageDiagnosis] reads it at trip time and returns one sentence for [RenderCircuitBreaker] to
+ * append to the open breaker's reason — the only diagnosis anyone outside the box ever sees. When
+ * the missing class's package matches one of the unresolved coordinates, the sentence names that
+ * artifact specifically; otherwise it reports the gap and lets the reader draw the line. A
+ * mismatched coordinate that explains the failure is reported ahead of an unresolved one: "these
+ * exact bytes are not the ones the bundle recorded" is a cause, where "something is missing" is a
+ * direction.
+ *
+ * Read at trip time rather than held in memory, mirroring [SkikoNativePairing.linkageDiagnosis]: a
+ * diagnosis nobody needs must not cost anything on the healthy path.
+ */
+internal object BundleClasspathGaps {
+
+  /** File name written beside the launch descriptor. */
+  private const val FILE_NAME = "classpath-gaps.json"
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  /** One unresolved coordinate, flattened to what a diagnosis needs. */
+  @Serializable
+  data class Gap(
+    /** `group:artifact:version`, as the bundle recorded it. */
+    val coordinate: String,
+    /** Kept apart from [coordinate] so a missing class can be matched back to its artifact. */
+    val group: String,
+    val artifact: String,
+  )
+
+  @Serializable
+  data class Gaps(
+    val unresolved: List<Gap> = emptyList(),
+    /**
+     * Coordinates that resolved to bytes whose sha256 is not the one the bundle recorded. Defaulted
+     * so a `classpath-gaps.json` written before this field existed still reads back.
+     */
+    val mismatched: List<Gap> = emptyList(),
+    /** How many Maven coordinates the bundle recorded in total, for proportion. */
+    val total: Int = 0,
+  )
+
+  /**
+   * Persist [unresolved] and [mismatched] beside the launch descriptor in [destDir] and log the
+   * aggregate. A no-op (and no file) when every coordinate resolved to the bytes the bundle
+   * recorded, so the diagnosis can never fire on a healthy catalog.
+   */
+  fun record(
+    destDir: File,
+    unresolved: List<BundleReader.ClasspathEntry.Maven>,
+    total: Int,
+    system: String,
+    onLog: (String) -> Unit,
+    mismatched: List<BundleReader.ClasspathEntry.Maven> = emptyList(),
+    fileSystem: FileSystem = SystemFileSystem,
+  ) {
+    if (unresolved.isEmpty() && mismatched.isEmpty()) return
+    if (unresolved.isNotEmpty()) {
+      onLog(
+        "catalog $system: ${unresolved.size} of $total classpath coordinate(s) did not resolve — " +
+          "the live daemon starts with an incomplete classpath and any render that needs one of " +
+          "them will fail with a linkage error. Unresolved: " +
+          unresolved.joinToString { "${it.group}:${it.artifact}:${it.version}" }
+      )
+    }
+    if (mismatched.isNotEmpty()) {
+      onLog(
+        "catalog $system: ${mismatched.size} of $total classpath coordinate(s) resolved to bytes " +
+          "that are not the ones the bundle recorded — the version string matches but the artifact " +
+          "does not, so the daemon links code from two builds of the same library and a render " +
+          "that crosses the seam fails with NoSuchMethodError / NoSuchFieldError. Mismatched: " +
+          mismatched.joinToString { "${it.group}:${it.artifact}:${it.version}" }
+      )
+    }
+    val gaps =
+      Gaps(
+        unresolved = unresolved.map { it.toGap() },
+        mismatched = mismatched.map { it.toGap() },
+        total = total,
+      )
+    runCatching {
+      fileSystem.write(File(destDir, FILE_NAME).path.toPath()) {
+        writeUtf8(json.encodeToString(Gaps.serializer(), gaps))
+      }
+    }
+  }
+
+  /**
+   * One sentence attributing a **fatal** linkage [reason] to this catalog's unresolved coordinates,
+   * or null when the classpath was complete, the record is unreadable, or the failure isn't the
+   * kind an absent artifact explains.
+   *
+   * [descriptorPath] is the daemon's `daemon-launch.json`; the record sits beside it.
+   */
+  fun linkageDiagnosis(
+    reason: String,
+    descriptorPath: File,
+    fileSystem: FileSystem = SystemFileSystem,
+  ): String? =
+    attributedDiagnosis(reason, descriptorPath, fileSystem)
+      ?: unattributedDiagnosis(reason, descriptorPath, fileSystem)
+
+  /**
+   * The half of [linkageDiagnosis] that names the artifact the failing type actually lives in: a
+   * mismatched coordinate, or an unresolved one whose group and artifact tokens appear in the
+   * failure. Null when this record can point at nothing in particular.
+   *
+   * Split from [unattributedDiagnosis] so a caller with a **more specific** diagnosis of its own
+   * can sit between the two. The generic half fires on any unresolved coordinate, related or not —
+   * a catalog missing one optional dependency would otherwise answer every linkage failure in the
+   * process with "something is missing", including the ones
+   * [RemoteComposePairing][RemoteComposePairing.linkageDiagnosis] can explain exactly. Attribution
+   * earns the first word; a bare gap does not.
+   */
+  fun attributedDiagnosis(
+    reason: String,
+    descriptorPath: File,
+    fileSystem: FileSystem = SystemFileSystem,
+  ): String? {
+    val gaps = readGaps(reason, descriptorPath, fileSystem) ?: return null
+    val dotted = reason.replace('/', '.')
+    // A mismatched coordinate the failing type points at is reported first and alone: it names the
+    // artifact AND says what is wrong with it, which is strictly more than the unresolved list can
+    // say. Unattributed mismatches fall through — "some artifact is the wrong build" without a name
+    // is weaker than an unresolved list that does name one.
+    mismatchDiagnosis(gaps, dotted)?.let {
+      return it
+    }
+    val culprit = gaps.unresolved.bestExplanationOf(dotted) ?: return null
+    return unresolvedSentence(
+      gaps,
+      " — including ${culprit.coordinate}, which is where the missing type lives",
+    )
+  }
+
+  /**
+   * The half that reports the gap without naming a culprit — "these ${'$'}n coordinates are missing
+   * and one of them is probably it". A direction rather than a cause, and correspondingly the last
+   * diagnosis to be tried.
+   */
+  fun unattributedDiagnosis(
+    reason: String,
+    descriptorPath: File,
+    fileSystem: FileSystem = SystemFileSystem,
+  ): String? {
+    val gaps = readGaps(reason, descriptorPath, fileSystem) ?: return null
+    if (gaps.unresolved.isEmpty()) return null
+    return unresolvedSentence(gaps, " — one of them is likely where the missing type lives")
+  }
+
+  private fun unresolvedSentence(gaps: Gaps, attribution: String): String =
+    "This catalog's bundle records ${gaps.total} Maven coordinate(s) and this server could not " +
+      "resolve ${gaps.unresolved.size} of them, so the daemon is running on an incomplete " +
+      "classpath$attribution. Unresolved: ${gaps.unresolved.joinToString { it.coordinate }}. " +
+      "Republish the catalog from a build whose repositories the bundle records, or give this " +
+      "server access to them (--extra-maven-repos)."
+
+  /** The record beside [descriptorPath], or null when [reason] is not a linkage failure at all. */
+  private fun readGaps(reason: String, descriptorPath: File, fileSystem: FileSystem): Gaps? {
+    if (MISSING_TYPE_MARKERS.none { it in reason }) return null
+    val file = File(descriptorPath.parentFile ?: return null, FILE_NAME)
+    return runCatching {
+      fileSystem
+        .read(file.path.toPath()) { readUtf8() }
+        .let { json.decodeFromString(Gaps.serializer(), it) }
+    }
+      .getOrNull()
+  }
+
+  /**
+   * The sentence for a linkage failure inside a coordinate whose bytes are not the ones the bundle
+   * recorded, or null when no mismatch explains this failure.
+   *
+   * Attribution is required here, unlike the unresolved case. A `NoSuchFieldError` in a package no
+   * mismatched artifact ships is not this record's to claim — some other dependency is at fault and
+   * saying "one of these is probably wrong" would send the reader down the wrong path. The whole
+   * mismatch list still rides along once one of them does match, because these artifacts travel in
+   * families and the reader needs to see the rest of the family.
+   */
+  private fun mismatchDiagnosis(gaps: Gaps, dottedReason: String): String? {
+    val culprit = gaps.mismatched.bestExplanationOf(dottedReason) ?: return null
+    return "This catalog's bundle records a sha256 for each of its ${gaps.total} Maven " +
+      "coordinate(s), and ${gaps.mismatched.size} of them resolved to different bytes — including " +
+      "${culprit.coordinate}, which is where the missing member lives. The version string matched, " +
+      "so the daemon linked two builds of one library together; that is a linkage error no retry " +
+      "can clear. Mismatched: ${gaps.mismatched.joinToString { it.coordinate }}. This is expected " +
+      "to be a stale cache when the coordinate is a `-SNAPSHOT` (its version names no single " +
+      "build); republishing the catalog against released versions removes the ambiguity."
+  }
+
+  /** The gap that best explains the type in [dottedReason], or null when none says anything. */
+  private fun List<Gap>.bestExplanationOf(dottedReason: String): Gap? = maxByOrNull {
+    attributionScore(dottedReason, it)
+  }
+    ?.takeIf { attributionScore(dottedReason, it) > 0 }
+
+  private fun BundleReader.ClasspathEntry.Maven.toGap() =
+    Gap(coordinate = "$group:$artifact:$version", group = group, artifact = artifact)
+
+  /**
+   * How well [gap] explains the type named in [dottedReason] (the failure text with `/` rewritten
+   * to `.`, since a `NoClassDefFoundError` prints the internal form). Zero means "says nothing".
+   *
+   * The group has to appear at all — the naming convention every AndroidX / JetBrains / Square
+   * artifact follows — and then each hyphen-separated token of the artifact id that also appears
+   * breaks the tie between siblings in one group. So for
+   * `androidx/compose/remote/player/view/RemoteComposePlayer` the group `androidx.compose.remote`
+   * matches five unresolved artifacts, and `remote-player-view` (whose `player` and `view` tokens
+   * are both in the package) outscores `remote-core`. When nothing scores, the diagnosis stays
+   * general rather than naming an artifact it can't stand behind.
+   */
+  private fun attributionScore(dottedReason: String, gap: Gap): Int {
+    if (!dottedReason.contains(gap.group)) return 0
+    val tokenHits = gap.artifact.split('-').count { it.length > 2 && dottedReason.contains(it) }
+    return 1 + tokenHits
+  }
+
+  /**
+   * Linkage markers an absent artifact explains. Deliberately narrower than
+   * [RenderFailureClassifier]'s fatal set: a `VerifyError` or an `UnsatisfiedLinkError` is a
+   * different fault (bad bytecode, a native pairing — see [SkikoNativePairing]) and an unresolved
+   * coordinate says nothing useful about it.
+   */
+  private val MISSING_TYPE_MARKERS =
+    listOf(
+      "NoClassDefFoundError",
+      "ClassNotFoundException",
+      "NoSuchMethodError",
+      "NoSuchFieldError",
+    )
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogImagePaths.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogImagePaths.kt
@@ -1,0 +1,31 @@
+package ee.schimke.composeai.cli.serve
+
+/**
+ * The layout convention for a published catalog's baked images: where they live under the catalog
+ * root, and how an image path becomes the route-safe preview id that names it everywhere else.
+ *
+ * Split out of `ServeCatalogStore`'s companion, which is where it was written and where it still
+ * reads from (that class is in `:server`, so it is named here rather than linked). It is here
+ * because [PreviewHistoryManifest] needs it and lives in `:render-host` — the `history manifest`
+ * command has to turn the image paths it diffs between two commits into preview ids, and that is
+ * the only thing it wanted from a 3,900-line catalog store bound to the server.
+ *
+ * Shape and a pure function, deliberately. Nothing here reads a file, so both sides of the module
+ * boundary can agree on the convention without either owning the other's I/O.
+ */
+object CatalogImagePaths {
+  /** Directory, relative to the catalog root, holding the baked preview PNGs. */
+  const val IMAGES_DIR = "images"
+
+  /**
+   * The single-path-segment preview id for a catalog image path. The serve routes (`/p/{name}`,
+   * `/render/{name}.png`, `/ws/{name}`) capture one segment, so a catalog image's subdirectory `/`
+   * (e.g. `images/button-filled/ideal__default__dark.png`) must be flattened or the preview is
+   * listed but can't be opened/rendered. We drop the `images/` prefix + `.png` suffix and replace
+   * `/` with `__` (the same separator the variant keys already use), giving a stable, route-safe id
+   * like `button-filled__ideal__default__dark`. The design-parity catalog exporter derives the
+   * `livePreview` deep link the same way so the link resolves to this id.
+   */
+  fun previewIdFor(imagePath: String): String =
+    imagePath.removePrefix("$IMAGES_DIR/").removeSuffix(".png").replace("/", "__")
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
@@ -1,0 +1,888 @@
+package ee.schimke.composeai.cli.serve
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.serialization.Serializable
+
+/** Progress for one catalog generation's server-side theme-cache optimization. */
+@Serializable
+data class ThemeOptimizationSnapshot(
+  val state: String,
+  val total: Int,
+  val cached: Int,
+  val remaining: Int,
+  val failed: Int,
+  val cachedBytes: Long,
+  val fullyOptimized: Boolean,
+  val startedAtEpochMillis: Long? = null,
+  val completedAtEpochMillis: Long? = null,
+  /**
+   * Entries cached per minute over the pass's lifetime, and the projected seconds to finish at that
+   * rate. Null before the pass has done enough to divide by.
+   *
+   * The point of publishing a RATE rather than only `cached`/`remaining`: a cumulative count read
+   * twice looks the same whether the pass is keeping up or crawling, and reading progress off a
+   * lifetime average (which includes the server's startup, when the pass is parked) understates the
+   * current rate. Both mistakes were made against this catalog before this existed.
+   */
+  val entriesPerMinute: Double? = null,
+  val etaSeconds: Long? = null,
+  /**
+   * Where the pass's wall-clock actually goes: inside renders vs. waiting. This is the split that
+   * says whether throughput is render-bound (nothing to fix without a faster renderer) or
+   * wait-bound (a scheduling problem), which `cached` alone cannot distinguish.
+   */
+  /** [batchMillis] + [warmMillis], kept as the single "rendering" total. */
+  val renderMillis: Long = 0,
+  /**
+   * The render bucket, separated — because a cold start and a steady-state render are not the same
+   * cost and the sum reads as though they were.
+   *
+   * [batchMillis] is time inside theme-render batches: the recurring, per-entry cost, and the only
+   * part that scales with how much is left to do. [warmMillis] is time waiting out a cold daemon,
+   * paid once per daemon per pass but running to **34–68s** on an Android/Robolectric lane — so on
+   * a pass that has had only a handful of turns it can be most of [renderMillis] while producing
+   * nothing.
+   *
+   * Reading only the total, a box whose renders are genuinely slow is indistinguishable from one
+   * that is fast but keeps paying for cold starts — and "the renderer is the bottleneck" is the
+   * wrong conclusion to draw from the second. It was very nearly drawn from this catalog.
+   */
+  val batchMillis: Long = 0,
+  val warmMillis: Long = 0,
+  /** [gateWaitMillis] + [permitWaitMillis], kept as the single "not rendering" total. */
+  val waitingMillis: Long = 0,
+  /**
+   * The two waits, separated — because they have opposite fixes and the sum cannot tell them apart.
+   *
+   * [gateWaitMillis] is time the idle gate withheld a turn: the box looked busy, so the pass is
+   * being deliberately polite and the lever is the quiet window. [permitWaitMillis] is time the
+   * pass HAD its turn and queued behind other catalogs for a server-wide render permit: the box was
+   * idle and the pass was merely outnumbered, and the lever is how many catalogs prefetch at once.
+   *
+   * Reading only the total, a deployment where every catalog optimizes simultaneously and starves
+   * on permits is indistinguishable from one where a trickle of traffic keeps the gate shut — and
+   * loosening the quiet window, the obvious response to the latter, does nothing for the former.
+   */
+  val gateWaitMillis: Long = 0,
+  val permitWaitMillis: Long = 0,
+  /** How often the idle gate granted the pass its turn, and how often traffic took it back. */
+  val turnsGranted: Int = 0,
+  val turnsYielded: Int = 0,
+  /**
+   * Turns the *ceiling* granted because the gate had withheld one for too long, counted inside
+   * [turnsGranted].
+   *
+   * A number climbing here says the box never looks quiet to the optimizer and the only progress it
+   * makes is the forced kind — which is a working cache and a broken gate, not a healthy server. On
+   * a box whose idle clock is pinned by a leaked session lease this is the *only* counter that
+   * would ever move.
+   */
+  val turnsForced: Int = 0,
+  /**
+   * Daemons that actually rendered **concurrently** in the last batch, and the most so far.
+   *
+   * Deliberately not the batch's job count. The optimizer submits N jobs to an executor and the
+   * shared pool hands each one a daemon — but when the live-seat budget affords no replica the pool
+   * does not spawn one, it queues the job onto a host already in circulation. So N jobs can be N
+   * threads taking turns on a single daemon, and a count of jobs submitted reports that as "N
+   * wide". This is the peak concurrent borrow observed inside the batch, which is the number that
+   * distinguishes the two.
+   */
+  val lastBatchWidth: Int = 0,
+  val maxBatchWidth: Int = 0,
+  /**
+   * Cached entries carried over from an older build and still awaiting re-render.
+   *
+   * Counted inside [cached], not beside it: they are warm and they are being served. This says how
+   * much of that warmth is another build's work, which is the difference between a catalog that has
+   * converged on this renderer and one that is merely inheriting. Falling steadily is the
+   * background regeneration doing its job; stuck with `remaining` at 0 means the pass believes it
+   * has finished and is not picking the queue up.
+   */
+  val dirty: Int = 0,
+) {
+  /**
+   * Every target warm **and** produced by the renderer that is running — the condition the pass may
+   * actually stop on.
+   *
+   * [fullyOptimized] is deliberately left meaning "nothing is missing", because that is what the
+   * status row and the completion state have always reported. It is the wrong gate for the worker:
+   * a dirty entry is cached, so a catalog that has inherited a whole generation reads as fully
+   * optimized while none of it is this build's work.
+   */
+  val converged: Boolean
+    get() = fullyOptimized && dirty == 0
+}
+
+/**
+ * One catalog generation's rendered-preview cache: memory occupancy, what the reads did, and the
+ * disk tier behind it.
+ *
+ * [entries]/[bytes]/[maxBytes]/[evictions] describe the memory window. Everything after them exists
+ * to answer a question occupancy cannot: whether the cache is *being used*. A cache that is filling
+ * and a cache that is filling and never read look the same from the outside, and with a disk tier
+ * the second one costs I/O on every render for nothing.
+ */
+@Serializable
+data class CatalogRenderCacheSnapshot(
+  val entries: Int,
+  val bytes: Long,
+  val maxBytes: Long,
+  val evictions: Long,
+  /** Reads served from the memory window. */
+  val memoryHits: Long = 0,
+  /** Reads the memory window missed and the disk tier answered. */
+  val diskHits: Long = 0,
+  /** Reads neither tier could answer, so a render had to happen. */
+  val misses: Long = 0,
+  /**
+   * Reads deliberately refused because the generation was adopted from a previous process and had
+   * not yet been verified.
+   *
+   * Kept out of [misses] so it cannot be read as the cache failing: these are entries the cache
+   * holds and is choosing not to serve, and during a cold start they can outnumber real misses.
+   * Counted so a hit rate that looks terrible for the first few minutes of a process is explainable
+   * rather than alarming.
+   */
+  val withheld: Long = 0,
+  /**
+   * Hits over reads — `(memoryHits + diskHits) / (memoryHits + diskHits + misses)` — or null before
+   * anything has been read.
+   *
+   * Published rather than left to the reader because the counters are cumulative over the process
+   * and a cumulative pair read once tells you nothing about whether the cache is currently earning
+   * its keep. [withheld] is excluded from the denominator for the reason given above.
+   */
+  val hitRate: Double? = null,
+  /** The disk tier's own counters, or null when this catalog has none — see [persistenceOff]. */
+  val persisted: ThemeCacheGenerationSnapshot? = null,
+  /**
+   * Why this catalog has no disk tier, when it has none.
+   *
+   * Every reason a catalog falls back to memory-only used to be indistinguishable from "the server
+   * was started without a cache directory" — an unreadable launch descriptor, a classpath entry the
+   * fingerprint could not digest, a generation directory that could not be created. Those are
+   * exactly the failures worth knowing about, because they are silent and permanent for the life of
+   * the host, so they are named here.
+   */
+  val persistenceOff: String? = null,
+)
+
+/**
+ * Rendered PNGs and theme-optimization progress shared by every host incarnation of one catalog
+ * generation.
+ *
+ * A live catalog host is normally suspended after an idle window. Keeping this object in
+ * [ServeSessionState] lets the optimized PNGs survive that daemon suspension and be reused when the
+ * catalog resumes. Although the optimizer only targets declared themes, the render map also keeps
+ * successful on-demand override renders (knobs, locale, font scale, and so on). A catalog refresh
+ * builds a fresh session state and therefore a fresh cache, so entries accumulate for exactly as
+ * long as the catalog content they were rendered from remains current.
+ */
+class CatalogThemeCache(
+  maxBytes: Long =
+    System.getProperty("composeai.serve.catalogRenderCacheMaxBytes")?.toLongOrNull()
+      ?: DEFAULT_MAX_BYTES,
+  /**
+   * Disk tier for this catalog generation, or null to keep the historical memory-only behaviour.
+   *
+   * **Memory is a window onto this, not a copy of it.** The in-memory cap is 128 MB and a fully
+   * warmed m3-catalog is 10,120 PNGs — several times that — so preloading the generation would just
+   * thrash the LRU and, worse, would report `cached` as whatever happened to fit rather than what
+   * is actually warm. Instead [get] falls through to disk and promotes, and every count of what is
+   * cached asks both tiers. That is what lets `cached` keep climbing past the point where memory
+   * alone would have started evicting.
+   */
+  private val persistence: ThemeCacheStore.Generation? = null,
+  /**
+   * Why there is no disk tier, when [persistence] is null — surfaced as
+   * [CatalogRenderCacheSnapshot.persistenceOff].
+   */
+  private val persistenceOffReason: String? = null,
+) {
+  val maxBytes: Long = maxBytes.coerceAtLeast(0)
+  private val renderLock = Any()
+  // Access-order map: the byte cap evicts the least-recently-read render first.
+  private val renders = LinkedHashMap<String, ByteArray>(16, 0.75f, true)
+  private val targetKeys = ConcurrentHashMap.newKeySet<String>()
+  // The bounded set the DISK tier accepts — see [configurePersistable] for why it is not
+  // targetKeys.
+  private val persistableKeys = ConcurrentHashMap.newKeySet<String>()
+  // False while renders ADOPTED FROM A PREVIOUS PROCESS are still unverified — see [get]. Only
+  // those
+  // are in question: anything this process rendered came from this renderer and needs no checking,
+  // which is why the quarantine is keyed on `wasAdopted` rather than on having a disk tier at all.
+  private val persistenceTrusted = java.util.concurrent.atomic.AtomicBoolean(false)
+  private val failedKeys = ConcurrentHashMap.newKeySet<String>()
+  // Consecutive live-render failures per key, and the last reason seen. Both are cleared by a
+  // successful [put], so a key only stays latched while it keeps failing.
+  private val failureCounts = ConcurrentHashMap<String, Int>()
+  private val failureReasons = ConcurrentHashMap<String, String>()
+  // Consecutive background `Busy` outcomes per key. Separate from [failureCounts] because the two
+  // have very different tolerances — see [BUSY_LATCH]. Cleared by a successful [put] like the rest.
+  private val busyCounts = ConcurrentHashMap<String, Int>()
+  private val byteCount = AtomicLong(0)
+  private val evictionCount = AtomicLong(0)
+  // Read outcomes, so `/status` can say whether this cache is answering anything at all. Split by
+  // tier because the two have different costs and different fixes: a memory hit is free, a disk hit
+  // is the persistence tier earning its I/O, and a miss is a render.
+  private val memoryHits = AtomicLong(0)
+  private val diskHits = AtomicLong(0)
+  private val readMisses = AtomicLong(0)
+  private val withheldReads = AtomicLong(0)
+  private val state = AtomicReference("waiting")
+  private val startedAt = AtomicLong(0)
+  private val completedAt = AtomicLong(0)
+  private val batchMillis = AtomicLong(0)
+  private val warmMillis = AtomicLong(0)
+  private val gateWaitMillis = AtomicLong(0)
+  private val permitWaitMillis = AtomicLong(0)
+  private val turnsGranted = java.util.concurrent.atomic.AtomicInteger(0)
+  private val turnsYielded = java.util.concurrent.atomic.AtomicInteger(0)
+  private val turnsForced = java.util.concurrent.atomic.AtomicInteger(0)
+  private val lastBatchWidth = java.util.concurrent.atomic.AtomicInteger(0)
+  private val maxBatchWidth = java.util.concurrent.atomic.AtomicInteger(0)
+  // Entries the OPTIMIZER produced. The rate's denominator is optimizer time, so its numerator has
+  // to be optimizer output: foreground renders land in this same cache via `cacheCatalogRender`,
+  // and counting them would report a prefetch rate the prefetcher never achieved.
+  private val optimizerProduced = java.util.concurrent.atomic.AtomicInteger(0)
+
+  /** The idle gate handed the pass its turn. */
+  fun recordTurnGranted() {
+    turnsGranted.incrementAndGet()
+  }
+
+  /** Traffic took the turn back. */
+  fun recordTurnYielded() {
+    turnsYielded.incrementAndGet()
+  }
+
+  /**
+   * The ceiling granted a turn the gate would not have. Counted in [recordTurnGranted] too, so
+   * `turnsGranted` stays the total and this is the slice of it the box never actually offered.
+   */
+  fun recordTurnForced() {
+    turnsForced.incrementAndGet()
+    turnsGranted.incrementAndGet()
+  }
+
+  /** Wall-clock the idle gate withheld a turn because the box looked busy. */
+  fun recordGateWait(millis: Long) {
+    if (millis > 0) gateWaitMillis.addAndGet(millis)
+  }
+
+  /** Wall-clock spent holding a turn but queued behind other catalogs for a render permit. */
+  fun recordPermitWait(millis: Long) {
+    if (millis > 0) permitWaitMillis.addAndGet(millis)
+  }
+
+  /**
+   * One batch completed. [width] is the peak number of daemons that rendered **concurrently**, not
+   * the job count — see [ThemeOptimizationSnapshot.lastBatchWidth] for why those differ.
+   */
+  fun recordBatch(width: Int, millis: Long) {
+    lastBatchWidth.set(width)
+    maxBatchWidth.accumulateAndGet(width, ::maxOf)
+    if (millis > 0) batchMillis.addAndGet(millis)
+  }
+
+  /** Entries this batch actually produced — the rate's numerator. */
+  fun recordProduced(count: Int) {
+    if (count > 0) optimizerProduced.addAndGet(count)
+  }
+
+  /**
+   * A cold daemon warm the optimizer waited out. Real render work, so it counts toward
+   * [ThemeOptimizationSnapshot.renderMillis] and the rate's denominator — leaving it out of every
+   * bucket made a cold catalog report a rate it was nowhere near. But it is kept apart from
+   * [recordBatch] time because it produces no entries and does not recur per entry.
+   */
+  fun recordWarm(millis: Long) {
+    if (millis > 0) warmMillis.addAndGet(millis)
+  }
+
+  fun configureTargets(keys: Collection<String>) {
+    targetKeys += keys
+    configurePersistable(keys)
+    refreshCompletion()
+  }
+
+  /**
+   * Declare the finite set of keys the disk tier will accept, without claiming them as optimization
+   * targets.
+   *
+   * The two are separate because the eager prefetch pass can be switched off
+   * (`-Dcomposeai.serve.themeOptimization=false`) while foreground renders of those same declared
+   * themes carry on. Gating persistence on [targetKeys] alone meant a disabled optimizer left the
+   * set empty for the host's lifetime, so every render a visitor actually asked for was refused by
+   * the disk tier and every restart began again — persistence silently doing nothing on exactly the
+   * configuration that most needs the renders it does get to be durable.
+   *
+   * Kept out of [targetKeys] so `/status` still reports no optimization row for a disabled pass,
+   * rather than one parked at "waiting" forever.
+   */
+  fun configurePersistable(keys: Collection<String>) {
+    persistableKeys += keys
+  }
+
+  /**
+   * The render for [key] from memory, or from disk (promoted into memory), or null.
+   *
+   * The disk read is on the miss path only, so a warm working set costs exactly what it did before
+   * persistence existed.
+   */
+  fun get(key: String): ByteArray? {
+    synchronized(renderLock) { renders[key] }
+      ?.let {
+        memoryHits.incrementAndGet()
+        return it
+      }
+    // Adopted-but-unverified bytes are NOT served. Verification is asynchronous — it needs a lane
+    // and a warm daemon — and until it settles these renders are exactly the thing the fingerprint
+    // might have got wrong. Serving them meanwhile hands out stale pixels precisely in the window
+    // the safety check exists to cover, and traffic can hold that window open for a long time by
+    // keeping the box non-idle. A miss here costs a fresh render; a hit here could cost the truth.
+    //
+    // Only the READ path is withheld. [contains] still reports them, so the optimizer does not
+    // re-render what is already on disk while the question is open.
+    val store =
+      persistence
+        ?: run {
+          readMisses.incrementAndGet()
+          return null
+        }
+    if (!persistenceTrusted.get() && store.wasAdopted(key)) {
+      withheldReads.incrementAndGet()
+      return null
+    }
+    // Sampled BEFORE the read, so the comparison below spans the whole unlocked window.
+    val epoch = dropEpoch.get()
+    val fromDisk =
+      store.get(key)
+        ?: run {
+          readMisses.incrementAndGet()
+          return null
+        }
+    diskHits.incrementAndGet()
+    // Promoted through the ordinary write path so it takes part in the LRU and the byte accounting
+    // like any other entry — but NOT written back to disk, which is where it just came from.
+    //
+    // Only if no drop has happened since the epoch was sampled. The disk read above holds neither
+    // the render lock nor the generation write lock, by design — a visitor must not queue behind
+    // another replica's writes — so a `dropPersisted` can unlink the generation and clear memory
+    // in the gap between the sample and here. Promoting then would reinsert the very bytes the
+    // drop just declared wrong into the tier in FRONT of the one that was emptied, and every
+    // subsequent request would be served them from an empty disk. The bytes still go back to this
+    // caller: it asked before the drop and a render it already holds is not made wrong by one.
+    remember(key, fromDisk, validEpoch = epoch)
+    return fromDisk
+  }
+
+  /**
+   * Bumped by every [dropPersisted]. Read either side of an unlocked disk read so bytes fetched
+   * before a drop cannot be promoted into memory after it.
+   */
+  private val dropEpoch = AtomicLong()
+
+  /**
+   * Targets held from an older build and queued for re-render, in a stable order.
+   *
+   * Dirty entries are *warm* — [contains] reports them and, once the sample has vouched for the
+   * generation, [get] serves them — so the optimizer's "not cached yet" filter passes straight over
+   * them, which is correct: a possibly-stale preview beats a cold render, and a build whose
+   * renderer genuinely moved is caught by the sample rather than by re-rendering everything on
+   * spec. This is the second queue, worked once the gaps are filled, so the store converges on
+   * pixels this renderer actually produced instead of trusting a version boundary forever.
+   */
+  fun dirtyTargets(): List<String> {
+    val store = persistence ?: return emptyList()
+    if (store.dirtyCount() == 0) return emptyList()
+    // Walked from the TARGETS, not from the directory: the store holds hashed file names and the
+    // hash is one-way, so what is on disk cannot name itself. The declared target set is the only
+    // place the keys still exist.
+    return targetKeys.filter(store::isDirty).sorted()
+  }
+
+  /**
+   * Whether a background pass exists that could refill this cache.
+   *
+   * The same question [markPersistedDirty] answers with `-1`, asked by a caller that has already
+   * done its work and only needs to know whether waking anything would achieve something. With
+   * `-Dcomposeai.serve.themeOptimization=false` the startup configures [persistableKeys] and
+   * deliberately leaves [targetKeys] empty: renders still persist, but there is no pass with a
+   * queue to work, so a wake buys nothing and costs a resumed host, a possible Android daemon cold
+   * start and a live seat.
+   */
+  val hasOptimizationTargets: Boolean
+    get() = targetKeys.isNotEmpty()
+
+  /**
+   * Mark every persisted render for this catalog dirty, and report how many.
+   *
+   * The operator's "regenerate this catalog", for pixels suspected wrong by something no
+   * fingerprint sees. Deliberately not a delete: the entries keep serving while the background pass
+   * replaces them.
+   */
+  fun markPersistedDirty(): Int {
+    val store = persistence ?: return 0
+    // A pass that was never given targets cannot regenerate anything. With
+    // `-Dcomposeai.serve.themeOptimization=false` the startup configures `persistableKeys` and
+    // deliberately leaves `targetKeys` empty, so marking would report a queue the optimizer has no
+    // way to work — an operator told "1,606 queued" would wait for a regeneration that is never
+    // coming. -1 says the action is unavailable here, which the route reports rather than fakes.
+    if (targetKeys.isEmpty()) return -1
+    return store.markAllDirty()
+  }
+
+  /**
+   * Throw this catalog's persisted renders away outright, and forget them in memory too.
+   *
+   * The decisive half of the pair, for pixels an operator has decided are wrong rather than merely
+   * suspect. Every preview goes cold at once and is re-rendered from nothing — which is the cost
+   * [markPersistedDirty] exists to avoid, so this is the second choice of the two, not the default.
+   *
+   * The memory window is cleared with it. Leaving it would keep serving the very renders just
+   * declared wrong, from the tier in front of the one that was emptied.
+   */
+  fun dropPersisted(): Boolean {
+    // `true` when there is no disk tier: the memory window below is all this cache has, clearing it
+    // is the whole of the drop, and it cannot fail. Reporting false would send the caller into a
+    // retry loop against a generation write lock that does not exist — the route turns false into a
+    // 409 whose contract is "contended, try again", and every retry would answer the same.
+    val discarded = persistence?.discard() ?: true
+    synchronized(renderLock) {
+      // Inside the lock and BEFORE the clear: a promotion racing this drop takes the lock to
+      // insert, so bumping here means it either lands before the clear (and is cleared) or reads
+      // the new epoch and declines. Bumping after the clear would leave a window where it does
+      // neither.
+      dropEpoch.incrementAndGet()
+      renders.clear()
+      byteCount.set(0)
+    }
+    state.set("paused")
+    completedAt.set(0)
+    return discarded
+  }
+
+  /** Whether [key] is warm in either tier, without paying to read the bytes. */
+  fun contains(key: String): Boolean =
+    synchronized(renderLock) { renders.containsKey(key) } || persistence?.contains(key) == true
+
+  fun put(key: String, png: ByteArray) {
+    // Disk first, and NOT gated on the memory cap: the disk tier has its own budget and is the
+    // authoritative store behind a deliberately smaller memory window, so a render too large for
+    // that window must still be persisted rather than silently re-rendered after every restart.
+    //
+    // **Only configured targets are persisted.** This method also takes successful foreground
+    // renders with arbitrary overrides — widths, locales, devices, knob values — and those are
+    // unbounded in a way `previews × declaredThemes` is not: on a public box a visitor could mint
+    // distinct keys indefinitely, and since a live generation is never evicted to honour
+    // `--theme-cache-max-bytes`, that fills the volume. Ad-hoc override renders stay in the bounded
+    // memory tier, exactly as they did before persistence existed.
+    // While quarantined, a fresh render REPLACES the adopted copy rather than being dropped because
+    // a file already sits at that key — see [ThemeCacheStore.Generation.put].
+    if (key in persistableKeys)
+      persistence?.put(
+        key,
+        png,
+        // Dirty as well as quarantined. A regenerated entry is the whole point of the dirty queue
+        // and it must overwrite the older build's bytes; without this the pass renders it, the
+        // store declines the write, and the flag never clears.
+        replaceExisting = !persistenceTrusted.get() || persistence.isDirty(key),
+      )
+    remember(key, png, replaceExisting = true)
+    failedKeys.remove(key)
+    failureCounts.remove(key)
+    failureReasons.remove(key)
+    busyCounts.remove(key)
+    refreshCompletion()
+  }
+
+  /** Hold [png] in the memory tier under the byte cap, evicting least-recently-read first. */
+  private fun remember(
+    key: String,
+    png: ByteArray,
+    replaceExisting: Boolean = false,
+    /**
+     * Insert only while [dropEpoch] still reads this value — see [get], where a disk read runs
+     * unlocked and a drop can land underneath it. Checked INSIDE the lock: comparing before taking
+     * it only narrows the window, because the drop that invalidates these bytes can happen between
+     * the comparison and the insert.
+     */
+    validEpoch: Long? = null,
+  ) {
+    synchronized(renderLock) {
+      if (validEpoch != null && dropEpoch.get() != validEpoch) return@synchronized
+      if (renders.containsKey(key)) {
+        // A regenerated dirty entry has to displace the copy the memory window is still serving,
+        // or the read path would keep handing out the older build's pixels for as long as the LRU
+        // held them — the disk tier converged and the tier in front of it did not.
+        if (!replaceExisting) return@synchronized
+        renders.remove(key)?.let { byteCount.addAndGet(-it.size.toLong()) }
+      }
+      if (png.size.toLong() > maxBytes) return@synchronized
+      renders[key] = png
+      byteCount.addAndGet(png.size.toLong())
+      while (byteCount.get() > maxBytes && renders.isNotEmpty()) {
+        val eldest = renders.entries.iterator().next()
+        renders.remove(eldest.key)
+        byteCount.addAndGet(-eldest.value.size.toLong())
+        evictionCount.incrementAndGet()
+        // An eviction only un-completes the catalog when the entry is gone for good. With a disk
+        // tier it is not: the memory cap is smaller than a warmed catalog by design, so treating
+        // every eviction as lost progress would park a fully-warmed catalog at `paused` forever and
+        // send the optimizer back to re-render what is already on disk.
+        if (eldest.key in targetKeys && persistence?.contains(eldest.key) != true) {
+          state.set("paused")
+          completedAt.set(0)
+        }
+      }
+    }
+  }
+
+  /**
+   * Check a sample of the persisted generation against what the renderer produces **now**, and drop
+   * the whole generation if they disagree.
+   *
+   * This is the safety net for the one thing [ThemeCacheFingerprint] cannot promise. The
+   * fingerprint covers the inputs it was told about; an input nobody thought of — a base image
+   * bumped without a release, a render default that never reached the config string — changes the
+   * pixels without changing the name, and every entry under that name is then quietly wrong. Wrong
+   * pixels matter more here than in an ordinary build cache: a stale build artifact gets caught by
+   * a test, a stale preview is shown to an agent as ground truth.
+   *
+   * [render] returns the freshly rendered bytes for a cache key, or null if it could not render —
+   * which is **not** a mismatch and must not drop anything, or a busy daemon would wipe the cache.
+   *
+   * Returns true if the generation is trustworthy (verified, or nothing to verify).
+   */
+  fun verifySample(
+    sampleSize: Int = VERIFY_SAMPLE,
+    render: (String) -> ByteArray?,
+  ): VerifyOutcome {
+    val store = persistence ?: return VerifyOutcome.NOTHING_TO_VERIFY
+    // Only entries ADOPTED FROM THE PREVIOUS PROCESS can answer the question. On a partly warmed
+    // restart, foreground traffic persists missing keys before the idle verification task runs, and
+    // sampling those would let five renders this process just made "verify" a generation whose old
+    // bytes were never looked at — trusting the cache on the strength of checking itself.
+    val candidates = persistableKeys.filter(store::wasAdopted).sorted().take(sampleSize)
+    if (candidates.isEmpty()) {
+      // Nothing was adopted, so nothing can be stale: everything from here is this renderer's own.
+      persistenceTrusted.set(true)
+      return VerifyOutcome.NOTHING_TO_VERIFY
+    }
+    var compared = 0
+    for (key in candidates) {
+      val cached = store.get(key) ?: continue
+      val fresh = render(key) ?: continue
+      compared++
+      if (!fresh.contentEquals(cached)) {
+        // Only the ADOPTED entries — the ones that were on disk when this generation opened. A
+        // generation can now hold renders from two processes at once, and the sample has just
+        // *confirmed* the ones this process made by disagreeing with the ones it inherited. Taking
+        // the lot would throw away however long this process has spent rendering, to fix a problem
+        // those renders do not have.
+        //
+        // Adopted, NOT dirty. Dirtiness asks "did a different BUILD write this", and the sample
+        // never tests that question: it draws its candidates from `wasAdopted`. A same-version
+        // restart inherits the previous process's renders as clean, so narrowing to dirty here
+        // would delete an older build's leftovers, report a positive count that suppresses the
+        // fallback `discard`, lift the quarantine, and go straight back to serving the entries the
+        // sample was drawn from.
+        val dropped = store.discardAdopted()
+        val discarded = if (dropped >= 0) dropped > 0 || store.discard() else false
+        synchronized(renderLock) {
+          // Same hazard as a drop, and the same fix: these bytes have just been proved wrong, so a
+          // promotion already in flight must not put them back after the clear.
+          dropEpoch.incrementAndGet()
+          renders.clear()
+          byteCount.set(0)
+        }
+        state.set("paused")
+        completedAt.set(0)
+        // Trust follows the DISCARD, not the detection. `discard` can fail — its generation write
+        // lock is held by a concurrent foreground render, and it retries but does not block
+        // forever — and trusting persistence anyway would leave the very PNGs just proved wrong on
+        // disk and immediately serve them as verified. While `persistenceTrusted` stays false the
+        // adopted entries are withheld from the read path (see [get]) and the next verification
+        // pass tries again, which is the quarantine this case needs.
+        if (discarded) persistenceTrusted.set(true)
+        return if (discarded) VerifyOutcome.MISMATCH else VerifyOutcome.MISMATCH_UNDISCARDED
+      }
+    }
+    // Zero successful comparisons is NOT a pass. Every sampled render can come back Busy, Failed or
+    // served from a cache during a cold start, and treating that as "verified" would latch the
+    // check permanently on the one occasion it was never actually performed — leaving a stale
+    // generation to serve wrong pixels for the life of the process. The caller retries instead.
+    if (compared > 0) persistenceTrusted.set(true)
+    return if (compared > 0) VerifyOutcome.VERIFIED else VerifyOutcome.NO_EVIDENCE
+  }
+
+  /** What [verifySample] managed to establish. */
+  enum class VerifyOutcome {
+    /** At least one persisted render was re-rendered and matched. */
+    VERIFIED,
+    /** No disk tier, or nothing adopted from it — there is nothing that could be stale. */
+    NOTHING_TO_VERIFY,
+    /** The renderer answered nothing usable, so the question is still open. Ask again. */
+    NO_EVIDENCE,
+    /** A persisted render no longer matches; the generation has been discarded. */
+    MISMATCH,
+    /**
+     * A persisted render no longer matches, and the generation could **not** be discarded — its
+     * write lock stayed held through every retry.
+     *
+     * Separate from [MISMATCH] because the two need opposite treatment from the caller. After a
+     * successful discard the question is answered: the suspect bytes are gone and verification can
+     * latch. Here they are still on disk, so the caller must NOT latch — the adopted entries stay
+     * withheld from the read path and the next pass has to ask again. Latching would leave them
+     * quarantined for the life of the process while the optimizer, which reads `contains`, went on
+     * believing they were present: repeated foreground renders, stale files, and no further attempt
+     * to clear either.
+     */
+    MISMATCH_UNDISCARDED;
+
+    /** Whether the persisted renders may be trusted from here on. */
+    val settled: Boolean
+      get() = this == VERIFIED || this == NOTHING_TO_VERIFY
+  }
+
+  fun markRunning(nowMillis: Long) {
+    startedAt.compareAndSet(0, nowMillis)
+    state.set("running")
+  }
+
+  fun markPaused() {
+    if (!snapshot().fullyOptimized) state.set("paused")
+  }
+
+  /**
+   * Mark [key] as one the optimizer could not fill, for the `/status` `failed` count.
+   *
+   * This is a **metric**, not a verdict: the optimizer gives up after a bounded number of attempts,
+   * and it gives up on a key the daemon was merely too busy to get to just as it does on one that
+   * genuinely threw. Only a [reason] — captured from a real [RenderOutcome.Failed] — makes the key
+   * terminal for [failureReason]. Without that distinction, three `Busy` outcomes during a warm
+   * would tell the next visitor the preview can never render.
+   */
+  fun markFailed(key: String, reason: String? = null) {
+    failedKeys += key
+    reason?.let { failureReasons[key] = it }
+  }
+
+  /**
+   * Record one live-render failure for [key] on the **on-demand** lane and report whether that key
+   * has now latched as unrenderable ([FAILURE_LATCH] consecutive failures).
+   *
+   * Without this, only the background optimizer ever marked a key failed, so a preview the daemon
+   * genuinely cannot render — a `painterResource` whose drawable isn't in the bundle, say — was
+   * re-attempted on every request forever. Each attempt occupies the daemon's render lock long
+   * enough to make *other* previews back off as [RenderOutcome.Busy], so one broken card degrades
+   * the whole grid. Latching lets the render lane answer immediately instead.
+   *
+   * [FAILURE_LATCH] rather than one strike because a first failure can be a cold-start timeout or a
+   * daemon restart; a successful [put] clears the count, so only a run of failures latches.
+   */
+  fun recordRenderFailure(key: String, reason: String): Boolean {
+    failureReasons[key] = reason
+    val count = failureCounts.merge(key, 1, Int::plus) ?: 1
+    if (count < FAILURE_LATCH) return false
+    failedKeys += key
+    return true
+  }
+
+  /**
+   * Record one **background** `Busy` outcome for [key] and report whether it has now latched
+   * ([BUSY_LATCH] consecutive).
+   *
+   * `Busy` is "ask again", and for a warming daemon that is exactly right — which is why the
+   * optimizer deliberately left it unmarked. But "ask again" with no ceiling is indistinguishable
+   * from "never", and the optimizer has no other way to notice: it does not re-enter a finished
+   * pass, so a key that answers `Busy` on the one pass it gets is simply abandoned, uncounted.
+   *
+   * Latching supplies the missing terminal state. Once latched the key gets a [reason], so
+   * [failureReason] answers the request lane immediately instead of sending the browser back into a
+   * `retry-after` loop it can never win, `markPassFinished` reports `degraded` rather than a
+   * `paused` that looks like ordinary throttling, and `/status` shows a non-zero `failed` naming
+   * how many previews are stuck. A successful [put] clears the count, so a genuinely contended key
+   * that eventually renders is never penalised.
+   */
+  fun recordBackgroundBusy(key: String): Boolean {
+    val count = busyCounts.merge(key, 1, Int::plus) ?: 1
+    if (count < BUSY_LATCH) return false
+    failedKeys += key
+    failureReasons[key] =
+      "no live lane produced this theme render after $count attempts (daemon busy or absent)"
+    return true
+  }
+
+  /**
+   * Why [key] cannot be rendered, once it has latched as failed; null while it may still succeed.
+   * Callers use this to answer a request without going near the daemon.
+   *
+   * Requires **both** halves: the key is latched, *and* a real render failure supplied a reason. A
+   * key in [failedKeys] with no reason is one the optimizer ran out of attempts on — retryable
+   * `Busy`, most often — and must stay retryable for a request, or a preview that was merely
+   * contended during the optimization pass would be reported as permanently dead to every later
+   * visitor.
+   */
+  fun failureReason(key: String): String? = if (key in failedKeys) failureReasons[key] else null
+
+  fun markPassFinished(nowMillis: Long) {
+    if (targetKeys.all(::contains)) {
+      completedAt.compareAndSet(0, nowMillis)
+      state.set("complete")
+    } else {
+      state.set(if (failedKeys.isEmpty()) "paused" else "degraded")
+    }
+  }
+
+  fun snapshot(): ThemeOptimizationSnapshot {
+    // Counted across BOTH tiers. Counting memory alone would report a fully warmed catalog as
+    // partially cached the moment the 128 MB window started evicting, which is precisely the
+    // condition persistence exists to create.
+    val cachedTargets = targetKeys.count(::contains)
+    val total = targetKeys.size
+    val complete = total > 0 && cachedTargets == total
+    // Read each counter ONCE and derive everything from those values. Reading them per-field lets a
+    // wait that finishes mid-snapshot land in one field and not another, publishing a row where
+    // `waitingMillis < gateWaitMillis + permitWaitMillis` — a self-contradicting diagnostic is
+    // worse than a slightly stale one.
+    val batch = batchMillis.get()
+    val warm = warmMillis.get()
+    val render = batch + warm
+    val gateWait = gateWaitMillis.get()
+    val permitWait = permitWaitMillis.get()
+    val waiting = gateWait + permitWait
+    val rate = ratePerMinute(render + waiting)
+    // Read the dirty tier ONCE, here, for the same reason the counters above are read once — and
+    // with one extra constraint: `dirtyCount` is where the rollout reconcile hangs, so calling it
+    // in the `dirty` field below would run that reconcile *after* `failed` had already asked
+    // `isDirty` about each failed key. A key the reconcile re-dirties would then land in one field
+    // and not the other. Reconciling first makes both fields describe the same instant.
+    val dirtyTotal = persistence?.dirtyCount() ?: 0
+    return ThemeOptimizationSnapshot(
+      state =
+        if (complete) "complete" else state.get().let { if (it == "complete") "paused" else it },
+      total = total,
+      cached = cachedTargets,
+      remaining = (total - cachedTargets).coerceAtLeast(0),
+      // A failed key that is now cached has been rendered since, so it is no longer a failure —
+      // EXCEPT when what is cached is another build's work. A dirty entry is `contains` by design
+      // (that is the whole point of serving it while the pass replaces it), so `!contains` alone
+      // counted a repeatedly-failing dirty re-render as zero, and the status row this catalog's
+      // dirty state exists to drive could never report one. Cheap despite the per-key question:
+      // this walks `failedKeys`, which is empty on a healthy catalog, not the 10,440 target keys.
+      failed =
+        failedKeys.count {
+          it in targetKeys && (!contains(it) || persistence?.isDirty(it) == true)
+        },
+      cachedBytes = byteCount.get(),
+      fullyOptimized = complete,
+      startedAtEpochMillis = startedAt.get().takeIf { it > 0 },
+      completedAtEpochMillis = completedAt.get().takeIf { it > 0 },
+      // Rate over the pass's ACTIVE time (render + gate wait), not wall-clock since it started:
+      // wall-clock includes stretches where the pass held no turn at all, which drags the figure
+      // toward zero and hides whether it is keeping up while it runs.
+      entriesPerMinute = rate,
+      etaSeconds =
+        rate
+          ?.takeIf { it > 0 }
+          ?.let { ((total - cachedTargets).coerceAtLeast(0) / it * 60).toLong() },
+      renderMillis = render,
+      batchMillis = batch,
+      warmMillis = warm,
+      waitingMillis = waiting,
+      gateWaitMillis = gateWait,
+      permitWaitMillis = permitWait,
+      turnsGranted = turnsGranted.get(),
+      turnsYielded = turnsYielded.get(),
+      turnsForced = turnsForced.get(),
+      lastBatchWidth = lastBatchWidth.get(),
+      maxBatchWidth = maxBatchWidth.get(),
+      // The store's own count, not `dirtyTargets().size`: `/status` snapshots every catalog on
+      // every request and m3-catalog alone declares 10,440 targets, so the filtered walk belongs on
+      // the optimizer's path — which runs per slice — and not on this one. Read above, so the
+      // reconcile it carries runs before `failed` reads the same state.
+      dirty = dirtyTotal,
+    )
+  }
+
+  fun renderCacheSnapshot(): CatalogRenderCacheSnapshot {
+    // Read once and derive, for the reason [snapshot] gives: a rate computed from counters read
+    // separately can publish a hit rate that does not match the counts printed beside it.
+    val memory = memoryHits.get()
+    val disk = diskHits.get()
+    val missed = readMisses.get()
+    val reads = memory + disk + missed
+    return synchronized(renderLock) {
+      CatalogRenderCacheSnapshot(
+        entries = renders.size,
+        bytes = byteCount.get(),
+        maxBytes = maxBytes,
+        evictions = evictionCount.get(),
+        memoryHits = memory,
+        diskHits = disk,
+        misses = missed,
+        withheld = withheldReads.get(),
+        hitRate = if (reads > 0) (memory + disk).toDouble() / reads else null,
+        persisted = persistence?.stats(),
+        persistenceOff = if (persistence == null) persistenceOffReason else null,
+      )
+    }
+  }
+
+  /** [activeMillis] is passed in so the rate divides by the same numbers the snapshot publishes. */
+  private fun ratePerMinute(activeMillis: Long): Double? {
+    val produced = optimizerProduced.get()
+    if (produced <= 0 || activeMillis <= 0) return null
+    return produced / (activeMillis / 60_000.0)
+  }
+
+  private fun refreshCompletion() {
+    if (targetKeys.isNotEmpty() && targetKeys.all(::contains)) {
+      state.set("complete")
+    }
+  }
+
+  companion object {
+    const val DEFAULT_MAX_BYTES: Long = 128L * 1024 * 1024
+
+    /**
+     * Persisted renders re-rendered and compared when a generation is adopted.
+     *
+     * Small on purpose. This is a smoke test for "did the fingerprint miss an input", and an input
+     * that changes the renderer changes it for every preview — so a handful of entries answers the
+     * question as well as a thousand would, at a cost (a few seconds) that a startup can absorb
+     * against the 28 hours of rendering it is protecting.
+     */
+    const val VERIFY_SAMPLE: Int = 5
+
+    /**
+     * Consecutive on-demand render failures before a key is treated as permanently unrenderable.
+     */
+    const val FAILURE_LATCH = 3
+
+    /**
+     * Consecutive `Busy` outcomes on the BACKGROUND lane before a key is treated as one the
+     * optimizer cannot fill.
+     *
+     * Deliberately far looser than [FAILURE_LATCH]: `Busy` really does mean "ask again" for a
+     * warming daemon, and a key that is merely contended must survive a long run of them. What it
+     * must not have is *no* ceiling. Without one the pass can never converge — `markPassFinished`
+     * only reports `complete` when every target is cached, and a key that answers `Busy` forever is
+     * neither cached nor failed, so the catalog sits at `paused` with `failed: 0` and nothing ever
+     * says which previews are stuck.
+     *
+     * Observed on meshcore-mobile: 84 of 372 targets (21 previews x 4 declared themes) pinned at
+     * `paused 288/372, failed: 0` across two server lifetimes, while all fourteen other catalogs on
+     * the same box reached `complete`. On the request lane those same previews answered `503 render
+     * busy; retry shortly` on 39 of 39 attempts spread over several minutes — a `retry-after` the
+     * server could never honour, which the grid's three retries then burned before showing "Theme
+     * preview unavailable".
+     */
+    const val BUSY_LATCH = 12
+  }
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/DaemonPoolSnapshot.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/DaemonPoolSnapshot.kt
@@ -1,0 +1,12 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlinx.serialization.Serializable
+
+/** Resident child-daemon pool occupancy, additive on `/status.json`. */
+@Serializable
+data class DaemonPoolSnapshot(
+  val name: String,
+  val open: Int,
+  val maxOpen: Int,
+  val activeStreams: Int,
+)

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/GitWorktrees.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/GitWorktrees.kt
@@ -1,0 +1,168 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * Runs a `git` subcommand in [workdir]. Injected so [GitWorktrees] is testable without a real repo.
+ */
+fun interface GitRunner {
+  fun run(workdir: File, args: List<String>): GitResult
+}
+
+data class GitResult(val exitCode: Int, val stdout: String) {
+  val ok: Boolean
+    get() = exitCode == 0
+}
+
+/**
+ * Manages git **worktrees** for serving multiple revisions of one repo from a single server. Each
+ * resolved commit gets one detached worktree under [cacheRoot] (`<cacheRoot>/<sha>`), reused on
+ * later requests — so a revision is checked out at most once. Resolution + add are serialised so
+ * two concurrent first-requests for the same revision don't race to add the same worktree.
+ *
+ * Worktrees share the repo's object store, so they're cheap; they outlive the [ServeRenderHost]s
+ * built from them (the registry evicts hosts, not checkouts) and are cleaned up on [close] / `git
+ * worktree prune`.
+ */
+class GitWorktrees(
+  private val repoRoot: File,
+  private val cacheRoot: File,
+  /**
+   * Refs whose history a requested revision must be reachable from to be served. Empty = nothing is
+   * allowed (project mode fails closed): a client-supplied `?session=<rev>` is only checked out
+   * when it's an ancestor of one of these operator-trusted refs, so arbitrary fetched PR/fork
+   * commits can't be materialized or (downstream) built.
+   *
+   * A short name like `main` or `origin/main` is **qualified** to `refs/heads/…` / `refs/remotes/…`
+   * before the ancestry check (see [qualify]): gitrevisions resolves an ambiguous `<name>` as
+   * `refs/tags/<name>` *before* the branch, so a same-named malicious tag could otherwise satisfy
+   * the allowlist for commits reachable only from that tag. Tags are never auto-matched — to allow
+   * one, pass it fully qualified as `refs/tags/<name>`.
+   */
+  private val allowedRefs: List<String> = emptyList(),
+  private val git: GitRunner = RealGitRunner,
+  private val onLog: (String) -> Unit = {},
+) : AutoCloseable {
+
+  private val lock = ReentrantLock()
+
+  // Reference count per worktree directory, NOT a plain set: two different revisions (e.g. a branch
+  // name and its SHA, or a revision session and a same-ref catalog session) resolve to the SAME
+  // `<cacheRoot>/<sha>` directory, so a shared worktree must survive until *every* holder has
+  // reclaimed it (issue #2022 review). Each [prepare] increments; each [remove] decrements and only
+  // `git worktree remove`s at zero.
+  private val prepared = HashMap<File, Int>()
+
+  /**
+   * Resolve [rev] to a commit and ensure a worktree for it exists; returns the worktree directory,
+   * or `null` when the revision can't be resolved, isn't allowed by policy, or can't be created.
+   * Registers a reference on the worktree — balance it with a [remove] (or a terminal [close]).
+   */
+  fun prepare(rev: String): File? = lock.withLock {
+    val sha = resolve(rev) ?: return null
+    if (!isAllowed(sha)) {
+      onLog("serve: revision '$rev' ($sha) is not reachable from an allowed ref; refusing")
+      return null
+    }
+    val dir = File(cacheRoot, sha)
+    // A `.git` file/dir in the worktree means it's already a valid checkout — reuse it (another
+    // revision that resolved to the same commit, or a survivor from an earlier run).
+    if (File(dir, ".git").exists()) {
+      prepared.merge(dir, 1, Int::plus)
+      return dir
+    }
+    cacheRoot.mkdirs()
+    val add =
+      git.run(repoRoot, listOf("worktree", "add", "--detach", "--force", dir.absolutePath, sha))
+    if (!add.ok) {
+      onLog("serve: 'git worktree add' failed for $sha")
+      return null
+    }
+    prepared.merge(dir, 1, Int::plus)
+    dir
+  }
+
+  /** True when [sha] is reachable from (an ancestor of, or equal to) at least one allowed ref. */
+  private fun isAllowed(sha: String): Boolean = allowedRefs.any { ref ->
+    val qualified = qualify(ref) ?: return@any false
+    git.run(repoRoot, listOf("merge-base", "--is-ancestor", sha, "$qualified^{commit}")).ok
+  }
+
+  /**
+   * Qualify an allowlist [ref] to an unambiguous fully-qualified ref, or null if it doesn't exist.
+   * A `refs/…` ref is verified as-is (so a tag can be allowed explicitly via `refs/tags/<name>`); a
+   * short name is tried as a branch then a remote-tracking branch only — never a tag — so a
+   * same-named tag can't hijack the allowlist.
+   */
+  private fun qualify(ref: String): String? {
+    val candidates =
+      if (ref.startsWith("refs/")) listOf(ref) else listOf("refs/heads/$ref", "refs/remotes/$ref")
+    return candidates.firstOrNull { exists(it) }
+  }
+
+  /** True when [fullRef] resolves to a commit. */
+  private fun exists(fullRef: String): Boolean =
+    git.run(repoRoot, listOf("rev-parse", "--verify", "--quiet", "$fullRef^{commit}")).ok
+
+  /** Resolve [rev] to a full commit sha, or null when it isn't a valid revision. */
+  private fun resolve(rev: String): String? {
+    val res = git.run(repoRoot, listOf("rev-parse", "--verify", "--quiet", "$rev^{commit}"))
+    val sha = res.stdout.trim()
+    return if (res.ok && sha.isNotEmpty()) sha else null
+  }
+
+  /**
+   * Release one reference on a worktree this instance prepared — the second-level GC of a long-idle
+   * revision session (issue #2022). The worktree is only `git worktree remove`d once its **last**
+   * reference is released, so GC of one revision alias can't delete a `<cacheRoot>/<sha>` directory
+   * another still-live session (a same-commit alias, or a same-ref catalog session) is resuming or
+   * rendering from. A no-op for a [dir] this instance didn't prepare, so a stray reclaim can't `git
+   * worktree remove` an unrelated path. Best-effort; a later `git worktree prune` (on [close]) mops
+   * up any residue. A subsequent [prepare] of the same revision re-adds the worktree from the
+   * shared object store.
+   */
+  fun remove(dir: File) = lock.withLock {
+    val refs = prepared[dir] ?: return@withLock
+    if (refs > 1) {
+      prepared[dir] = refs - 1
+      return@withLock
+    }
+    prepared.remove(dir)
+    onLog("serve: reclaiming worktree ${dir.name}")
+    runCatching { git.run(repoRoot, listOf("worktree", "remove", "--force", dir.absolutePath)) }
+  }
+
+  /** Remove the worktrees this instance created and prune stale registrations. Best-effort. */
+  override fun close() {
+    val dirs = lock.withLock { prepared.keys.toList().also { prepared.clear() } }
+    dirs.forEach { dir ->
+      runCatching { git.run(repoRoot, listOf("worktree", "remove", "--force", dir.absolutePath)) }
+    }
+    runCatching { git.run(repoRoot, listOf("worktree", "prune")) }
+  }
+
+  /** Default [GitRunner] backed by the `git` CLI. */
+  object RealGitRunner : GitRunner {
+    override fun run(workdir: File, args: List<String>): GitResult {
+      return try {
+        val process =
+          ProcessBuilder(listOf("git") + args).directory(workdir).redirectErrorStream(true).start()
+        val output = process.inputStream.bufferedReader().readText()
+        val finished = process.waitFor(GIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        if (!finished) {
+          process.destroyForcibly()
+          GitResult(exitCode = -1, stdout = output)
+        } else {
+          GitResult(exitCode = process.exitValue(), stdout = output)
+        }
+      } catch (e: Exception) {
+        GitResult(exitCode = -1, stdout = e.message ?: "")
+      }
+    }
+
+    private const val GIT_TIMEOUT_SECONDS = 120L
+  }
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmission.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmission.kt
@@ -1,0 +1,748 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import java.io.RandomAccessFile
+import java.nio.channels.FileChannel
+import java.nio.channels.FileLock
+import java.nio.channels.OverlappingFileLockException
+import java.security.MessageDigest
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.serialization.Serializable
+
+/** One observation of the host resources background optimization must yield to. */
+data class HostResourceSample(
+  val loadPerCpu: Double?,
+  val cpuUtilization: Double?,
+  /** The governing headroom: the smaller of [memoryHost] and [memoryCgroup]. */
+  val memoryAvailableFraction: Double?,
+  /**
+   * The two ceilings [memoryAvailableFraction] is the minimum of, retained so `/status.json` can
+   * say which one governs. Null when that ceiling does not exist or could not be read — an
+   * unlimited cgroup leaves [memoryCgroup] null, which is what a bare-metal host reports.
+   */
+  val memoryHost: Double? = null,
+  val memoryCgroup: Double? = null,
+)
+
+/**
+ * Thresholds deliberately have separate stop/resume sides so a busy host cannot flap.
+ *
+ * Serializable because these are published on `/status.json` under
+ * `themeOptimizer.pressure.thresholds`. A reading without its threshold is not diagnosable: the
+ * page showed `loadPerCpu 2.06` and `paused: load 2.06 per CPU` while an operator had no way to
+ * tell whether the limit was the 0.85 default or a deployment override several times larger, and
+ * therefore no way to tell a gate doing its job from one tuned past the point of doing it. The
+ * override is a system property set outside the image, so the source cannot answer it either.
+ */
+@Serializable
+data class OptimizerPressureThresholds(
+  val stopLoadPerCpu: Double = 0.85,
+  val resumeLoadPerCpu: Double = 0.60,
+  val stopCpuUtilization: Double = 0.85,
+  val resumeCpuUtilization: Double = 0.70,
+  val stopMemoryAvailableFraction: Double = 0.15,
+  val resumeMemoryAvailableFraction: Double = 0.25,
+  val resumeQuietMillis: Long = 30_000L,
+  val sampleIntervalMillis: Long = 2_000L,
+  /**
+   * Longest the gate may withhold admission while **no** reading is over a stop threshold.
+   *
+   * The gap between a stop and its resume side is a dead band, and a host can sit in one
+   * indefinitely: memory available 18% is neither `<= 0.15` (so nothing re-trips, and the reason
+   * degrades to the bare "host recovering") nor `>= 0.25` (so [OptimizerPressureGate] never starts
+   * counting [resumeQuietMillis]). Observed in production as a gate held for eight hours while the
+   * host sat at 2% CPU, with theme optimization stalled at 0.35% of its entries.
+   *
+   * Hysteresis exists to delay resumption, not to prevent it, so cap the hold. The stop thresholds
+   * are the real danger line; once the reading is back on their safe side, a bounded duty cycle —
+   * admit, possibly trip again, wait again — is the correct failure mode for best-effort work,
+   * where a permanent latch is not.
+   */
+  val maxRecoveryMillis: Long = 10 * 60_000L,
+  /**
+   * Longest a hold whose stop threshold keeps **re-tripping** may withhold admission before the
+   * gate opens for [dutyCycleMillis]. `0` restores the old permanent latch.
+   *
+   * [maxRecoveryMillis] bounds the dead band; this bounds the other permanent latch, and it is the
+   * one production actually sat in. preview.coo.ee runs 17 resident render daemons on an 8 GB box,
+   * so `MemAvailable` there is a steady 14-15% — under the 15% stop side on every sample. Nothing
+   * is recovering, so the dead-band cap never engages, and theme optimization simply never ran:
+   * `/status.json` reported `paused · memory available 15%` with `wear-m3` warmed to 5 of its 170
+   * entries across a 15-hour uptime.
+   *
+   * A steady-state reading is the host's baseline, not an emergency, and best-effort work that
+   * never runs is indistinguishable from work that was never scheduled. So the same reasoning
+   * [maxRecoveryMillis] records applies: bound the hold, admit a slice, let it trip again. What
+   * stays permanent is a genuine emergency — see [dutyCycleFloorMemoryAvailableFraction].
+   */
+  val starvationCapMillis: Long = 30 * 60_000L,
+  /**
+   * How long the gate stays open once [starvationCapMillis] is exhausted. `0` disables the cap.
+   *
+   * This must be comfortably longer than one cold Android daemon warm (34-68s in production). The
+   * old one-minute window was commonly spent entirely in that warm: the next per-batch gate check
+   * saw the window closed and yielded with zero cache entries written. Five minutes matches the
+   * optimizer's normal lane slice, so a concession can pay for the warm and still do useful work
+   * without turning the pressure backstop into an unbounded admission.
+   */
+  val dutyCycleMillis: Long = 5 * 60_000L,
+  /**
+   * Memory headroom below which the duty cycle never opens, whatever the hold has cost.
+   *
+   * The stop side (15%) is "back off"; this is "the next allocation may be the one that OOM-kills
+   * the replica". A host there keeps the permanent latch, because slow progress is not worth a
+   * killed server.
+   */
+  val dutyCycleFloorMemoryAvailableFraction: Double = 0.05,
+) {
+  companion object {
+    /**
+     * Thresholds overridden by `composeai.serve.optimizer*` system properties.
+     *
+     * Deployments differ in what "constrained" means — a box whose steady state is 18% available
+     * memory (17 resident render daemons will do that) has a resume threshold set *below* its own
+     * baseline, so the gate is guaranteed to latch on the first transient dip. That is a property
+     * of the host, not of the code, and it needs to be settable without a rebuild.
+     */
+    fun fromSystemProperties(): OptimizerPressureThresholds {
+      val defaults = OptimizerPressureThresholds()
+      return OptimizerPressureThresholds(
+        // `ratio`, NOT `fraction`. Load average per CPU is not bounded by 1.0 — it is a queue
+        // depth, and a host rendering flat out sits well above one runnable task per core.
+        stopLoadPerCpu = ratio("optimizerStopLoadPerCpu") ?: defaults.stopLoadPerCpu,
+        resumeLoadPerCpu = ratio("optimizerResumeLoadPerCpu") ?: defaults.resumeLoadPerCpu,
+        stopCpuUtilization = fraction("optimizerStopCpuUtilization") ?: defaults.stopCpuUtilization,
+        resumeCpuUtilization =
+          fraction("optimizerResumeCpuUtilization") ?: defaults.resumeCpuUtilization,
+        stopMemoryAvailableFraction =
+          fraction("optimizerStopMemoryAvailableFraction") ?: defaults.stopMemoryAvailableFraction,
+        resumeMemoryAvailableFraction =
+          fraction("optimizerResumeMemoryAvailableFraction")
+            ?: defaults.resumeMemoryAvailableFraction,
+        resumeQuietMillis = millis("optimizerResumeQuietMillis") ?: defaults.resumeQuietMillis,
+        sampleIntervalMillis =
+          millis("optimizerSampleIntervalMillis") ?: defaults.sampleIntervalMillis,
+        maxRecoveryMillis = millis("optimizerMaxRecoveryMillis") ?: defaults.maxRecoveryMillis,
+        starvationCapMillis =
+          millis("optimizerStarvationCapMillis") ?: defaults.starvationCapMillis,
+        dutyCycleMillis = millis("optimizerDutyCycleMillis") ?: defaults.dutyCycleMillis,
+        dutyCycleFloorMemoryAvailableFraction =
+          fraction("optimizerDutyCycleFloorMemoryAvailableFraction")
+            ?: defaults.dutyCycleFloorMemoryAvailableFraction,
+      )
+    }
+
+    /** A ratio in `0.0..1.0`; anything outside that is a typo, so ignore it rather than obey it. */
+    private fun fraction(name: String): Double? =
+      System.getProperty("composeai.serve.$name")?.toDoubleOrNull()?.takeIf { it in 0.0..1.0 }
+
+    /**
+     * A load average per CPU, which is a **queue depth and not a fraction**: one runnable task per
+     * core reads 1.0, and a host deliberately rendering flat out sits above that.
+     *
+     * These two thresholds were parsed by [fraction] and silently lost every value over 1.0. On
+     * preview.coo.ee, whose load while the optimizer works measures 1.03 to 1.74 per CPU, that made
+     * the load limb impossible to relax: the stop side could not be raised past its 0.85 default,
+     * so the gate tripped on the optimizer's own rendering and the override an operator wrote was
+     * dropped without a word. Failing closed is right for a typo in a percentage; it is wrong for a
+     * number whose legitimate range simply is not `0..1`.
+     *
+     * Still bounded, because a typo is still a typo — but at a ceiling no real box reaches rather
+     * than at one every busy box exceeds. Above it, the default stands, as before.
+     */
+    private fun ratio(name: String): Double? =
+      System.getProperty("composeai.serve.$name")?.toDoubleOrNull()?.takeIf {
+        it in 0.0..MAX_LOAD_PER_CPU
+      }
+
+    /**
+     * Ceiling for a load-per-CPU threshold. A box whose load average is 64x its core count is not a
+     * box an operator is tuning; it is one that has already fallen over.
+     */
+    private const val MAX_LOAD_PER_CPU = 64.0
+
+    /** Zero is meaningful (sample every call, never hold), so only negatives are rejected. */
+    private fun millis(name: String): Long? =
+      System.getProperty("composeai.serve.$name")?.toLongOrNull()?.takeIf { it >= 0L }
+  }
+}
+
+/** The individual readings [OptimizerPressureGate] can trip on, so resumption can be per-signal. */
+private enum class PressureSignal {
+  LOAD,
+  CPU,
+  MEMORY;
+
+  /** Whether this signal is back on the safe side of its **resume** threshold. */
+  fun recovered(sample: HostResourceSample, thresholds: OptimizerPressureThresholds): Boolean =
+    when (this) {
+      LOAD -> sample.loadPerCpu?.let { it <= thresholds.resumeLoadPerCpu } != false
+      CPU -> sample.cpuUtilization?.let { it <= thresholds.resumeCpuUtilization } != false
+      MEMORY ->
+        sample.memoryAvailableFraction?.let { it >= thresholds.resumeMemoryAvailableFraction } !=
+          false
+    }
+}
+
+/** Host-pressure state published on `/status.json` with the optimizer admission counters. */
+@Serializable
+data class OptimizerPressureSnapshot(
+  val constrained: Boolean,
+  val reason: String? = null,
+  val loadPerCpu: Double? = null,
+  val cpuUtilization: Double? = null,
+  val memoryAvailableFraction: Double? = null,
+  val sampledAtEpochMillis: Long? = null,
+  /** How long the current uninterrupted hold has withheld admission, or null when open. */
+  val heldMillis: Long? = null,
+  /** Set while the starvation cap has opened the gate on a host that is still over a threshold. */
+  val dutyCycleUntilEpochMillis: Long? = null,
+  /** How many times the starvation cap has had to open this gate since the server started. */
+  val dutyCycles: Int = 0,
+  /**
+   * The thresholds [constrained] was judged against — the effective values after any
+   * `composeai.serve.optimizer*` override, not the compiled defaults.
+   *
+   * Published because every other field here is a reading, and a reading alone cannot say whether
+   * the gate is behaving. Null only when a snapshot is built without a gate to ask.
+   */
+  val thresholds: OptimizerPressureThresholds? = null,
+  /**
+   * The two memory ceilings behind [memoryAvailableFraction], which is the SMALLER of them.
+   *
+   * Kept apart because collapsing them loses the fact that decides what to do. A box reporting
+   * `memory available 0%` reads as an emergency; if that 0% is [memoryCgroupAvailableFraction]
+   * while [memoryHostAvailableFraction] sits at 60%, the machine is fine and the container's own
+   * limit is the whole problem — a one-line cap change, not a bigger box. The collapsed number
+   * cannot tell those apart, and the wrong reading points at the wrong fix.
+   */
+  val memoryHostAvailableFraction: Double? = null,
+  val memoryCgroupAvailableFraction: Double? = null,
+)
+
+/**
+ * Hysteretic host-resource gate for best-effort optimization.
+ *
+ * A high reading stops admission immediately. Resumption requires every reading that tripped the
+ * hold to be back on its resume side for [OptimizerPressureThresholds.resumeQuietMillis], so a
+ * render finishing does not instantly admit another cold daemon while the host is still recovering.
+ *
+ * Because the stop and resume sides differ, a reading can settle between them and satisfy neither.
+ * [OptimizerPressureThresholds.maxRecoveryMillis] bounds how long that costs: hysteresis delays
+ * resumption, and this is what stops it preventing resumption outright.
+ *
+ * A reading that stays on the *stop* side is the other way a hold becomes permanent, and it is the
+ * one a busy host reaches by simply being busy. [OptimizerPressureThresholds.starvationCapMillis]
+ * bounds that one the same way: after the cap the gate opens for a bounded window, then holds
+ * again. Only a host under [OptimizerPressureThresholds.dutyCycleFloorMemoryAvailableFraction]
+ * keeps the latch.
+ */
+class OptimizerPressureGate(
+  private val sample: () -> HostResourceSample?,
+  private val thresholds: OptimizerPressureThresholds = OptimizerPressureThresholds(),
+  private val clock: () -> Long = System::currentTimeMillis,
+) {
+  private val lock = Any()
+  private var cached = OptimizerPressureSnapshot(constrained = false)
+  private var nextSampleAt = Long.MIN_VALUE
+  private var safeSince = Long.MIN_VALUE
+
+  /** Signals that tripped this hold; only these have to recover to clear it. Empty when open. */
+  private var trippedBy = emptySet<PressureSignal>()
+
+  /** When the current hold last saw every stop threshold clear — the [maxRecoveryMillis] anchor. */
+  private var recoveringSince = Long.MIN_VALUE
+
+  /** Whether the pressure logic itself wants to hold, before the starvation cap has its say. */
+  private var held = false
+
+  /**
+   * When the next concession is measured from — moved to the end of each window the cap opens, and
+   * to the moment a window is cut short, so the cap always means "at most this long without one".
+   */
+  private var capAnchor = Long.MIN_VALUE
+
+  /** When the current uninterrupted hold began. Reporting only — `heldMillis` on `/status.json`. */
+  private var holdStartedAt = Long.MIN_VALUE
+
+  /** End of the window the starvation cap has opened, or [Long.MIN_VALUE] when not duty-cycling. */
+  private var dutyCycleUntil = Long.MIN_VALUE
+
+  private var dutyCycles = 0
+
+  /** What was over a stop threshold on the previous sample — the [newlyTripped] baseline. */
+  private var lastTripped = emptySet<PressureSignal>()
+
+  fun snapshot(): OptimizerPressureSnapshot =
+    synchronized(lock) {
+      val now = clock()
+      if (now < nextSampleAt) return@synchronized cachedClosingExpiredDutyCycle(now)
+      nextSampleAt = now + thresholds.sampleIntervalMillis.coerceAtLeast(0L)
+      val current =
+        runCatching(sample).getOrNull() ?: return@synchronized cachedClosingExpiredDutyCycle(now)
+      val tripped = buildList {
+        current.loadPerCpu
+          ?.takeIf { it >= thresholds.stopLoadPerCpu }
+          ?.let { add(PressureSignal.LOAD to "load ${formatRatio(it)} per CPU") }
+        current.cpuUtilization
+          ?.takeIf { it >= thresholds.stopCpuUtilization }
+          ?.let { add(PressureSignal.CPU to "CPU ${formatPercent(it)}") }
+        current.memoryAvailableFraction
+          ?.takeIf { it <= thresholds.stopMemoryAvailableFraction }
+          ?.let { add(PressureSignal.MEMORY to "memory available ${formatPercent(it)}") }
+      }
+      // Only what actually stopped us has to come back: a hold taken for memory should not also
+      // wait on a CPU reading that never crossed its own stop threshold.
+      val safe = trippedBy.all { it.recovered(current, thresholds) }
+      // What is over a stop threshold *right now*, and what was over one on the previous sample.
+      // The difference is what has to cut a duty cycle short. Comparing against `trippedBy` would
+      // not do: that set accumulates for the life of the hold, so a signal that tripped once, went
+      // quiet, and spiked again while memory kept the hold alive would read as "already tripped"
+      // and buy the rest of the window.
+      val activeSignals = tripped.map { it.first }.toSet()
+      val newlyTripped = activeSignals - lastTripped
+      lastTripped = activeSignals
+      val holding =
+        if (tripped.isNotEmpty()) {
+          trippedBy = trippedBy + tripped.map { it.first }
+          safeSince = Long.MIN_VALUE
+          recoveringSince = Long.MIN_VALUE
+          true
+        } else if (!held) {
+          // `held`, not the published `constrained`: a starvation duty cycle publishes an open gate
+          // while the hold is still on, and reading that back would end the hold without the quiet
+          // window it is owed.
+          false
+        } else {
+          // Nothing is over a stop threshold any more, so the hold is now bounded either way:
+          // it ends when the resume side is held for `resumeQuietMillis`, or when the dead band
+          // between the two sides has withheld admission for `maxRecoveryMillis`.
+          if (recoveringSince == Long.MIN_VALUE) recoveringSince = now
+          val recoveryExhausted = now - recoveringSince >= thresholds.maxRecoveryMillis
+          val quiet =
+            if (!safe) {
+              safeSince = Long.MIN_VALUE
+              false
+            } else {
+              if (safeSince == Long.MIN_VALUE) safeSince = now
+              now - safeSince >= thresholds.resumeQuietMillis
+            }
+          !quiet && !recoveryExhausted
+        }
+      if (holding) {
+        if (!held) {
+          holdStartedAt = now
+          capAnchor = now
+        }
+      } else {
+        trippedBy = emptySet()
+        safeSince = Long.MIN_VALUE
+        recoveringSince = Long.MIN_VALUE
+        holdStartedAt = Long.MIN_VALUE
+        capAnchor = Long.MIN_VALUE
+        dutyCycleUntil = Long.MIN_VALUE
+      }
+      held = holding
+      val constrained = holding && !dutyCycling(current, now, newlyTripped)
+      cached =
+        OptimizerPressureSnapshot(
+          constrained = constrained,
+          reason =
+            when {
+              !holding -> null
+              tripped.isNotEmpty() -> tripped.joinToString(", ") { it.second }
+              else -> recoveringReason(current)
+            },
+          loadPerCpu = current.loadPerCpu,
+          cpuUtilization = current.cpuUtilization,
+          memoryAvailableFraction = current.memoryAvailableFraction,
+          sampledAtEpochMillis = now,
+          heldMillis = heldMillis(now, holding),
+          dutyCycleUntilEpochMillis = dutyCycleUntil.takeIf { it > now },
+          dutyCycles = dutyCycles,
+          thresholds = thresholds,
+          memoryHostAvailableFraction = current.memoryHost,
+          memoryCgroupAvailableFraction = current.memoryCgroup,
+        )
+      cached
+    }
+
+  /**
+   * The cached snapshot, with an elapsed duty-cycle window closed first.
+   *
+   * Both paths that reuse [cached] — inside the sample interval, and when sampling fails outright —
+   * would otherwise publish an open gate for as long as they last. Inside the sample interval that
+   * is at most one interval; when `/proc` stops being readable it is forever, and the 60-second
+   * window becomes a permanent admission of optimizer work under pressure nobody can see any more.
+   * The window is a *bounded* concession, so it expires on the clock rather than on the next
+   * successful reading.
+   */
+  private fun cachedClosingExpiredDutyCycle(now: Long): OptimizerPressureSnapshot {
+    if (!held || dutyCycleUntil == Long.MIN_VALUE || now < dutyCycleUntil) return cached
+    closeWindow(at = dutyCycleUntil)
+    // `heldMillis` is recomputed rather than carried over: the cached value was taken while the
+    // window was open, and republishing it would report a gate that has been shut for hours as
+    // having withheld admission for however long it had at the moment the sampler died.
+    cached =
+      cached.copy(
+        constrained = true,
+        dutyCycleUntilEpochMillis = null,
+        heldMillis = heldMillis(now, holding = true),
+      )
+    return cached
+  }
+
+  /** How long the current hold has withheld admission, or null when the gate is not holding. */
+  private fun heldMillis(now: Long, holding: Boolean): Long? =
+    if (holding && holdStartedAt != Long.MIN_VALUE) (now - holdStartedAt).coerceAtLeast(0L)
+    else null
+
+  /**
+   * Ends the open window, if any, and re-arms the cap from [at].
+   *
+   * A window cut short — by new pressure, or by memory dropping under the floor — must not leave
+   * the next concession measured from the end it never reached: that would withhold admission for
+   * up to `starvationCapMillis + dutyCycleMillis`, which is not what the cap says it does. So a
+   * live window closes at `now`.
+   *
+   * A window that simply *elapsed* is the other case, and it anchors at its scheduled end even when
+   * nothing observed the expiry until later: the concession was served in full, and a sampler that
+   * went blind for the next nine seconds is not a reason to charge the host another cap for them.
+   */
+  private fun closeWindow(at: Long) {
+    if (dutyCycleUntil == Long.MIN_VALUE) return
+    dutyCycleUntil = Long.MIN_VALUE
+    capAnchor = at
+  }
+
+  /**
+   * Whether the starvation cap should let this held gate through right now.
+   *
+   * Opens a [OptimizerPressureThresholds.dutyCycleMillis] window once a hold has withheld admission
+   * for [OptimizerPressureThresholds.starvationCapMillis], then re-arms: hold, admit a slice, hold
+   * again. The window is closed early — and never opened — while memory sits under (or cannot be
+   * read against) [OptimizerPressureThresholds.dutyCycleFloorMemoryAvailableFraction], so the one
+   * case that can actually kill the server keeps the permanent latch; and closed early when a
+   * signal that was not already holding crosses its stop threshold, so the concession never covers
+   * pressure it did not answer for.
+   *
+   * The reason string keeps naming the reading that is holding, because it still is: a duty cycle
+   * is progress *despite* the pressure, not an all-clear. `dutyCycles` on `/status.json` is what
+   * says the host has been running on it.
+   */
+  private fun dutyCycling(
+    sample: HostResourceSample,
+    now: Long,
+    newlyTripped: Set<PressureSignal>,
+  ): Boolean {
+    // A zero-length window admits nothing, so it is not a duty cycle — counting one would leave
+    // `/status.json` reporting concessions the gate never made. Both knobs disable the cap.
+    if (thresholds.starvationCapMillis <= 0L || thresholds.dutyCycleMillis <= 0L) return false
+    // `dutyCycleUntil` means "a window is live", and it has to be retired the moment one elapses:
+    // the two early closes below anchor at `now` because they are cutting a live window short, and
+    // a stale marker makes them do that to a window that already ran its course — re-anchoring a
+    // cap that was correctly anchored at the window's end when it opened.
+    if (dutyCycleUntil != Long.MIN_VALUE && now >= dutyCycleUntil) closeWindow(at = dutyCycleUntil)
+    // An unknown memory reading is not a safe one. `LinuxHostResourceSampler` returns a partial
+    // sample when `/proc/meminfo` is unreadable but load and CPU are not, and a load hold would
+    // then earn a concession with the OOM floor unverified. A host that never reports memory keeps
+    // the permanent latch, which is the conservative half of that trade.
+    val headroom = sample.memoryAvailableFraction
+    if (headroom == null || headroom < thresholds.dutyCycleFloorMemoryAvailableFraction) {
+      closeWindow(at = now)
+      return false
+    }
+    // "A high reading stops admission immediately" is the gate's contract, and an open window must
+    // not buy a *different* signal up to `dutyCycleMillis` of grace. The signal that earned the
+    // concession may stay over its threshold — that is the whole point — but a new one closes it.
+    if (newlyTripped.isNotEmpty()) {
+      closeWindow(at = now)
+      return false
+    }
+    if (now < dutyCycleUntil) return true
+    if (capAnchor == Long.MIN_VALUE) return false
+    if (now - capAnchor < thresholds.starvationCapMillis) return false
+    dutyCycleUntil = now + thresholds.dutyCycleMillis
+    capAnchor = dutyCycleUntil
+    dutyCycles++
+    return true
+  }
+
+  /**
+   * Why a hold with no reading over a stop threshold is still held.
+   *
+   * The bare "host recovering" this replaces was actively misleading during the eight-hour stall
+   * [OptimizerPressureThresholds.maxRecoveryMillis] documents: it reads as "nearly there" whether
+   * the gate is counting down its quiet window or parked in a dead band it cannot leave. Naming the
+   * signal and the bar it has to clear makes the two distinguishable from `/status.json` alone.
+   */
+  private fun recoveringReason(sample: HostResourceSample): String {
+    val waiting =
+      trippedBy
+        .filterNot { it.recovered(sample, thresholds) }
+        .sorted()
+        .map { signal ->
+          when (signal) {
+            PressureSignal.LOAD ->
+              "load per CPU ${formatRatio(sample.loadPerCpu ?: 0.0)}" +
+                " above resume ${formatRatio(thresholds.resumeLoadPerCpu)}"
+            PressureSignal.CPU ->
+              "CPU ${formatPercent(sample.cpuUtilization ?: 0.0)}" +
+                " above resume ${formatPercent(thresholds.resumeCpuUtilization)}"
+            PressureSignal.MEMORY ->
+              "memory available ${formatPercent(sample.memoryAvailableFraction ?: 0.0)}" +
+                " below resume ${formatPercent(thresholds.resumeMemoryAvailableFraction)}"
+          }
+        }
+    return if (waiting.isEmpty()) "host recovering"
+    else "host recovering: ${waiting.joinToString(", ")}"
+  }
+
+  private fun formatRatio(value: Double): String = "%.2f".format(java.util.Locale.ROOT, value)
+
+  private fun formatPercent(value: Double): String =
+    "%.0f%%".format(java.util.Locale.ROOT, value * 100.0)
+}
+
+/**
+ * Reads Linux load, CPU time and available memory through the proc filesystem — and, when this
+ * process is inside a memory-limited cgroup, through that cgroup as well.
+ *
+ * **Why the cgroup half exists.** `/proc/meminfo` inside a container reports the HOST's memory, not
+ * the container's limit. The deployed profiles cap preview at 3 GiB (`deploy/vps`) and 6 GiB
+ * (`deploy/oracle`) on hosts with far more than that, so a replica sitting a hair under its own OOM
+ * limit still saw plenty of "available" memory host-wide — and the admission gate kept letting
+ * optimizer work in at precisely the moment it needed to stop. The reported fraction is the SMALLER
+ * of the two headrooms, so whichever ceiling is nearer is the one that governs.
+ */
+class LinuxHostResourceSampler(
+  private val procRoot: File = File("/proc"),
+  private val cgroupRoot: File = File("/sys/fs/cgroup"),
+) {
+  private val previousCpu = AtomicReference<CpuTimes?>()
+
+  fun sample(): HostResourceSample? {
+    if (!procRoot.isDirectory) return null
+    val statLines = runCatching { File(procRoot, "stat").readLines() }.getOrNull().orEmpty()
+    val cpuCount =
+      statLines
+        .count { it.startsWith("cpu") && it.length > 3 && it[3].isDigit() }
+        .coerceAtLeast(Runtime.getRuntime().availableProcessors().coerceAtLeast(1))
+    val load = runCatching {
+      File(procRoot, "loadavg").readText().trim().substringBefore(' ').toDouble() / cpuCount
+    }
+      .getOrNull()
+    val cpu = statLines.firstOrNull()?.takeIf { it.startsWith("cpu ") }?.let(::cpuUtilization)
+    val memory = runCatching {
+      val values =
+        File(procRoot, "meminfo").useLines { lines ->
+          lines
+            .mapNotNull { line ->
+              val key = line.substringBefore(':', missingDelimiterValue = "")
+              val value = line.substringAfter(':', "").trim().substringBefore(' ').toLongOrNull()
+              value?.let { key to it }
+            }
+            .toMap()
+        }
+      val total = values["MemTotal"]?.takeIf { it > 0 } ?: return@runCatching null
+      values["MemAvailable"]?.toDouble()?.div(total)
+    }
+      .getOrNull()
+    // Whichever ceiling is nearer governs. An unlimited or unreadable cgroup contributes nothing,
+    // which is what keeps a bare-metal host reading exactly as it did before.
+    val cgroup = cgroupMemoryAvailableFraction()
+    val constrained = listOfNotNull(memory, cgroup).minOrNull()
+    if (load == null && cpu == null && constrained == null) return null
+    return HostResourceSample(load, cpu, constrained, memoryHost = memory, memoryCgroup = cgroup)
+  }
+
+  /**
+   * The fraction of this process's cgroup memory allowance still available, or null when there is
+   * no limit to speak of.
+   *
+   * Both cgroup generations are read because the deployment targets do not agree: v2 exposes
+   * `memory.max`/`memory.current` at the root, v1 the `memory/memory.limit_in_bytes` pair. A v1
+   * limit is reported as a huge sentinel rather than a word, so anything at or above the host's own
+   * `MemTotal` is treated as "no limit" rather than compared against.
+   *
+   * `inactive_file` is subtracted from usage because it is page cache the kernel reclaims under
+   * pressure rather than memory this process cannot give back. Counting it would make a container
+   * that has merely read a lot of files look permanently full, and the gate would then refuse
+   * optimizer work forever — the opposite failure, and a quieter one.
+   */
+  private fun cgroupMemoryAvailableFraction(): Double? = runCatching {
+    readCgroupV2Memory() ?: readCgroupV1Memory()
+  }
+    .getOrNull()
+
+  private fun readCgroupV2Memory(): Double? {
+    val limit =
+      File(cgroupRoot, "memory.max").takeIf { it.isFile }?.readText()?.trim() ?: return null
+    if (limit == "max") return null
+    val max = limit.toLongOrNull()?.takeIf { it > 0 } ?: return null
+    val current =
+      File(cgroupRoot, "memory.current").takeIf { it.isFile }?.readText()?.trim()?.toLongOrNull()
+        ?: return null
+    val reclaimable = cgroupStatValue(File(cgroupRoot, "memory.stat"), "inactive_file")
+    return availableFraction(max, current, reclaimable)
+  }
+
+  private fun readCgroupV1Memory(): Double? {
+    val directory = File(cgroupRoot, "memory")
+    val max =
+      File(directory, "memory.limit_in_bytes")
+        .takeIf { it.isFile }
+        ?.readText()
+        ?.trim()
+        ?.toLongOrNull()
+        ?.takeIf { it > 0 } ?: return null
+    // v1 spells "unlimited" as a sentinel near Long.MAX_VALUE rather than a word.
+    if (max >= UNLIMITED_CGROUP_V1_LIMIT) return null
+    val current =
+      File(directory, "memory.usage_in_bytes")
+        .takeIf { it.isFile }
+        ?.readText()
+        ?.trim()
+        ?.toLongOrNull() ?: return null
+    val reclaimable = cgroupStatValue(File(directory, "memory.stat"), "total_inactive_file")
+    return availableFraction(max, current, reclaimable)
+  }
+
+  private fun availableFraction(max: Long, current: Long, reclaimable: Long): Double {
+    val used = (current - reclaimable).coerceAtLeast(0L)
+    return ((max - used).toDouble() / max).coerceIn(0.0, 1.0)
+  }
+
+  private fun cgroupStatValue(file: File, key: String): Long =
+    runCatching {
+      file
+        .useLines { lines ->
+          lines.firstOrNull { it.startsWith("$key ") }?.substringAfter(' ')?.trim()?.toLongOrNull()
+        }
+        .orZero()
+    }
+      .getOrNull() ?: 0L
+
+  private fun Long?.orZero(): Long = this ?: 0L
+
+  private fun cpuUtilization(line: String): Double? {
+    val values = line.trim().split(Regex("\\s+")).drop(1).mapNotNull(String::toLongOrNull)
+    if (values.size < 4) return null
+    val idle = values[3] + values.getOrElse(4) { 0L }
+    val total = values.sum()
+    val now = CpuTimes(total, idle)
+    val before = previousCpu.getAndSet(now) ?: return null
+    val totalDelta = now.total - before.total
+    if (totalDelta <= 0) return null
+    return (1.0 - (now.idle - before.idle).toDouble() / totalDelta).coerceIn(0.0, 1.0)
+  }
+
+  private data class CpuTimes(val total: Long, val idle: Long)
+
+  private companion object {
+    // cgroup v1 writes `PAGE_COUNTER_MAX * PAGE_SIZE` when there is no limit; on 64-bit that is a
+    // number in the exabytes. Anything at or above this is "unlimited", not a ceiling to measure.
+    const val UNLIMITED_CGROUP_V1_LIMIT = 0x7FFFFFFFFFFFF000L
+  }
+}
+
+/** A host-wide optimizer lease. Closing it releases both the catalog and lane locks. */
+fun interface OptimizerHostLease : AutoCloseable
+
+/** Cross-process admission used by every preview replica sharing one coordination directory. */
+fun interface OptimizerHostCoordinator {
+  fun tryAcquire(system: String): OptimizerHostLease?
+
+  companion object {
+    val NONE = OptimizerHostCoordinator { OptimizerHostLease {} }
+  }
+}
+
+/**
+ * Coordinates optimizer work across server replicas with advisory file locks.
+ *
+ * A per-system lock prevents two replicas warming the same generation concurrently. A lane lock
+ * caps all optimizer passes on the physical host, rather than multiplying the configured lane count
+ * by the number of replicas. Locks are released by the kernel if a replica exits or is OOM-killed.
+ */
+class FileOptimizerHostCoordinator(
+  private val directory: File,
+  private val lanes: Int,
+) : OptimizerHostCoordinator, AutoCloseable {
+  @Volatile private var leaderLock: HeldFileLock? = null
+
+  init {
+    Runtime.getRuntime().addShutdownHook(Thread({ close() }, "optimizer-host-lock-release"))
+  }
+
+  override fun tryAcquire(system: String): OptimizerHostLease? {
+    if (!(directory.isDirectory || directory.mkdirs())) return null
+    // One replica owns optimization for its lifetime. A pass-sized system lock alone prevents
+    // simultaneous work, but the next slice could move to a replica whose in-memory view predates
+    // the first replica's writes and redundantly warm the same generation. Leadership keeps the
+    // cache/index view coherent; the kernel hands it to a survivor if the owner exits or is killed.
+    if (!ensureLeader()) return null
+    val systemLock = tryLock(File(directory, "system-${digest(system)}.lock")) ?: return null
+    for (lane in 0 until lanes.coerceAtLeast(1)) {
+      val laneLock = tryLock(File(directory, "lane-$lane.lock"))
+      if (laneLock != null) {
+        return OptimizerHostLease {
+          laneLock.close()
+          systemLock.close()
+        }
+      }
+    }
+    systemLock.close()
+    return null
+  }
+
+  @Synchronized
+  private fun ensureLeader(): Boolean {
+    if (leaderLock != null) return true
+    leaderLock = tryLock(File(directory, "leader.lock"))
+    return leaderLock != null
+  }
+
+  @Synchronized
+  override fun close() {
+    leaderLock?.close()
+    leaderLock = null
+  }
+
+  private fun tryLock(file: File): HeldFileLock? {
+    val randomAccess = runCatching { RandomAccessFile(file, "rw") }.getOrNull() ?: return null
+    val channel = randomAccess.channel
+    val lock =
+      try {
+        channel.tryLock()
+      } catch (_: OverlappingFileLockException) {
+        null
+      } catch (_: Exception) {
+        null
+      }
+    if (lock == null) {
+      runCatching { channel.close() }
+      runCatching { randomAccess.close() }
+      return null
+    }
+    return HeldFileLock(randomAccess, channel, lock)
+  }
+
+  private fun digest(value: String): String =
+    MessageDigest.getInstance("SHA-256")
+      .digest(value.toByteArray(Charsets.UTF_8))
+      .take(12)
+      .joinToString("") { "%02x".format(it.toInt() and 0xff) }
+
+  private class HeldFileLock(
+    private val randomAccess: RandomAccessFile,
+    private val channel: FileChannel,
+    private val lock: FileLock,
+  ) : AutoCloseable {
+    override fun close() {
+      runCatching { lock.release() }
+      runCatching { channel.close() }
+      runCatching { randomAccess.close() }
+    }
+  }
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiter.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiter.kt
@@ -1,0 +1,249 @@
+package ee.schimke.composeai.cli.serve
+
+import java.util.concurrent.Semaphore
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Bounds concurrent **live** (daemon-backed) stream sessions by a *permit budget* rather than a
+ * flat session count, so a cheap desktop CMP daemon and a heavy Robolectric Android daemon don't
+ * cost the same seat. [totalPermits] is the whole-box budget (memory-derived on the deployed image,
+ * see `deploy/image/entrypoint.sh`); each session acquires permits equal to its backend's
+ * **weight** — `1` for a desktop CMP daemon, more for a heavier Android one ([ServeBundleDaemon]'s
+ * `ANDROID_LIVE_SEAT_WEIGHT]`). A session that can't get its permits is refused (the caller closes
+ * the WebSocket with 1013 "Try Again Later") instead of spawning a daemon that would risk the OOM
+ * killer.
+ *
+ * Why weighting fixes the reported starvation: with a flat cap of 1, a single heavy `wear-m3`
+ * Android daemon holds the only seat and turns away the cheap `compose-m3` CMP daemon even though
+ * the box has memory for it. Under a budget of 2 with Android weight 2, two CMP sessions coexist,
+ * while a lone Android session still runs (its weight is [coerced][acquire] down to the budget so
+ * it never deadlocks against a ceiling smaller than its weight).
+ *
+ * [totalPermits] `<= 0` means **unbounded** — the historical local-`serve` behaviour — and every
+ * [acquire] returns a free ticket. A weight `<= 0` (a static snapshot/Wasm session that spawns no
+ * daemon) is likewise always free.
+ *
+ * Thread-safe: the backing [Semaphore] is fair-agnostic like the old flat gate, and each [Ticket]
+ * releases its permits at most once.
+ */
+class LiveSeatLimiter(
+  val totalPermits: Int,
+  /**
+   * Permits carved out of [totalPermits] that **only** [acquireBackground] can draw on — the
+   * per-preview lane's guaranteed slice.
+   *
+   * Without it that lane can be starved to a standstill, and was. On preview.coo.ee the eight
+   * resident catalog daemons held all 8 permits with `activeStreams: 0`, so every
+   * `acquireBackground` was refused, [ServePerPreviewDaemonPool.get] returned null, and
+   * `ServeCatalogLiveHost.renderInternal` turned that `NotFound` into `Busy` — a `503 render busy;
+   * retry shortly` on 39 of 39 attempts for all 21 of meshcore-mobile's supplement-module previews,
+   * for the life of the server. The catalog's theme prefetch then pinned at 288/372 forever because
+   * those 84 targets could never be filled.
+   *
+   * It is deliberately small — one desktop daemon's worth by default. The point is not to give the
+   * lane a fair share, only to make it impossible to starve completely: a preview whose ONLY live
+   * lane is its own per-preview bundle (a catalog with a supplement module, where the monolithic
+   * daemon simply does not carry the id) has no fallback that renders, unlike a burst replica which
+   * can narrow onto the primary.
+   */
+  val perPreviewReserve: Int = DEFAULT_PER_PREVIEW_RESERVE,
+) {
+  // The reserve is held in its own semaphore rather than subtracted from a single one, so no
+  // amount of general-lane demand can consume it. `acquire` never sees it at all.
+  //
+  // Carved out ONLY down to [STREAM_RESERVE] — the heaviest single backend — so the general lane
+  // can always hold one at its true weight. Take more than that and the budget silently
+  // over-admits: on a `--live-seats 2` box a general lane of 1 would coerce an Android stream
+  // (weight 2) down to a single permit, and a per-preview daemon could then take the reserved one,
+  // putting three permits' worth of processes on a box budgeted for two. The whole point of the
+  // weighting is that it does not do that.
+  //
+  // So a box too small to afford the slice simply doesn't get one, and keeps its old behaviour
+  // exactly. That is the correct answer rather than a regression: a box that can barely run one
+  // Android daemon cannot run a second daemon of any kind, and the starvation this reserve fixes
+  // only arises where there are seats to be hoarded in the first place.
+  //
+  // Public because it is what `/status` must publish: [perPreviewReserve] is what was *asked for*,
+  // and reporting that would state a slice the limiter may not actually hold — on a small box it is
+  // clamped to nothing, and an oversized custom value would otherwise be reported as larger than
+  // the whole budget. A diagnostic added to make starvation visible must not itself be able to lie.
+  val perPreviewPermits: Int =
+    if (totalPermits > 0)
+      perPreviewReserve.coerceIn(0, (totalPermits - STREAM_RESERVE).coerceAtLeast(0))
+    else 0
+  /**
+   * Permits the general lane (streams, burst replicas) may draw on — the budget minus the slice.
+   */
+  private val generalPermits: Int = (totalPermits - perPreviewPermits).coerceAtLeast(0)
+  private val semaphore: Semaphore? = if (totalPermits > 0) Semaphore(generalPermits) else null
+  private val perPreviewSemaphore: Semaphore? =
+    if (perPreviewPermits > 0) Semaphore(perPreviewPermits) else null
+
+  /** True when this limiter imposes no bound (`totalPermits <= 0`). */
+  val unbounded: Boolean
+    get() = semaphore == null
+
+  /**
+   * Try to reserve [weight] permits for a live session. Returns a [Ticket] the caller **must**
+   * [close][Ticket.close] when the session ends (release the permits), or `null` when the budget is
+   * exhausted and the session should be refused.
+   *
+   * A [weight] `<= 0` (static/no-daemon session) and an [unbounded] limiter both return a
+   * zero-permit ticket that always succeeds. A positive [weight] larger than [totalPermits] is
+   * coerced down to [totalPermits], so a backend heavier than the whole budget can still run alone
+   * rather than being permanently refused.
+   */
+  fun acquire(weight: Int, verified: Boolean = true, countRefusal: Boolean = true): Ticket? {
+    val sem = semaphore ?: return Ticket(0)
+    if (weight <= 0) return Ticket(0)
+    // Coerced to the GENERAL lane's capacity, not [totalPermits]: the reserve is not available
+    // here, so coercing to the whole budget would ask for more permits than this semaphore can
+    // ever hold and refuse a heavy backend forever — the deadlock the coercion exists to avoid.
+    val permits = weight.coerceIn(1, generalPermits)
+    if (sem.tryAcquire(permits)) return Ticket(permits)
+    // Seats are reserved before the session is leased (see the stream lane), so a request naming
+    // a session the registry doesn't have reaches the budget too. Those are split off rather than
+    // dropped: on a public box they are mostly noise anyone could generate, but on a `--revisions`
+    // box a valid revision is *legitimately* unknown until its first lease builds it, and its
+    // refusals are real demand. Two counters keep both readings honest.
+    // Only count callers that actually turn someone away. A caller that degrades instead — the
+    // shared replica pool narrows its burst onto a host already in circulation and still serves the
+    // render — must not inflate this, or the one number that answers "is the budget too small here"
+    // starts reporting throttled batches as refused visitors.
+    if (countRefusal) {
+      if (verified) refusals.incrementAndGet() else unverifiedRefusals.incrementAndGet()
+    }
+    return null
+  }
+
+  /**
+   * Reserve [weight] permits for a **background** holder — a pooled render daemon — leaving at
+   * least [STREAM_RESERVE] free for an interactive stream. Returns null (without counting a
+   * refusal) when that headroom isn't there.
+   *
+   * Render pools and streams are not equal claims on the box. A pooled daemon exists to make a
+   * *thumbnail* faster and its caller always has a fallback — baked pixels, or the monolithic
+   * daemon — while a refused stream is a visitor staring at "Live preview is at capacity". Charging
+   * both against one flat budget let the cheap, deferrable work take the last seat and turn the
+   * valuable, undeferrable work away: on a `--live-seats 1` box the first pooled daemon refused
+   * every stream that followed.
+   *
+   * Implemented as "take weight + reserve atomically, then hand the reserve straight back", so it
+   * can never over-admit under a race — the worst case is a background holder briefly seeing less
+   * headroom than really exists and declining, which is the safe direction.
+   */
+  fun acquireBackground(
+    weight: Int,
+    reserve: Int = STREAM_RESERVE,
+    /**
+     * Whether this caller may draw on the per-preview slice. True for the per-preview lane the
+     * slice was carved out for; **false** for any other background holder.
+     *
+     * The shared prefetch pool is background work but it is not per-preview work. Letting it take
+     * the slice would hand away the one seat a supplement-only preview is guaranteed — and once the
+     * general lane fills to its stream headroom that preview cannot open its only daemon and falls
+     * back to Busy/503, which is exactly the starvation the slice was added to prevent.
+     */
+    dedicatedSlice: Boolean = true,
+  ): Ticket? {
+    val sem = semaphore ?: return Ticket(0)
+    if (weight <= 0) return Ticket(0)
+    val permits = weight.coerceIn(1, totalPermits)
+    // The dedicated slice first (see above). It exists precisely so a saturated general lane cannot
+    // refuse
+    // this, so it is taken WITHOUT the stream headroom check — those permits were never available
+    // to a stream in the first place, and demanding headroom that by construction cannot exist
+    // would make the reserve unusable.
+    if (dedicatedSlice) {
+      perPreviewSemaphore?.let {
+        if (it.tryAcquire(permits)) return Ticket(permits, reserved = true)
+      }
+    }
+    // Otherwise the general lane, still leaving room for an interactive stream.
+    if (!sem.tryAcquire(permits + reserve.coerceAtLeast(0))) return null
+    if (reserve > 0) sem.release(reserve)
+    return Ticket(permits)
+  }
+
+  /**
+   * Permits currently available across BOTH lanes — for tests/diagnostics and `/status`.
+   *
+   * Summed rather than reporting the general lane alone, so the figure stays comparable to
+   * [totalPermits]: a box with its slice free but its general lane full is not at capacity, and
+   * reporting `0 free / 8` there would restate the very confusion this reserve fixes.
+   */
+  fun availablePermits(): Int =
+    semaphore?.let { it.availablePermits() + (perPreviewSemaphore?.availablePermits() ?: 0) }
+      ?: Int.MAX_VALUE
+
+  /** Permits free in the per-preview slice alone — lets `/status` show the lane isn't starved. */
+  fun perPreviewPermitsAvailable(): Int =
+    perPreviewSemaphore?.availablePermits() ?: if (unbounded) Int.MAX_VALUE else 0
+
+  /**
+   * How many live sessions this limiter has turned away since startup, monotonic.
+   *
+   * Deliberately a **counter, not a gauge**: a refusal is an event lasting as long as it takes the
+   * caller to give up, while [availablePermits] is a level you happen to sample. On a box with a
+   * handful of viewers, polling the level essentially never catches the moment of pressure, so "is
+   * the seat budget actually too small here?" was unanswerable from `/status` — you would read a
+   * comfortable-looking figure whatever the truth. This is the number that answers it, and it is
+   * the evidence any change to the budget (or to evicting an idle daemon in favour of an active
+   * one) should be argued from.
+   */
+  fun refusalCount(): Long = refusals.get()
+
+  /**
+   * Refusals for a session id the registry did not have at admission time, monotonic.
+   *
+   * Two populations share this bucket and only the caller's deployment tells them apart: a request
+   * for something that was never here (noise on a public box — anyone can generate it, which is why
+   * it must not touch [refusalCount]), and a lazily-created session that is valid but unbuilt, as
+   * `--revisions` produces on its first request. Read it alongside [refusalCount] rather than
+   * instead of it.
+   */
+  fun unverifiedRefusalCount(): Long = unverifiedRefusals.get()
+
+  companion object {
+    /**
+     * Permits [acquireBackground] must leave free for interactive streams. Sized at
+     * [ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT] — the most expensive single stream — so one can
+     * always start no matter how much render residency has built up.
+     */
+    const val STREAM_RESERVE: Int = ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT
+
+    /**
+     * Default [perPreviewReserve]: one desktop daemon's worth (weight 1).
+     *
+     * Enough that a catalog whose supplement module carries its own per-preview bundles can always
+     * open one, which is the difference between those previews rendering and never rendering at
+     * all. Kept to one so the general lane — streams, and the burst replicas that widen a themed
+     * batch — gives up as little as possible; a second concurrent per-preview daemon still competes
+     * for the general pool exactly as before.
+     */
+    const val DEFAULT_PER_PREVIEW_RESERVE: Int = 1
+  }
+
+  private val refusals = AtomicLong()
+  private val unverifiedRefusals = AtomicLong()
+
+  /**
+   * A held reservation of [permits] live-seat permits; [close] returns them (idempotent).
+   *
+   * [reserved] records which pool they came from, so they go back where they came from — returning
+   * a reserved permit to the general semaphore would quietly transfer the per-preview lane's slice
+   * to the general one, and the starvation this class now prevents would reappear after the first
+   * eviction.
+   */
+  inner class Ticket internal constructor(val permits: Int, private val reserved: Boolean = false) :
+    AutoCloseable {
+    private val released = AtomicBoolean(false)
+
+    override fun close() {
+      if (permits > 0 && released.compareAndSet(false, true)) {
+        if (reserved) perPreviewSemaphore?.release(permits) else semaphore?.release(permits)
+      }
+    }
+  }
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundApi.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundApi.kt
@@ -1,0 +1,291 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Wire types for the **playground** REST surface — the Stage-1 "compile a snippet, get a result +
+ * an expiring preview token" contract described in
+ * [docs/design/PLAYGROUND.md](../../../../../../../../docs/design/PLAYGROUND.md).
+ *
+ * The request/response shapes are deliberately a **superset** of the `kotlin-compiler-server`
+ * `/api/{version}/compiler/run` contract that a stock `kotlin-playground` frontend speaks, so an
+ * unmodified editor can POST to us: it sends `{ args, files, confType }` and reads `{ text,
+ * exception, errors }`. The two fields it does **not** know about — [PlaygroundRunResponse.image]
+ * and [PlaygroundRunResponse.previewToken] — are additive; a stock frontend ignores them and ours
+ * surfaces them as the still frame + the "Open live preview →" handoff.
+ *
+ * These are pure data types with no server behaviour; the route handler and the compile/render
+ * plumbing live elsewhere.
+ */
+
+/** Which renderer + permalink target a snippet compiles for. See PLAYGROUND.md §3. */
+@Serializable
+enum class PlaygroundMode {
+  /** Compose Multiplatform, desktop (Skiko) daemon → live streaming session. */
+  @SerialName("compose-cmp") CMP,
+  /** Jetpack Compose, Robolectric daemon → live streaming session. */
+  @SerialName("compose-android") ANDROID,
+  /** Snippet emits a RemoteDocument → `/d/<id>` document permalink, played client-side. */
+  @SerialName("remote-compose") REMOTE_COMPOSE;
+
+  companion object {
+    /**
+     * Resolve the request's `confType` to a mode. Accepts our own ids (the [SerialName]s above) and
+     * tolerates the stock `kotlin-playground` target ids so an unmodified frontend still lands on a
+     * sensible mode: `canvas`/`js`/`wasm`/`compose-wasm` (its in-browser Compose targets) map to
+     * [CMP], everything else defaults to [CMP] as well — the one mode a from-source box can always
+     * serve. An empty/absent `confType` is [CMP].
+     */
+    fun fromConfType(confType: String?): PlaygroundMode =
+      when (confType?.trim()?.lowercase()) {
+        "compose-android",
+        "android" -> ANDROID
+        "remote-compose",
+        "remotecompose",
+        "rc" -> REMOTE_COMPOSE
+        else -> CMP
+      }
+  }
+}
+
+/**
+ * One editor file in a run request. `publicId` is carried through but unused server-side.
+ *
+ * A request may carry **several**: every file is staged into the snippet's source dir and passed to
+ * one compile, so files see each other's declarations (they are one module, not N compiles). Names
+ * are sanitised and de-duplicated by [PlaygroundCompileService]; only the text matters to the
+ * compiler, since Kotlin does not require a file name to match its declarations.
+ */
+@Serializable
+data class PlaygroundFile(val name: String, val text: String, val publicId: String = "")
+
+/**
+ * A Stage-1 run request. Mirrors the `kotlin-compiler-server` body so a stock frontend fits; [args]
+ * is accepted and ignored (a preview has no argv), and the mode comes from [confType] via
+ * [PlaygroundMode.fromConfType].
+ *
+ * [catalog] is ours, and additive: a stock frontend omits it and lands on the host's pinned
+ * `--playground-bundle` default exactly as before.
+ */
+@Serializable
+data class PlaygroundRunRequest(
+  val args: String = "",
+  val files: List<PlaygroundFile> = emptyList(),
+  val confType: String = "",
+  /**
+   * Which served catalog to compile against (`compose-m3`), chosen per request by the editor's
+   * catalog selector. Empty ⇒ the host's pinned default for [confType]'s mode. An unknown or
+   * unloaded id is a clean "not available" response, never a fallback to the default — silently
+   * compiling against a *different* design system than the one asked for would report success for
+   * the wrong thing.
+   */
+  val catalog: String = "",
+  /**
+   * Optional single-user editing lease. Empty keeps the original stateless, one-shot compile.
+   * Non-empty values are accepted only from the authenticated owner that acquired the lease.
+   */
+  val editLease: String = "",
+  /** Monotonic client revision within [editLease]. Required to increase on every leased compile. */
+  val revision: Long = 0,
+)
+
+/** Result of explicitly acquiring the host's one stateful Playground editing lease. */
+@Serializable
+data class PlaygroundEditLeaseResponse(
+  val acquired: Boolean,
+  val lease: String? = null,
+  val expiresAtEpochMs: Long? = null,
+  /** Last revision accepted by this lease, so a reattached editor can continue monotonically. */
+  val revision: Long = 0,
+  val message: String,
+)
+
+/** Body for `POST /api/{version}/compiler/edit-lease`. [client] is unique to one browser tab. */
+@Serializable data class PlaygroundEditLeaseAcquireRequest(val client: String = "")
+
+/** Body for `POST /api/{version}/compiler/edit-lease/release`. */
+@Serializable
+data class PlaygroundEditLeaseReleaseRequest(
+  val lease: String = "",
+  /** Empty preserves the original whole-lease release contract for non-browser API callers. */
+  val client: String = "",
+)
+
+/**
+ * One entry in the editor's catalog selector (`GET /api/{version}/compiler/catalogs`).
+ *
+ * [modes] is what makes this worth a round trip rather than a static page: a catalog's bundle
+ * backend decides its renderer, so selecting `compose-m3` (desktop) and selecting an Android
+ * catalog offer different mode sets. The client repopulates its mode control from the selected
+ * entry instead of offering modes the host would then refuse.
+ */
+@Serializable
+data class PlaygroundCatalogInfo(
+  /** The `catalog` value to send back on a run. Empty for the host's pinned default entry. */
+  val id: String,
+  /** What the selector shows. */
+  val label: String,
+  /** `desktop` | `android`, or empty for the pinned default (which spans whatever was pinned). */
+  val backend: String = "",
+  val modes: List<PlaygroundMode> = emptyList(),
+  /**
+   * True once this catalog's classpath is resolved — the first run against it pays for the unpack.
+   */
+  val resolved: Boolean = false,
+  /** Served catalog system, distinct from a module-qualified [id]. */
+  val system: String = id,
+  /** Owning Gradle module when this entry is one target in a repository-wide catalog. */
+  val module: String = "",
+)
+
+/** `GET /api/{version}/compiler/catalogs`: what the editor's catalog selector may offer. */
+@Serializable
+data class PlaygroundCatalogsResponse(val catalogs: List<PlaygroundCatalogInfo> = emptyList())
+
+/** Severity of a compiler diagnostic, spelled the way the editor's highlight lane expects. */
+@Serializable
+enum class PlaygroundSeverity {
+  @SerialName("error") ERROR,
+  @SerialName("warning") WARNING,
+  @SerialName("info") INFO,
+}
+
+/**
+ * One compiler diagnostic. Line/char positions are **0-based** to match CodeMirror (what
+ * `kotlin-playground` renders against); a null position is a file-level diagnostic with no anchor.
+ */
+@Serializable
+data class PlaygroundDiagnostic(
+  val severity: PlaygroundSeverity,
+  val message: String,
+  val file: String? = null,
+  val line: Int? = null,
+  val ch: Int? = null,
+  val endLine: Int? = null,
+  val endCh: Int? = null,
+)
+
+/** A CodeMirror position in the stock `errors`-map shape (0-based line + char). */
+@Serializable data class PlaygroundPosition(val line: Int, val ch: Int)
+
+/** A `[start, end)` span in the stock `errors`-map shape. */
+@Serializable
+data class PlaygroundInterval(val start: PlaygroundPosition, val end: PlaygroundPosition)
+
+/**
+ * One diagnostic in the **stock `kotlin-compiler-server`** `errors`-map shape — the wire form a
+ * stock `kotlin-playground` frontend reads to draw inline squiggles. Distinct from
+ * [PlaygroundDiagnostic] (our flat internal shape): the stock frontend iterates the `errors` map
+ * per file and reads `error.interval.start`, so the position must be **nested** under `interval`,
+ * and `severity` is the upstream uppercase spelling (`ERROR`/`WARNING`). [PlaygroundErrorsWire]
+ * projects our diagnostics into this shape.
+ */
+@Serializable
+data class PlaygroundStockError(
+  val interval: PlaygroundInterval,
+  val message: String,
+  val severity: String,
+  val className: String,
+)
+
+/**
+ * The Stage-1 result.
+ *
+ * On a clean compile: [diagnostics] carries any warnings, [image] is the first-frame render as a
+ * `data:image/png;base64,…` URI, and [previewToken] / [previewUrl] are the handoff to the live
+ * Stage-2 session. On a compile error: [diagnostics] carries the errors and **no** token is minted
+ * ([previewToken] stays null). [exception] is reserved for a server-side failure that isn't a user
+ * compile error (e.g. the render subprocess died).
+ *
+ * [documentUrl] is the [PlaygroundMode.REMOTE_COMPOSE] terminal instead of a token: the snippet's
+ * captured `.rc` document is published as an expiring `/d/<id>` permalink the browser plays
+ * client-side (PLAYGROUND.md §3). A run yields **either** a [previewToken] (the live CMP/Android
+ * modes) **or** a [documentUrl] (RC) — never both — and [previewToken] stays null on the RC path.
+ *
+ * [previewId] is the `@Preview` this run actually rendered and tokenized, and [previews] is every
+ * `@Preview` the snippet declared — a multi-file snippet can hold several, and only one drives the
+ * first frame and the Stage-2 session. Both are additive fields a stock frontend ignores; ours uses
+ * them to say *which* preview it drew when a snippet declares more than one.
+ *
+ * [errors] is the **same** diagnostics projected into the stock `kotlin-compiler-server` wire shape
+ * (a map keyed by file name → [PlaygroundStockError]s with nested `interval` positions), so an
+ * unmodified `kotlin-playground` frontend can render inline squiggles. Our own frontend reads the
+ * richer [diagnostics] instead; both are populated, so neither client is second-class.
+ */
+@Serializable
+data class PlaygroundRunResponse(
+  val diagnostics: List<PlaygroundDiagnostic> = emptyList(),
+  val errors: Map<String, List<PlaygroundStockError>> = emptyMap(),
+  val text: String = "",
+  val exception: String? = null,
+  val image: String? = null,
+  val previewToken: String? = null,
+  val previewUrl: String? = null,
+  val documentUrl: String? = null,
+  val previewId: String? = null,
+  val previews: List<String> = emptyList(),
+  /** Echoed only for stateful editing compiles. */
+  val editLease: String? = null,
+  /** The accepted stateful revision. Null on the original one-shot path. */
+  val revision: Long? = null,
+  /** True when this revision used BTA incremental compilation rather than the full fallback. */
+  val incremental: Boolean = false,
+)
+
+/**
+ * `GET /usage/{previewId}`: the plain-Compose usage code behind one catalog card — what the
+ * viewer's **Source** panel shows, and the same derivation the playground handoff seeds from.
+ *
+ * Served as its own lazily-fetched resource rather than baked into the viewer page. Producing it
+ * costs a GitHub read on a cold cache ([PlaygroundSeedResolver]), and most visitors to a preview
+ * never open the panel — so a page load must not pay for it.
+ */
+@Serializable
+data class UsageSnippetResponse(
+  /** The cleaned Kotlin. */
+  val text: String,
+  /** The declaration the card's render comes from, for the panel's caption. */
+  val entryFunction: String? = null,
+  /**
+   * True when the catalog declared what its own helpers mean. False ⇒ only the shared annotations
+   * came off and the catalog's own helpers are still in [text]; the panel says so rather than
+   * presenting machinery as usage.
+   */
+  val scaffoldsDeclared: Boolean = false,
+  /** Declared scaffolding that survived, so the panel can name what will not resolve. */
+  val residue: List<String> = emptyList(),
+  /** The preview's source on GitHub — "the whole sticker" for anyone who wants it. */
+  val blobUrl: String? = null,
+  /** Where "open in playground" goes, so the panel and the provenance row cannot disagree. */
+  val playgroundHref: String? = null,
+  /**
+   * The KDoc pages for the platform APIs [text] uses, derived from its own imports by [ApiDocLinks]
+   * — composables first, in the order the code names them, so the component this card is about
+   * leads the list.
+   *
+   * Rides the snippet rather than the viewer page for the same reason the snippet does: it is
+   * derived FROM the snippet, so there is nothing to serve until that read has happened, and a
+   * visitor who never opens Source pays for neither.
+   */
+  val apiDocs: List<ApiDocLink> = emptyList(),
+)
+
+/**
+ * One entry of [UsageSnippetResponse.apiDocs]: a symbol the usage code uses, and its reference
+ * page.
+ *
+ * The wire shape of [ApiDocLinks.Link], kept as its own serializable type so the internal resolver
+ * stays free to carry things the viewer has no use for.
+ */
+@Serializable
+data class ApiDocLink(
+  /** The name as the snippet writes it — an `as` alias where the code renamed one. */
+  val name: String,
+  /** The imported fully-qualified name, shown as the link's tooltip. */
+  val fqn: String,
+  /** True when this resolved to a top-level `@Composable`, which the panel groups separately. */
+  val composable: Boolean = false,
+  /** The `developer.android.com` reference page. */
+  val url: String,
+)

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundPreviews.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundPreviews.kt
@@ -1,0 +1,48 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.previewdata.PreviewInfo
+import ee.schimke.composeai.previewdata.PreviewManifest
+import kotlinx.serialization.json.Json
+
+/**
+ * Shared synthesis of a `previews.json` for a compiled playground snippet — the manifest a
+ * bundle-less daemon renders against. Both the Remote Compose capture
+ * ([PlaygroundRcCaptureService]) and the Android first-frame render
+ * ([PlaygroundAndroidRenderService]) stand a daemon over the snippet's own classes and need the
+ * identical manifest, so the synthesis lives here rather than in either service.
+ */
+// Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
+// and the `:server` call sites are in a different module now. Not a widened API by intent.
+object PlaygroundPreviews {
+
+  private val json = Json {
+    encodeDefaults = true
+    ignoreUnknownKeys = true
+  }
+
+  /**
+   * A `previews.json` the daemon can render: each discovered id split back into its `className` +
+   * `functionName` (the id is `"$className.$functionName"`, per [PlaygroundPreviewDiscoverer]),
+   * ordered as the snippet declared them so entry 0 is the one the still frame drew.
+   */
+  fun previewManifestJson(snippet: PlaygroundTokenStore.PlaygroundSnippet): String {
+    val manifest =
+      PreviewManifest(
+        module = snippet.moduleName,
+        variant = "",
+        // EVERY preview the snippet declared, not just the one the still frame drew. The daemon
+        // resolves a streamed preview by looking it up here, so an id absent from this list is one
+        // the live session can never show — which is what limited a redeemed snippet to a single
+        // preview no matter how many it compiled.
+        previews =
+          snippet.previewIds.map { id ->
+            PreviewInfo(
+              id = id,
+              functionName = id.substringAfterLast('.'),
+              className = id.substringBeforeLast('.'),
+            )
+          },
+      )
+    return json.encodeToString(PreviewManifest.serializer(), manifest)
+  }
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSandbox.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSandbox.kt
@@ -1,0 +1,562 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import kotlin.math.ceil
+import kotlin.math.roundToInt
+
+/**
+ * The playground's **per-session sandbox** policy — Phase 4 of
+ * [docs/design/PLAYGROUND.md](../../../../../../../../docs/design/PLAYGROUND.md) §6, the gate
+ * between a token-gated internal tool and a playground open under `--public`.
+ *
+ * Every playground lane already runs a snippet in its **own child JVM** (the first-frame render,
+ * the remote-compose capture, and the Stage-2 live session each spawn a fresh daemon subprocess
+ * over that snippet's classes — never a hot-swap into a shared, long-lived daemon). What this type
+ * adds is the containment around that child:
+ * - **an argv prefix** ([command]) that launches the JVM inside an OS jail — no network namespace,
+ *   a read-only view of the host, a scrubbed environment;
+ * - **JVM-level caps** ([jvmArgs]) that bound heap, CPU parallelism and temp files even on a
+ *   profile whose jail carries no cgroup;
+ * - **a hard wall-clock TTL** ([ttlSeconds]) the spawner arms as a `destroyForcibly` watchdog, so a
+ *   snippet that wedges its JVM is killed rather than lingering to its token's expiry.
+ *
+ * The type is pure: it computes argv and never spawns anything, so every profile's containment is
+ * unit-testable without the tool being installed. Whether a configured sandbox *actually* contains
+ * anything is a separate, empirical question answered by [PlaygroundSandboxProbe] — and under
+ * `--public` a passing probe is mandatory ([PlaygroundPublicGate]), because a profile's advertised
+ * properties are a claim and the probe is the evidence.
+ */
+data class PlaygroundSandbox(
+  val profile: Profile,
+  /** Heap + cgroup memory ceiling for one snippet JVM. */
+  val memoryMb: Int = DEFAULT_MEMORY_MB,
+  /** CPU budget for one snippet JVM: a cgroup `CPUQuota` and `-XX:ActiveProcessorCount`. */
+  val cpus: Double = DEFAULT_CPUS,
+  /** Task/pid ceiling, so a snippet can't fork-bomb the box. */
+  val pids: Int = DEFAULT_PIDS,
+  /** Hard wall-clock lifetime of one snippet JVM, enforced by kill — not by cooperation. */
+  val ttlSeconds: Long = DEFAULT_TTL_SECONDS,
+  /**
+   * Extra host paths the jail binds **read-only**, on top of the snippet's classpath and the JDK.
+   * The escape hatch for caches a render legitimately reads with no network to fetch them (the
+   * Robolectric `android-all` cache, the downloadable-font cache).
+   */
+  val extraReadOnlyPaths: List<String> = emptyList(),
+  /** Operator-supplied argv for [Profile.CUSTOM]; ignored by every other profile. */
+  val customCommand: List<String> = emptyList(),
+  /**
+   * Set by [droppingJail] when the configured jail **cannot launch on this host** and the lane was
+   * admitted on something other than containment. [command] then yields no argv while every other
+   * cap stays on — see that function for why this state exists at all.
+   */
+  val jailDropped: Boolean = false,
+) {
+
+  /**
+   * How the child JVM is jailed. The `declares…` flags are the profile's **claim** about what its
+   * jail provides — used for startup logging and for the "you asked for `--public` with no
+   * containment at all" refusal. They are never a substitute for [PlaygroundSandboxProbe]; a
+   * `--public` host must still prove the claim empirically.
+   */
+  enum class Profile(
+    val id: String,
+    val declaresEgressBlocked: Boolean,
+    val declaresFilesystemContained: Boolean,
+    val declaresResourceCaps: Boolean,
+  ) {
+    /**
+     * No jail — the pre-Phase-4 behaviour. Fine for a token-gated dev host; never for `--public`.
+     */
+    NONE("none", false, false, false),
+
+    /**
+     * `unshare(1)`: a fresh user + network + pid namespace, child killed with the parent. Blocks
+     * egress and process visibility with no privileges and no extra package, but leaves the host
+     * filesystem visible — so it is a good local default and **not** enough for `--public`.
+     */
+    UNSHARE("unshare", true, false, false),
+
+    /**
+     * `bwrap(1)` (bubblewrap): network unshared, environment cleared, the host bound **read-only**
+     * with a tmpfs `/tmp` and exactly one writable path (the snippet's work dir). Containment
+     * without cgroups — heap/CPU come from [jvmArgs].
+     */
+    BWRAP("bwrap", true, true, false),
+
+    /**
+     * `systemd-run --scope` with `MemoryMax` / `MemorySwapMax` / `CPUQuota` / `TasksMax`. Real
+     * cgroup caps — and **only** cgroup caps.
+     *
+     * A transient **scope** takes cgroup resource properties but *not* service execution settings
+     * (`PrivateNetwork`, `PrivateTmp`, `ProtectSystem`, `NoNewPrivileges`): those live in a service
+     * unit's exec context, and passing them to `--scope` fails unit creation outright. Rather than
+     * move the daemon into a transient service — which would put systemd between us and the JVM's
+     * stdio, the JSON-RPC transport — this profile owns resource control alone and delegates
+     * isolation to [STRICT]'s `bwrap` half. Hence: no egress or filesystem claim here.
+     */
+    SYSTEMD("systemd", false, false, true),
+
+    /**
+     * `systemd-run --scope … bwrap …` — [SYSTEMD]'s cgroup caps around [BWRAP]'s namespace and
+     * filesystem containment. The profile a `--public` host should run: it is the only built-in
+     * that provides every property [PlaygroundPublicGate] requires.
+     */
+    STRICT("strict", true, true, true),
+
+    /**
+     * An operator-supplied argv prefix. Claims nothing — a `--public` host running `custom` is
+     * admitted purely on its probe result.
+     */
+    CUSTOM("custom", false, false, false),
+  }
+
+  /** The host paths one snippet JVM needs: its writable work dir, its read-only inputs, the JDK. */
+  data class Paths(val workDir: File, val readOnly: List<File>, val javaHome: File)
+
+  /** True when this sandbox does anything at all — [Profile.NONE] is the only no-op. */
+  val isActive: Boolean
+    get() = profile != Profile.NONE
+
+  /**
+   * Drop the jail argv but keep every other cap — the recovery for a configured jail that cannot
+   * launch on this host (`unshare` under a seccomp/AppArmor policy that forbids user namespaces,
+   * `bwrap` absent from the image).
+   *
+   * Without this, that host is *silently broken*: [PlaygroundPublicGate] admits the lane on the
+   * repo-access posture, `/playground` answers normally, and then every snippet JVM and every
+   * jailed compile fails to spawn because they all launch behind an argv that returns EPERM. The
+   * failure surfaces to a user as a compile that never produces an image, and to an operator as
+   * nothing at all.
+   *
+   * Dropping the jail is better than both alternatives *for a profile whose caps are JVM-level*.
+   * Against *keeping* it: a jail that cannot launch contains nothing, so there is no isolation to
+   * lose. Against *disabling the sandbox entirely* ([Profile.NONE]): that would also discard
+   * `-Xmx`, the CPU cap, `ExitOnOutOfMemoryError`, the temp-dir confinement and the hard TTL — and
+   * on a host with a large cgroup limit an uncapped snippet JVM sizes its default heap at a quarter
+   * of that limit, which is the more dangerous failure of the two.
+   *
+   * **Not for [Profile.SYSTEMD] or [Profile.STRICT].** Their `MemoryMax` / `CPUQuota` / `TasksMax`
+   * are enforced by the `systemd-run` prefix that [command] emits, so dropping the argv drops the
+   * enforcement with it, leaving only heap and JVM pool sizing — no native-memory bound, no CPU
+   * quota, no pid cap. `ServeCommand` therefore refuses the lane outright for any profile with
+   * [Profile.declaresResourceCaps] rather than calling this. A [Profile.CUSTOM] argv may also have
+   * supplied caps we cannot see; it is dropped anyway (the alternative is a lane that cannot run at
+   * all) and the startup warning says so.
+   *
+   * Deliberately **not** reachable when containment is what admitted the lane: an anonymous
+   * `--public` host whose probe never ran is refused outright by [PlaygroundPublicGate], so the
+   * caller never gets far enough to call this.
+   */
+  fun droppingJail(): PlaygroundSandbox = copy(jailDropped = true)
+
+  /**
+   * The argv prefix the snippet JVM launches behind — empty for [Profile.NONE], and empty when
+   * [jailDropped]. Paths are bound with the `-try` variants where a host may legitimately lack
+   * them, so one missing `/lib64` can't turn a containment profile into a failed spawn.
+   */
+  fun command(paths: Paths): List<String> =
+    if (jailDropped) emptyList()
+    else
+      when (profile) {
+        Profile.NONE -> emptyList()
+        Profile.UNSHARE -> unshareCommand()
+        Profile.BWRAP -> bwrapCommand(paths)
+        Profile.SYSTEMD -> systemdCommand()
+        Profile.STRICT -> systemdCommand() + bwrapCommand(paths)
+        Profile.CUSTOM -> customCommand
+      }
+
+  /**
+   * JVM-level caps applied to **every** active profile, so heap and CPU are bounded even where the
+   * jail carries no cgroup (`unshare`, `bwrap`): a heap ceiling under the sandbox's memory budget,
+   * a CPU-parallelism ceiling matching its CPU budget, OOM as a *process exit* rather than a
+   * thrashing JVM, and a temp dir inside the one writable path. Empty for [Profile.NONE], which
+   * keeps the pre-Phase-4 launch byte-identical.
+   */
+  fun jvmArgs(workDir: File): List<String> {
+    if (!isActive) return emptyList()
+    return listOf(
+      "-Xmx${heapMb()}m",
+      "-XX:ActiveProcessorCount=${activeProcessorCount()}",
+      "-XX:+ExitOnOutOfMemoryError",
+      // The session work dir is the one writable path in the jail — and it is deleted with the
+      // snippet's token, so a snippet's temp files are ephemeral by construction.
+      "-Djava.io.tmpdir=${workDir.absolutePath}",
+    )
+  }
+
+  /**
+   * Add the host Maven repository to a jailed Robolectric launch explicitly. Bwrap replaces `HOME`
+   * with [Paths.workDir], so Robolectric's default `user.home/.m2/repository` lookup points at an
+   * empty ephemeral directory even when the operator exposed the real cache with
+   * `--playground-sandbox-ro`. `maven.repo.local` is Robolectric's supported override and remains
+   * readable through that read-only bind.
+   *
+   * Inactive sandboxes return [base] unchanged, preserving the pre-sandbox launch byte-for-byte.
+   * Relative `maven.repo.local` overrides are made absolute before the jail changes directory.
+   */
+  fun robolectricSystemProperties(
+    base: Map<String, String>,
+    mavenRepoLocal: String? = System.getProperty("maven.repo.local"),
+    userHome: String? = System.getProperty("user.home"),
+  ): Map<String, String> {
+    if (!isActive) return base
+    val repository =
+      mavenRepoLocal?.takeIf { it.isNotBlank() }?.let(::File)
+        ?: userHome?.takeIf { it.isNotBlank() }?.let { File(it, ".m2/repository") }
+        ?: return base
+    return base + ("maven.repo.local" to repository.absolutePath)
+  }
+
+  /**
+   * Heap ceiling: three quarters of the memory budget, leaving room for the JVM's own non-heap
+   * footprint (metaspace, code cache, Skiko/Robolectric native allocations) under a cgroup that
+   * would otherwise OOM-kill the process before the heap limit ever bit.
+   */
+  internal fun heapMb(): Int = (memoryMb * 3 / 4).coerceAtLeast(MIN_HEAP_MB)
+
+  internal fun activeProcessorCount(): Int = ceil(cpus).toInt().coerceAtLeast(1)
+
+  /** One-line summary for the startup log — what this host will do to a stranger's snippet. */
+  fun describe(): String =
+    if (!isActive) "sandbox=none (playground refused under --public)"
+    else
+      "sandbox=${profile.id}${if (jailDropped) " (jail dropped — caps only)" else ""} " +
+        "mem=${memoryMb}MB heap=${heapMb()}MB cpus=$cpus pids=$pids ttl=${ttlSeconds}s"
+
+  private fun unshareCommand(): List<String> =
+    listOf(
+      "unshare",
+      // A fresh user namespace is what lets an unprivileged serve host create the others.
+      "--user",
+      "--map-root-user",
+      // The whole point: no route to anything. A snippet gets loopback in an empty netns.
+      "--net",
+      // Own pid namespace + /proc, so a snippet can neither see nor signal host processes.
+      "--pid",
+      "--fork",
+      "--mount-proc",
+      // The daemon dies with the serve host; no orphan JVM survives a crash.
+      "--kill-child",
+    )
+
+  private fun bwrapCommand(paths: Paths): List<String> = buildList {
+    add("bwrap")
+    add("--die-with-parent")
+    add("--unshare-all")
+    // Redundant under --unshare-all, but egress is the property we most want to be explicit about.
+    add("--unshare-net")
+    add("--new-session")
+    // The serve JVM's environment carries operator secrets (--admin-token, cloud credentials); a
+    // snippet must not be able to read them out of /proc/self/environ.
+    add("--clearenv")
+    add("--setenv")
+    add("HOME")
+    add(paths.workDir.absolutePath)
+    add("--setenv")
+    add("PATH")
+    add("/usr/bin:/bin")
+    add("--setenv")
+    add("LANG")
+    add("C.UTF-8")
+    add("--proc")
+    add("/proc")
+    add("--dev")
+    add("/dev")
+    add("--tmpfs")
+    add("/tmp")
+    SYSTEM_READ_ONLY_PATHS.forEach { roBindTry(it) }
+    roBindTry(paths.javaHome.absolutePath)
+    // The classpath (catalog jars + the compiled snippet) and any operator-declared cache. Bound
+    // one entry at a time rather than by common ancestor: an ancestor bind would hand the snippet
+    // every *other* jar in the Gradle/Maven cache too.
+    (paths.readOnly.map { it.absolutePath } + extraReadOnlyPaths).distinct().forEach {
+      roBindTry(it)
+    }
+    // Exactly one writable path — and it is deleted with the snippet's token.
+    add("--bind")
+    add(paths.workDir.absolutePath)
+    add(paths.workDir.absolutePath)
+    add("--chdir")
+    add(paths.workDir.absolutePath)
+    add("--")
+  }
+
+  private fun MutableList<String>.roBindTry(path: String) {
+    add("--ro-bind-try")
+    add(path)
+    add(path)
+  }
+
+  private fun systemdCommand(): List<String> =
+    listOf(
+      "systemd-run",
+      "--scope",
+      "--quiet",
+      "--collect",
+      "-p",
+      "MemoryMax=${memoryMb}M",
+      "-p",
+      "MemorySwapMax=0",
+      "-p",
+      "CPUQuota=${(cpus * 100).roundToInt()}%",
+      "-p",
+      "TasksMax=$pids",
+      // Deliberately cgroup properties only. `PrivateNetwork` / `PrivateTmp` / `ProtectSystem` /
+      // `NoNewPrivileges` are service exec-context settings that a transient *scope* cannot take —
+      // passing them fails unit creation, so a profile that advertised them would fail preflight on
+      // every host. Isolation is bwrap's job (STRICT); the wall-clock deadline is the spawner's
+      // kill watchdog, which needs no systemd version floor (`RuntimeMaxSec` on a scope wants
+      // systemd 244+).
+    )
+
+  companion object {
+    const val DEFAULT_MEMORY_MB = 1536
+    const val DEFAULT_CPUS = 1.0
+    const val DEFAULT_PIDS = 256
+
+    /**
+     * 15 minutes: comfortably longer than [PlaygroundTokenStore.DEFAULT_TTL_SECONDS] (so an
+     * ordinary session ends by its token expiring, not by being shot), short enough that a wedged
+     * JVM is reclaimed the same hour.
+     */
+    const val DEFAULT_TTL_SECONDS = 900L
+
+    /** Below this a JVM can't even boot Skiko/Robolectric; refuse to configure a useless heap. */
+    const val MIN_HEAP_MB = 256
+
+    private const val MIN_MEMORY_MB = 384
+
+    /**
+     * Host paths a JVM needs to exec at all; `-try` because layouts differ (usr-merge, musl…).
+     *
+     * `/nix/store` is on the list for a reason worth writing down: a Nix-provisioned JDK's
+     * `bin/java` resolves its ELF interpreter and libc out of *other* store paths, so binding only
+     * `java.home` produces `execvp … No such file or directory` inside the jail. The store is
+     * immutable and world-readable, so binding it read-only costs nothing where it exists and is a
+     * no-op everywhere else.
+     */
+    private val SYSTEM_READ_ONLY_PATHS =
+      listOf(
+        "/usr",
+        "/lib",
+        "/lib64",
+        "/bin",
+        "/etc/alternatives",
+        "/etc/ssl/certs",
+        "/nix/store",
+        "/opt",
+      )
+
+    val NONE = PlaygroundSandbox(profile = Profile.NONE)
+
+    /**
+     * Parse a `--playground-sandbox` value: a profile id (`none`, `unshare`, `bwrap`, `systemd`,
+     * `strict`) or `custom:<argv>` where `<argv>` is a whitespace-separated command prefix. Null or
+     * blank ⇒ [NONE], the pre-Phase-4 default.
+     */
+    fun parseProfile(spec: String?): Result<PlaygroundSandbox> {
+      val raw = spec?.trim().orEmpty()
+      if (raw.isEmpty()) return Result.success(NONE)
+      if (raw.startsWith("custom:")) {
+        val argv =
+          raw.removePrefix("custom:").trim().split(Regex("\\s+")).filter { it.isNotBlank() }
+        if (argv.isEmpty()) {
+          return Result.failure(
+            IllegalArgumentException("--playground-sandbox custom:<argv> needs a command")
+          )
+        }
+        return Result.success(PlaygroundSandbox(profile = Profile.CUSTOM, customCommand = argv))
+      }
+      val profile =
+        Profile.entries.firstOrNull { it.id == raw.lowercase() && it != Profile.CUSTOM }
+          ?: return Result.failure(
+            IllegalArgumentException(
+              "unknown --playground-sandbox profile '$raw' — expected one of " +
+                Profile.entries.filter { it != Profile.CUSTOM }.joinToString(", ") { it.id } +
+                ", or custom:<argv>"
+            )
+          )
+      return Result.success(PlaygroundSandbox(profile = profile))
+    }
+
+    /**
+     * Validate the resource knobs, so a typo (`--playground-sandbox-memory-mb 15`) fails at startup
+     * rather than as an unexplained daemon that never comes up.
+     */
+    fun validate(sandbox: PlaygroundSandbox): Result<PlaygroundSandbox> {
+      if (!sandbox.isActive) return Result.success(sandbox)
+      if (sandbox.memoryMb < MIN_MEMORY_MB) {
+        return Result.failure(
+          IllegalArgumentException(
+            "--playground-sandbox-memory-mb must be at least $MIN_MEMORY_MB (got ${sandbox.memoryMb})"
+          )
+        )
+      }
+      if (sandbox.cpus <= 0.0) {
+        return Result.failure(
+          IllegalArgumentException("--playground-sandbox-cpus must be > 0 (got ${sandbox.cpus})")
+        )
+      }
+      if (sandbox.pids < 16) {
+        return Result.failure(
+          IllegalArgumentException(
+            "--playground-sandbox-pids must be at least 16 (got ${sandbox.pids})"
+          )
+        )
+      }
+      if (sandbox.ttlSeconds !in 30..24 * 3600) {
+        return Result.failure(
+          IllegalArgumentException(
+            "--playground-sandbox-ttl must be between 30s and 24h (got ${sandbox.ttlSeconds}s)"
+          )
+        )
+      }
+      return Result.success(sandbox)
+    }
+  }
+}
+
+/**
+ * The `--public` admission decision for the playground lane — the literal "gate" of PLAYGROUND.md
+ * §6 and issue #3016.
+ *
+ * Before Phase 4 this was a flat refusal: `--playground-bundle` under `--public` disabled the lane,
+ * because the serve host's founding constraint is that it never runs untrusted code. The constraint
+ * has not moved; what changed is that a snippet can now be run somewhere that *isn't* the host. So
+ * the gate opens on evidence, never on configuration alone:
+ * 1. a sandbox profile must be configured (`none` is still a flat refusal),
+ * 2. the startup [probe][PlaygroundSandboxProbe] must have run **inside that jail** and come back
+ *    with egress blocked, the host filesystem contained, and the process namespace isolated, and
+ * 3. the jail must actually **cap CPU and process count**, which the probe cannot measure. A
+ *    snippet inside a perfectly sealed `bwrap` can still spawn CPU-bound threads until it starves
+ *    the box: `-Xmx` bounds heap and `-XX:ActiveProcessorCount` only sizes JVM pools. So a built-in
+ *    profile with no cgroup behind it (`unshare`, `bwrap`) is refused under `--public` and pointed
+ *    at `strict`; a `custom:` jail is taken at its word here (its caps are the operator's to
+ *    supply) but still has to pass the probe.
+ *
+ * A profile that merely *claims* containment ([PlaygroundSandbox.Profile.declaresEgressBlocked] and
+ * friends) is not enough: `bwrap` on a kernel with user namespaces disabled, or a `custom:` wrapper
+ * with a typo, both claim everything and contain nothing. Fail-closed in every direction — an
+ * absent probe report is a refusal, not a pass.
+ *
+ * ## Two admission postures (issue #3210)
+ *
+ * The chain above answers "is a **stranger's** snippet contained?". That is the right question only
+ * when a stranger can actually reach the lane. All three playground surfaces (`/playground`, `POST
+ * /api/{v}/compiler/run`, `/pg/{token}`) already reject a caller who is not a signed-in GitHub user
+ * *with **write** access to `--github-auth-repo`* (#3313) — so on a box with GitHub auth
+ * configured, the code being compiled comes from someone who can already push to the repo whose CI
+ * builds this image. That is the same trust level as the token-gated posture Phases 1–3 shipped
+ * under, where the gate returns `Allow` with no sandbox at all.
+ *
+ * So [decide] takes [repoAccessGated] as a second, independent basis for admission:
+ * - **contained** — `--public`, anyone may call, the jail is proved: the evidence chain above;
+ * - **repo-access-gated** — `--public`, but only repo collaborators may call: admitted, with the
+ *   sandbox still applied when configured (defence in depth, no longer a precondition).
+ *
+ * The one combination that is never admitted is *anonymous **and** uncontained* — the refusal now
+ * names both remedies rather than only the sandbox one (issue #3214). [Decision.Allow.detail] says
+ * which posture admitted the lane, so an operator cannot mistake "admitted because collaborators
+ * only" for "admitted because contained".
+ */
+object PlaygroundPublicGate {
+
+  sealed interface Decision {
+    /** The lane may serve; [detail] is the startup log line. */
+    data class Allow(val detail: String) : Decision
+
+    /** The lane stays disabled; [reason] is printed and is actionable. */
+    data class Refuse(val reason: String) : Decision
+  }
+
+  /**
+   * Decide whether the playground may serve. [isPublic] false ⇒ always allowed (the token-gated
+   * posture Phases 1–3 shipped under), and the sandbox — configured or not — is still applied.
+   *
+   * [repoAccessGated] is true when the host has GitHub auth configured, i.e. when the playground
+   * routes' `rejectMissingGithubRepoAccess` is a real check rather than a no-op. It admits the lane
+   * on a public box without requiring containment — see the class KDoc.
+   */
+  fun decide(
+    isPublic: Boolean,
+    repoAccessGated: Boolean,
+    sandbox: PlaygroundSandbox,
+    probe: PlaygroundSandboxProbe.Report?,
+  ): Decision {
+    if (!isPublic) {
+      return Decision.Allow(
+        if (sandbox.isActive) "token-gated; ${sandbox.describe()}"
+        else "token-gated; no sandbox (add --playground-sandbox to rehearse the public posture)"
+      )
+    }
+    // Posture 2: the routes admit only repo collaborators, so the containment evidence chain below
+    // is answering a question nobody is asking. The sandbox stays applied when configured — it is
+    // now defence in depth rather than the precondition.
+    if (repoAccessGated) {
+      return Decision.Allow(
+        "public host, repo-access-gated (GitHub sign-in with write access to --github-auth-repo); " +
+          if (sandbox.isActive) "${sandbox.describe()} — defence in depth, not the admission basis"
+          else
+            "no sandbox — a collaborator's snippet runs unconfined on this host " +
+              "(add --playground-sandbox for defence in depth)"
+      )
+    }
+    if (!sandbox.isActive) {
+      // Anonymous AND uncontained: the one combination that never serves. Name both remedies —
+      // configuring GitHub auth is the cheaper one on a box that cannot jail a snippet (#3214).
+      return Decision.Refuse(
+        "--playground-bundle / --playground-android-bundle under --public need EITHER GitHub " +
+          "repo-access gating (--github-auth-client-id / --github-auth-client-secret / " +
+          "--github-auth-cookie-secret / --github-auth-repo), which limits the lane to repo " +
+          "collaborators, OR a per-session sandbox: --playground-sandbox " +
+          "<bwrap|strict|systemd|unshare|custom:…>. With neither, an anonymous stranger's snippet " +
+          "would run unconfined on the server (PLAYGROUND.md §6)."
+      )
+    }
+    if (probe == null) {
+      return Decision.Refuse(
+        "playground sandbox preflight did not run — refusing to serve the playground under " +
+          "--public on an unverified sandbox."
+      )
+    }
+    if (!probe.ran) {
+      return Decision.Refuse(
+        "playground sandbox preflight could not launch the jail (${probe.detail}) — is " +
+          "'${sandbox.profile.id}' installed and permitted on this host?"
+      )
+    }
+    val failures = probe.failedChecks()
+    if (failures.isNotEmpty()) {
+      return Decision.Refuse(
+        "playground sandbox preflight failed under profile '${sandbox.profile.id}': " +
+          failures.joinToString("; ") +
+          ". The playground stays disabled under --public until the jail contains a snippet."
+      )
+    }
+    // Containment proven — but the probe cannot measure CPU or process-count caps, and a sealed
+    // jail with none of those still lets a snippet burn the box down from the inside.
+    if (
+      !sandbox.profile.declaresResourceCaps && sandbox.profile != PlaygroundSandbox.Profile.CUSTOM
+    ) {
+      return Decision.Refuse(
+        "profile '${sandbox.profile.id}' contains a snippet but applies no CPU or process-count " +
+          "cap, so one snippet can still starve the box (-Xmx bounds heap only). Use " +
+          "--playground-sandbox strict (cgroup caps around the same jail), or a custom: jail that " +
+          "applies its own caps."
+      )
+    }
+    val caveat =
+      if (
+        sandbox.profile == PlaygroundSandbox.Profile.CUSTOM && !sandbox.profile.declaresResourceCaps
+      )
+        " (resource caps are the custom jail's responsibility — verify MemoryMax/CPUQuota/TasksMax " +
+          "or equivalent yourself)"
+      else ""
+    return Decision.Allow(
+      "public and ANONYMOUS (no GitHub auth configured); verified ${sandbox.describe()}$caveat. " +
+        "Admitted on containment alone — configure --github-auth-repo to also bound who can " +
+        "reach the lane."
+    )
+  }
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSandboxProbe.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSandboxProbe.kt
@@ -1,0 +1,268 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.util.concurrent.TimeUnit
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * The empirical half of the Phase-4 gate: launch a **throwaway JVM inside the configured jail** and
+ * have it report what it can still reach. [PlaygroundPublicGate] admits the playground under
+ * `--public` only on a clean report, so "is this box sandboxed?" is answered by measurement rather
+ * than by trusting a profile name or an operator's `custom:` argv.
+ *
+ * The probe deliberately runs the **same launch shape** a snippet gets — same jail argv, same JDK,
+ * same read-only classpath binds, same writable work dir — so a jail that would break a real render
+ * (no `/lib64` bound, `bwrap` blocked by a hardened kernel) fails preflight loudly at startup
+ * instead of silently degrading every playground run to "no image".
+ *
+ * Four checks, each a property the sandbox exists to provide:
+ * - **egress blocked** — a snippet must not be able to reach the network from the serve box.
+ * - **filesystem contained** — a canary file the parent creates *outside* the jail's bind set must
+ *   be invisible to the child.
+ * - **process isolated** — the serve host's own pid must not be visible in the child's `/proc`.
+ * - **work dir writable** — the containment must not be so total that a real render can't run.
+ */
+object PlaygroundSandboxProbe {
+
+  /**
+   * The single line the in-jail probe prints, so ordinary JVM noise on stdout can't be mistaken.
+   */
+  const val REPORT_PREFIX = "PLAYGROUND_SANDBOX_PROBE "
+
+  /** Main class of the in-jail probe; spawned as `java -cp <cli classpath> <this>`. */
+  const val PROBE_MAIN_CLASS = "ee.schimke.composeai.cli.serve.PlaygroundSandboxProbeMain"
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  /**
+   * What the child observed. [ran] false means the jail never produced a report at all (the tool is
+   * missing, the kernel refused the namespace, the JVM died) — a refusal, not a pass; the checks
+   * are then meaningless and left false.
+   */
+  @Serializable
+  data class Report(
+    val ran: Boolean = false,
+    val detail: String = "",
+    val egressBlocked: Boolean = false,
+    val filesystemContained: Boolean = false,
+    val processIsolated: Boolean = false,
+    val workDirWritable: Boolean = false,
+  ) {
+    /** Human-readable list of the properties this jail failed to provide; empty ⇒ clean. */
+    fun failedChecks(): List<String> = buildList {
+      if (!ran) add("the probe JVM never reported")
+      if (!egressBlocked) add("outbound network reachable from inside the sandbox")
+      if (!filesystemContained) add("host files outside the session work dir are readable")
+      if (!processIsolated) add("host processes are visible from inside the sandbox")
+      if (!workDirWritable) add("the session work dir is not writable (a render could not run)")
+    }
+
+    fun summary(): String =
+      if (!ran) "sandbox preflight did not run: $detail"
+      else
+        "sandbox preflight: egressBlocked=$egressBlocked filesystemContained=$filesystemContained " +
+          "processIsolated=$processIsolated workDirWritable=$workDirWritable"
+  }
+
+  /** One spawned probe's raw outcome; injected in tests instead of forking a JVM. */
+  data class Launch(val exitCode: Int, val stdout: String, val stderr: String)
+
+  /**
+   * Run the preflight for [sandbox].
+   *
+   * @param javaHome the JDK the snippet JVMs launch from (bound read-only into the jail).
+   * @param classpath the CLI's own classpath — the probe main lives in it, and binding it is also
+   *   the closest analogue of a snippet's catalog classpath.
+   * @param workRoot the playground work root; the probe gets a fresh writable dir under it.
+   * @param launcher spawns argv and returns its outcome; defaults to a real subprocess.
+   */
+  fun run(
+    sandbox: PlaygroundSandbox,
+    javaHome: File,
+    classpath: List<String>,
+    workRoot: File,
+    timeoutSeconds: Long = DEFAULT_TIMEOUT_SECONDS,
+    launcher: (List<String>, File) -> Launch = ::spawn,
+  ): Report {
+    if (!sandbox.isActive) return Report(ran = false, detail = "no sandbox profile configured")
+    if (classpath.isEmpty()) {
+      return Report(ran = false, detail = "the serve process reported an empty classpath")
+    }
+    val probeDir = File(workRoot, "sandbox-probe").apply { deleteRecursively() }
+    val canaryDir = File(workRoot, "sandbox-probe-canary").apply { deleteRecursively() }
+    return try {
+      probeDir.mkdirs()
+      canaryDir.mkdirs()
+      // The canary lives OUTSIDE everything the jail is told to bind. A child that can read it has
+      // the run of the host filesystem.
+      val canary = File(canaryDir, "canary.txt").apply { writeText("playground-sandbox-canary") }
+      val javaBin = File(javaHome, "bin/java").absolutePath
+      val argv =
+        sandbox.command(
+          PlaygroundSandbox.Paths(
+            workDir = probeDir,
+            readOnly = classpath.map { File(it) },
+            javaHome = javaHome,
+          )
+        ) +
+          listOf(
+            javaBin,
+            "-XX:+ExitOnOutOfMemoryError",
+            "-Xmx${PlaygroundSandbox.MIN_HEAP_MB}m",
+            "-cp",
+            classpath.joinToString(File.pathSeparator),
+            PROBE_MAIN_CLASS,
+            probeDir.absolutePath,
+            canary.absolutePath,
+            ProcessHandle.current().pid().toString(),
+          )
+      val launch =
+        try {
+          launcher(argv, probeDir)
+        } catch (e: Exception) {
+          return Report(
+            ran = false,
+            detail =
+              "could not launch '${argv.firstOrNull()}': ${e.message ?: e.javaClass.simpleName}",
+          )
+        }
+      parse(launch)
+    } catch (e: Exception) {
+      Report(ran = false, detail = "preflight failed: ${e.message ?: e.javaClass.simpleName}")
+    } finally {
+      runCatching { probeDir.deleteRecursively() }
+      runCatching { canaryDir.deleteRecursively() }
+    }
+  }
+
+  /** Pull the report line out of a launch's stdout, or explain why there wasn't one. */
+  internal fun parse(launch: Launch): Report {
+    val line = launch.stdout.lineSequence().firstOrNull { it.startsWith(REPORT_PREFIX) }
+    if (line == null) {
+      val why =
+        launch.stderr.lineSequence().filter { it.isNotBlank() }.lastOrNull()
+          ?: "exit code ${launch.exitCode}, no output"
+      return Report(ran = false, detail = why.take(400))
+    }
+    return try {
+      json.decodeFromString(Report.serializer(), line.removePrefix(REPORT_PREFIX)).copy(ran = true)
+    } catch (e: Exception) {
+      Report(
+        ran = false,
+        detail = "unreadable probe report: ${e.message ?: e.javaClass.simpleName}",
+      )
+    }
+  }
+
+  private fun spawn(argv: List<String>, workDir: File): Launch {
+    val process =
+      ProcessBuilder(argv)
+        .directory(workDir)
+        .redirectOutput(ProcessBuilder.Redirect.PIPE)
+        .redirectError(ProcessBuilder.Redirect.PIPE)
+        .start()
+    val out = StringBuilder()
+    val err = StringBuilder()
+    val outThread = drain(process.inputStream, out, "playground-probe-stdout")
+    val errThread = drain(process.errorStream, err, "playground-probe-stderr")
+    val finished = process.waitFor(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+    if (!finished) {
+      process.destroyForcibly()
+      process.waitFor(5, TimeUnit.SECONDS)
+    }
+    outThread.join(2_000)
+    errThread.join(2_000)
+    return Launch(
+      exitCode = if (finished) process.exitValue() else -1,
+      stdout = out.toString(),
+      stderr =
+        if (finished) err.toString() else "probe timed out after ${DEFAULT_TIMEOUT_SECONDS}s",
+    )
+  }
+
+  private fun drain(stream: java.io.InputStream, into: StringBuilder, name: String): Thread =
+    Thread(
+        {
+          runCatching {
+            stream.bufferedReader().forEachLine { synchronized(into) { into.appendLine(it) } }
+          }
+        },
+        name,
+      )
+      .apply {
+        isDaemon = true
+        start()
+      }
+
+  /** A cold JVM inside a fresh namespace; generous, but the whole preflight is once per startup. */
+  const val DEFAULT_TIMEOUT_SECONDS = 60L
+}
+
+/**
+ * The in-jail half of [PlaygroundSandboxProbe]: runs *inside* the sandbox, measures what it can
+ * still reach, prints one [PlaygroundSandboxProbe.Report] line, and exits. Deliberately dependency-
+ * free beyond the CLI jar itself, because it must start under the tightest jail the operator can
+ * build (cleared environment, read-only host, empty network namespace).
+ *
+ * `argv`: `<writable work dir> <canary path outside the jail> <serve host pid>`.
+ */
+object PlaygroundSandboxProbeMain {
+
+  @JvmStatic
+  fun main(args: Array<String>) {
+    val workDir = File(args.getOrElse(0) { "." })
+    val canary = File(args.getOrElse(1) { "/nonexistent-canary" })
+    val hostPid = args.getOrNull(2)?.toLongOrNull()
+    val report = probe(workDir, canary, hostPid)
+    println(
+      PlaygroundSandboxProbe.REPORT_PREFIX +
+        Json.encodeToString(PlaygroundSandboxProbe.Report.serializer(), report)
+    )
+  }
+
+  /** Exposed for tests: the same measurement, without the process/stdout wrapper. */
+  fun probe(workDir: File, canary: File, hostPid: Long?): PlaygroundSandboxProbe.Report =
+    PlaygroundSandboxProbe.Report(
+      ran = true,
+      detail = "probed from pid ${ProcessHandle.current().pid()}",
+      egressBlocked = egressBlocked(),
+      filesystemContained = !canReadCanary(canary),
+      // With no host pid to look for, treat isolation as unproven rather than proven.
+      processIsolated = hostPid != null && !File("/proc/$hostPid").exists(),
+      workDirWritable = workDirWritable(workDir),
+    )
+
+  /**
+   * Every probe target must be unreachable. Routable, well-known addresses (no DNS — resolution
+   * would hang rather than fail in an empty netns, and a blocked resolver is not the property we're
+   * testing). A single successful connect means the sandbox leaks egress.
+   */
+  private fun egressBlocked(): Boolean = EGRESS_TARGETS.none { (host, port) ->
+    runCatching {
+        Socket().use { it.connect(InetSocketAddress(host, port), EGRESS_TIMEOUT_MILLIS) }
+        true
+      }
+      .getOrDefault(false)
+  }
+
+  private fun canReadCanary(canary: File): Boolean = runCatching {
+    canary.readText().isNotEmpty()
+  }
+    .getOrDefault(false)
+
+  private fun workDirWritable(workDir: File): Boolean = runCatching {
+    val probeFile = File(workDir, "writable.probe")
+    probeFile.writeText("ok")
+    val readBack = probeFile.readText() == "ok"
+    probeFile.delete()
+    readBack
+  }
+    .getOrDefault(false)
+
+  private val EGRESS_TARGETS = listOf("1.1.1.1" to 443, "8.8.8.8" to 53, "93.184.216.34" to 80)
+
+  private const val EGRESS_TIMEOUT_MILLIS = 2_000
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundTokenStore.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundTokenStore.kt
@@ -1,0 +1,219 @@
+package ee.schimke.composeai.cli.serve
+
+import java.security.SecureRandom
+import java.util.Base64
+import java.util.concurrent.ConcurrentHashMap
+import okio.FileSystem
+import okio.Path
+
+/**
+ * The expiring **preview-token** capability behind `/pg/<token>` — the Stage-1 → Stage-2 handoff in
+ * [docs/design/PLAYGROUND.md](../../../../../../../../docs/design/PLAYGROUND.md).
+ *
+ * Sibling of [ServeDocStore]: where that holds a client-uploaded *document* and hands back a
+ * `/d/<id>` playback link, this holds a **just-compiled snippet** ([PlaygroundSnippet]) and hands
+ * back a `/pg/<id>` link that redeems into a live daemon session (CMP/Android) or a document
+ * permalink (Remote Compose). A token is minted only after a *clean* compile, so possessing one
+ * means "there are real classes on disk ready to render".
+ *
+ * Safety model mirrors [ServeDocStore]:
+ * - **Id is the capability.** 128 bits of [SecureRandom], base64url, `pg_`-prefixed. Unguessable,
+ *   so a link is safe to hand to one person without listing it.
+ * - **Expiring.** After [ttlSeconds] the token is dropped and `/pg/<id>` 404s without disclosing
+ *   whether the id ever existed.
+ * - **Bounded.** A [maxTokens] cap evicts nearest-expiry first on overflow. Each token owns a temp
+ *   work directory ([PlaygroundSnippet.workDir]); dropping the token **deletes that directory**, so
+ *   the cap bounds disk, not just the map.
+ *
+ * Unlike [ServeDocStore] this store owns on-disk state, so every removal path (expiry, overflow,
+ * explicit [remove], [clear]) routes through [disposeSnippet] to delete the work dir. The delete is
+ * best-effort — a failure is swallowed so one undeletable directory can't wedge purging.
+ */
+class PlaygroundTokenStore(
+  /** How long a preview token stays redeemable. Short by design — minutes, not hours. */
+  val ttlSeconds: Long = DEFAULT_TTL_SECONDS,
+  private val maxTokens: Int = DEFAULT_MAX_TOKENS,
+  /** Injected per the repo's Okio-everywhere rule; tests pass a `FakeFileSystem`. */
+  private val fileSystem: FileSystem = FileSystem.SYSTEM,
+  /** Injected so tests can drive expiry without sleeping. */
+  private val clock: () -> Long = System::currentTimeMillis,
+  private val mintId: () -> String = ::randomId,
+  /**
+   * Invoked as a token is dropped (expiry, overflow eviction, [remove], [clear]), after its work
+   * dir is deleted. Stage 2 wires this to [PlaygroundRedeemService.release] so a dropped token also
+   * unregisters + closes any live session it stood up. Best-effort — a throw here must not wedge
+   * purging — so it runs under `runCatching`. Defaults to a no-op (mint-only hosts).
+   */
+  private val onRemove: (Token) -> Unit = {},
+) {
+
+  /**
+   * A compiled snippet a token points at — everything Stage 2 needs to stand up (or, for Remote
+   * Compose, replay) the preview without recompiling.
+   */
+  data class PlaygroundSnippet(
+    val mode: PlaygroundMode,
+    /** Temp root for this snippet; **deleted** when its token is dropped. */
+    val workDir: Path,
+    /** Compiled `.class` output, on [classpath] for the render. */
+    val classesDir: Path,
+    /** Full render classpath (catalog live-bundle jars + [classesDir]). */
+    val classpath: List<Path>,
+    /** Kotlin `MODULE_NAME` the snippet compiled under. */
+    val moduleName: String,
+    /** The `@Preview` id Stage 2 opens on, and the one the Stage-1 still frame draws. */
+    val previewId: String,
+    /**
+     * **Every** `@Preview` the snippet declared, [previewId] first.
+     *
+     * A snippet routinely declares more than one — a multi-file snippet almost always does — and
+     * for a long time the live session was told about exactly one of them, so the others could be
+     * compiled and then never looked at. The redeemed session's `previews.json` lists all of these,
+     * which is what makes the viewer's ordinary preview navigation work on a snippet the same way
+     * it works on a catalog.
+     *
+     * Defaults to just [previewId] so a caller that doesn't care (and every existing test) is
+     * unchanged.
+     */
+    val previewIds: List<String> = listOf(previewId),
+  )
+
+  /** One minted token and its lifetime. */
+  data class Token(
+    val id: String,
+    val snippet: PlaygroundSnippet,
+    val createdAtMillis: Long,
+    val expiresAtMillis: Long,
+  ) {
+    /** The redeem path — the id is the capability, so this is the whole share. */
+    val path: String
+      get() = "/pg/$id"
+
+    fun secondsUntilExpiry(nowMillis: Long): Long =
+      ((expiresAtMillis - nowMillis) / 1000).coerceAtLeast(0)
+
+    // Keyed by id, like ServeDocStore.Doc — array/path-reference equality would be surprising.
+    override fun equals(other: Any?): Boolean = other is Token && other.id == id
+
+    override fun hashCode(): Int = id.hashCode()
+  }
+
+  private val tokens = ConcurrentHashMap<String, Token>()
+
+  /**
+   * Mint a token for [snippet] and return it. The store now owns [snippet]'s [workDir] and will
+   * delete it on expiry/eviction/[remove]. [isSecurityChecked] is the greppable audit marker
+   * [ServeDocStore.add] uses (no runtime enforcement): the caller passes `true` only once the
+   * request has cleared the playground route's gate.
+   */
+  fun add(snippet: PlaygroundSnippet, isSecurityChecked: Boolean): Token {
+    val now = clock()
+    purgeExpired(now)
+    val token =
+      Token(
+        id = mintId(),
+        snippet = snippet,
+        createdAtMillis = now,
+        expiresAtMillis = now + ttlSeconds * 1000,
+      )
+    tokens[token.id] = token
+    evictOverflow()
+    return token
+  }
+
+  /** The live token for [id], or null when it's unknown **or expired** (expired ⇒ dropped). */
+  fun get(id: String): Token? {
+    val now = clock()
+    purgeExpired(now)
+    return tokens[id]?.takeIf { it.expiresAtMillis > now }
+  }
+
+  /**
+   * Seconds left on [token], measured on the **store's** clock — the one that decides expiry.
+   * Callers must not read the wall clock themselves.
+   */
+  fun remainingSeconds(token: Token): Long = token.secondsUntilExpiry(clock())
+
+  /** Explicitly drop [id] (and delete its work dir); returns true if it was present. */
+  fun remove(id: String): Boolean {
+    val removed = tokens.remove(id) ?: return false
+    drop(removed)
+    return true
+  }
+
+  /** Drop every token whose TTL has run out (deleting each work dir); returns how many went. */
+  fun purgeExpired(nowMillis: Long = clock()): Int {
+    var dropped = 0
+    val it = tokens.entries.iterator()
+    while (it.hasNext()) {
+      val entry = it.next()
+      if (entry.value.expiresAtMillis <= nowMillis) {
+        it.remove()
+        drop(entry.value)
+        dropped++
+      }
+    }
+    return dropped
+  }
+
+  /** Live tokens, soonest expiry first — for the status page. */
+  fun snapshot(): List<Token> {
+    val now = clock()
+    purgeExpired(now)
+    return tokens.values.sortedBy { it.expiresAtMillis }
+  }
+
+  /** Drop everything (deleting every work dir) — for host shutdown. */
+  fun clear() {
+    val all = tokens.values.toList()
+    tokens.clear()
+    all.forEach { drop(it) }
+  }
+
+  /**
+   * Enforce the count cap by dropping the tokens closest to expiry first — a burst evicts the
+   * oldest shares (deleting their work dirs) rather than being refused, so disk + heap stay
+   * bounded.
+   */
+  private fun evictOverflow() {
+    while (tokens.size > maxTokens) {
+      val oldest = tokens.values.minByOrNull { it.expiresAtMillis } ?: return
+      tokens.remove(oldest.id)?.let { drop(it) }
+    }
+  }
+
+  /** The single drop path for every removal: delete the work dir, then fire [onRemove]. */
+  private fun drop(token: Token) {
+    disposeSnippet(token.snippet)
+    runCatching { onRemove(token) }
+  }
+
+  /** Best-effort delete of a dropped snippet's work dir; a failure must not wedge purging. */
+  private fun disposeSnippet(snippet: PlaygroundSnippet) {
+    try {
+      fileSystem.deleteRecursively(snippet.workDir, mustExist = false)
+    } catch (_: Exception) {
+      // The directory may already be gone, or held open on Windows; leaking one temp dir is
+      // strictly better than throwing out of a purge and stranding the rest.
+    }
+  }
+
+  companion object {
+    /** Ten minutes: long enough to click through and refresh a tab, short enough to not linger. */
+    const val DEFAULT_TTL_SECONDS = 600L
+
+    const val DEFAULT_MAX_TOKENS = 64
+
+    /** 128 bits of [SecureRandom], base64url, `pg_`-prefixed — the id IS the capability. */
+    private val random = SecureRandom()
+
+    fun randomId(): String {
+      val bytes = ByteArray(16)
+      random.nextBytes(bytes)
+      return "pg_" + Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+    }
+
+    /** True when [id] could be one of ours — cheap shape check before a map lookup. */
+    fun isWellFormedId(id: String): Boolean = id.matches(Regex("pg_[A-Za-z0-9_-]{16,64}"))
+  }
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PreviewHistory.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PreviewHistory.kt
@@ -1,0 +1,364 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+
+/**
+ * Per-preview render history, read off a baseline delivery branch (`compose-preview/main`,
+ * `design-artifacts/<system>`) whose commits are full snapshots of the rendered output.
+ *
+ * The branches carry one commit per publish, so the raw commit list badly overstates how much a
+ * preview actually changed: an unstable preview re-renders differently on every run and therefore
+ * appears in *every* commit. The whole point of this file is the collapse — adjacent commits whose
+ * render bytes are identical are one [Version], and a preview that keeps returning to a render it
+ * had already moved away from is [Timeline.unstable] rather than a preview with hundreds of
+ * changes.
+ *
+ * Measured on `compose-preview/main` at 770 commits — 811 render paths, 1375 observations:
+ * - the run-collapse is a **no-op in practice**, because `git log --raw -- <path>` only reports
+ *   commits in which the file actually changed, so consecutive observations for one path never
+ *   share a blob. It is kept for correctness (a merge or mode-only entry can repeat a blob, and it
+ *   makes [Version.commits] meaningful), not for the reduction;
+ * - trimming the unstable ones ([Timeline.displayVersions]) is where the reduction comes from: 1375
+ *   entries → 826, a 40% cut, from just **5** previews. The worst is 226 runs of 4 renders.
+ *
+ * That concentration is the argument for trimming at all: a handful of non-deterministic previews
+ * would otherwise dominate every timeline in the manifest, and the two wear renders alone account
+ * for over 400 of the entries removed.
+ *
+ * Everything here is pure — [parseGitLog] takes the text of one `git log` invocation and the git
+ * call itself is isolated in [read] — so the collapse rules are unit-testable without a repo.
+ */
+object PreviewHistory {
+
+  /**
+   * The `git log` arguments this parser expects, over [pathspec] on [ref].
+   *
+   * `--raw --no-abbrev` is what makes a whole branch affordable: the raw diff line already carries
+   * the post-image blob sha for every touched file, so the render bytes at each commit are known
+   * without a `rev-parse <commit>:<path>` subprocess per file per commit. One invocation covers the
+   * entire branch — measured at ~1.6s for 770 commits over 537 files.
+   *
+   * `%x01` prefixes a header line and `%x1f` separates its fields, because both are control
+   * characters git will never emit inside a sha, an ISO date, or a path, while a commit *subject*
+   * is free-form and could contain anything more printable.
+   *
+   * `-c core.quotePath=false` matters more than it looks: git's default is to C-quote and
+   * octal-escape any non-ASCII path, so a preview whose name carries an em-dash — which this repo
+   * really does produce, see the UTF-8 note in `design-artifacts-reusable.yml` — would key its
+   * history under `"renders/…Foo\342\200\224dash.png"` and never join back to the preview it
+   * belongs to. Turning quoting off is not sufficient on its own (see [unquotePath]), but it keeps
+   * the common case exact rather than round-tripping every path through an unescaper.
+   */
+  fun logArgs(ref: String, pathspec: String): List<String> =
+    listOf(
+      "-c",
+      "core.quotePath=false",
+      "log",
+      "--format=%x01%H%x1f%aI%x1f%s",
+      "--raw",
+      "--no-abbrev",
+      "--no-renames",
+      ref,
+      "--",
+      pathspec,
+    )
+
+  /**
+   * Decode a git-quoted pathname back to its real bytes, or return [raw] unchanged when it isn't
+   * quoted.
+   *
+   * [logArgs] already asks git not to quote non-ASCII, but `core.quotePath=false` only covers that
+   * case: a path containing a double quote, a backslash, or a control character is still wrapped
+   * and escaped. Rather than leave a class of paths silently mis-keyed, decode the full C-style
+   * syntax — `\\`, `\"`, the `\a \b \f \n \r \t \v` singles, and `\nnn` octal bytes.
+   *
+   * Octal escapes are per **byte**, so they're accumulated into a byte buffer and decoded as UTF-8
+   * at the end; decoding them one-by-one as characters would mangle every multi-byte codepoint.
+   */
+  internal fun unquotePath(raw: String): String {
+    if (raw.length < 2 || !raw.startsWith('"') || !raw.endsWith('"')) return raw
+    val body = raw.substring(1, raw.length - 1)
+    val bytes = java.io.ByteArrayOutputStream(body.length)
+    var i = 0
+    while (i < body.length) {
+      val ch = body[i]
+      if (ch != '\\') {
+        bytes.write(ch.toString().toByteArray(Charsets.UTF_8))
+        i++
+        continue
+      }
+      i++
+      if (i >= body.length) break
+      when (val esc = body[i]) {
+        'a' -> bytes.write(0x07).also { i++ }
+        'b' -> bytes.write(0x08).also { i++ }
+        'f' -> bytes.write(0x0C).also { i++ }
+        'n' -> bytes.write(0x0A).also { i++ }
+        'r' -> bytes.write(0x0D).also { i++ }
+        't' -> bytes.write(0x09).also { i++ }
+        'v' -> bytes.write(0x0B).also { i++ }
+        '\\',
+        '"' -> bytes.write(esc.code).also { i++ }
+        in '0'..'7' -> {
+          var value = 0
+          var digits = 0
+          while (i < body.length && digits < 3 && body[i] in '0'..'7') {
+            value = value * 8 + (body[i] - '0')
+            i++
+            digits++
+          }
+          bytes.write(value and 0xFF)
+        }
+        // Unknown escape: keep the escaped character verbatim rather than dropping it.
+        else -> bytes.write(esc.toString().toByteArray(Charsets.UTF_8)).also { i++ }
+      }
+    }
+    return String(bytes.toByteArray(), Charsets.UTF_8)
+  }
+
+  /** One commit on the delivery branch in which a given render had particular bytes. */
+  data class Observation(
+    /** Delivery-branch commit sha. */
+    val commit: String,
+    /** Author date, ISO-8601, as git emitted it. */
+    val date: String,
+    /** The commit subject, kept so [sourceSha] can be re-derived and for display. */
+    val subject: String,
+    /** Content sha of the render *at* this commit — the post-image blob. */
+    val blob: String,
+    /** True when this commit deleted the render (post-image is the all-zero sha). */
+    val deleted: Boolean,
+  ) {
+    /**
+     * The source commit this snapshot was rendered from, recovered from the publish subject.
+     *
+     * Both publishers stamp it, in their own wording — `Update preview baselines from <sha>` and
+     * `chore(design-artifacts): regenerate <system> catalog (<date>, <sha>)` — so the join back to
+     * the change that moved a pixel is a subject parse rather than a second data source. Null when
+     * the subject predates the stamping or doesn't match.
+     */
+    val sourceSha: String?
+      get() = SOURCE_SHA.find(subject)?.groupValues?.get(1)
+  }
+
+  /**
+   * A maximal run of consecutive commits whose render bytes were identical — one *visible* version
+   * of a preview, however many publishes it survived.
+   */
+  data class Version(
+    /** Content sha of the render. */
+    val blob: String,
+    /** Path on the delivery branch, e.g. `renders/samples:wear/Foo.png`. */
+    val path: String,
+    /** The commit that introduced these bytes (oldest in the run). */
+    val since: Observation,
+    /** The newest commit still carrying these bytes. */
+    val until: Observation,
+    /** How many publishes carried them. */
+    val commits: Int,
+    /**
+     * How many separate runs had these bytes. Always 1 for an untrimmed run; on a trimmed unstable
+     * timeline it's how many times the preview came back to this state, which is the honest way to
+     * show a recurring state once without pretending it only happened once.
+     */
+    val occurrences: Int = 1,
+  ) {
+    /** True when these bytes recurred — the state was returned to after changing away. */
+    val recurring: Boolean
+      get() = occurrences > 1
+  }
+
+  /** The full history of one render path, newest version first. */
+  data class Timeline(
+    val path: String,
+    /** Newest first. */
+    val versions: List<Version>,
+    /** Raw commits touching this path, before collapsing. */
+    val observations: Int,
+  ) {
+    /** Distinct render bytes ever seen. */
+    val distinctBlobs: Int
+      get() = versions.map { it.blob }.toSet().size
+
+    /**
+     * How many times the render *returned* to bytes it had already moved away from.
+     *
+     * `runs - distinctBlobs` counts exactly the re-appearances: a preview that changes cleanly N
+     * times has N runs and N distinct blobs and so scores 0, while one alternating A/B/A/B scores
+     * one per flip. A legitimate revert scores 1, which is why [unstable] needs more than one.
+     */
+    val flapCount: Int
+      get() = versions.size - distinctBlobs
+
+    /**
+     * True when the render keeps reverting to earlier bytes — the signature of a non-deterministic
+     * preview (clock, animation frame, randomness), not of a preview that changed a lot.
+     *
+     * Deliberately not a "changed more than N times" threshold: a genuinely churny preview is
+     * usually fine, whereas two returns to a previous render is already something no deterministic
+     * pipeline should produce by accident.
+     */
+    val unstable: Boolean
+      get() = flapCount >= UNSTABLE_FLAP_THRESHOLD
+
+    /**
+     * The states this preview keeps flipping between — bytes that occupy more than one run.
+     *
+     * This is the set a reviewer actually wants named: for the worst offender on
+     * `compose-preview/main` it's 4 renders that 226 commits shuffle between, not 226 changes.
+     */
+    val recurringBlobs: Set<String>
+      get() = versions.groupingBy { it.blob }.eachCount().filterValues { it > 1 }.keys
+
+    /**
+     * The timeline to actually display: unchanged when the preview is stable, and **deduplicated to
+     * one entry per distinct state** when it isn't.
+     *
+     * An unstable preview's run list is almost entirely noise — the same handful of renders
+     * alternating — so showing every run buries the real content under hundreds of identical
+     * thumbnails. Trimming keeps each distinct state once (widest span, summed commits, with
+     * [Version.occurrences] recording how many runs it had) so the timeline shows *what* the
+     * preview flips between instead of *how often* it flipped. [observations], [flapCount] and
+     * [unstable] still carry the raw counts, so nothing is hidden — only collapsed.
+     */
+    val displayVersions: List<Version>
+      get() = if (!unstable) versions else trimRecurring(versions)
+  }
+
+  /**
+   * Collapse an unstable timeline's runs to one [Version] per distinct blob, newest first.
+   *
+   * Ordering follows each state's most recent appearance, so the newest render still leads. `since`
+   * takes the oldest run's introducing commit and `until` the newest run's last one, making the
+   * entry span the whole period the state was in play.
+   */
+  private fun trimRecurring(versions: List<Version>): List<Version> {
+    val byBlob = LinkedHashMap<String, MutableList<Version>>()
+    versions.forEach { byBlob.getOrPut(it.blob) { mutableListOf() }.add(it) }
+    return byBlob.values.map { runs ->
+      // `versions` is newest-first, so runs.first() is the most recent appearance.
+      runs
+        .first()
+        .copy(
+          since = runs.last().since,
+          commits = runs.sumOf { it.commits },
+          occurrences = runs.size,
+        )
+    }
+  }
+
+  /**
+   * Collapse raw newest-first [observations] per path into [Timeline]s.
+   *
+   * Deletions terminate a path's history rather than becoming a version: a preview that was removed
+   * and later re-added should not read as having "returned" to its old bytes and so score a flap.
+   */
+  fun collapse(observations: Map<String, List<Observation>>): Map<String, Timeline> =
+    observations.mapValues { (path, rows) ->
+      collapseOne(path, rows)
+    }
+
+  private fun collapseOne(path: String, rows: List<Observation>): Timeline {
+    val live = rows.takeWhile { !it.deleted }
+    val versions = mutableListOf<Version>()
+    var run = mutableListOf<Observation>()
+    for (row in live) {
+      if (run.isNotEmpty() && run.first().blob != row.blob) {
+        versions += toVersion(path, run)
+        run = mutableListOf()
+      }
+      run += row
+    }
+    if (run.isNotEmpty()) versions += toVersion(path, run)
+    return Timeline(path = path, versions = versions, observations = live.size)
+  }
+
+  /** [run] is newest-first, so its last entry is the commit that introduced the bytes. */
+  private fun toVersion(path: String, run: List<Observation>) =
+    Version(
+      blob = run.first().blob,
+      path = path,
+      since = run.last(),
+      until = run.first(),
+      commits = run.size,
+    )
+
+  /**
+   * Parse the output of a [logArgs] invocation into newest-first observations per path.
+   *
+   * Tolerant by design: this reads a branch that CI writes and that predates the parser, so a line
+   * that doesn't fit the expected shape is skipped rather than failing the whole history. A raw
+   * line arriving before any header (impossible from git, possible from a truncated capture) is
+   * dropped for the same reason.
+   */
+  fun parseGitLog(output: String): Map<String, List<Observation>> {
+    val byPath = LinkedHashMap<String, MutableList<Observation>>()
+    var commit: String? = null
+    var date = ""
+    var subject = ""
+    for (line in output.lineSequence()) {
+      if (line.startsWith(HEADER_MARK)) {
+        val fields = line.substring(1).split(FIELD_SEP)
+        if (fields.size >= 3) {
+          commit = fields[0]
+          date = fields[1]
+          subject = fields[2]
+        } else {
+          commit = null
+        }
+        continue
+      }
+      if (!line.startsWith(':') || commit == null) continue
+      val tab = line.indexOf('\t')
+      if (tab < 0) continue
+      // ":<srcmode> <dstmode> <srcsha> <dstsha> <status>\t<path>" — split() over the whole
+      // whitespace run so a status like "M100" or a mode column width change can't shift indices.
+      val meta = line.substring(1, tab).split(' ').filter { it.isNotEmpty() }
+      if (meta.size < 5) continue
+      val blob = meta[3]
+      val path = unquotePath(line.substring(tab + 1))
+      byPath
+        .getOrPut(path) { mutableListOf() }
+        .add(
+          Observation(
+            commit = commit,
+            date = date,
+            subject = subject,
+            blob = blob,
+            deleted = blob == NULL_SHA,
+          )
+        )
+    }
+    return byPath
+  }
+
+  /**
+   * Read the history of [pathspec] on [ref] from the repo at [repoRoot]. Returns an empty map when
+   * the ref is absent (a clone that never fetched the delivery branch) rather than throwing — the
+   * history surface is additive, and a viewer without it should degrade to no timeline, not fail.
+   */
+  fun read(
+    repoRoot: File,
+    ref: String,
+    pathspec: String = "renders",
+    git: GitRunner = GitWorktrees.RealGitRunner,
+  ): Map<String, Timeline> {
+    val result = git.run(repoRoot, logArgs(ref, pathspec))
+    if (!result.ok) return emptyMap()
+    return collapse(parseGitLog(result.stdout))
+  }
+
+  /** Two returns to previously-seen bytes before a preview is called unstable. See [Timeline]. */
+  const val UNSTABLE_FLAP_THRESHOLD: Int = 2
+
+  private const val HEADER_MARK = "\u0001"
+  private const val FIELD_SEP = "\u001F"
+  private const val NULL_SHA = "0000000000000000000000000000000000000000"
+
+  /**
+   * The source sha in a publish subject: `…baselines from <sha>` (compose-preview) or the `(<date>,
+   * <sha>)` tail (design-artifacts). Both are short shas today; accept 7–40 hex so a future
+   * full-sha stamp still parses.
+   */
+  private val SOURCE_SHA = Regex("(?:from|,)\\s+([0-9a-f]{7,40})\\b")
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PreviewHistoryManifest.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PreviewHistoryManifest.kt
@@ -1,0 +1,268 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * `history.json` — the precomputed render history that ships alongside the renders on a delivery
+ * branch, so a viewer can show a preview's timeline without a git checkout.
+ *
+ * This exists because the hosted viewer has no repository. `serve` only has git in project mode
+ * (`--revisions`, rooted at the local project repo), so a direct [PreviewHistory] walk can never
+ * reach `preview.coo.ee`. CI already has the branch checked out when it publishes, so it computes
+ * the history once and commits the answer.
+ *
+ * **Keyed by preview id, not render path.** [PreviewHistory] works in branch paths
+ * (`renders/<module>/<basename>`) because that is what git reports, but every consumer — the
+ * viewer, the diff bot, `baselines.json` itself — addresses previews by id
+ * (`<module>/<fqName>_<label>`). The join happens here, once, so no consumer has to reconstruct a
+ * path convention.
+ *
+ * ### Relationship to `daemon.history`
+ *
+ * Not the same feature as the daemon's history archive (`HistorySource`, `GitRefHistorySource`,
+ * `compose-preview history list|read|diff`), despite the shared word. That one reads the daemon's
+ * *reporting branch*, whose layout is one directory per preview with `entry.json` sidecars carrying
+ * semantics / a11y / theme snapshots. This reads the *baseline delivery branches*, written by CI in
+ * a flat `renders/<module>/` layout with no sidecars at all.
+ *
+ * They are kept separate deliberately: a [HistoryEntry][ee.schimke.composeai.daemon.history]-shaped
+ * record would be almost entirely null for delivery-branch data, and this side's job is to be a
+ * small static file a viewer fetches rather than a live source API. If the two ever converge, this
+ * is the file to fold in.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+object PreviewHistoryManifest {
+
+  /**
+   * Bumped when the shape changes incompatibly, so a viewer can refuse a manifest it can't read.
+   */
+  const val FORMAT_VERSION: String = "compose-preview-history/v1"
+
+  /** The file's name on the delivery branch, beside `baselines.json`. */
+  const val FILE_NAME: String = "history.json"
+
+  /**
+   * Its neighbour, and the only source of the render-path → preview-id join
+   * ([renderPathsToPreviewIds]). Named here so a reader of the delivery branch — CI's
+   * `HistoryManifestCommand`, `serve`'s project-mode [ServeProjectHistory] — doesn't restate the
+   * filename per call site.
+   */
+  const val BASELINES_FILE_NAME: String = "baselines.json"
+
+  @Serializable
+  data class Manifest(
+    /**
+     * [EncodeDefault] is load-bearing, not decoration: [JSON] sets `encodeDefaults = false` so the
+     * redundant fields below stay off the wire, and without this the version discriminator would be
+     * dropped by exactly the same rule — leaving every published manifest with nothing for a viewer
+     * to version-check against. Kept as a *default* rather than a required parameter so a manifest
+     * that somehow lacks it still decodes.
+     */
+    @EncodeDefault(EncodeDefault.Mode.ALWAYS)
+    @SerialName("formatVersion")
+    val formatVersion: String = FORMAT_VERSION,
+    /**
+     * The newest delivery-branch commit **touching renders** that this timeline covers — not the
+     * branch tip.
+     *
+     * The distinction is load-bearing. The manifest ships in its own commit, so a tip-derived value
+     * would change on every publish even when no render did; the regenerated file would never match
+     * the published one and each run would append another history commit forever. Anchoring to the
+     * render tip makes an unchanged branch regenerate byte-identically. A viewer comparing
+     * staleness should compare against the newest render commit, which is exactly this.
+     */
+    @SerialName("generatedFrom") val generatedFrom: String,
+    /** Keyed by preview id, the same keys `baselines.json` uses. */
+    @SerialName("previews") val previews: Map<String, PreviewTimeline>,
+  )
+
+  @Serializable
+  data class PreviewTimeline(
+    /** Render path on the branch, so a viewer can fetch any version's bytes. */
+    @SerialName("path") val path: String,
+    /** Newest first. Trimmed when [unstable] — see [PreviewHistory.Timeline.displayVersions]. */
+    @SerialName("versions") val versions: List<ManifestVersion>,
+    /** Raw commits touching this render, before any collapsing or trimming. */
+    @SerialName("observations") val observations: Int,
+    /**
+     * True when this render keeps reverting to bytes it had already moved away from. Present so a
+     * viewer can label the timeline as unreliable rather than silently showing a trimmed list that
+     * doesn't add up to [observations].
+     */
+    @SerialName("unstable") val unstable: Boolean,
+    /** Returns to previously-seen bytes. Non-zero with `unstable: false` means a lone revert. */
+    @SerialName("flapCount") val flapCount: Int,
+  )
+
+  @Serializable
+  data class ManifestVersion(
+    /** Content sha of the render — stable across commits, so a viewer can cache by it. */
+    @SerialName("blob") val blob: String,
+    /** Newest delivery-branch commit carrying these bytes. */
+    @SerialName("commit") val commit: String,
+    /** Author date of [commit], ISO-8601. */
+    @SerialName("date") val date: String,
+    /** Source commit these bytes were rendered from, when the publish subject recorded one. */
+    @SerialName("sourceSha") val sourceSha: String? = null,
+    /**
+     * Delivery-branch commit that introduced these bytes. Omitted when it equals [commit], which is
+     * every single-publish version — the common case, and 40 redundant hex characters each. Readers
+     * should fall back to [commit]; [introducedBy] does that.
+     */
+    @SerialName("sinceCommit") val sinceCommit: String? = null,
+    /** Publishes carrying these bytes. */
+    @SerialName("commits") val commits: Int,
+    /**
+     * Separate runs that had these bytes. Omitted when 1 (the overwhelming majority), so the file
+     * doesn't carry a redundant field on every stable entry.
+     */
+    @SerialName("occurrences") val occurrences: Int? = null,
+  ) {
+    /** The commit that introduced these bytes, resolving the omitted-when-equal [sinceCommit]. */
+    val introducedBy: String
+      get() = sinceCommit ?: commit
+  }
+
+  /**
+   * The two delivery-branch layouts a manifest can be built over, and how each one answers "which
+   * preview is this render?".
+   *
+   * They differ in the only place that matters. A **baseline** branch (`compose-preview/main`)
+   * stores `renders/<module>/<basename>` and needs `baselines.json` to say which preview each file
+   * belongs to. A **design catalog** branch (`design-artifacts/<system>`) stores
+   * `images/<slug>/<variant>.png` and needs no sidecar at all: the id the viewer addresses a
+   * preview by *is* the path, flattened — which is exactly what [CatalogImagePaths.previewIdFor]
+   * computes for the serve routes.
+   *
+   * Reusing that function rather than restating the rule is the point: a manifest keyed by anything
+   * other than the id the routes use is a manifest the viewer silently finds nothing in, and a
+   * second spelling of the derivation is how the two would drift apart without anyone noticing.
+   */
+  enum class Layout(val dir: String) {
+    /** `renders/<module>/<basename>`, joined through `baselines.json`. */
+    RENDERS("renders"),
+    /** `images/<slug>/<variant>.png`, joined by flattening the path. */
+    IMAGES(CatalogImagePaths.IMAGES_DIR);
+
+    companion object {
+      /** Parse a `--layout` value, or null when it names neither layout. */
+      fun of(value: String?): Layout? = entries.firstOrNull { it.name.equals(value, true) }
+    }
+  }
+
+  /**
+   * Map image path → preview id for a [Layout.IMAGES] branch, by flattening each path the way the
+   * serve routes do.
+   *
+   * Takes the paths git actually reported rather than a manifest, because on this layout there is
+   * nothing to read: the derivation is total, so every render the branch has is a render the
+   * timeline can key. Paths outside `images/` are dropped — the extractor is already scoped to that
+   * pathspec, so one appearing here means something is wrong and inventing an id for it would put a
+   * bogus key in the manifest.
+   */
+  fun imagePathsToPreviewIds(paths: Iterable<String>): Map<String, String> {
+    val byPath = LinkedHashMap<String, String>()
+    for (path in paths) {
+      if (!path.startsWith("${CatalogImagePaths.IMAGES_DIR}/") || !path.endsWith(".png")) continue
+      if (".." in path.split("/")) continue
+      byPath[path] = CatalogImagePaths.previewIdFor(path)
+    }
+    return byPath
+  }
+
+  /**
+   * Map render path → preview id, parsed from a `baselines.json` payload.
+   *
+   * The delivery branch stores `renders/<module>/<renderBasename>` and `baselines.json` records
+   * `module` + `renderBasename` per preview, so this reverses that into the lookup [build] needs.
+   * Entries missing either field are skipped rather than guessed at — a preview whose path can't be
+   * reconstructed is better absent from the manifest than present under a wrong key.
+   */
+  fun renderPathsToPreviewIds(baselinesJson: String): Map<String, String> {
+    val root =
+      runCatching { Json.parseToJsonElement(baselinesJson).jsonObject }.getOrNull()
+        ?: return emptyMap()
+    val byPath = LinkedHashMap<String, String>()
+    for ((previewId, entry) in root) {
+      val obj = entry as? JsonObject ?: continue
+      val module = obj["module"]?.jsonPrimitive?.contentOrNullSafe() ?: continue
+      val basename = obj["renderBasename"]?.jsonPrimitive?.contentOrNullSafe() ?: continue
+      if (module.isEmpty() || basename.isEmpty()) continue
+      byPath["renders/$module/$basename"] = previewId
+    }
+    return byPath
+  }
+
+  /**
+   * Build the manifest from extracted [timelines], keyed by preview id via [pathToPreviewId].
+   *
+   * A render path with no matching preview id is dropped. That is the normal fate of history for a
+   * preview that has since been deleted or renamed: it still has commits on the branch, but nothing
+   * in `baselines.json` points at it, so no viewer could address it anyway.
+   *
+   * Previews are emitted in sorted key order so regenerating an unchanged branch produces a
+   * byte-identical file — otherwise every publish would show a spurious `history.json` diff.
+   */
+  fun build(
+    timelines: Map<String, PreviewHistory.Timeline>,
+    pathToPreviewId: Map<String, String>,
+    generatedFrom: String,
+  ): Manifest {
+    val previews = sortedMapOf<String, PreviewTimeline>()
+    for ((path, timeline) in timelines) {
+      val previewId = pathToPreviewId[path] ?: continue
+      if (timeline.versions.isEmpty()) continue
+      previews[previewId] =
+        PreviewTimeline(
+          path = path,
+          versions = timeline.displayVersions.map { it.toManifestVersion() },
+          observations = timeline.observations,
+          unstable = timeline.unstable,
+          flapCount = timeline.flapCount,
+        )
+    }
+    return Manifest(generatedFrom = generatedFrom, previews = previews)
+  }
+
+  private fun PreviewHistory.Version.toManifestVersion() =
+    ManifestVersion(
+      blob = blob,
+      commit = until.commit,
+      date = until.date,
+      sourceSha = until.sourceSha,
+      sinceCommit = since.commit.takeIf { it != until.commit },
+      commits = commits,
+      occurrences = occurrences.takeIf { it > 1 },
+    )
+
+  /**
+   * Serialize for committing. Pretty-printed because this file lands on a branch that humans and
+   * the diff bot read: a one-line JSON blob would make every regeneration an unreviewable diff,
+   * whereas one field per line keeps a changed timeline legible in a PR.
+   */
+  fun encode(manifest: Manifest): String = JSON.encodeToString(manifest) + "\n"
+
+  /** Lenient on read so a manifest written by a newer CLI (extra fields) still loads. */
+  fun decode(text: String): Manifest? = runCatching {
+    JSON.decodeFromString<Manifest>(text)
+  }
+    .getOrNull()
+
+  private val JSON = Json {
+    prettyPrint = true
+    encodeDefaults = false
+    explicitNulls = false
+    ignoreUnknownKeys = true
+  }
+
+  /** `jsonPrimitive.contentOrNull` throws on a non-string primitive; this never does. */
+  private fun kotlinx.serialization.json.JsonPrimitive.contentOrNullSafe(): String? =
+    if (isString) content else null
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/RcJvmServerRenderer.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/RcJvmServerRenderer.kt
@@ -1,0 +1,383 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.bundle.bundleSidecarSearchDescription
+import ee.schimke.composeai.bundle.locateBundleSidecarJars
+import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
+import ee.schimke.composeai.io.composeAiCacheDir
+import java.io.File
+import java.util.Base64
+import java.util.concurrent.TimeUnit
+
+/**
+ * Renders a captured Remote Compose document to PNG or layered SVG for the serve viewer's
+ * **cmp-jvm** chip, by spawning the embedded desktop player ([ee.schimke.composeai.rcembedded.jvm]
+ * `RcJvmRenderMain`) as a one-shot subprocess off an isolated classpath — the same subprocess
+ * isolation `BundleRenderer` uses for the desktop `@Preview` renderer, and for the same reason:
+ * Compose Desktop + Skiko's per-OS natives are kept off the CLI's own classpath so a cross-platform
+ * release doesn't bake in one host's natives.
+ *
+ * The classpath joins the CLI install's `lib-rcjvm/` (the embedded jvm player + its Compose API
+ * deps, staged by the CLI build) with `lib-daemon-desktop/` (the Compose Desktop runtime + Skiko
+ * natives the desktop daemon already carries), so the natives are shared rather than bundled twice.
+ * When either sidecar is absent (a build that didn't stage them, or a headless host that dropped
+ * the desktop lane) [isAvailable] is false and the viewer never lights the chip.
+ */
+// Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
+// and the `:server` call sites are in a different module now. Not a widened API by intent.
+object RcJvmServerRenderer {
+
+  private const val MAIN_CLASS = "ee.schimke.composeai.rcembedded.jvm.RcJvmRenderMainKt"
+  private const val RENDER_TIMEOUT_SECONDS = 120L
+
+  /**
+   * Least budget worth starting a cold one-shot render with. Below this the retry cannot finish (a
+   * fresh JVM needs ~2.3s just to boot Compose + Skiko before it draws anything), so spending the
+   * remainder on a render that is going to be killed anyway only delays the failure.
+   */
+  private const val MIN_FALLBACK_SECONDS = 10L
+  private const val DRAIN_FLUSH_MILLIS = 1000L
+
+  /**
+   * The subprocess classpath: the embedded jvm player (`lib-rcjvm`) plus the desktop Compose +
+   * Skiko runtime (`lib-daemon-desktop`). Empty when either sidecar dir is missing.
+   */
+  private fun classpath(): List<File> {
+    val rcjvm = locateBundleSidecarJars("lib-rcjvm")
+    val desktop = locateBundleSidecarJars("lib-daemon-desktop")
+    if (rcjvm.isEmpty() || desktop.isEmpty()) return emptyList()
+    return rcjvm + desktop
+  }
+
+  /** True when both sidecar classpaths are present, so a cmp-jvm render can actually be spawned. */
+  fun isAvailable(): Boolean = classpath().isNotEmpty()
+
+  /** Human-readable description of where the sidecars were looked for, for error messages. */
+  fun unavailableReason(): String =
+    "cmp-jvm render needs lib-rcjvm and lib-daemon-desktop on the CLI install " +
+      "(${bundleSidecarSearchDescription("lib-rcjvm")}; " +
+      "${bundleSidecarSearchDescription("lib-daemon-desktop")})"
+
+  /**
+   * Render [docBytes] to [format] at [spec]'s pixel size and density, applying any [seeds] (the
+   * serve `rc.<name>=…` knob edits) on top of the document's authored defaults. Reports whether the
+   * subprocess is unavailable, timed out, or could not draw the document.
+   */
+  fun render(
+    docBytes: ByteArray,
+    spec: RcJvmRenderSpec,
+    seeds: Map<String, RemoteNamedValue> = emptyMap(),
+    format: Format = Format.PNG,
+    /**
+     * Which branch a `ColorTheme` operation selects. Defaults to light rather than to the machine's
+     * desktop setting: this renderer is headless, so "the host's theme" is not a real question, and
+     * a render that changed colour with the build machine's OS would not be reproducible. Documents
+     * with no `ColorTheme` are unaffected either way.
+     */
+    theme: RenderTheme = RenderTheme.LIGHT,
+  ): RenderResult {
+    val cp = classpath()
+    if (cp.isEmpty()) return RenderResult.Unavailable(unavailableReason())
+
+    // One budget for the whole request, spent across both lanes. Without this a pooled worker could
+    // burn its full watchdog and *then* hand a fresh one-shot render another full timeout, so a
+    // request that used to fail at 120s would hold its caller's render-semaphore slot for ~240s and
+    // starve unrelated renders.
+    val startNanos = System.nanoTime()
+    fun secondsLeft(): Long =
+      RENDER_TIMEOUT_SECONDS - (System.nanoTime() - startNanos) / 1_000_000_000L
+
+    // Warm path: a pooled worker draws this on an already-booted JVM (~85 ms) instead of paying
+    // Compose Desktop + Skiko startup again (~2.3 s). Only `Unusable` falls through to the one-shot
+    // path below — a `Failed` is the player's real answer about this document, and re-rendering it
+    // cold would double the cost of every document that cannot be drawn.
+    pool(cp)?.let { pool ->
+      val pooled =
+        pool.render(
+          docBytes,
+          spec,
+          seedLines(seeds).joinToString("\n"),
+          format,
+          theme,
+          secondsLeft(),
+        )
+      when (pooled) {
+        is RcJvmWorkerPool.PoolResult.Ok -> return RenderResult.Ok(pooled.bytes)
+        is RcJvmWorkerPool.PoolResult.Failed -> return RenderResult.Failed(pooled.reason)
+        is RcJvmWorkerPool.PoolResult.Unusable -> {
+          // A pool that declined instantly (disabled, stale sidecar, spawn refused) leaves the
+          // budget intact and the cold retry is free to use it. A pool that declined by *timing
+          // out* has already spent it — retrying cold would only blow through the deadline the
+          // caller is holding a semaphore permit against, so report the failure instead.
+          if (secondsLeft() < MIN_FALLBACK_SECONDS) {
+            return RenderResult.Failed(
+              "${pooled.reason}; no time left in the ${RENDER_TIMEOUT_SECONDS}s render budget " +
+                "for a one-shot retry"
+            )
+          }
+        }
+      }
+    }
+
+    return renderOneShot(cp, docBytes, spec, seeds, format, theme, secondsLeft())
+  }
+
+  /**
+   * The original process-per-document path, kept as the fallback for every way the pool can decline
+   * to serve: pooling switched off, a `lib-rcjvm/` too old to speak the worker protocol, a worker
+   * that could not be spawned, or one that broke mid-request. Behaviour here is unchanged, so the
+   * worst case of the pool existing is the cost that was already being paid.
+   */
+  private fun renderOneShot(
+    cp: List<File>,
+    docBytes: ByteArray,
+    spec: RcJvmRenderSpec,
+    seeds: Map<String, RemoteNamedValue>,
+    format: Format,
+    theme: RenderTheme,
+    timeoutSeconds: Long = RENDER_TIMEOUT_SECONDS,
+  ): RenderResult {
+    val input = File.createTempFile("rcjvm-in-", ".rc")
+    val output = File.createTempFile("rcjvm-out-", ".${format.wire}")
+    val seedsFile = writeSeedsFile(seeds)
+    try {
+      input.writeBytes(docBytes)
+      output.delete() // the subprocess creates it; absence after the run signals failure
+
+      val command = buildList {
+        add(javaBin())
+        addAll(renderJvmArgs())
+        add("-cp")
+        add(cp.joinToString(File.pathSeparator) { it.absolutePath })
+        add(MAIN_CLASS)
+        add("--input")
+        add(input.absolutePath)
+        add("--output")
+        add(output.absolutePath)
+        add("--width")
+        add(spec.widthPx.toString())
+        add("--height")
+        add(spec.heightPx.toString())
+        add("--density")
+        add(spec.density.toString())
+        add("--format")
+        add(format.wire)
+        add("--theme")
+        add(theme.wire)
+        if (seedsFile != null) {
+          add("--seeds")
+          add(seedsFile.absolutePath)
+        }
+      }
+
+      val process =
+        ProcessBuilder(command).redirectErrorStream(true).start().also { it.outputStream.close() }
+      // Drain the merged stdout/stderr on a daemon thread *concurrently* with the timed wait — a
+      // blocking readText() here would wait for EOF, which a hung Skiko/native render never
+      // reaches,
+      // so the timeout below (and the render-semaphore permit the caller holds) would never
+      // release.
+      // Mirrors BundleRenderer.runRenderProcess.
+      val log = StringBuilder()
+      val drain = Thread {
+        process.inputStream.bufferedReader().forEachLine { log.appendLine(it) }
+      }
+        .apply {
+          isDaemon = true
+          start()
+        }
+      val finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
+      if (!finished) {
+        process.destroyForcibly()
+        drain.join(DRAIN_FLUSH_MILLIS)
+        return RenderResult.Failed("cmp-jvm render timed out after ${timeoutSeconds}s")
+      }
+      // The process exited, so the reader has hit EOF; this join just flushes the last lines.
+      drain.join(DRAIN_FLUSH_MILLIS)
+      if (process.exitValue() != 0 || !output.isFile || output.length() == 0L) {
+        return RenderResult.Failed(
+          "cmp-jvm render failed (exit ${process.exitValue()})" +
+            log
+              .toString()
+              .trim()
+              .takeIf { it.isNotEmpty() }
+              ?.let { ": ${it.lines().last().take(300)}" }
+              .orEmpty()
+        )
+      }
+      return RenderResult.Ok(output.readBytes())
+    } finally {
+      input.delete()
+      output.delete()
+      seedsFile?.delete()
+    }
+  }
+
+  /**
+   * The JVM flags every cmp-jvm render runs under, shared by the pooled worker and the one-shot
+   * subprocess.
+   *
+   * Shared deliberately, not by coincidence: the font cache directory below decides which typeface
+   * a `google:`-named family resolves to, so a pooled worker started without it would draw text
+   * differently from the one-shot fallback. Two lanes that are supposed to be interchangeable must
+   * boot identically, or "did the pool serve this?" becomes visible in the pixels — exactly the
+   * property `RcJvmHotWorkerDeterminismTest` exists to protect.
+   */
+  private fun renderJvmArgs(): List<String> = buildList {
+    add("--enable-native-access=ALL-UNNAMED")
+    // Skiko draws offscreen; keep the JVM out of the macOS Dock / app-switcher when spawned
+    // on a developer's Mac, matching BundleRenderer's desktop renderer launch.
+    add("-Dapple.awt.UIElement=true")
+    // The player's `GoogleFontTypefaceResolver` downloads a `google:`-named family into the
+    // shared font cache — the same directory the Android and desktop daemons are pointed at,
+    // so a family already fetched for another lane is reused rather than re-downloaded. With
+    // no cache directory the resolver stays off and the lane substitutes a local face, so this
+    // is what makes the cmp-jvm chip show a branded typeface at all. The offline switch is
+    // forwarded when this process carries one.
+    add("-Dcomposeai.fonts.cacheDir=${composeAiCacheDir("fonts").absolutePath}")
+    System.getProperty("composeai.fonts.offline")?.let { add("-Dcomposeai.fonts.offline=$it") }
+  }
+
+  /**
+   * The process-wide worker pool, created on first use so a cli invocation that never renders a
+   * cmp-jvm document never spawns a JVM. Null when pooling is switched off
+   * ([RcJvmWorkerPool.SYS_PROP_ENABLED]`=off`), which forces every render down the one-shot path.
+   */
+  @Volatile private var poolInstance: RcJvmWorkerPool? = null
+
+  private fun pool(cp: List<File>): RcJvmWorkerPool? {
+    if (!RcJvmWorkerPool.isEnabled()) return null
+    poolInstance?.let {
+      return it
+    }
+    return synchronized(this) {
+      poolInstance
+        ?: RcJvmWorkerPool(
+            classpath = cp,
+            javaBin = javaBin(),
+            extraJvmArgs = renderJvmArgs(),
+            maxWorkers = RcJvmWorkerPool.configuredWorkers(),
+            maxRendersPerWorker = RcJvmWorkerPool.configuredMaxRenders(),
+            maxWorkerAgeMillis = RcJvmWorkerPool.configuredMaxAgeMillis(),
+            renderTimeoutSeconds = RENDER_TIMEOUT_SECONDS,
+          )
+          .also { created ->
+            poolInstance = created
+            // Workers outlive any single render, so nothing else would reap them if the cli exits
+            // while some are parked.
+            Runtime.getRuntime().addShutdownHook(Thread({ created.close() }, "rcjvm-pool-shutdown"))
+          }
+    }
+  }
+
+  /** Releases every pooled worker. Exposed for tests and for an explicit serve shutdown. */
+  fun shutdownPool() {
+    synchronized(this) {
+      poolInstance?.close()
+      poolInstance = null
+    }
+  }
+
+  /**
+   * Serialize [seeds] to the line-based format the player reads (`<kind> <base64Name> <value>`,
+   * kind ∈ str/float/int/color). Normalizes the wire types the jvm player does not need to
+   * distinguish — `dp` collapses to float and `bool` to int, matching the daemon's
+   * `applyConnectorOverrides` — and drops a colour whose `#AARRGGBB` string won't parse.
+   *
+   * One producer for both lanes: the pooled worker receives these lines inline in its request
+   * frame, the one-shot subprocess reads them from the file [writeSeedsFile] writes. The parser is
+   * `parseSeedText` in the player module.
+   */
+  internal fun seedLines(seeds: Map<String, RemoteNamedValue>): List<String> {
+    if (seeds.isEmpty()) return emptyList()
+    val b64 = Base64.getEncoder()
+    fun enc(s: String) = b64.encodeToString(s.toByteArray(Charsets.UTF_8))
+    return seeds.mapNotNull { (name, value) ->
+      val n = enc(name)
+      when (value) {
+        is RemoteNamedValue.StringValue -> "str $n ${enc(value.value)}"
+        is RemoteNamedValue.FloatValue -> "float $n ${value.value}"
+        is RemoteNamedValue.DpValue -> "float $n ${value.value}"
+        is RemoteNamedValue.IntValue -> "int $n ${value.value}"
+        is RemoteNamedValue.BooleanValue -> "int $n ${if (value.value) 1 else 0}"
+        is RemoteNamedValue.ColorValue -> rcColorToArgb(value.argb)?.let { "color $n $it" }
+      }
+    }
+  }
+
+  /** [seedLines] as the temp file the one-shot `--seeds` flag points at, or null when empty. */
+  private fun writeSeedsFile(seeds: Map<String, RemoteNamedValue>): File? {
+    val lines = seedLines(seeds)
+    if (lines.isEmpty()) return null
+    return File.createTempFile("rcjvm-seeds-", ".txt").also {
+      it.writeText(lines.joinToString("\n"))
+    }
+  }
+
+  /**
+   * Parse an rc colour string to an ARGB int, matching the JS lane's `parseRcColor`: strip a
+   * leading `#` (or URL-encoded `%23`), treat a 6-digit `#RRGGBB` as **opaque** (prepend `FF` —
+   * without it a six-digit value becomes `0x00RRGGBB`, fully transparent), and accept only a
+   * resulting 8 hex digits. Null when it won't parse.
+   */
+  // Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
+  // and the `:server` call sites are in a different module now. Not a widened API by intent.
+  fun rcColorToArgb(raw: String): Int? {
+    val hex = raw.removePrefix("%23").removePrefix("#")
+    val opaque = if (hex.length == 6) "FF$hex" else hex
+    return opaque.takeIf { it.length == 8 }?.toLongOrNull(16)?.toInt()
+  }
+
+  private fun javaBin(): String {
+    val home = System.getProperty("java.home")
+    val candidate = File(home, "bin/java")
+    return if (candidate.canExecute()) candidate.absolutePath else "java"
+  }
+
+  sealed interface RenderResult {
+    data class Ok(val bytes: ByteArray) : RenderResult
+
+    data class Failed(val reason: String) : RenderResult
+
+    data class Unavailable(val reason: String) : RenderResult
+  }
+
+  enum class Format(val wire: String) {
+    PNG("png"),
+    SVG("svg"),
+  }
+
+  /**
+   * The `ColorTheme` branch a cmp-jvm render selects.
+   *
+   * Deliberately this module's own type rather than `remote-core`'s `Theme` int: the CLI drives the
+   * player as a subprocess and carries no compile dependency on it, which is what lets the worker's
+   * classpath be staged independently. [wire] and [frame] are the two forms that cross the boundary
+   * — a `--theme` argument on the one-shot path, and an int in the pooled worker's request frame,
+   * whose values `RcJvmRenderWorkerMain` mirrors.
+   */
+  enum class RenderTheme(val wire: String, val frame: Int) {
+    LIGHT("light", 0),
+    DARK("dark", 1),
+  }
+}
+
+/**
+ * The pixel size and density a cmp-jvm render should use — matched to the baked/View-player lane.
+ */
+data class RcJvmRenderSpec(val widthPx: Int, val heightPx: Int, val density: Float)

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/RcJvmWorkerPool.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/RcJvmWorkerPool.kt
@@ -1,0 +1,518 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ee.schimke.composeai.cli.serve
+
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.File
+import java.io.IOException
+import java.util.ArrayDeque
+import java.util.concurrent.Executors
+import java.util.concurrent.Semaphore
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * A pool of long-lived `RcJvmRenderWorkerMain` processes, so a cmp-jvm render costs a frame on a
+ * warm JVM (~85 ms) instead of a fresh Compose Desktop + Skiko boot (~2.3 s).
+ *
+ * A worker holds nothing project-derived — a `.rc` document is self-describing, which is why the
+ * browser's JS player draws the same bytes with no knowledge of any catalog — so **any** worker can
+ * serve **any** document, from any module or repository, in any order. There is deliberately no
+ * affinity, no per-catalog warmup and no keying: that is the whole difference from the `@Preview`
+ * daemon, which must stay per-module because it holds the consumer's classloader.
+ *
+ * ## Why this is allowed to exist
+ *
+ * `rc-compare` gates the PR on pixel parity, so a render that depended on how many documents a
+ * worker had already drawn would convert a correctness gate into a flake source.
+ * `RcJvmHotWorkerDeterminismTest` is the standing proof that it does not: it renders a corpus cold,
+ * churns the process with dozens of renders at varied sizes, densities, seeds and formats, then
+ * re-renders and asserts byte identity. If that test ever fails, the correct response is to disable
+ * this pool ([SYS_PROP_ENABLED]`=off`), not to relax the assertion.
+ *
+ * ## Failure posture
+ *
+ * Every failure mode degrades to the pre-existing one-shot subprocess rather than to a broken
+ * render:
+ * * a sidecar too old to speak the protocol, or a worker that cannot be spawned, reports
+ *   [PoolResult.Unusable] and the caller falls back;
+ * * after [MAX_START_FAILURES] consecutive spawn/handshake failures the pool disables itself for
+ *   the life of the process, so a systematically broken pool costs one failed spawn, not one per
+ *   render;
+ * * a worker that wedges is destroyed by the watchdog and never returned to the idle set;
+ * * a document the player genuinely cannot draw reports [PoolResult.Failed] — that is a real answer
+ *   and is **not** retried on the one-shot path, which would double the cost of every bad document.
+ *
+ * Workers are recycled after [maxRendersPerWorker] renders or [maxWorkerAgeMillis], bounding any
+ * native leak without giving up the amortisation.
+ *
+ * Thread-safe: [maxWorkers] permits gate admission, and a worker is only ever checked out to one
+ * thread at a time, so a worker's streams are never touched concurrently.
+ */
+// Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
+// and the `:server` call sites are in a different module now. Not a widened API by intent.
+class RcJvmWorkerPool(
+  private val classpath: List<File>,
+  private val javaBin: String,
+  private val extraJvmArgs: List<String>,
+  private val maxWorkers: Int,
+  private val maxRendersPerWorker: Int,
+  private val maxWorkerAgeMillis: Long,
+  private val renderTimeoutSeconds: Long,
+  private val clock: () -> Long = System::currentTimeMillis,
+  /**
+   * The worker entry point to spawn. Overridden only by tests, which point it at a stub that speaks
+   * the same frames without Compose or Skiko — so the protocol, the retire policy and every failure
+   * path are covered on a machine with no native render stack.
+   */
+  private val workerMainClass: String = WORKER_MAIN_CLASS,
+) : AutoCloseable {
+
+  sealed interface PoolResult {
+    data class Ok(val bytes: ByteArray) : PoolResult
+
+    /** The player answered, and the answer is "I cannot draw this". Do not fall back. */
+    data class Failed(val reason: String) : PoolResult
+
+    /** The pool could not serve this at all. The caller should use the one-shot path. */
+    data class Unusable(val reason: String) : PoolResult
+  }
+
+  private val permits = Semaphore(maxWorkers, /* fair= */ true)
+  private val idle = ArrayDeque<Worker>()
+
+  /**
+   * Every worker this pool has started and not yet discarded — **including** the ones currently
+   * checked out to a render thread.
+   *
+   * [idle] alone is not enough to shut down: a worker that is mid-render is absent from it, so
+   * closing only the parked ones would leave its child JVM alive and its caller blocked on a pipe
+   * read that nothing will ever complete (shutting the watchdog down drops the scheduled kill that
+   * would otherwise free it).
+   */
+  private val liveWorkers = LinkedHashSet<Worker>()
+  private val lock = Any()
+  private val requestIds = AtomicInteger(0)
+  private var startFailures = 0
+  private var disabledReason: String? = null
+  private var closed = false
+
+  private val watchdog = Executors.newSingleThreadScheduledExecutor { r ->
+    Thread(r, "rcjvm-pool-watchdog").apply { isDaemon = true }
+  }
+
+  fun render(
+    docBytes: ByteArray,
+    spec: RcJvmRenderSpec,
+    seedsText: String,
+    format: RcJvmServerRenderer.Format,
+    /**
+     * The `ColorTheme` branch to select — see `RcJvmServerRenderer.render`. Light by default,
+     * matching that entry point: a headless render has no host theme to follow, and one that varied
+     * with the machine's desktop setting would not be reproducible.
+     */
+    theme: RcJvmServerRenderer.RenderTheme = RcJvmServerRenderer.RenderTheme.LIGHT,
+    /**
+     * Budget for this render, so the caller can bound pool-attempt + fallback together rather than
+     * letting each lane spend the full timeout in turn. Defaults to the pool's own timeout.
+     */
+    timeoutSeconds: Long = renderTimeoutSeconds,
+  ): PoolResult {
+    synchronized(lock) {
+      disabledReason?.let {
+        return PoolResult.Unusable(it)
+      }
+      if (closed) return PoolResult.Unusable("cmp-jvm worker pool is closed")
+    }
+
+    permits.acquire()
+    var worker: Worker? = null
+    try {
+      worker =
+        takeIdle()
+          ?: when (val started = startWorker(timeoutSeconds)) {
+            is StartOutcome.Started -> started.worker
+            is StartOutcome.Failed -> return PoolResult.Unusable(started.reason)
+          }
+
+      val result =
+        worker.render(
+          docBytes,
+          spec,
+          seedsText,
+          format,
+          theme,
+          requestIds.incrementAndGet(),
+          timeoutSeconds,
+        )
+      if (result is PoolResult.Unusable) {
+        // The worker broke mid-request (wedged, died, desynchronised). It is already destroyed;
+        // dropping it here means the next caller spawns a fresh one.
+        discard(worker)
+        worker = null
+      }
+      return result
+    } finally {
+      val finished = worker
+      if (finished != null) {
+        if (finished.shouldRetire(clock(), maxRendersPerWorker, maxWorkerAgeMillis)) {
+          discard(finished)
+        } else {
+          returnIdle(finished)
+        }
+      }
+      permits.release()
+    }
+  }
+
+  /**
+   * Hand out a parked worker, discarding any that died while idle (an OOM-killer, a stray `pkill
+   * java`) or that aged out while parked — handing back a corpse would surface its EOF as a render
+   * failure on a document that is perfectly fine.
+   */
+  private fun takeIdle(): Worker? {
+    val doomed = ArrayList<Worker>()
+    val chosen =
+      synchronized(lock) {
+        var picked: Worker? = null
+        while (picked == null) {
+          val candidate = idle.pollFirst() ?: break
+          if (
+            candidate.isAlive() &&
+              !candidate.shouldRetire(clock(), maxRendersPerWorker, maxWorkerAgeMillis)
+          ) {
+            picked = candidate
+          } else {
+            doomed += candidate
+          }
+        }
+        picked
+      }
+    doomed.forEach { discard(it) }
+    return chosen
+  }
+
+  private fun returnIdle(worker: Worker) {
+    val parked =
+      synchronized(lock) {
+        if (closed || !worker.isAlive()) false
+        else {
+          idle.addLast(worker)
+          true
+        }
+      }
+    if (!parked) discard(worker)
+  }
+
+  /**
+   * Forget a worker and destroy its process. Idempotent, so the races that can double-discard one —
+   * [close] running while a render thread is finishing with it, say — are harmless.
+   */
+  private fun discard(worker: Worker) {
+    synchronized(lock) {
+      liveWorkers.remove(worker)
+      idle.remove(worker)
+    }
+    worker.close()
+  }
+
+  private sealed interface StartOutcome {
+    class Started(val worker: Worker) : StartOutcome
+
+    class Failed(val reason: String) : StartOutcome
+  }
+
+  private fun startWorker(timeoutSeconds: Long): StartOutcome {
+    val command = buildList {
+      add(javaBin)
+      addAll(extraJvmArgs)
+      add("-cp")
+      add(classpath.joinToString(File.pathSeparator) { it.absolutePath })
+      add(workerMainClass)
+    }
+    return try {
+      val worker = Worker(command, watchdog, clock())
+      worker.handshake(minOf(HANDSHAKE_TIMEOUT_SECONDS, timeoutSeconds.coerceAtLeast(1)))
+      val registered =
+        synchronized(lock) {
+          startFailures = 0
+          // `close()` may have run while this worker was booting. Registering it now would leak a
+          // child JVM that nothing will ever reap.
+          if (closed) false else liveWorkers.add(worker)
+        }
+      if (!registered) {
+        worker.close()
+        StartOutcome.Failed("cmp-jvm worker pool is closed")
+      } else {
+        StartOutcome.Started(worker)
+      }
+    } catch (e: Exception) {
+      val reason = "cmp-jvm worker pool could not start a worker: ${e.message}"
+      synchronized(lock) {
+        startFailures++
+        if (startFailures >= MAX_START_FAILURES) {
+          disabledReason =
+            "$reason (disabled after $startFailures consecutive failures; " +
+              "falling back to one-shot renders)"
+        }
+      }
+      StartOutcome.Failed(reason)
+    }
+  }
+
+  override fun close() {
+    val doomed =
+      synchronized(lock) {
+        closed = true
+        idle.clear()
+        liveWorkers.toList().also { liveWorkers.clear() }
+      }
+    // Every worker, not just the parked ones. Destroying a checked-out worker's process is what
+    // unblocks the render thread waiting on its pipe — and it has to happen *before* the watchdog
+    // stops, because `shutdownNow()` drops the scheduled kill that is the only other way out of
+    // that read.
+    doomed.forEach { it.close() }
+    watchdog.shutdownNow()
+  }
+
+  /**
+   * One worker process plus the frame streams and the bookkeeping that decides when to retire it.
+   */
+  private class Worker(
+    command: List<String>,
+    private val watchdog: java.util.concurrent.ScheduledExecutorService,
+    private val bornAtMillis: Long,
+  ) {
+    private val process = ProcessBuilder(command).redirectErrorStream(false).start()
+    private val toWorker = DataOutputStream(process.outputStream.buffered())
+    private val fromWorker = DataInputStream(process.inputStream.buffered())
+    private val stderrTail = ArrayDeque<String>()
+    private var renders = 0
+
+    init {
+      Thread {
+        try {
+          process.errorStream.bufferedReader().forEachLine { line ->
+            synchronized(stderrTail) {
+              stderrTail.addLast(line)
+              while (stderrTail.size > STDERR_TAIL_LINES) stderrTail.pollFirst()
+            }
+          }
+        } catch (_: IOException) {
+          // The process went away; nothing to drain.
+        }
+      }
+        .apply {
+          name = "rcjvm-worker-stderr"
+          isDaemon = true
+          start()
+        }
+    }
+
+    fun isAlive(): Boolean = process.isAlive
+
+    fun shouldRetire(now: Long, maxRenders: Int, maxAgeMillis: Long): Boolean =
+      renders >= maxRenders || (now - bornAtMillis) >= maxAgeMillis
+
+    /**
+     * Read the worker's hello frame, under a watchdog: a JVM that starts but never speaks (a broken
+     * classpath that hangs, a native loader stuck on a lock) must not block a render thread
+     * forever.
+     */
+    fun handshake(timeoutSeconds: Long) {
+      val guard = armWatchdog(timeoutSeconds)
+      try {
+        val magic = fromWorker.readInt()
+        if (magic != MAGIC_HELLO) {
+          throw IOException("unexpected hello magic $magic (is lib-rcjvm stale?)")
+        }
+        val version = fromWorker.readInt()
+        if (version != PROTOCOL_VERSION) {
+          throw IOException(
+            "worker speaks protocol $version, this cli speaks $PROTOCOL_VERSION " +
+              "(is lib-rcjvm stale?)"
+          )
+        }
+      } catch (e: Exception) {
+        close()
+        throw IOException("${e.message.orEmpty()}${stderrSuffix()}", e)
+      } finally {
+        guard.disarm()
+      }
+    }
+
+    fun render(
+      docBytes: ByteArray,
+      spec: RcJvmRenderSpec,
+      seedsText: String,
+      format: RcJvmServerRenderer.Format,
+      theme: RcJvmServerRenderer.RenderTheme,
+      requestId: Int = 0,
+      renderTimeoutSeconds: Long,
+    ): PoolResult {
+      val guard = armWatchdog(renderTimeoutSeconds)
+      var timedOut = false
+      try {
+        val seeds = seedsText.toByteArray(Charsets.UTF_8)
+        toWorker.writeInt(MAGIC_REQUEST)
+        toWorker.writeInt(requestId)
+        toWorker.writeInt(spec.widthPx)
+        toWorker.writeInt(spec.heightPx)
+        toWorker.writeInt(spec.density.toRawBits())
+        toWorker.writeInt(
+          if (format == RcJvmServerRenderer.Format.SVG) WIRE_FORMAT_SVG else WIRE_FORMAT_PNG
+        )
+        // After `format`, matching `RcJvmRenderWorkerMain`. Both ends ship from the same build, so
+        // the frame is versioned by the build rather than negotiated.
+        toWorker.writeInt(theme.frame)
+        toWorker.writeInt(seeds.size)
+        toWorker.write(seeds)
+        toWorker.writeInt(docBytes.size)
+        toWorker.write(docBytes)
+        toWorker.flush()
+
+        val magic = fromWorker.readInt()
+        if (magic != MAGIC_RESPONSE) {
+          throw IOException("unexpected response magic $magic")
+        }
+        fromWorker.readInt() // requestId — single in-flight request per worker, so informational.
+        val status = fromWorker.readInt()
+        val payloadLen = fromWorker.readInt()
+        if (payloadLen < 0) throw IOException("negative payload length $payloadLen")
+        val payload = ByteArray(payloadLen).also { fromWorker.readFully(it) }
+
+        renders++
+        return if (status == STATUS_OK) {
+          PoolResult.Ok(payload)
+        } else {
+          PoolResult.Failed("cmp-jvm render failed: ${String(payload, Charsets.UTF_8).take(300)}")
+        }
+      } catch (e: Exception) {
+        timedOut = guard.fired()
+        close()
+        val reason =
+          if (timedOut) {
+            "cmp-jvm render timed out after ${renderTimeoutSeconds}s"
+          } else {
+            "cmp-jvm pooled worker failed: ${e.message}${stderrSuffix()}"
+          }
+        // Unusable, not Failed: the *worker* broke, so nothing was learned about the document and
+        // the caller is entitled to try the one-shot path.
+        return PoolResult.Unusable(reason)
+      } finally {
+        guard.disarm()
+      }
+    }
+
+    /**
+     * Arm the kill-switch that bounds a blocking frame read.
+     *
+     * A pipe read has no timeout, so destroying the process is the only thing that can unblock the
+     * render thread. The returned guard records whether it actually *fired*: inferring that from
+     * `!process.isAlive` instead would race, because `destroyForcibly` returns before the OS has
+     * reaped the process, and a timeout would then be reported as a generic worker failure.
+     */
+    private fun armWatchdog(timeoutSeconds: Long): Guard {
+      val fired = java.util.concurrent.atomic.AtomicBoolean(false)
+      val future =
+        watchdog.schedule(
+          {
+            fired.set(true)
+            process.destroyForcibly()
+          },
+          timeoutSeconds,
+          TimeUnit.SECONDS,
+        )
+      return Guard(fired, future)
+    }
+
+    class Guard(
+      private val fired: java.util.concurrent.atomic.AtomicBoolean,
+      private val future: java.util.concurrent.ScheduledFuture<*>,
+    ) {
+      fun fired(): Boolean = fired.get()
+
+      fun disarm() {
+        future.cancel(false)
+      }
+    }
+
+    private fun stderrSuffix(): String {
+      val tail = synchronized(stderrTail) { stderrTail.lastOrNull() }
+      return tail?.takeIf { it.isNotBlank() }?.let { ": ${it.take(300)}" }.orEmpty()
+    }
+
+    fun close() {
+      runCatching { toWorker.close() }
+      runCatching { fromWorker.close() }
+      runCatching { process.destroyForcibly() }
+    }
+  }
+
+  // Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
+  // and the `:server` call sites are in a different module now. Not a widened API by intent.
+  companion object {
+    const val WORKER_MAIN_CLASS = "ee.schimke.composeai.rcembedded.jvm.RcJvmRenderWorkerMainKt"
+
+    // Mirrors `RcJvmRenderWorkerMain.kt`. The cli cannot depend on the player module (its Skiko
+    // natives are deliberately kept off the cli classpath — that is why the render is a subprocess
+    // at all), so the wire constants are duplicated here on purpose. The version check in
+    // [Worker.handshake] is what keeps the duplication honest: a sidecar that disagrees is refused
+    // and the caller falls back, rather than the two sides silently misreading each other.
+    const val MAGIC_HELLO = 0x52435731
+    const val MAGIC_REQUEST = 0x52435131
+    const val MAGIC_RESPONSE = 0x52435231
+    // 2 adds the per-request `theme` field; see `RcJvmRenderWorkerMain`'s frame layout.
+    const val PROTOCOL_VERSION = 2
+    const val STATUS_OK = 0
+    const val STATUS_FAILED = 1
+    const val WIRE_THEME_LIGHT = 0
+    const val WIRE_THEME_DARK = 1
+    const val WIRE_FORMAT_PNG = 0
+    const val WIRE_FORMAT_SVG = 1
+
+    const val HANDSHAKE_TIMEOUT_SECONDS = 60L
+    const val MAX_START_FAILURES = 3
+    const val STDERR_TAIL_LINES = 40
+
+    const val SYS_PROP_ENABLED = "composeai.rcjvm.pool"
+    const val SYS_PROP_WORKERS = "composeai.rcjvm.pool.workers"
+    const val SYS_PROP_MAX_RENDERS = "composeai.rcjvm.pool.maxRenders"
+    const val SYS_PROP_MAX_AGE_MINUTES = "composeai.rcjvm.pool.maxAgeMinutes"
+
+    /**
+     * Default worker count. Each worker is a full Compose Desktop JVM, so this is deliberately
+     * small and independent of core count past a point — serve's own render semaphore already
+     * bounds concurrency, and more workers buy resident memory rather than throughput.
+     */
+    fun defaultWorkers(): Int = (Runtime.getRuntime().availableProcessors() / 2).coerceIn(1, 3)
+
+    fun isEnabled(): Boolean =
+      !System.getProperty(SYS_PROP_ENABLED).equals("off", ignoreCase = true)
+
+    fun configuredWorkers(): Int =
+      System.getProperty(SYS_PROP_WORKERS)?.toIntOrNull()?.coerceIn(1, 16) ?: defaultWorkers()
+
+    fun configuredMaxRenders(): Int =
+      System.getProperty(SYS_PROP_MAX_RENDERS)?.toIntOrNull()?.coerceAtLeast(1) ?: 200
+
+    fun configuredMaxAgeMillis(): Long =
+      (System.getProperty(SYS_PROP_MAX_AGE_MINUTES)?.toLongOrNull()?.coerceAtLeast(1) ?: 30L) *
+        60_000L
+  }
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/RcPlayerBackend.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/RcPlayerBackend.kt
@@ -1,0 +1,127 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.RemoteComposePlayerKind
+
+/**
+ * A Remote Compose render backend the `compose-preview serve` viewer can offer as a per-preview
+ * option — the live counterpart of the columns the offline `rc-compare` pipeline diffs.
+ *
+ * The four are genuinely different renderers of the *same* captured `ir/<id>.rc` document, not
+ * skins over one engine, so a preview can look different under each:
+ *
+ * * [JS] — the vendored TypeScript player (`RC.RcdPlayer`, `third_party/remote-compose-player`),
+ *   run **client-side** in the viewer's `<canvas>`. Needs only the `.rc` bytes (served over `GET
+ *   /render/<id>.rc`); no daemon, no server render. This is the long-standing in-browser lane.
+ * * [CMP_WASM] — this repository's non-JVM Compose Multiplatform player, compiled to Wasm and
+ *   painting through Skiko in a browser iframe. It consumes the same captured bytes as [JS], but
+ *   its codecs and behavior are implemented against AndroidX remote-core rather than the vendored
+ *   TypeScript player.
+ * * [JAVA] — the AOSP `remote-player-view` `RemoteComposePlayer` (an Android `View` painting into a
+ *   framework `Canvas`), driven **server-side** by the daemon via [RemoteComposePlayerKind.VIEW].
+ *   Was the default snapshot player for a Remote Compose preview on an Android backend; that is now
+ *   [CMP_ANDROID], and this lane is what a preview pins itself to (or a `?rcPlayer=java` asks for)
+ *   when the framework `Canvas` is the point.
+ * * [CMP_ANDROID] — the vendored AndroidX embedded `RcPlayer` (`:third-party-rc-embedded-player`),
+ *   which interprets the document's operation tree into Compose layout/draw nodes directly, driven
+ *   server-side via [RemoteComposePlayerKind.EMBEDDED]. The default: it is what a capture bakes
+ *   through, what an unqualified replay uses, and what the viewer opens on.
+ * * [CMP_JVM] — the same embedded player over Skiko/Desktop
+ *   (`:third-party-rc-embedded-player-jvm`), rendered **server-side** by [RcJvmServerRenderer]: it
+ *   spawns the module's `RcJvmRenderMain` as a one-shot subprocess off the CLI install's
+ *   `lib-rcjvm`
+ *     + `lib-daemon-desktop` sidecars (Compose Desktop + Skiko kept out of the CLI's own
+ *       classpath). Unlike [JAVA] / [CMP_ANDROID] it does **not** ride the daemon
+ *       `remoteCompose.player` override — [playerKind] stays null and [ServeHttpServer] renders it
+ *       directly from the captured `.rc` — so a host enables it (via [ServeHost.supportsCmpJvm])
+ *       whenever it carries the document, can size a render for it, and the sidecar is installed.
+ *       Where the sidecar is absent (a headless host, or a build that didn't stage it) the chip
+ *       stays disabled, exactly as before this lane existed.
+ *
+ * The viewer always renders every entry as a chip and enables the subset a host reports through
+ * [ServeHost.enabledRcPlayersFor]; the rest are shown disabled. [wire] is the stable id used both
+ * in the `rcPlayer=` render query param and the `/api/previews` capability list.
+ */
+enum class RcPlayerBackend(
+  /** Stable wire id — the `rcPlayer=` query value and the `/api/previews` capability spelling. */
+  val wire: String,
+  /** Short human label for the selector chip. */
+  val label: String,
+  /**
+   * The daemon player kind a **server-side** backend renders through, or null for the lanes that
+   * don't ride the daemon `remoteCompose.player` override: the client-side [JS] lane and the
+   * [CMP_JVM] lane (which renders in its own isolated subprocess, see [RcJvmServerRenderer]).
+   * Drives [ServeOverrides]'s mapping of the `rcPlayer=` param onto
+   * [ee.schimke.composeai.daemon.protocol.RemoteComposeOverride.player].
+   */
+  val playerKind: RemoteComposePlayerKind?,
+  /**
+   * True when the browser plays the `.rc` document itself (the [JS] lane); false for a PNG lane.
+   */
+  val clientSide: Boolean,
+  /**
+   * This backend's column id in the catalog's published `rc-compare` staging
+   * ([RcCompareManifest.lanes]), or null when the offline pipeline has no column for it.
+   *
+   * The offline parity run already draws every `ir/<id>.rc` document with every player, so this is
+   * what lets a bare `?rcPlayer=<wire>` browse be answered from published bytes instead of a daemon
+   * render.
+   *
+   * [JAVA] maps to **nothing**. It used to own the `baked` column, because the catalog's baked PNG
+   * was a view-backed capture and therefore the reference the other lanes were scored against. It
+   * isn't any more: `RemoteOverridablePreview` defaults to [RemoteComposePlayerKind.EMBEDDED], so
+   * `baked` is an embedded capture and serving it for `?rcPlayer=java` would hand back the wrong
+   * player's pixels under a confident `200`. The java lane therefore routes to the daemon, which
+   * can still draw it on request.
+   */
+  val rcCompareLane: String?,
+) {
+  JS("js", "JS", playerKind = null, clientSide = true, rcCompareLane = "js"),
+  CMP_WASM(
+    "cmp-wasm",
+    "CMP Wasm",
+    playerKind = null,
+    clientSide = true,
+    rcCompareLane = "cmp-wasm",
+  ),
+  JAVA(
+    "java",
+    "Java",
+    playerKind = RemoteComposePlayerKind.VIEW,
+    clientSide = false,
+    rcCompareLane = null,
+  ),
+  CMP_ANDROID(
+    "cmp-android",
+    "CMP Android",
+    playerKind = RemoteComposePlayerKind.EMBEDDED,
+    clientSide = false,
+    rcCompareLane = "embedded",
+  ),
+  CMP_JVM("cmp-jvm", "CMP JVM", playerKind = null, clientSide = false, rcCompareLane = "cmp-jvm");
+
+  companion object {
+    /** The fixed universe the viewer renders as chips, in display order. */
+    val UNIVERSE: List<RcPlayerBackend> = entries.toList()
+
+    /** The backend for [wire], or null when it names none. Case-insensitive. */
+    fun fromWire(wire: String?): RcPlayerBackend? =
+      wire?.lowercase()?.let { v -> entries.firstOrNull { it.wire == v } }
+
+    /**
+     * The server-side backend a `rcPlayer=` render param selects **through the daemon**, or null
+     * otherwise. Accepts the backend [wire] ids (`java`, `cmp-android`) and the daemon-native
+     * player-kind spellings (`view`, `embedded`) as aliases, so a link can be written either way.
+     * `js` (client-side) and `cmp-jvm` yield null: `js` replays in-browser, and `cmp-jvm` renders
+     * in its own subprocess lane ([ServeHttpServer] handles `rcPlayer=cmp-jvm` directly), so
+     * neither rides the daemon override this maps.
+     */
+    fun serverSideFromParam(raw: String): RcPlayerBackend? =
+      when (raw.lowercase()) {
+        "java",
+        "view" -> JAVA
+        "cmp-android",
+        "embedded" -> CMP_ANDROID
+        else -> null
+      }
+  }
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/RemoteComposePairing.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/RemoteComposePairing.kt
@@ -1,0 +1,368 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.io.SystemFileSystem
+import java.io.File
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+/**
+ * Keeps a served bundle's Remote Compose artifacts on **one line** — and says which line, when the
+ * bundle and the daemon sidecar each hold half of one.
+ *
+ * ## The failure this exists to name
+ *
+ * `androidx.compose.remote:*` is a family whose members are compiled against each other:
+ * `remote-player-core`'s `RemoteDocument` reads `RemoteClock.SYSTEM` out of `remote-core`, the
+ * `remote-creation*` artifacts write the documents the players read. Two of them from two builds on
+ * one classpath is a linkage error waiting for the first render — exactly the shape
+ * [SkikoNativePairing] guards for Skiko's bindings/native pair.
+ *
+ * The serve path mixes lines structurally. A bundle records its own Remote Compose coordinates and
+ * [ServeBundleDaemon.shouldPrecedeDaemonSidecar] promotes them ahead of the daemon sidecar (they
+ * are `androidx.`), so the artifacts the bundle **carries** win. The sidecar keeps its own pin for
+ * everything else — and the sidecar's IR replay connector
+ * ([ee.schimke.composeai.daemon.RemoteComposeIrReplay]) links against whatever answers. So a bundle
+ * that carries part of the family leaves the rest at the sidecar's version, and the two halves meet
+ * inside the first IR replay:
+ * ```
+ * java.lang.NoSuchFieldError: Class androidx.compose.remote.core.RemoteClock
+ *   does not have member field 'androidx.compose.remote.core.RemoteClock SYSTEM'
+ *     at androidx.compose.remote.player.core.RemoteDocument.<clinit>(RemoteDocument.java:44)
+ * ```
+ *
+ * — `meshcore-mobile`, whose bundle pins the family at `1.0.0-SNAPSHOT` from an androidx.dev build
+ * against a sidecar on released alphas. The [RenderCircuitBreaker] classifies that as fatal (a
+ * linkage error no retry can clear, correctly), latches the whole catalog's live lane behind it,
+ * and shows the reason as-is: a field name and no cause at all (compose-preview-server#187).
+ *
+ * ## What this adds
+ *
+ * [BundleClasspathGaps] explains a coordinate that went **missing** or came back as the **wrong
+ * bytes**. This is the third shape: everything resolved, every hash matched, and the classpath
+ * still carries two Remote Compose lines because the bundle and the sidecar each supplied part of
+ * the family. Nothing in the resolution record can see that — it is a property of the two lists
+ * side by side, which is where [skew] reads it.
+ *
+ * Deliberately narrow, matching [SkikoNativePairing.classpathSkew]'s "leading half-pair" rule. A
+ * bundle that carries **every** family artifact the sidecar has shadows the sidecar's copies whole
+ * and is coherent whatever its version; a bundle that carries none of them runs entirely on the
+ * sidecar's line and is coherent too. Only a bundle carrying *some* of the family at a version that
+ * is not the sidecar's mixes the two, and only that is reported.
+ *
+ * ## Which side wins
+ *
+ * In that one state, and **only on a bundle that carries IR** ([ServeBundleDaemon] passes `hasIr`),
+ * the bundle's copies stop being promoted ahead of the sidecar ([isFamilyMember] drops them out of
+ * the parent overlay). The gate matters: what makes the sidecar authoritative is that
+ * `RemoteComposeIrReplay` is **sidecar** code and a replayed document has no consumer class of its
+ * own to keep a version priority for. A bundle with no IR has the opposite property — its previews
+ * are consumer bytecode compiled against the versions the bundle records — so
+ * [ServeBundleDaemon.shouldPrecedeDaemonSidecar]'s "the catalog's framework versions win" rule
+ * stands there untouched, and a split family is reported without being rearranged.
+ *
+ * On an IR bundle the exception costs nothing that rule was protecting: a half-promoted family wins
+ * nothing — it links its own half against the sidecar's other half and every render dies. A mixed
+ * bundle (IR previews *and* class-backed ones) is the one place the trade is real, and it goes the
+ * same way: the class-backed previews may lose their own Remote Compose versions, but the
+ * alternative is the fatal breaker latching the lane for **every** preview in the catalog, IR or
+ * not. The worst case after demotion is a document the sidecar's player is too old to replay, which
+ * fails that render and leaves the lane, the rest of the catalog and the background optimizer pass
+ * alive.
+ */
+internal object RemoteComposePairing {
+
+  /**
+   * What every Remote Compose group and package has in common — `androidx.compose.remote`,
+   * `androidx.wear.compose.remote` — so one marker identifies both a coordinate's group and the
+   * package a linkage error names (the internal `androidx/compose/remote/…` form is dotted first).
+   */
+  private const val FAMILY_MARKER = "compose.remote"
+
+  /**
+   * The family's main line, and the group a sidecar jar belongs to unless its artifact says Wear.
+   */
+  const val BASE_GROUP: String = "androidx.compose.remote"
+
+  /** The Wear line, versioned independently of [BASE_GROUP]. */
+  private const val WEAR_GROUP = "androidx.wear.compose.remote"
+
+  /**
+   * Artifacts published by [WEAR_GROUP] rather than [BASE_GROUP]. Needed only for the sidecar side,
+   * where the group is not in the path — a `:cli:installDist` `lib/` is flat, so `remote-material3`
+   * is all there is to go on. The bundle side carries its real group on the coordinate.
+   */
+  private val WEAR_ARTIFACTS = setOf("remote-material3")
+
+  /** File name written beside the launch descriptor, mirroring [BundleClasspathGaps]. */
+  private const val FILE_NAME = "remote-compose-line.json"
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  /**
+   * One Remote Compose artifact, the version the classpath will load it at, and the line it belongs
+   * to.
+   *
+   * [group] is what keeps the **base** family (`androidx.compose.remote`) and the **Wear** one
+   * (`androidx.wear.compose.remote`) from being compared against each other. They version
+   * independently and legitimately — this server's own sidecar ships `remote-core` at
+   * `1.0.0-alpha18` beside `remote-material3` at `1.0.0-alpha10` — so a single "one version across
+   * the whole family" rule would call every such bundle skewed. Defaulted to the base group so a
+   * record written before this field existed still reads back as what it was.
+   */
+  @Serializable
+  data class Member(
+    val artifact: String,
+    val version: String,
+    val group: String = BASE_GROUP,
+  )
+
+  /**
+   * What each side of the daemon `-cp` contributes to the family: the artifacts the bundle carries
+   * (promoted ahead of the sidecar) and the ones the sidecar ships. Persisted so a trip can be
+   * diagnosed without re-deriving a classpath the daemon assembled at materialization.
+   */
+  @Serializable
+  data class Line(
+    val bundle: List<Member> = emptyList(),
+    val sidecar: List<Member> = emptyList(),
+    /**
+     * Whether [ServeBundleDaemon] demoted the bundle's copies behind the sidecar to keep the family
+     * on one line. Defaulted so a record written before the demotion existed still reads back.
+     */
+    val demoted: Boolean = false,
+  )
+
+  /** Whether [coordinate] belongs to the Remote Compose family at all. */
+  fun isFamilyMember(coordinate: BundleReader.ClasspathEntry.Maven): Boolean =
+    coordinate.group.contains(FAMILY_MARKER)
+
+  /**
+   * Whether [coordinate] is in one of the [skewedGroups] this bundle must stop promoting — the
+   * group's own supply is split, so its version priority is worth nothing. A group the bundle
+   * covers coherently keeps its priority even when a sibling group next to it does not.
+   */
+  fun isDemoted(coordinate: BundleReader.ClasspathEntry.Maven, skewedGroups: Set<String>): Boolean =
+    isFamilyMember(coordinate) && coordinate.group in skewedGroups
+
+  /** The family members among the bundle's **resolved** coordinates. */
+  fun bundleMembers(coords: List<BundleReader.ClasspathEntry.Maven>): List<Member> =
+    coords
+      .filter { isFamilyMember(it) }
+      .map { Member(it.artifact, it.version, it.group) }
+      .distinct()
+
+  /**
+   * The family members on the daemon sidecar's own classpath, read off jar filenames.
+   *
+   * The sidecar is a `:cli:installDist` layout — `lib/<artifact>-<version>.jar` — so the artifact
+   * and version are both in the name. Bundle-side artifacts are NOT read this way: a resolved
+   * `.aar` reaches the classpath as `extracted/<sha256>/classes.jar`, which carries neither, which
+   * is why [bundleMembers] reads the coordinates instead.
+   */
+  fun sidecarMembers(sidecarClasspath: List<String>): List<Member> =
+    sidecarClasspath
+      .mapNotNull { path ->
+        val filename = path.replace('\\', '/').substringAfterLast('/')
+        REMOTE_ARTIFACT.matchEntire(filename)?.let {
+          val artifact = it.groupValues[1]
+          Member(
+            artifact,
+            it.groupValues[2],
+            if (artifact in WEAR_ARTIFACTS) WEAR_GROUP else BASE_GROUP,
+          )
+        }
+      }
+      .distinct()
+
+  /**
+   * The sentence for a classpath that will load two Remote Compose lines, or null when the family
+   * is coherent — one side supplies all of it, or both sides agree on the version.
+   *
+   * A version both sides agree on is taken at face value here even when it is a `-SNAPSHOT` that
+   * names no single build: acting on that suspicion at materialization would demote a family that
+   * is probably fine. [mutableVersionSuspicion] carries it to the one place it is evidence.
+   *
+   * "Coherent" is judged per artifact and not per version count: the bundle's copies precede the
+   * sidecar's, so a family artifact the bundle carries is the bundle's whatever else is behind it,
+   * and only an artifact the bundle does **not** carry falls through to the sidecar's version.
+   */
+  fun skew(line: Line): String? {
+    val split = skewedGroups(line)
+    if (split.isEmpty()) return null
+    val bundle = line.bundle.filter { it.group in split }
+    val fallthrough = line.fallthrough().filter { it.group in split }
+    val bundleVersions = bundle.map { it.version }.distinct()
+    val fallthroughVersions = fallthrough.map { it.version }.distinct()
+    val remedy =
+      if (line.demoted)
+        "The server therefore let the sidecar's line win those artifacts: the bundle's copies " +
+          "stay on the classpath but behind the sidecar's, so the daemon's own IR replay links " +
+          "against one coherent set. A document authored against a newer player may still fail to " +
+          "replay — as a per-render error, not a dead lane."
+      else
+        "These artifacts are compiled against each other, so a render that crosses the seam fails " +
+          "with NoSuchFieldError / NoSuchMethodError and no retry can clear it."
+    return "This catalog's bundle carries ${bundle.size} artifact(s) of ${split.joinToString()} " +
+      "at ${bundleVersions.joinToString()}, but ${fallthrough.size} more that the render needs " +
+      "are not in the bundle and come from the daemon sidecar instead, at " +
+      "${fallthroughVersions.joinToString()} — ${fallthrough.joinToString { it.artifact }}. " +
+      "$remedy Republish the catalog against the Remote Compose version this server ships, or " +
+      "against one whose whole family the bundle records."
+  }
+
+  /**
+   * The Remote Compose groups whose supply is split between the bundle and the sidecar at differing
+   * versions — the groups [ServeBundleDaemon] must stop promoting on an IR bundle, and empty when
+   * the classpath is coherent.
+   *
+   * Judged **per group**, never across the family as a whole. `androidx.compose.remote` and
+   * `androidx.wear.compose.remote` version independently (alpha18 beside alpha10 in this server's
+   * own sidecar), so a bundle carrying both lines is normal and comparing one against the other
+   * would report a skew that is not there — and then demote a base family the bundle carries
+   * coherently, which is the failure this whole file exists to prevent.
+   *
+   * Within a group it is judged per artifact and not per version count: the bundle's copies precede
+   * the sidecar's, so an artifact the bundle carries is the bundle's whatever else is behind it,
+   * and only an artifact it does **not** carry falls through to the sidecar's version.
+   */
+  fun skewedGroups(line: Line): Set<String> {
+    if (line.bundle.isEmpty()) return emptySet()
+    val fallthrough = line.fallthrough()
+    return line.bundle
+      .map { it.group }
+      .distinct()
+      .filterTo(mutableSetOf()) { group ->
+        val carried = line.bundle.filter { it.group == group }.map { it.version }.distinct()
+        val missing = fallthrough.filter { it.group == group }
+        if (missing.isEmpty()) false
+        else carried.size != 1 || carried != missing.map { it.version }.distinct()
+      }
+  }
+
+  /** The family artifacts the render takes from the sidecar because the bundle records none. */
+  private fun Line.fallthrough(): List<Member> {
+    val carried = bundle.mapTo(mutableSetOf()) { it.group to it.artifact }
+    return sidecar.filter { (it.group to it.artifact) !in carried }
+  }
+
+  /**
+   * Persist the two sides beside the launch descriptor in [destDir] and log the skew, if any.
+   *
+   * The record is written whenever the bundle names the family at all — a healthy catalog costs one
+   * small file and lets a later trip say "the line was coherent" by finding nothing to report,
+   * rather than by finding nothing at all.
+   */
+  fun record(
+    destDir: File,
+    bundle: List<Member>,
+    sidecar: List<Member>,
+    system: String,
+    onLog: (String) -> Unit,
+    demoted: Boolean = false,
+    fileSystem: FileSystem = SystemFileSystem,
+  ) {
+    if (bundle.isEmpty()) return
+    val line = Line(bundle = bundle, sidecar = sidecar, demoted = demoted)
+    skew(line)?.let { onLog("catalog $system: $it") }
+    runCatching {
+      fileSystem.write(File(destDir, FILE_NAME).path.toPath()) {
+        writeUtf8(json.encodeToString(Line.serializer(), line))
+      }
+    }
+  }
+
+  /**
+   * The split a **mutable** version hides: the two sides read the same `-SNAPSHOT`, which names no
+   * single build, so version equality proves nothing about whether they came from one. Null when
+   * the family is not split at all, or when the versions that agree are released ones.
+   *
+   * Not enough to act on at materialization — demoting a family that is probably coherent would
+   * cost every catalog on a snapshot line its own versions for no evidence. It IS enough once a
+   * Remote Compose linkage error has actually happened, which is the only place it is read: at that
+   * point the classpath has demonstrated the split that the version strings could not rule out.
+   * This is the shape that killed `meshcore-mobile` before content-keyed extraction landed
+   * (compose-ai-tools#5015) — both sides said `1.0.0-SNAPSHOT` and a stale extraction served one of
+   * them from another build.
+   */
+  private fun mutableVersionSuspicion(line: Line): String? {
+    if (line.bundle.isEmpty()) return null
+    val fallthrough = line.fallthrough()
+    for (group in line.bundle.map { it.group }.distinct()) {
+      val missing = fallthrough.filter { it.group == group }
+      if (missing.isEmpty()) continue
+      val version =
+        (line.bundle.filter { it.group == group } + missing)
+          .map { it.version }
+          .distinct()
+          .singleOrNull() ?: continue
+      if (!version.endsWith("-SNAPSHOT")) continue
+      return "This catalog's bundle carries ${line.bundle.count { it.group == group }} artifact(s) " +
+        "of $group and ${missing.size} more that the render needs come from the daemon sidecar " +
+        "instead — ${missing.joinToString { it.artifact }}. Both sides read $version, which names " +
+        "no single build, so that is not evidence they came from one; a linkage error inside these " +
+        "packages is exactly what two builds of one snapshot look like. Republish the catalog " +
+        "against released Remote Compose versions, which do name a build."
+    }
+    return null
+  }
+
+  /**
+   * One sentence attributing a **fatal** linkage [reason] inside the Remote Compose packages to a
+   * classpath that mixes two of its lines — or null when the failure is not Remote Compose's, the
+   * record is unreadable, or the family was coherent and the failure has some other cause.
+   *
+   * Read at trip time from [descriptorPath]'s directory, mirroring
+   * [SkikoNativePairing.linkageDiagnosis] and [BundleClasspathGaps.linkageDiagnosis]: the open
+   * breaker's reason is the only report anyone outside the box reads.
+   */
+  fun linkageDiagnosis(
+    reason: String,
+    descriptorPath: File,
+    fileSystem: FileSystem = SystemFileSystem,
+  ): String? {
+    if (LINKAGE_MARKERS.none { it in reason }) return null
+    if (FAMILY_MARKER !in reason.replace('/', '.')) return null
+    val file = File(descriptorPath.parentFile ?: return null, FILE_NAME)
+    val line =
+      runCatching {
+        fileSystem
+          .read(file.path.toPath()) { readUtf8() }
+          .let { json.decodeFromString(Line.serializer(), it) }
+      }
+        .getOrNull() ?: return null
+    return skew(line) ?: mutableVersionSuspicion(line)
+  }
+
+  /**
+   * `remote-core-1.0.0-alpha18.jar`, `remote-player-view-1.0.0-SNAPSHOT.jar`,
+   * `remote-material3-1.0.0-alpha10.jar` — the family's published artifacts, named from a flat
+   * `lib/` directory where the group is not in the path.
+   *
+   * The second segment is enumerated rather than left open (`remote-\w+`) so an unrelated
+   * `remote-…` jar from some other group cannot be read as a Remote Compose member and reported as
+   * a skew that isn't one. Every published family artifact starts with one of these: `remote-core`,
+   * `remote-player-*`, `remote-creation-*`, `remote-tooling-preview`, `remote-foundation`,
+   * `remote-material3`.
+   */
+  private val REMOTE_ARTIFACT =
+    Regex(
+      """^(remote-(?:core|player|creation|tooling|foundation|material3)(?:-[a-z0-9]+)*)-""" +
+        """(\d[\w.\-]*)\.jar$"""
+    )
+
+  /**
+   * Linkage markers a mixed family explains. The same set [BundleClasspathGaps] uses and for the
+   * same reason: a `VerifyError` or an `UnsatisfiedLinkError` is a different fault, and two Remote
+   * Compose lines say nothing useful about it.
+   */
+  private val LINKAGE_MARKERS =
+    listOf(
+      "NoSuchFieldError",
+      "NoSuchMethodError",
+      "NoClassDefFoundError",
+      "ClassNotFoundException",
+    )
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/RenderCircuitBreaker.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/RenderCircuitBreaker.kt
@@ -1,0 +1,240 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Classifies a render failure reason as **fatal** (a fault no retry of any request can clear) or
+ * transient.
+ *
+ * A daemon that fails to link a native symbol, resolve a class, or find a method is broken at the
+ * classpath/runtime level: the same call will fail identically for every preview, every override,
+ * forever. Retrying is not merely useless, it is actively harmful — see [RenderCircuitBreaker].
+ */
+object RenderFailureClassifier {
+  /**
+   * Substrings of a failure reason that mean "linkage/classpath fault". Matched against the reason
+   * text because that is all the serve host has: the daemon reports its render failure as a message
+   * (`render failed: UnsatisfiedLinkError: 'long org.jetbrains.skia…'`), not a typed throwable
+   * across the RPC boundary.
+   *
+   * Every entry is a [LinkageError] subtype (or [ClassNotFoundException], its checked cousin) —
+   * deliberately narrow. A `NullPointerException` from one preview's composition says nothing about
+   * the next preview; a `NoSuchMethodError` says the two halves of the classpath disagree, which no
+   * input can route around.
+   */
+  private val FATAL_MARKERS =
+    listOf(
+      "UnsatisfiedLinkError",
+      "NoClassDefFoundError",
+      "NoSuchMethodError",
+      "NoSuchFieldError",
+      "ClassNotFoundException",
+      "ExceptionInInitializerError",
+      "IncompatibleClassChangeError",
+      "AbstractMethodError",
+      "UnsupportedClassVersionError",
+      "VerifyError",
+      // The base type, last: a daemon that reports a bare `LinkageError` is in the same bucket.
+      "LinkageError",
+    )
+
+  /** The linkage fault named in [reason], or null when it is an ordinary (retryable) failure. */
+  fun fatalMarker(reason: String): String? = FATAL_MARKERS.firstOrNull { it in reason }
+
+  fun isFatal(reason: String): Boolean = fatalMarker(reason) != null
+}
+
+/**
+ * Per-daemon breaker that stops a [ServeRenderHost] from re-attempting renders it has proved it
+ * cannot serve.
+ *
+ * ## Why
+ *
+ * Issue #3448: an `m3-catalog` daemon hit an `UnsatisfiedLinkError` — a JVM linkage failure that
+ * cannot succeed on retry, ever, for any input — and the host retried it **3794 times in ~14
+ * minutes**, still going. Nothing backed off and nothing gave up, with three separate consequences:
+ * the theme-optimization pass kept feeding a renderer that could not render (275s of gate wait, a
+ * ~7h ETA on work where every item fails); user requests never reached the renderer and timed out
+ * into `503 render busy; retry shortly`, a diagnosis wrong in both directions; and the catalog went
+ * on advertising itself live and healthy at a 95% failure rate.
+ *
+ * ## What
+ *
+ * Two independent trips, because the first is precise and the second is the backstop:
+ * - **Fatal classification.** The first failure [RenderFailureClassifier] calls fatal opens the
+ *   breaker **terminally** — no cooldown, no probe. There is nothing to wait for.
+ * - **Sustained failure rate.** Regardless of class, once [minSamples] outcomes are in the rolling
+ *   window and at least [failureRateThreshold] of them failed, the breaker opens. This catches an
+ *   unclassified fatal error (a message shape nobody anticipated) without needing to name it. A
+ *   rate-tripped breaker is *not* terminal: after [probeCooldownMillis] it lets exactly one render
+ *   through, and a success closes it — a genuine wave of transient failures heals itself.
+ *
+ * While open, [blockedReason] short-circuits renders with the underlying failure text, which is
+ * what turns the useless `503 busy; retry shortly` into an actionable answer naming the linkage
+ * error, and what lets the host drop its `hasLiveStream` / publish a [ServeDegradation] instead of
+ * claiming health.
+ *
+ * Thread-safe; every method takes one short critical section.
+ */
+class RenderCircuitBreaker(
+  /** Outcomes that must be in the window before the rate trip can fire at all. */
+  private val minSamples: Int = MIN_SAMPLES,
+  /** Failure fraction of the window at or above which the rate trip fires. */
+  private val failureRateThreshold: Double = FAILURE_RATE_THRESHOLD,
+  private val windowSize: Int = WINDOW_SIZE,
+  /** How long a rate-tripped breaker stays shut before admitting one probe render. */
+  private val probeCooldownMillis: Long = PROBE_COOLDOWN_MILLIS,
+  private val clock: () -> Long = System::currentTimeMillis,
+  /**
+   * Given the failure text of a **fatal** trip, one extra sentence explaining it — or null when
+   * there is nothing to add.
+   *
+   * The open breaker's reason is what every refused render answers with, so it is the only
+   * diagnosis anyone outside the box ever sees. A bare `UnsatisfiedLinkError: 'int
+   * org.jetbrains.skia…'` names the missing symbol and nothing that explains it, which is how
+   * issue #4220 was reported and why its cause had to be inferred from outside; the serve path
+   * supplies [SkikoNativePairing.linkageDiagnosis] here so the same body also names the Skiko skew
+   * the daemon's own classpath carries. Called once, under the lock, on the trip only — never on
+   * the hot path. Anything it throws is dropped: a diagnosis must not cost the trip.
+   */
+  private val linkageDiagnosis: (String) -> String? = { null },
+) {
+  private val lock = Any()
+
+  // Rolling outcome window: true = failed. Bounded, so the rate reflects recent behaviour rather
+  // than an all-time blur — a daemon that served fine for an hour before breaking must still trip.
+  private val window = ArrayDeque<Boolean>()
+
+  private var openReason: String? = null
+  private var fatal = false
+  private var openedAtEpochMillis: Long? = null
+  private var tripFailureRate: Double? = null
+  // When the next probe may be admitted; only meaningful for a rate trip.
+  private var nextProbeAtMillis: Long = 0
+  private var shortCircuited = 0L
+
+  /**
+   * Why this render must not be attempted, or null to proceed.
+   *
+   * **Mutating**: a rate-tripped breaker past its cooldown returns null here and arms the next
+   * cooldown, admitting exactly one probe render. Use [peekReason] for a read-only look (status
+   * reporting, the HTTP failure latch) so a status poll can't spend the probe.
+   */
+  fun blockedReason(): String? =
+    synchronized(lock) {
+      val reason = openReason ?: return null
+      if (fatal) {
+        shortCircuited++
+        return reason
+      }
+      val now = clock()
+      if (now >= nextProbeAtMillis) {
+        // Half-open: admit this one render and re-arm, so a probe that also fails doesn't open the
+        // floodgates until the next cooldown elapses.
+        nextProbeAtMillis = now + probeCooldownMillis
+        return null
+      }
+      shortCircuited++
+      reason
+    }
+
+  /** Read-only [blockedReason]: never admits a probe, never counts a short-circuit. */
+  fun peekReason(): String? = synchronized(lock) { openReason }
+
+  /** A render succeeded. Closes a rate-tripped breaker; a fatal one stays open. */
+  fun recordOk(): Unit =
+    synchronized(lock) {
+      push(false)
+      if (fatal) return
+      openReason = null
+      openedAtEpochMillis = null
+      tripFailureRate = null
+      window.clear()
+    }
+
+  /** A render failed with [reason]; trips the breaker when fatal or when the rate says so. */
+  fun recordFailure(reason: String): Unit =
+    synchronized(lock) {
+      push(true)
+      if (fatal) return
+      val marker = RenderFailureClassifier.fatalMarker(reason)
+      if (marker != null) {
+        fatal = true
+        val diagnosis = runCatching { linkageDiagnosis(reason) }.getOrNull()
+        openReason =
+          "render lane disabled after a non-recoverable $marker — retrying cannot help. " +
+            "Last failure: $reason" +
+            diagnosis?.let { " $it" }.orEmpty()
+        openedAtEpochMillis = clock()
+        tripFailureRate = failureRate()
+        return
+      }
+      if (window.size < minSamples) return
+      val rate = failureRate()
+      if (rate < failureRateThreshold) return
+      if (openReason == null) {
+        openedAtEpochMillis = clock()
+        nextProbeAtMillis = clock() + probeCooldownMillis
+      }
+      tripFailureRate = rate
+      openReason =
+        "render lane disabled after ${(rate * 100).toInt()}% of the last ${window.size} renders " +
+          "failed; retrying periodically. Last failure: $reason"
+    }
+
+  /** Point-in-time state for `/status.json`, or null while the breaker has never tripped. */
+  fun snapshot(): RenderBreakerSnapshot? =
+    synchronized(lock) {
+      val reason = openReason ?: return null
+      RenderBreakerSnapshot(
+        open = true,
+        fatal = fatal,
+        reason = reason,
+        openedAtEpochMillis = openedAtEpochMillis,
+        failureRate = tripFailureRate,
+        sampleCount = window.size,
+        shortCircuitedRenders = shortCircuited,
+      )
+    }
+
+  private fun push(failed: Boolean) {
+    window.addLast(failed)
+    while (window.size > windowSize) window.removeFirst()
+  }
+
+  private fun failureRate(): Double =
+    if (window.isEmpty()) 0.0 else window.count { it }.toDouble() / window.size
+
+  companion object {
+    const val MIN_SAMPLES: Int = 20
+    const val FAILURE_RATE_THRESHOLD: Double = 0.9
+    const val WINDOW_SIZE: Int = 50
+
+    /**
+     * Cooldown between probe renders on a rate-tripped breaker. Long enough that a wedged daemon
+     * costs one render a minute instead of thousands (the #3448 behaviour), short enough that a
+     * transient wave — a daemon restart, a burst of cold-start timeouts — heals within a browse.
+     */
+    const val PROBE_COOLDOWN_MILLIS: Long = 60_000L
+  }
+}
+
+/**
+ * Open-breaker state for one daemon's render lane, serialized onto `/status.json` under
+ * `renderStats.breaker`. Present only while the breaker is open — its absence is the healthy case.
+ * Additive on `compose-preview-serve/status/v1`.
+ */
+@Serializable
+data class RenderBreakerSnapshot(
+  val open: Boolean,
+  /** A linkage/classpath fault: terminal, never probed, needs a redeploy rather than a retry. */
+  val fatal: Boolean,
+  /** Human-readable text also returned to callers in place of the render. */
+  val reason: String,
+  val openedAtEpochMillis: Long? = null,
+  /** Failure fraction of the outcome window when the breaker tripped. */
+  val failureRate: Double? = null,
+  val sampleCount: Int = 0,
+  /** Renders refused outright while open — the work this breaker is not doing. */
+  val shortCircuitedRenders: Long = 0,
+)

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/RenderPerfStats.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/RenderPerfStats.kt
@@ -1,0 +1,271 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Aggregate render-performance counters for one daemon-backed [ServeHost] — the serve-side
+ * companion to the daemon's own `compose-ai-daemon: [+Nms]` stderr markers, kept queryable so
+ * `/status.json` can report cold vs warm render behaviour without anyone tailing container logs.
+ *
+ * Recorded by [ServeRenderHost.render] around the full serve-side render round-trip (renderNow →
+ * renderFinished → PNG read), which is the latency a `/render` caller actually experiences —
+ * deliberately not the daemon-internal engine time, which the per-phase trace recorder
+ * (`composeai.daemon.perfettoTrace`) already covers.
+ *
+ * Thread-safe; all methods take one short critical section. Percentiles come from a bounded ring of
+ * the most recent [WINDOW_SIZE] successful render durations, so a long-lived daemon reports recent
+ * behaviour rather than an all-time blur (the all-time min/max/avg/first are kept separately).
+ */
+class RenderPerfStats {
+  private val lock = Any()
+
+  private var renders = 0L
+  private var ok = 0L
+  private var failed = 0L
+  private var timedOut = 0L
+  private var busy = 0L
+  private var shortCircuited = 0L
+  private var cacheHits = 0L
+  private var coldOk = 0L
+  private var firstRenderMs: Long? = null
+  private var coldMaxMs = 0L
+  private var minMs = Long.MAX_VALUE
+  private var maxMs = 0L
+  private var totalMs = 0L
+  private var lastMs: Long? = null
+  private var lastRenderFailed = false
+  private var lastFailureReason: String? = null
+  private var lastFailureAtEpochMillis: Long? = null
+  private val recentFailures = ArrayDeque<RenderFailureSample>()
+  private val window = LongArray(WINDOW_SIZE)
+  private var windowCount = 0
+  private var windowIdx = 0
+
+  /** A `/render` served straight from the PNG cache — no daemon round-trip. */
+  fun recordCacheHit(): Unit = synchronized(lock) { cacheHits++ }
+
+  /** The bounded render-lock acquire backed off ([RenderOutcome.Busy] → caller serves baked). */
+  fun recordBusy(): Unit = synchronized(lock) { busy++ }
+
+  /**
+   * A render refused without asking the daemon because this host's [RenderCircuitBreaker] is open.
+   * Its own counter rather than a [recordFailed]: the daemon was never asked, so folding these into
+   * `failed` would inflate the very failure rate that tripped the breaker and hide how much work
+   * the breaker is saving.
+   */
+  fun recordShortCircuit(): Unit = synchronized(lock) { shortCircuited++ }
+
+  /**
+   * A render that ended in [RenderOutcome.Failed]; [timeout] when it blew its render budget.
+   * [reason] is the outcome's failure text — kept (truncated) so `/status.json` can say WHY a
+   * catalog's live lane is failing without anyone tailing container logs: a daemon whose every
+   * render fails otherwise shows only a climbing `failed` counter while the composite silently
+   * serves baked fallback.
+   */
+  fun recordFailed(durationMs: Long, timeout: Boolean, reason: String? = null): Unit =
+    synchronized(lock) {
+      renders++
+      failed++
+      lastRenderFailed = true
+      if (timeout) timedOut++
+      lastMs = durationMs
+      if (reason != null) {
+        lastFailureReason = reason.take(MAX_FAILURE_REASON_LENGTH)
+        lastFailureAtEpochMillis = System.currentTimeMillis()
+        recentFailures.addLast(
+          RenderFailureSample(
+            atEpochMillis = lastFailureAtEpochMillis!!,
+            durationMs = durationMs,
+            timedOut = timeout,
+            reason = lastFailureReason!!,
+          )
+        )
+        while (recentFailures.size > FAILURE_WINDOW_SIZE) recentFailures.removeFirst()
+      }
+    }
+
+  /**
+   * A successful render taking [durationMs] end-to-end. [cold] marks renders issued while the host
+   * had not yet completed any successful render — the cold-start population the background-boot /
+   * warm-render work targets — so `/status` can separate first-render latency from steady state.
+   */
+  fun recordOk(durationMs: Long, cold: Boolean): Unit =
+    synchronized(lock) {
+      renders++
+      ok++
+      lastRenderFailed = false
+      if (cold) {
+        coldOk++
+        if (firstRenderMs == null) firstRenderMs = durationMs
+        if (durationMs > coldMaxMs) coldMaxMs = durationMs
+      }
+      if (durationMs < minMs) minMs = durationMs
+      if (durationMs > maxMs) maxMs = durationMs
+      totalMs += durationMs
+      lastMs = durationMs
+      window[windowIdx] = durationMs
+      windowIdx = (windowIdx + 1) % window.size
+      if (windowCount < window.size) windowCount++
+    }
+
+  fun snapshot(): RenderPerfSnapshot =
+    synchronized(lock) {
+      val sorted = window.copyOf(windowCount).also { it.sort() }
+      fun pct(p: Double): Long? =
+        if (sorted.isEmpty()) null else sorted[((sorted.size - 1) * p).toInt()]
+      RenderPerfSnapshot(
+        renders = renders,
+        ok = ok,
+        failed = failed,
+        timedOut = timedOut,
+        busy = busy,
+        shortCircuited = shortCircuited,
+        cacheHits = cacheHits,
+        coldRenders = coldOk,
+        firstRenderMs = firstRenderMs,
+        coldMaxMs = if (coldOk > 0) coldMaxMs else null,
+        minMs = if (ok > 0) minMs else null,
+        maxMs = if (ok > 0) maxMs else null,
+        avgMs = if (ok > 0) totalMs / ok else null,
+        lastMs = lastMs,
+        p50Ms = pct(0.5),
+        p95Ms = pct(0.95),
+        windowSize = windowCount,
+        lastRenderFailed = lastRenderFailed,
+        lastFailureReason = lastFailureReason,
+        lastFailureAtEpochMillis = lastFailureAtEpochMillis,
+        recentFailures = recentFailures.toList().asReversed(),
+      )
+    }
+
+  companion object {
+    /** Ring size for the recent-durations percentile window. */
+    const val WINDOW_SIZE: Int = 128
+
+    /** Cap on the carried failure-reason text — enough for a message, not a stack trace. */
+    const val MAX_FAILURE_REASON_LENGTH: Int = 300
+
+    /** Number of render errors retained for the human status page. */
+    const val FAILURE_WINDOW_SIZE: Int = 10
+  }
+}
+
+/** One recent failed render, newest-first in [RenderPerfSnapshot.recentFailures]. */
+@Serializable
+data class RenderFailureSample(
+  val atEpochMillis: Long,
+  val durationMs: Long,
+  val timedOut: Boolean,
+  val reason: String,
+)
+
+/**
+ * Point-in-time projection of [RenderPerfStats], serialized verbatim onto `/status.json`
+ * (`runningServers[].renderStats` and the server-wide `renderStats` aggregate). All duration fields
+ * are wall-clock milliseconds of the serve-side render round-trip; null means "no sample yet".
+ * Additive on `compose-preview-serve/status/v1`.
+ */
+@Serializable
+data class RenderPerfSnapshot(
+  /** Renders attempted against the daemon (ok + failed; excludes cache hits and busy backoffs). */
+  val renders: Long,
+  val ok: Long,
+  val failed: Long,
+  /** Subset of [failed] that blew the render budget. */
+  val timedOut: Long,
+  /** Bounded lock acquires that backed off to baked ([RenderOutcome.Busy]). */
+  val busy: Long,
+  /**
+   * Renders refused without asking the daemon because the host's [RenderCircuitBreaker] is open —
+   * the retry storm that is no longer happening. Excluded from [renders] and [failed]: the daemon
+   * was never asked.
+   */
+  val shortCircuited: Long = 0,
+  /** `/render`s served from the PNG cache without waking the daemon. */
+  val cacheHits: Long,
+  /** Successful renders issued before the host's first success — the cold-start population. */
+  val coldRenders: Long,
+  /** Duration of the host's very first successful render (the cold-start headline number). */
+  val firstRenderMs: Long? = null,
+  val coldMaxMs: Long? = null,
+  val minMs: Long? = null,
+  val maxMs: Long? = null,
+  val avgMs: Long? = null,
+  /** Duration of the most recent render (ok or failed). */
+  val lastMs: Long? = null,
+  /** Percentiles over the last [windowSize] successful renders. */
+  val p50Ms: Long? = null,
+  val p95Ms: Long? = null,
+  val windowSize: Int = 0,
+  /** Current lane signal: true only when the most recently completed daemon render failed. */
+  val lastRenderFailed: Boolean = false,
+  /**
+   * The most recent failure's reason text (truncated) + when it happened — the "why" behind a
+   * non-zero [failed] counter, so a catalog whose live lane silently falls back to baked is
+   * diagnosable from `/status.json` alone.
+   */
+  val lastFailureReason: String? = null,
+  val lastFailureAtEpochMillis: Long? = null,
+  /** Bounded, newest-first failure detail for status diagnostics. */
+  val recentFailures: List<RenderFailureSample> = emptyList(),
+  /**
+   * Set while this lane's [RenderCircuitBreaker] is open — the host has stopped attempting renders
+   * and is answering with [RenderBreakerSnapshot.reason] instead. Null is the healthy case.
+   */
+  val breaker: RenderBreakerSnapshot? = null,
+) {
+  companion object {
+    /**
+     * Server-wide roll-up across daemons for the `/status` summary. Counts sum; min/max span;
+     * `avgMs` is ok-weighted; `firstRenderMs` reports the WORST first render (the number the
+     * cold-start work drives down). Percentiles don't merge across windows, so they stay null.
+     */
+    fun aggregate(snapshots: List<RenderPerfSnapshot>): RenderPerfSnapshot? {
+      if (snapshots.isEmpty()) return null
+      val ok = snapshots.sumOf { it.ok }
+      return RenderPerfSnapshot(
+        renders = snapshots.sumOf { it.renders },
+        ok = ok,
+        failed = snapshots.sumOf { it.failed },
+        timedOut = snapshots.sumOf { it.timedOut },
+        busy = snapshots.sumOf { it.busy },
+        shortCircuited = snapshots.sumOf { it.shortCircuited },
+        cacheHits = snapshots.sumOf { it.cacheHits },
+        coldRenders = snapshots.sumOf { it.coldRenders },
+        firstRenderMs = snapshots.mapNotNull { it.firstRenderMs }.maxOrNull(),
+        coldMaxMs = snapshots.mapNotNull { it.coldMaxMs }.maxOrNull(),
+        minMs = snapshots.mapNotNull { it.minMs }.minOrNull(),
+        maxMs = snapshots.mapNotNull { it.maxMs }.maxOrNull(),
+        avgMs = if (ok > 0) snapshots.sumOf { (it.avgMs ?: 0) * it.ok } / ok else null,
+        lastMs = null,
+        p50Ms = null,
+        p95Ms = null,
+        windowSize = snapshots.sumOf { it.windowSize },
+        lastRenderFailed = snapshots.any { it.lastRenderFailed },
+        // Most recent failure across daemons (by timestamp) so the roll-up carries a "why" too.
+        lastFailureReason =
+          snapshots
+            .filter { it.lastFailureAtEpochMillis != null }
+            .maxByOrNull { it.lastFailureAtEpochMillis!! }
+            ?.lastFailureReason,
+        lastFailureAtEpochMillis = snapshots.mapNotNull { it.lastFailureAtEpochMillis }.maxOrNull(),
+        recentFailures =
+          snapshots
+            .flatMap { it.recentFailures }
+            .sortedByDescending { it.atEpochMillis }
+            .take(RenderPerfStats.FAILURE_WINDOW_SIZE),
+        // A fatal (linkage) trip wins over a rate trip, then the most recent — the roll-up should
+        // name the breaker that most needs a human, not whichever daemon happens to sort first.
+        breaker =
+          snapshots
+            .mapNotNull { it.breaker }
+            .filter { it.open }
+            .sortedWith(
+              compareByDescending<RenderBreakerSnapshot> { it.fatal }
+                .thenByDescending { it.openedAtEpochMillis ?: 0 }
+            )
+            .firstOrNull(),
+      )
+    }
+  }
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAnnotations.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAnnotations.kt
@@ -1,0 +1,197 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toOkioPath
+import okio.Path.Companion.toPath
+
+/**
+ * Design annotations — the typography and layout facts behind a rendered frame.
+ *
+ * The compare page can only diff pixels on its own: it shows that two frames differ, never *why*.
+ * An annotation carries the spec a designer reads off the mock — the type style and size, the
+ * padding and gap — anchored to a region so the page can draw it over either panel. With both sides
+ * annotated, "these look slightly off" becomes "reference says bodyLarge/16dp, actual says
+ * titleMedium/12dp".
+ *
+ * Producer-side, not inferred here. The reference layer comes from the design tool (the Figma
+ * adapter's captured layout geometry); the actual layer is walked from the Compose semantics tree.
+ * The serve host only transports and draws them, exactly as it does for design references — it
+ * never measures pixels or fetches design URLs itself.
+ */
+@Serializable
+data class AnnotationManifest(
+  val schema: String = SCHEMA,
+  /** Annotations over a preview's *rendered* frame, keyed by exact serve/catalog preview id. */
+  val previews: Map<String, List<DesignAnnotation>> = emptyMap(),
+  /** Annotations over a *reference* raster, keyed by [DesignReference.id]. */
+  val references: Map<String, List<DesignAnnotation>> = emptyMap(),
+) {
+  companion object {
+    const val SCHEMA = "compose-preview-annotations/v1"
+  }
+}
+
+/** Which spec layer an annotation belongs to; the compare page toggles them independently. */
+object AnnotationKind {
+  const val TYPOGRAPHY = "typography"
+
+  /**
+   * Box geometry and the tokens that shaped it — size, padding, arrangement gap, `defaultMinSize`.
+   * Authored by a producer for the reference side of the compare page, and since issue #4328 also
+   * derived live from a render's own semantics tree by [ServeDesignAnnotations], so the viewer's
+   * inspection layers can show the code side of the same redline.
+   */
+  const val LAYOUT = "layout"
+
+  /**
+   * Resolved theme attributes of a container — fill / border colour, corner radius, shape. Produced
+   * live from the render's own semantics tree by [ServeDesignAnnotations] for the viewer's
+   * inspection layers, rather than authored in a bundle's `annotations/index.json` (the compare
+   * page's producer-side layers are [TYPOGRAPHY] / [LAYOUT] only).
+   */
+  const val THEME = "theme"
+
+  val KNOWN = setOf(TYPOGRAPHY, LAYOUT, THEME)
+
+  /**
+   * The layers a **published bundle** can answer on its own, without a daemon.
+   *
+   * Typography alone, and the narrowness is the point. A producer authors [TYPOGRAPHY] and [LAYOUT]
+   * into `annotations/index.json`, but the published layout layer is the compare page's
+   * producer-side redline over a *reference* raster — [ServeBundleHost.drawableAnnotations] drops
+   * it from the viewer's overlay for that reason — and [THEME] is derived live from a render's
+   * semantics tree and is never authored into a bundle at all. So typography is the one layer for
+   * which "the bundle already has it" is true, and answering a request for either of the others
+   * from published bytes would return a payload silently missing what was asked for.
+   *
+   * [publishedLayersSuffice] is the predicate; this set is the reason it is not simply "whatever
+   * the bundle happens to carry".
+   */
+  val PUBLISHABLE = setOf(TYPOGRAPHY)
+
+  /**
+   * Whether a `.annotations` request naming exactly [layers] can be answered from a bundle's
+   * published index without losing a layer the caller asked for.
+   *
+   * False for a null (unscoped) request — a caller that named no layers is asking for all of them,
+   * which is what every client did before `layers=` existed, and what a hand-typed URL still does.
+   * Answering those from published bytes is precisely the regression #224 reverted.
+   */
+  fun publishedLayersSuffice(layers: Set<String>?): Boolean =
+    layers != null && layers.isNotEmpty() && PUBLISHABLE.containsAll(layers)
+
+  /**
+   * The `layers=` query value parsed into a validated kind set, or null when the request named none
+   * (or none that this build knows). Null means "every layer", the pre-`layers=` behaviour.
+   */
+  fun parseLayers(raw: String?): Set<String>? =
+    raw?.split(',')?.map { it.trim() }?.filter { it in KNOWN }?.toSet()?.takeIf { it.isNotEmpty() }
+}
+
+/**
+ * One annotation anchored to a region of the frame it describes.
+ *
+ * [bounds] are in the annotated image's own pixel space — the reference raster's for a reference
+ * annotation, the render's for a preview one. The two frames are usually different sizes, so the
+ * page scales each layer to its panel rather than assuming a shared coordinate space.
+ */
+@Serializable
+data class DesignAnnotation(
+  /** One of [AnnotationKind.KNOWN]. Unknown kinds are dropped on load. */
+  val kind: String,
+  val bounds: AnnotationBounds,
+  /**
+   * One-line spec as a designer would read it, e.g. `"bodyLarge 16sp/24"` or `"pad 16dp · gap
+   * 8dp"`.
+   */
+  val label: String,
+  /** Optional node/slot name, shown as the annotation's title. */
+  val role: String? = null,
+  /** Structured payload (token name, measured dp, …) for machine consumers and the hover card. */
+  val detail: Map<String, String> = emptyMap(),
+)
+
+/** Both panels' layers, as embedded in the compare page for the client to draw. */
+@Serializable
+data class AnnotationPayload(
+  val reference: List<DesignAnnotation> = emptyList(),
+  val actual: List<DesignAnnotation> = emptyList(),
+)
+
+private val ANNOTATION_JSON = Json { encodeDefaults = false }
+
+/**
+ * Encode a payload for embedding in a `<script type="application/json">` block.
+ *
+ * HTML escaping would be wrong here — entities are not decoded inside a script element, so `&quot;`
+ * would reach `JSON.parse` verbatim and throw. The only real hazard is a `</script>` inside a
+ * string value, which ends the block early; `<` is a valid JSON escape for `<` and closes that hole
+ * without touching the parsed value.
+ */
+fun encodeAnnotationPayload(payload: AnnotationPayload): String =
+  ANNOTATION_JSON.encodeToString(payload).replace("<", "\\u003c")
+
+/** A region in the annotated image's pixel space. */
+@Serializable data class AnnotationBounds(val x: Int, val y: Int, val width: Int, val height: Int)
+
+/**
+ * Validated, read-only view of a bundle/catalog's `annotations/index.json`.
+ *
+ * Fail-soft throughout, matching [ServeDesignReferenceStore]: a malformed manifest, an unknown
+ * kind, or a nonsensical box is dropped while the rest of the session serves normally. An
+ * annotation layer is a reading aid — losing one must never take the compare page down with it.
+ */
+class ServeAnnotationStore
+private constructor(
+  private val byPreview: Map<String, List<DesignAnnotation>>,
+  private val byReference: Map<String, List<DesignAnnotation>>,
+) {
+  fun forPreview(previewId: String): List<DesignAnnotation> = byPreview[previewId].orEmpty()
+
+  fun forReference(referenceId: String): List<DesignAnnotation> = byReference[referenceId].orEmpty()
+
+  val isEmpty: Boolean = byPreview.isEmpty() && byReference.isEmpty()
+
+  companion object {
+    const val DIRECTORY = "annotations"
+    const val INDEX_FILE = "index.json"
+    private val JSON = Json { ignoreUnknownKeys = true }
+
+    /** Empty store — a session that carries no annotations at all. */
+    val EMPTY = ServeAnnotationStore(emptyMap(), emptyMap())
+
+    fun load(bundleDir: File, fileSystem: FileSystem = FileSystem.SYSTEM): ServeAnnotationStore =
+      load(bundleDir.toOkioPath(), fileSystem)
+
+    fun load(bundleRoot: Path, fileSystem: FileSystem): ServeAnnotationStore {
+      val index = bundleRoot / DIRECTORY.toPath() / INDEX_FILE.toPath()
+      if (!fileSystem.exists(index)) return EMPTY
+      val manifest =
+        runCatching {
+          JSON.decodeFromString<AnnotationManifest>(fileSystem.read(index) { readUtf8() })
+        }
+          .getOrNull() ?: return EMPTY
+      if (manifest.schema != AnnotationManifest.SCHEMA) return EMPTY
+      return ServeAnnotationStore(
+        byPreview = manifest.previews.mapValues { (_, list) -> list.filter { it.isUsable() } },
+        byReference = manifest.references.mapValues { (_, list) -> list.filter { it.isUsable() } },
+      )
+    }
+
+    /**
+     * A box with no area can't be drawn, and a negative origin would paint outside the panel. Both
+     * indicate a producer bug rather than something to render badly.
+     */
+    private fun DesignAnnotation.isUsable(): Boolean =
+      kind in AnnotationKind.KNOWN &&
+        label.isNotBlank() &&
+        bounds.width > 0 &&
+        bounds.height > 0 &&
+        bounds.x >= 0 &&
+        bounds.y >= 0
+  }
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAnnotationsPayload.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAnnotationsPayload.kt
@@ -1,0 +1,80 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.encodeToJsonElement
+
+/**
+ * The `/render/<id>.annotations` response body, written in one place.
+ *
+ * Two hosts answer that URL from different sources — [ServeRenderHost] projects the layers off a
+ * render's own `compose/semantics` tree, [ServeBundleHost] replays what the catalog published over
+ * its baked frame — and the viewer's `<cp-inspect-layers>` parses one shape. A second copy of the
+ * encoding is the kind of drift nothing fails on: the overlay simply draws nothing for whichever
+ * lane's key it does not recognise, which reads as a broken layer rather than a wrong response.
+ */
+// Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
+// and the `:server` call sites are in a different module now. Not a widened API by intent.
+object ServeAnnotationsPayload {
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  /**
+   * `{"previewId":…, "annotations":[…], "tags":{…}}` — the annotations the viewer draws, plus
+   * [ServeSemanticsTags]' tag index over the same frame (empty where the source carries none).
+   */
+  fun encode(
+    previewId: String,
+    annotations: List<DesignAnnotation>,
+    tags: Map<String, ServeSemanticsTags.TagEntry>,
+  ): ByteArray =
+    json
+      .encodeToString(
+        JsonObject.serializer(),
+        buildJsonObject {
+          put("previewId", JsonPrimitive(previewId))
+          put(
+            "annotations",
+            json.encodeToJsonElement(ListSerializer(DesignAnnotation.serializer()), annotations),
+          )
+          put("tags", tagsJson(tags))
+        },
+      )
+      .encodeToByteArray()
+
+  /**
+   * `{"previewId":…, "tags":{…}}` — the **published** tag index on its own, for `GET /tags/{id}`.
+   *
+   * Two keys of the three above, and the same encoder for the one that matters, because the wire
+   * type is the load-bearing part: [ServeSemanticsTags.TagEntry] carries `space`, and
+   * [ServeTagIndexStore] refuses an entry that declares none rather than defaulting it. A second
+   * hand-rolled copy of this map is how one of the two lanes quietly stops naming its plane, and
+   * the symptom of that is not a parse failure anywhere — it is an element gate comparing bounds in
+   * a plane nobody stated.
+   *
+   * No `annotations` key, deliberately, rather than an empty one: this route answers from the
+   * catalog's published `tags/index.json` and performs no render, so it has no annotation layer to
+   * describe and must not look as though it found none.
+   */
+  fun encodeTags(previewId: String, tags: Map<String, ServeSemanticsTags.TagEntry>): ByteArray =
+    json
+      .encodeToString(
+        JsonObject.serializer(),
+        buildJsonObject {
+          put("previewId", JsonPrimitive(previewId))
+          put("tags", tagsJson(tags))
+        },
+      )
+      .encodeToByteArray()
+
+  private fun tagsJson(tags: Map<String, ServeSemanticsTags.TagEntry>) =
+    json.encodeToJsonElement(
+      MapSerializer(String.serializer(), ServeSemanticsTags.TagEntry.serializer()),
+      tags,
+    )
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWork.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWork.kt
@@ -1,0 +1,630 @@
+package ee.schimke.composeai.cli.serve
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Semaphore
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.locks.ReentrantLock
+import kotlinx.serialization.Serializable
+
+/**
+ * Server-wide admission for **background, best-effort catalog work** — today the catalog
+ * theme-cache optimizer ([ServeCatalogLiveHost]'s idle pass), which pre-renders every catalog
+ * preview under every declared theme so a later theme selection is instant.
+ *
+ * That work is worth doing and worth *never* doing at the expense of something a visitor is waiting
+ * for. Two things it must yield to, both learned from the deployed server:
+ *
+ * - **Catalog loading.** A public box brings its catalogs up one at a time, and each load fetches a
+ *   branch, resolves a live bundle's classpath and starts a render daemon. The optimizer reads the
+ *   registry's idle clock, which counts only *request* traffic — so on a freshly-rolled server with
+ *   no visitors yet, catalog #1's optimizer sees a perfectly idle server and starts hundreds of
+ *   renders while catalogs #2…#18 are still loading. Each loaded catalog adds another optimizer, so
+ *   the contention compounds: the later a catalog sits in the list, the longer its daemon waits for
+ *   a render slot, and a slow enough daemon start is recorded as `livebundle-unavailable` and
+ *   degrades the catalog to baked PNGs for the life of the process. [catalogsLoading] makes the
+ *   whole startup pass read as *busy* so the optimizer stays parked until the catalogs are up.
+ * - **Each other.** Once loading finishes, every catalog's optimizer becomes runnable at the same
+ *   instant. [withRenderPermit] caps the background lane at [maxConcurrentRenders] renders
+ *   server-wide, so the optimizers take turns instead of holding every live seat.
+ *
+ * Both knobs are process-wide: one instance is built per `serve` run and shared by every catalog
+ * host it opens.
+ */
+class ServeBackgroundWork(
+  /**
+   * Background renders admitted at once, server-wide. Defaults to the conservative single lane; a
+   * server that knows its seat budget passes [renderLaneFor] instead.
+   */
+  maxConcurrentRenders: Int = CONSERVATIVE_MAX_CONCURRENT_RENDERS,
+  private val clock: () -> Long = System::currentTimeMillis,
+  /**
+   * How many catalogs may be **inside an optimizer pass** at once, server-wide.
+   *
+   * [withRenderPermit] bounds the renders; nothing bounded the *passes*, and those are not the same
+   * thing. A pass that holds no render permit is still holding a turn, a warm daemon and a live
+   * seat, and is still queueing — so on the deployed box every loaded catalog entered its pass
+   * within half a second of the gate opening (measured: 11 catalogs inside 464 ms) and then 15 of
+   * them contended for 8 render permits. The result was 64% of all optimizer time spent waiting on
+   * that permit and 43.5% of what remained spent *re-warming* daemons that got yielded before they
+   * rendered anything: 10,120 entries with 8 cached after half an hour, an ETA of 21 days.
+   *
+   * Capping the passes fixes what capping the renders cannot: the rest are parked cheaply instead
+   * of parked expensively.
+   *
+   * **This must not be set below [maxConcurrentRenders].** A pass takes one permit for the whole of
+   * its batch — `withRenderPermit { renderOptimizerBatch(...) }` — so it holds exactly one however
+   * wide the batch is, and every permit past the lane count is unreachable. An earlier note here
+   * claimed the opposite, that two passes saturate an eight-permit lane "because each pass batches
+   * up to five wide"; the batch runs *inside* the one permit, so they saturate two. `ServeCommand`
+   * consequently passes the render lane for both, which also means an admitted pass never waits at
+   * the permit — the waiting this cap exists to prevent.
+   */
+  maxConcurrentOptimizers: Int = DEFAULT_MAX_CONCURRENT_OPTIMIZERS,
+  private val hostCoordinator: OptimizerHostCoordinator = OptimizerHostCoordinator.NONE,
+  private val pressureGate: OptimizerPressureGate? = null,
+) {
+  private val loadsInFlight = AtomicInteger()
+  private val initialLoadPending = AtomicBoolean(false)
+  private val renderPermits = Semaphore(maxConcurrentRenders.coerceAtLeast(1))
+  private val lastCatalogLoadFinishedAt = AtomicLong(Long.MIN_VALUE)
+
+  private val optimizerLanes = maxConcurrentOptimizers.coerceAtLeast(1)
+  // Admission is a priority handoff, not a semaphore — see [withOptimizerSlot]. All four fields
+  // below are guarded by [admissionLock].
+  private val admissionLock = ReentrantLock()
+  private val laneFreed = admissionLock.newCondition()
+  private var optimizerLanesInUse = 0
+  private val optimizerQueue = ArrayList<OptimizerWaiter>()
+  private var optimizerArrivals = 0L
+  /**
+   * When each system's last pass *ended*, and the whole of admission's memory.
+   *
+   * End, not start: a pass that held a lane for an hour finished recently, and keying on its start
+   * would let it outrank catalogs that have been waiting that entire hour. A system absent from
+   * this map has never run and sorts ahead of every system that has.
+   */
+  private val optimizerLastRanAt = ConcurrentHashMap<String, Long>()
+  // A refresh opens the replacement host before the registry closes the previous one, so two
+  // generations of one system can legitimately hold lanes together. A set collapses those two
+  // admissions and the first release removes the replacement from status as well; counts preserve
+  // both the total and the de-duplicated system labels.
+  private val optimizerRunning = ConcurrentHashMap<String, AtomicInteger>()
+  private val optimizerWaiting = AtomicInteger()
+  private val optimizerAdmissions = AtomicLong()
+  private val optimizerRefusals = AtomicLong()
+  private val optimizerAdmissionWaitMillis = AtomicLong()
+  private val optimizerHostSuspensions = AtomicLong()
+  private val optimizerHostResumes = AtomicLong()
+  private val optimizerPausedUntil = AtomicLong(Long.MIN_VALUE)
+  private val optimizerPauseReason = ConcurrentHashMap<String, String>()
+  private val optimizerHostRefusals = AtomicLong()
+
+  /**
+   * The clocks [idleClock] handed out, retained so [optimizerAdmissionSnapshot] can publish the
+   * value the optimizer's quiet gate actually reads.
+   *
+   * Every counter on `/status.json` described what the optimizer was doing *after* it got a turn,
+   * and none described the input that decides whether it ever gets one. A box where the gate never
+   * opens therefore reports the same all-zero row as a box with nothing left to do — which is how a
+   * server ran for hours with `turnsGranted 0` on all 23 catalogs and no page saying why.
+   * [publishedRequestIdleClock] is kept alongside the composed one so the null can be attributed: a
+   * held session lease and a catalog load are both "busy" to the gate and have nothing else in
+   * common.
+   */
+  @Volatile private var publishedIdleClock: (() -> Long?)? = null
+  @Volatile private var publishedRequestIdleClock: (() -> Long?)? = null
+
+  /**
+   * True while the server is bringing catalogs up: the startup pass hasn't finished, or a refresh /
+   * admin registration is fetching one right now. Background work treats this as "busy" even though
+   * no visitor is waiting, because a catalog that loads slowly enough loses its live lane.
+   */
+  val catalogsLoading: Boolean
+    get() = initialLoadPending.get() || loadsInFlight.get() > 0
+
+  /**
+   * Declare that a startup catalog pass is coming, before it starts. Called when the loader is
+   * built — not when it runs — so the window between "server up" and "first catalog load" is busy
+   * too, rather than a gap the optimizer can start in.
+   */
+  fun expectInitialCatalogLoad() {
+    initialLoadPending.set(true)
+  }
+
+  /** The startup pass is done (however it ended — loaded, failed, or shut down mid-pass). */
+  fun initialCatalogLoadFinished() {
+    initialLoadPending.set(false)
+    lastCatalogLoadFinishedAt.set(clock())
+  }
+
+  /** Run one catalog load, counted so background work stays parked for its duration. */
+  fun <T> whileLoadingCatalog(block: () -> T): T {
+    loadsInFlight.incrementAndGet()
+    try {
+      return block()
+    } finally {
+      loadsInFlight.decrementAndGet()
+      lastCatalogLoadFinishedAt.set(clock())
+    }
+  }
+
+  /**
+   * Wrap the registry's whole-server idle clock so a loading server reads as busy (`null`) and the
+   * clock restarts at zero when startup, refresh, or admin registration finishes. The catalog host
+   * applies its quiet-window threshold to the smaller of this and request/render idleness.
+   */
+  fun idleClock(idleMillis: () -> Long?): () -> Long? =
+    composeIdleClock(idleMillis).also {
+      // Every catalog host asks for one and they all wrap the same registry, so last-wins is the
+      // same clock each time. Retained purely so status can read it; nothing here drives behaviour.
+      publishedRequestIdleClock = idleMillis
+      publishedIdleClock = it
+    }
+
+  private fun composeIdleClock(idleMillis: () -> Long?): () -> Long? = {
+    if (catalogsLoading) {
+      null
+    } else {
+      val requestIdleMillis = idleMillis()
+      if (requestIdleMillis == null || catalogsLoading) {
+        null
+      } else {
+        val finishedAt = lastCatalogLoadFinishedAt.get()
+        val catalogIdleMillis =
+          if (finishedAt == Long.MIN_VALUE) Long.MAX_VALUE
+          else (clock() - finishedAt).coerceAtLeast(0)
+        minOf(requestIdleMillis, catalogIdleMillis)
+      }
+    }
+  }
+
+  /**
+   * Run one background render under the server-wide permit. Returns null — and leaves the thread
+   * interrupted — when the wait was interrupted (shutdown), which the caller treats as "stop".
+   */
+  /**
+   * Hold one of the [maxConcurrentOptimizers] pass slots for [system] while [block] runs, or return
+   * null when none came free within [waitMillis] (or the optimizer is paused, or the thread was
+   * interrupted).
+   *
+   * Refusal is the *point*, not a failure: a catalog that cannot get a slot parks and tries again
+   * on the next pass instead of joining a queue with a warm daemon in hand. The wait is bounded so
+   * a parked catalog re-checks the idle gate rather than sleeping through the quiet window it was
+   * waiting for.
+   */
+  fun <T : Any> withOptimizerSlot(system: String, waitMillis: Long, block: () -> T): T? {
+    if (!acquireOptimizerLane(system, waitMillis)) {
+      optimizerRefusals.incrementAndGet()
+      return null
+    }
+    val hostLease = acquireHostLease(system, waitMillis)
+    if (hostLease == null) {
+      releaseOptimizerLane(system)
+      optimizerHostRefusals.incrementAndGet()
+      optimizerRefusals.incrementAndGet()
+      return null
+    }
+    optimizerAdmissions.incrementAndGet()
+    optimizerRunning.computeIfAbsent(system) { AtomicInteger() }.incrementAndGet()
+    return try {
+      block()
+    } finally {
+      optimizerRunning.computeIfPresent(system) { _, count ->
+        if (count.decrementAndGet() == 0) null else count
+      }
+      hostLease.close()
+      releaseOptimizerLane(system)
+    }
+  }
+
+  private fun acquireHostLease(system: String, waitMillis: Long): OptimizerHostLease? {
+    val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(waitMillis.coerceAtLeast(0L))
+    while (!optimizersPaused()) {
+      hostCoordinator.tryAcquire(system)?.let {
+        return it
+      }
+      if (System.nanoTime() >= deadline) return null
+      try {
+        Thread.sleep(HOST_COORDINATION_RETRY_MILLIS)
+      } catch (_: InterruptedException) {
+        Thread.currentThread().interrupt()
+        return null
+      }
+    }
+    return null
+  }
+
+  /**
+   * Take a lane for [system], preferring whoever has gone longest without one.
+   *
+   * **This was a fair `Semaphore` and fairness there did not reach far enough.** A semaphore orders
+   * the callers *currently blocked on it*, and an optimizer pass is only blocked for
+   * `OPTIMIZER_ADMISSION_WAIT_MILLIS` (20s) before it gives up and parks until the next presence
+   * heartbeat. So the ordering only ever covered whoever happened to be at the door inside the same
+   * 20s window, and a catalog refused on one attempt arrived at the next one with no advantage over
+   * a catalog that had just run. Nothing accumulated, so nothing prevented the same few systems
+   * winning every draw.
+   *
+   * Measured on the deployed box 45 minutes after v1.14.0: `admissions 5, refusals 20`, with three
+   * catalogs having taken both lanes and the other nineteen reporting `turnsGranted 0` — including
+   * `m3-catalog`, the largest queue on the box at 10,120 targets and therefore the one that most
+   * needed the time.
+   *
+   * [optimizerLastRanAt] is the memory the semaphore lacked. A never-run system outranks every
+   * system that has run, and among equals it is first-come — so **every catalog gets a lane before
+   * any catalog gets a second**, which is a stronger guarantee than a size heuristic and needs no
+   * knowledge of how much work each one has left.
+   */
+  private fun acquireOptimizerLane(system: String, waitMillis: Long): Boolean {
+    val waitedFrom = clock()
+    admissionLock.lock()
+    val waiter =
+      OptimizerWaiter(
+        system = system,
+        lastRanAt = optimizerLastRanAt[system] ?: Long.MIN_VALUE,
+        arrival = optimizerArrivals++,
+      )
+    optimizerQueue.add(waiter)
+    optimizerWaiting.incrementAndGet()
+    try {
+      var remainingNanos = TimeUnit.MILLISECONDS.toNanos(waitMillis.coerceAtLeast(0))
+      while (true) {
+        // Re-checked every wakeup rather than only on entry: a pause can land while this catalog is
+        // queueing, and admitting it then would let one pass slip past an operator who just asked
+        // for quiet.
+        if (optimizersPaused()) return false
+        if (optimizerLanesInUse < optimizerLanes && optimizerQueue.min() === waiter) {
+          optimizerLanesInUse++
+          return true
+        }
+        if (remainingNanos <= 0) return false
+        remainingNanos =
+          try {
+            laneFreed.awaitNanos(remainingNanos)
+          } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+            return false
+          }
+      }
+    } finally {
+      optimizerQueue.remove(waiter)
+      optimizerWaiting.decrementAndGet()
+      // Whether this waiter was admitted or gave up, the queue's head may have moved — and the
+      // remaining waiters are parked in `awaitNanos` with no other reason to look again. Without
+      // this, a free lane can sit unclaimed until someone's timeout happens to fire.
+      laneFreed.signalAll()
+      admissionLock.unlock()
+      optimizerAdmissionWaitMillis.addAndGet((clock() - waitedFrom).coerceAtLeast(0))
+    }
+  }
+
+  /**
+   * How many parked catalogs it is worth making resident again — the lanes nothing is holding,
+   * **plus one challenger**.
+   *
+   * [ServeSessionRegistry.resumeIdleOptimizers] reads this because resuming costs a cold Android
+   * daemon (34-68s) and roughly a gigabyte for as long as it stays up, so it must not resume a
+   * catalog that would merely stand at the door. But bounding it at the *free* lanes alone starves
+   * every catalog that is not already resident: a pass returns its lane on a slice boundary and
+   * re-queues immediately (see `ServeCatalogLiveHost.startThemeOptimization`), so on a box with
+   * more unfinished catalogs than lanes every later sweep reads zero free lanes and the parked ones
+   * wait for an incumbent to *finish* — hours, for a 10,440-target catalog.
+   *
+   * [PLUS_ONE_CHALLENGER] is what makes the rotation reach them. Admission's fairness
+   * ([acquireOptimizerLane]) orders catalogs **at the door** by who has gone longest without a
+   * lane, so a parked catalog wins its turn the moment it is standing there — but it has to be
+   * standing there. Keeping exactly one challenger queued hands it the next lane release ahead of
+   * the incumbent that just ran; the displaced incumbent then goes idle and is suspended in its
+   * turn. One extra resident buys a rotation whose period is the idle window rather than a
+   * catalog's whole backlog.
+   *
+   * Advisory, and deliberately tolerant of races: an admission landing in the same instant makes
+   * this read one too high and the resumed pass simply queues, which is what a challenger does
+   * anyway.
+   */
+  fun optimizerResumeSlots(): Int =
+    if (optimizersPaused()) 0
+    else
+      admissionLock.run {
+        lock()
+        try {
+          (optimizerLanes + PLUS_ONE_CHALLENGER - optimizerLanesInUse - optimizerQueue.size)
+            .coerceAtLeast(0)
+        } finally {
+          unlock()
+        }
+      }
+
+  /** A catalog with optimization left to do had its host released to reclaim its daemon's RAM. */
+  fun recordOptimizerHostSuspended() {
+    optimizerHostSuspensions.incrementAndGet()
+  }
+
+  /** A parked catalog was made resident again so it could take a lane. */
+  fun recordOptimizerHostResumed() {
+    optimizerHostResumes.incrementAndGet()
+  }
+
+  private fun releaseOptimizerLane(system: String) {
+    admissionLock.lock()
+    try {
+      optimizerLanesInUse--
+      optimizerLastRanAt[system] = clock()
+      laneFreed.signalAll()
+    } finally {
+      admissionLock.unlock()
+    }
+  }
+
+  /** One catalog queued for a lane. Ordered by [acquireOptimizerLane]'s priority rule. */
+  private class OptimizerWaiter(
+    val system: String,
+    val lastRanAt: Long,
+    val arrival: Long,
+  ) : Comparable<OptimizerWaiter> {
+    override fun compareTo(other: OptimizerWaiter): Int =
+      compareValuesBy(this, other, { it.lastRanAt }, { it.arrival })
+  }
+
+  /**
+   * Stop admitting optimizer passes for [millis], and ask the ones already running to stop at their
+   * next check ([optimizersPaused]).
+   *
+   * The operational hole this fills: the optimizer is the largest consumer of a busy box and there
+   * was no way to stand it down. Restarting the server did it, at the cost of every warm daemon and
+   * every catalog's load — so the lever people actually had was the one they least wanted to pull
+   * while the box was already struggling. [reason] is recorded for `/status.json` so a quiet server
+   * explains itself rather than looking broken.
+   *
+   * Returns the epoch instant the pause lifts.
+   */
+  fun pauseOptimizers(millis: Long, reason: String): Long {
+    val until = clock() + millis.coerceAtLeast(0)
+    optimizerPausedUntil.set(until)
+    optimizerPauseReason["reason"] = reason.take(MAX_PAUSE_REASON_CHARS)
+    // Wake the queue so a pause is felt at the door now, rather than when each waiter's admission
+    // timeout happens to expire.
+    admissionLock.lock()
+    try {
+      laneFreed.signalAll()
+    } finally {
+      admissionLock.unlock()
+    }
+    return until
+  }
+
+  /** Lift a pause early. */
+  fun resumeOptimizers() {
+    optimizerPausedUntil.set(Long.MIN_VALUE)
+    optimizerPauseReason.clear()
+  }
+
+  /** Whether optimizer passes are currently stood down. Cheap enough for a per-batch check. */
+  fun optimizersPaused(): Boolean =
+    clock() < optimizerPausedUntil.get() || pressureGate?.snapshot()?.constrained == true
+
+  /** Counters for `/status.json`; see [ThemeOptimizerAdmissionSnapshot]. */
+  fun optimizerAdmissionSnapshot(): ThemeOptimizerAdmissionSnapshot {
+    val until = optimizerPausedUntil.get()
+    val manuallyPaused = clock() < until
+    val pressure = pressureGate?.snapshot()
+    val paused = manuallyPaused || pressure?.constrained == true
+    val queued = admissionLock.run {
+      lock()
+      try {
+        optimizerQueue.sorted().map { it.system }
+      } finally {
+        unlock()
+      }
+    }
+    // Read the composed clock ONCE; the attribution below re-reads the request side only when it
+    // has already answered "busy", so the two can never contradict each other in the same row.
+    val serverIdle = publishedIdleClock?.invoke()
+    val idleBlockedBy =
+      when {
+        publishedIdleClock == null || serverIdle != null -> null
+        publishedRequestIdleClock?.invoke() == null -> IDLE_BLOCKED_BY_SESSION_LEASE
+        else -> IDLE_BLOCKED_BY_CATALOG_LOAD
+      }
+    return ThemeOptimizerAdmissionSnapshot(
+      lanes = optimizerLanes,
+      running = optimizerRunning.values.sumOf(AtomicInteger::get),
+      runningSystems = optimizerRunning.keys.toSortedSet().toList(),
+      waiting = optimizerWaiting.get(),
+      waitingSystems = queued,
+      admissions = optimizerAdmissions.get(),
+      refusals = optimizerRefusals.get(),
+      hostRefusals = optimizerHostRefusals.get(),
+      admissionWaitMillis = optimizerAdmissionWaitMillis.get(),
+      hostSuspensions = optimizerHostSuspensions.get(),
+      hostResumes = optimizerHostResumes.get(),
+      paused = paused,
+      pausedUntilEpochMillis = if (manuallyPaused) until else null,
+      pauseReason =
+        when {
+          manuallyPaused -> optimizerPauseReason["reason"]
+          pressure?.constrained == true -> pressure.reason
+          else -> null
+        },
+      pressure = pressure,
+      serverIdleMillis = serverIdle,
+      idleBlockedBy = idleBlockedBy,
+      idleThresholdMillis = themeOptimizationIdleMillisDefault(),
+    )
+  }
+
+  fun <T : Any> withRenderPermit(block: () -> T): T? {
+    try {
+      renderPermits.acquire()
+    } catch (_: InterruptedException) {
+      Thread.currentThread().interrupt()
+      return null
+    }
+    try {
+      return block()
+    } finally {
+      renderPermits.release()
+    }
+  }
+
+  companion object {
+    /**
+     * Whole-server quiet the idle theme-optimizer gate requires before a cold pass may start.
+     *
+     * Read through a function rather than held in a `val` so the system property is still honoured
+     * when it is set after this class loads. It lives here rather than on `ServeCatalogLiveHost`,
+     * which is the class that gates on it, because this class is the one that publishes it on
+     * `/status.json` and this module cannot see that one — the gate keeps an alias so both sides
+     * still read the single number.
+     *
+     * Public rather than `internal`: `ServeCatalogLiveHost` is in `:server` now, and `internal` is
+     * module-scoped.
+     */
+    fun themeOptimizationIdleMillisDefault(): Long =
+      System.getProperty("composeai.serve.themeOptimizationIdleMillis")?.toLongOrNull() ?: 60_000L
+
+    /**
+     * The historical lane: one background render server-wide. Still the right answer when nothing
+     * else bounds daemon count — see [renderLaneFor].
+     */
+    const val CONSERVATIVE_MAX_CONCURRENT_RENDERS: Int = 1
+
+    /**
+     * Catalogs allowed inside an optimizer pass at once. Two, not one: a single lane would leave
+     * the 8-permit render lane idle whenever the one admitted catalog is warming a daemon, and
+     * warming is where a pass spends most of its time. Two overlaps one catalog's warm with
+     * another's renders without recreating the free-for-all.
+     */
+    const val DEFAULT_MAX_CONCURRENT_OPTIMIZERS: Int = 2
+
+    /**
+     * The one queued challenger [optimizerResumeSlots] keeps beyond the lanes themselves, so a
+     * parked catalog can actually win a turn instead of waiting for an incumbent to finish.
+     */
+    const val PLUS_ONE_CHALLENGER: Int = 1
+
+    const val HOST_COORDINATION_RETRY_MILLIS: Long = 100L
+
+    /** Pause reasons are bounded before they reach a status page. */
+    const val MAX_PAUSE_REASON_CHARS: Int = 200
+
+    /** [ThemeOptimizerAdmissionSnapshot.idleBlockedBy]: a session holds an open lease. */
+    const val IDLE_BLOCKED_BY_SESSION_LEASE: String = "session-lease"
+
+    /** [ThemeOptimizerAdmissionSnapshot.idleBlockedBy]: catalogs are still loading. */
+    const val IDLE_BLOCKED_BY_CATALOG_LOAD: String = "catalog-load"
+
+    /** Widest lane [renderLaneFor] will derive on its own. Beyond this, ask for it explicitly. */
+    const val MAX_DERIVED_CONCURRENT_RENDERS: Int = 3
+
+    /**
+     * How many background renders this server admits at once, given its live-seat budget.
+     *
+     * **The lane was 1, and one permit shared by every catalog was the prefetcher's dominant
+     * bottleneck.** Measured on the deployed server (0.19.41, 15 catalogs, no visitors) once the
+     * gate/permit split made it visible: **74.3%** of the optimizer's active time spent waiting for
+     * this permit, against 10.1% at the idle gate and **6.3%** actually rendering. Every batch
+     * collapsed to a single daemon as a result.
+     *
+     * The 1 was chosen so "a foreground render is never queued behind more than one background
+     * one". That is cheaper to relax than it sounds: a background batch holds the permit only for
+     * its renders — the expensive part, a cold daemon warm of 34-68s, is awaited *outside* it — and
+     * a warm background render is sub-second.
+     *
+     * **But widening it is only safe because something else bounds daemon count.** Each admitted
+     * catalog submits up to five parallel renders and each one the pool can't serve opens another
+     * daemon, so a lane of 3 is a licence for up to fifteen concurrent daemons. On the deployed box
+     * the seat budget refuses that long before memory does; with [LiveSeatLimiter.unbounded] seats
+     * — the CLI default, `--live-seats 0`, for a local dev box — **nothing does**, and the same
+     * widening that helps a public server would spawn fifteen JVMs on a laptop. So an unbounded
+     * budget keeps [CONSERVATIVE_MAX_CONCURRENT_RENDERS]; only a bounded one derives a wider lane,
+     * from the daemons it could actually afford to run concurrently.
+     *
+     * `-Dcomposeai.serve.backgroundRenders=<n>` overrides both, for a deployment that knows better
+     * than either rule.
+     */
+    fun renderLaneFor(seats: LiveSeatLimiter?): Int {
+      System.getProperty("composeai.serve.backgroundRenders")?.toIntOrNull()?.let {
+        return it.coerceAtLeast(1)
+      }
+      if (seats == null || seats.unbounded) return CONSERVATIVE_MAX_CONCURRENT_RENDERS
+      // What the budget can hold beyond the stream reserve, at the heaviest backend's weight —
+      // the same arithmetic the pool does when it decides whether it can afford a replica.
+      val affordable =
+        (seats.totalPermits - LiveSeatLimiter.STREAM_RESERVE) /
+          ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT
+      return affordable.coerceIn(
+        CONSERVATIVE_MAX_CONCURRENT_RENDERS,
+        MAX_DERIVED_CONCURRENT_RENDERS,
+      )
+    }
+  }
+}
+
+/**
+ * Cross-catalog optimizer admission on `/status.json` (`themeOptimizer`).
+ *
+ * The number that matters when the box feels slow is [running] against [lanes], and [waiting]
+ * beside it: passes parked at the door are cheap, passes inside the door are not. [refusals]
+ * climbing while [admissions] holds steady is the cap doing its job.
+ *
+ * [waitingSystems] is who is at the door **in the order they will be let in**, which is the read
+ * that was missing when the cap starved the box's largest catalog: `refusals 20` said work was
+ * being turned away and nothing said the same system was being turned away every time.
+ */
+@Serializable
+data class ThemeOptimizerAdmissionSnapshot(
+  val lanes: Int,
+  val running: Int,
+  val runningSystems: List<String>,
+  val waiting: Int,
+  val waitingSystems: List<String> = emptyList(),
+  val admissions: Long,
+  val refusals: Long,
+  val hostRefusals: Long = 0,
+  val admissionWaitMillis: Long,
+  /**
+   * Catalogs whose host was released while they still had optimization left, and catalogs made
+   * resident again to take a lane — the residency the pass costs when it is *not* running.
+   *
+   * The pair is the read that was missing while every unfinished catalog stayed resident for the
+   * life of the process: `running`/`waiting` describe passes, and a parked pass looks free there
+   * while its daemon holds ~1.2 GB. A [hostSuspensions] that stays 0 on a box with more unfinished
+   * catalogs than [lanes] means the residency rule is not firing, whatever the memory reading says.
+   * [hostResumes] climbing far faster than [admissions] is the opposite fault: catalogs paying a
+   * cold start to queue rather than to render.
+   */
+  val hostSuspensions: Long = 0,
+  val hostResumes: Long = 0,
+  val paused: Boolean,
+  val pausedUntilEpochMillis: Long? = null,
+  val pauseReason: String? = null,
+  val pressure: OptimizerPressureSnapshot? = null,
+  /**
+   * The whole-server idle clock the optimizer's quiet gate reads, or null when it reads *busy*.
+   *
+   * This is the gate's input, and until it was published nothing on the page distinguished "the box
+   * is never quiet enough to start" from "there is nothing left to do": both showed a pass that had
+   * rendered nothing. Compare against [idleThresholdMillis] — a number consistently below it, or a
+   * persistent null, means no catalog will ever be granted a turn, whatever [lanes], [admissions]
+   * and [paused] say.
+   */
+  val serverIdleMillis: Long? = null,
+  /**
+   * Why [serverIdleMillis] is null, when it is: [IDLE_BLOCKED_BY_SESSION_LEASE] (a session holds an
+   * open lease *and is actively using it* — `daemons.busyLeasedSessions` names it, against
+   * `daemons.leasedSessions` for every holder) or [IDLE_BLOCKED_BY_CATALOG_LOAD] (catalogs are
+   * still being fetched). Null when the clock is running, or before any catalog host has asked for
+   * one.
+   *
+   * The two have opposite fixes and are indistinguishable from the outside: a lease that outlives
+   * its request is a bug that stands the optimizer down permanently, while a catalog load is the
+   * gate working as designed.
+   */
+  val idleBlockedBy: String? = null,
+  /** Quiet [serverIdleMillis] must reach before a cold pass may start. */
+  val idleThresholdMillis: Long = 0,
+)

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBakedTheme.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBakedTheme.kt
@@ -1,0 +1,123 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.UiMode
+
+/**
+ * The light/dark mode a published catalog render was **baked in**, from the catalog's own naming.
+ *
+ * The whole "browsing is instant" property of a trusted catalog rests on this one question: a
+ * `?uiMode=` that names the theme the sticker already shows is a no-op, so the request replays the
+ * baked PNG (`CatalogLiveRouting.withoutBakedNoOps`); one that names the other theme has to reach a
+ * daemon. Answer it too narrowly and every browse of a render whose theme cannot be named pays for
+ * a live render of pixels that are already on disk.
+ *
+ * Which is exactly what an **untagged** id used to cost. The catalog export names a sticker
+ * `<variant>__<state>[__theme][__size][…]` and omits the theme segment for the mode it draws by
+ * default — so `button-filled__ideal__l-square` (published alongside
+ * `button-filled__ideal__l-square__dark`) carries no token at all even though it is the light half
+ * of that pair, and its `previewId` says so outright:
+ * `…ButtonsKt.FilledButton_Light_VARIANT_l-square`. On `m3-catalog` that is 1977 of 4120 published
+ * renders whose ordinary light browse — the viewer writes `uiMode` into every render URL — routed
+ * to the daemon instead of the sticker, at seconds per image against a sub-second baked replay, and
+ * under `Cache-Control: no-store` so the next visit paid again (compose-ai-tools#4997).
+ *
+ * The pairing is the evidence, not a guess about light-first catalogs: the export refuses to emit
+ * two images of one component that share `{variant, state, theme, size, props}`, so an untagged id
+ * whose `__dark` twin is published differs from that twin in the theme axis alone. It is therefore
+ * the non-dark member of a folded pair. An untagged id with no such twin stays unnamed and keeps
+ * routing to the daemon — a catalog that bakes only one theme has said nothing about which. On
+ * `m3-catalog` all but 4 of those 1977 are paired, and the 4 are `color-role-grid` contrast
+ * specimens whose *state* is named `light-medium-contrast` / `dark-high-contrast`: no theme axis to
+ * pair across, and correctly left on the daemon.
+ *
+ * Deliberately **light-only** in the derived direction, and that asymmetry is not an oversight: a
+ * dark-first system never reaches this question, because `ServeWeb.SystemDisplay`'s
+ * `normalizeOverrideParams` strips `uiMode` from the raw parameter map before it is ever parsed. A
+ * dark-first catalog that bakes a light pair still names its light renders with an explicit
+ * `__light` token, which [token] reads.
+ */
+object ServeBakedTheme {
+
+  /**
+   * The explicit `light` / `dark` token a flattened catalog id carries, or null when it carries
+   * none.
+   *
+   * The **last** such segment past the component slug wins, matching `ServeUrls.wasmAppSrc` and
+   * `ServeWeb.cardTheme`. Scanning for `dark` first would misread a non-theme segment named `dark`
+   * in an otherwise-light variant, wrongly treating `uiMode=dark` as a no-op and dropping the
+   * override.
+   */
+  fun token(previewId: String): UiMode? =
+    when (previewId.split("__").drop(1).lastOrNull { it == "light" || it == "dark" }) {
+      "dark" -> UiMode.DARK
+      "light" -> UiMode.LIGHT
+      else -> null
+    }
+
+  /**
+   * The theme [previewId]'s baked pixels are drawn in, or null when the catalog names none.
+   *
+   * Three rungs, narrowing: the catalog's own [declaredTheme] for the record (`image.theme` in
+   * `catalog.json`), the id's explicit [token], then the folded-pair rule above — an untagged id is
+   * light when [publishesId] reports its dark twin published.
+   *
+   * Null is the honest answer, not a default: it leaves a `uiMode` request routed to a real render,
+   * which is what a session that cannot name the sticker's theme owes the caller.
+   */
+  fun resolve(
+    previewId: String,
+    declaredTheme: String? = null,
+    publishesId: (String) -> Boolean = { false },
+  ): UiMode? =
+    when (declaredTheme?.trim()?.lowercase()) {
+      "dark" -> UiMode.DARK
+      "light" -> UiMode.LIGHT
+      else ->
+        token(previewId)
+          ?: UiMode.LIGHT.takeIf { twinIn(previewId, UiMode.DARK, publishesId) != null }
+    }
+
+  /**
+   * The id of the sticker [previewId] is paired with in [theme] — the same component, variant,
+   * state, size and props, drawn in the other mode — or null when the catalog publishes none.
+   *
+   * **The theme segment is not a suffix**, which is the whole reason this is a function rather than
+   * string concatenation. The export names a sticker
+   * `<component>__<variant>__<state>[__theme][__size][__<k>-<v>…]`, so the theme sits in the middle
+   * of every id that carries a breakpoint or a prop: the dark twin of
+   * `bottomappbar-standard__ideal__four-actions__compact` is
+   * `bottomappbar-standard__ideal__four-actions__dark__compact`, not `…__compact__dark`. Appending
+   * instead of inserting silently missed 99 of `m3-catalog`'s 1973 paired renders — every one that
+   * names a size or a prop — which is exactly the population a catalog drawn across breakpoints is
+   * made of.
+   *
+   * Both spellings of the light half are tried, because a catalog may name it either way: the
+   * export omits the segment for the mode it draws by default, but nothing stops a record declaring
+   * `theme: "light"` explicitly, and 44 of `m3-catalog`'s do. Untagged is tried first — it is what
+   * the default mode actually produces.
+   */
+  fun twinIn(previewId: String, theme: UiMode, publishesId: (String) -> Boolean): String? {
+    val segments = previewId.split(THEME_SEPARATOR)
+    // Everything but the theme axis: the identity the pair shares. Drops the token [token] found,
+    // scanning from the same end so the two cannot disagree about which segment is the theme.
+    val themeAt = segments.indexOfLast { it == "light" || it == "dark" }.takeIf { it > 0 }
+    val base = if (themeAt == null) segments else segments.filterIndexed { i, _ -> i != themeAt }
+    // Where a theme segment belongs: after the component slug, variant and state, before the size
+    // and props. A shorter id (one the export would not itself emit) appends rather than throws.
+    val at = minOf(THEME_SEGMENT_INDEX, base.size)
+    val spellings = buildList {
+      // The default mode's own spelling — no segment at all — is only ever light's.
+      if (theme == UiMode.LIGHT) add(base)
+      add(base.subList(0, at) + theme.name.lowercase() + base.subList(at, base.size))
+    }
+    return spellings
+      .map { it.joinToString(THEME_SEPARATOR) }
+      .firstOrNull { it != previewId && publishesId(it) }
+  }
+
+  /** Separates the segments of a flattened catalog id. */
+  private const val THEME_SEPARATOR = "__"
+
+  /** `<component>__<variant>__<state>` precede the theme; the size and props follow it. */
+  private const val THEME_SEGMENT_INDEX = 3
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBranchFetch.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBranchFetch.kt
@@ -1,0 +1,159 @@
+package ee.schimke.composeai.cli.serve
+
+/**
+ * Why a read against a delivery branch failed, when it did.
+ *
+ * ### Why this exists
+ *
+ * Every branch read used to answer `ByteArray?`. A 404, a 429, a 503 and a socket timeout were all
+ * the same `null`, and that single value travelled all the way to the reader: the Motion lane's
+ * "The recorded interaction could not be loaded" was the server's whole vocabulary for "this was
+ * never published" *and* "GitHub is throttling us right now". Those want opposite handling — one is
+ * a permanent fact worth remembering, the other is a reason to wait and ask again — and no caller
+ * could tell them apart because the information was destroyed at the bottom of the stack.
+ *
+ * The distinction is load-bearing in two specific places:
+ * - **Negative caching.** [ServeBundleHost] remembers pinned misses forever, on the reasoning that
+ *   `(commit, path)` is immutable so "no such file" can never stop being true. That reasoning holds
+ *   for [NotFound] and for nothing else: memoising a throttle turns a blip into a permanent hole
+ *   that only a restart clears.
+ * - **Retrying.** Asking again after a 404 is waste. Asking again after a 429 is the entire fix,
+ *   provided the wait honours what the server asked for.
+ *
+ * Deliberately transport-agnostic and dependency-free so the classification and the backoff policy
+ * unit-test without a socket.
+ */
+sealed interface BranchFetch {
+
+  /** The bytes, read and size-capped. */
+  class Ok(val bytes: ByteArray) : BranchFetch
+
+  /**
+   * The branch answered, definitively, that there is no such file — `404`/`410`.
+   *
+   * The only outcome a caller may treat as permanent. Everything else below is a statement about
+   * *now*.
+   */
+  data object NotFound : BranchFetch
+
+  /**
+   * Rate limited — `429`, or a `403` that carries no body we asked for. [retryAfterSeconds] is the
+   * server's own `Retry-After` when it sent one, which is always a better number than any we'd
+   * invent.
+   *
+   * `403` lands here rather than under a "forbidden" case on purpose: GitHub answers `403` for some
+   * rate-limit conditions, and the cost of guessing wrong in this direction is one wasted retry,
+   * where guessing wrong in the other direction caches a throttle as a missing asset.
+   */
+  data class Throttled(val retryAfterSeconds: Long?) : BranchFetch
+
+  /**
+   * The branch host is unwell — any `5xx`, or a `4xx` that is neither missing nor throttled.
+   *
+   * Carries [retryAfterSeconds] for the same reason [Throttled] does: `Retry-After` is defined on
+   * `503` as much as on `429` (RFC 9110 §10.2.3), and a host that tells you when it will be back is
+   * giving you a better number than any schedule you'd invent. Dropping it here meant a `503`
+   * asking for ten seconds got 250 ms and 500 ms instead, spending both retries inside the outage
+   * and then reporting the asset as missing — the exact confusion this type exists to end.
+   */
+  data class Unavailable(val status: Int, val retryAfterSeconds: Long? = null) : BranchFetch
+
+  /** Never got an answer: connect/read timeout, DNS, TLS, reset. */
+  data class Transport(val detail: String) : BranchFetch
+
+  /**
+   * The branch has the file and it is **past the envelope this read was given** — the body outgrew
+   * [limitBytes] before it was fully read, so no bytes are handed back.
+   *
+   * A distinct case rather than a `null`, because "there is no such file" and "the file is bigger
+   * than we will carry" are opposite facts about the branch, and one writer at least has a contract
+   * that must tell them apart: `compose-preview-known-differences/v1` answers `too-large`/413 for
+   * an over-sized document or artifact and `unreadable`/404 for an absent one. Collapsed into
+   * [NotFound] — which is what discarding the outcome does — an asset refused by size is reported
+   * as one the producer never published, which is both a different verdict and one that hides why.
+   *
+   * Not transient: the file will be exactly as oversized on the next attempt, so there is nothing
+   * to retry. Not permanent-cacheable either, in the sense [NotFound] is — the branch ref may
+   * publish a smaller file tomorrow — but every caller that memoises does so on a pinned `(commit,
+   * path)`, where the size is as immutable as the bytes.
+   */
+  data class TooLarge(val limitBytes: Long) : BranchFetch
+
+  /** The bytes, or null for every failure — the shape the pre-existing call sites still want. */
+  val bytesOrNull: ByteArray?
+    get() = (this as? Ok)?.bytes
+
+  /**
+   * Whether asking again could plausibly answer differently. False for [Ok] (nothing to ask) and
+   * for [NotFound] (the answer will not change), true for the three "right now" outcomes.
+   */
+  val isTransient: Boolean
+    get() = this is Throttled || this is Unavailable || this is Transport
+
+  /** A short, log-safe reason. Never includes the URL — callers pair it with their own. */
+  val summary: String
+    get() =
+      when (this) {
+        is Ok -> "ok"
+        is NotFound -> "not found"
+        is Throttled -> "throttled" + (retryAfterSeconds?.let { " (retry after ${it}s)" } ?: "")
+        is Unavailable ->
+          "unavailable ($status)" + (retryAfterSeconds?.let { " (retry after ${it}s)" } ?: "")
+        is Transport -> "transport: $detail"
+        is TooLarge -> "too large (over $limitBytes bytes)"
+      }
+
+  companion object {
+    /** Longest we will ever honour a `Retry-After` for — beyond this, failing fast is kinder. */
+    const val MAX_RETRY_AFTER_SECONDS = 30L
+
+    /** Attempts after the first. Small: a request is waiting behind this. */
+    const val MAX_RETRIES = 2
+
+    /** First backoff step; doubled per attempt. */
+    const val BASE_BACKOFF_MILLIS = 250L
+
+    /**
+     * Classify one HTTP status.
+     *
+     * [retryAfterSeconds] is the parsed `Retry-After` header, or null. Only consulted for the
+     * statuses that can carry one.
+     */
+    fun ofStatus(status: Int, retryAfterSeconds: Long? = null): BranchFetch =
+      when {
+        status == 404 || status == 410 -> NotFound
+        status == 429 || status == 403 -> Throttled(retryAfterSeconds?.coerceAtLeast(0))
+        else -> Unavailable(status, retryAfterSeconds?.coerceAtLeast(0))
+      }
+
+    /**
+     * How long to wait before attempt [attempt] (1-based, so `1` is the first *retry*), or null
+     * when this outcome should not be retried at all or the attempts are spent.
+     *
+     * A server-supplied `Retry-After` wins over the exponential schedule when it is longer — it is
+     * the only party that knows when it will serve again — but is capped at
+     * [MAX_RETRY_AFTER_SECONDS] so a hostile or confused header cannot park a request thread for
+     * minutes.
+     */
+    fun retryDelayMillis(outcome: BranchFetch, attempt: Int): Long? {
+      if (!outcome.isTransient) return null
+      if (attempt < 1 || attempt > MAX_RETRIES) return null
+      val backoff = BASE_BACKOFF_MILLIS shl (attempt - 1)
+      val asked =
+        when (outcome) {
+          is Throttled -> outcome.retryAfterSeconds
+          is Unavailable -> outcome.retryAfterSeconds
+          else -> null
+        }
+      val requested = asked?.coerceAtMost(MAX_RETRY_AFTER_SECONDS)?.times(1000L)
+      return maxOf(backoff, requested ?: 0L)
+    }
+
+    /**
+     * Parse a `Retry-After` header. Only the delta-seconds form — the HTTP-date form is legal but
+     * needs a clock and a parse to answer the same question, and no branch host we read sends it.
+     * An unparseable value is simply absent, which falls back to the exponential schedule.
+     */
+    fun parseRetryAfter(header: String?): Long? = header?.trim()?.toLongOrNull()?.takeIf { it >= 0 }
+  }
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBroadcastHub.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBroadcastHub.kt
@@ -1,0 +1,206 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.StreamCodec
+import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/** Opens one upstream daemon stream. Matches [ServeRenderHost.startStream]. */
+fun interface StreamOpener {
+  fun open(
+    previewId: String,
+    overrides: PreviewOverrides,
+    codec: StreamCodec?,
+    maxFps: Int?,
+    onUnavailable: ((String) -> Unit)?,
+    onFrame: (StreamFrameParams) -> Unit,
+  ): StreamHandle?
+}
+
+/**
+ * Shares **one** upstream daemon stream across every watcher of the same preview + overrides +
+ * codec + fps. Without it, N browsers watching the same preview would open N held daemon sessions
+ * (N `stream/start`s); with it they ride a single held session whose frames fan out to all of them,
+ * and any watcher's input drives the shared composition.
+ *
+ * Keyed by [keyOf]: distinct overrides (or codec / fps) are distinct streams, so a viewer changing
+ * theme transparently moves to its own shared lane without disturbing the others. The upstream is
+ * opened lazily on the first subscriber for a key and torn down when the last one leaves
+ * (ref-counted), so an idle hub holds no daemon sessions.
+ *
+ * Late joiners are replayed the last *painted* frame immediately, so a watcher that connects
+ * between recompositions sees the current picture instead of a blank canvas until the next frame.
+ *
+ * Each [subscribe] returns a per-watcher [StreamHandle]: its [StreamHandle.input] forwards into the
+ * shared session and its [StreamHandle.close] drops just that watcher (closing the shared upstream
+ * only when it was the last).
+ */
+class ServeBroadcastHub(private val opener: StreamOpener) {
+
+  private val lock = ReentrantLock()
+  private val broadcasts = HashMap<String, Broadcast>()
+
+  /**
+   * Join the shared stream for [previewId] at these overrides/codec/fps, opening the upstream if
+   * this is the first watcher. Returns `null` (and opens nothing) when the backend can't stream, so
+   * the caller falls back to the snapshot lane — same contract as [ServeRenderHost.startStream].
+   */
+  fun subscribe(
+    previewId: String,
+    overrides: PreviewOverrides,
+    codec: StreamCodec? = null,
+    maxFps: Int? = null,
+    onUnavailable: ((String) -> Unit)? = null,
+    onFrame: (StreamFrameParams) -> Unit,
+  ): StreamHandle? = lock.withLock {
+    val key = keyOf(previewId, overrides, codec, maxFps)
+    val broadcast =
+      broadcasts[key]
+        ?: run {
+          val fresh = Broadcast(key)
+          // Hold the lock across the open so two racing first-subscribers can't open two upstreams
+          // for one key; opens are cheap relative to a dev server's client count. A failed open
+          // reports its reason through [onUnavailable] (forwarded to the opener) before the null.
+          val handle =
+            opener.open(previewId, overrides, codec, maxFps, onUnavailable, fresh::onUpstreamFrame)
+              ?: return@withLock null
+          fresh.handle = handle
+          broadcasts[key] = fresh
+          fresh
+        }
+    broadcast.addWatcher(onFrame)
+  }
+
+  /** Live shared upstream streams (one per distinct key). For tests / diagnostics. */
+  fun activeStreamCount(): Int = lock.withLock { broadcasts.size }
+
+  private fun release(broadcast: Broadcast, watcher: Broadcast.Watcher) {
+    lock.withLock {
+      if (broadcast.removeWatcher(watcher) == 0) {
+        broadcasts.remove(broadcast.key, broadcast)
+        broadcast.handle?.close()
+      } else {
+        // The departing watcher may have been the last hidden one holding the shared stream down,
+        // or the last visible one keeping it up.
+        broadcast.syncVisibility()
+      }
+    }
+  }
+
+  private inner class Broadcast(val key: String) {
+    @Volatile var handle: StreamHandle? = null
+    private val watchers = CopyOnWriteArrayList<Watcher>()
+    @Volatile private var lastPainted: StreamFrameParams? = null
+
+    /**
+     * The visibility last pushed upstream, so [syncVisibility] only sends on a real change — a grid
+     * of twenty cards scrolling past sends twenty flips a second, and all but the ones that move
+     * the shared answer are noise on the daemon's reader thread.
+     */
+    private var upstreamVisible: Boolean = true
+    private var upstreamFps: Int? = null
+
+    /** One watcher's frame sink plus the visibility it last reported. */
+    inner class Watcher(val onFrame: (StreamFrameParams) -> Unit) {
+      @Volatile var visible: Boolean = true
+      @Volatile var fps: Int? = null
+    }
+
+    /**
+     * Fan an upstream frame out to every watcher; cache it if it paints (for late-joiner replay).
+     */
+    fun onUpstreamFrame(frame: StreamFrameParams) {
+      // Payload-less `unchanged` heartbeats don't paint, so they don't become the replay frame.
+      if (frame.payloadBase64 != null) lastPainted = frame
+      watchers.forEach { it.onFrame(frame) }
+    }
+
+    /** Add a watcher and replay the current picture to it. Caller holds [lock]. */
+    fun addWatcher(onFrame: (StreamFrameParams) -> Unit): StreamHandle {
+      val watcher = Watcher(onFrame)
+      // Register *before* replaying: onUpstreamFrame is lock-free, so a frame painted between the
+      // replay and the add would otherwise reach neither the live fan-out (not yet a watcher) nor
+      // the replay (already read) and leave a static preview blank. Registering first means the
+      // worst case is a harmless duplicate of the current frame (newest-wins paint), never a miss.
+      watchers.add(watcher)
+      // A new watcher is visible by definition, so it un-throttles a stream every existing watcher
+      // had hidden.
+      syncVisibility()
+      lastPainted?.let(onFrame)
+      return object : StreamHandle {
+        private val closed = AtomicBoolean(false)
+
+        override fun input(
+          kind: InteractiveInputKind,
+          pixelX: Int?,
+          pixelY: Int?,
+          pointerId: Int?,
+          scrollDeltaY: Float?,
+          keyCode: String?,
+          text: String?,
+          pointerType: String?,
+        ) {
+          if (closed.get()) return
+          handle?.input(kind, pixelX, pixelY, pointerId, scrollDeltaY, keyCode, text, pointerType)
+        }
+
+        override fun visibility(visible: Boolean, fps: Int?) {
+          if (closed.get()) return
+          watcher.visible = visible
+          watcher.fps = fps
+          lock.withLock { syncVisibility() }
+        }
+
+        override fun close() {
+          if (closed.compareAndSet(false, true)) release(this@Broadcast, watcher)
+        }
+      }
+    }
+
+    /**
+     * Push the watchers' *aggregate* visibility upstream. One held session serves everyone on this
+     * key, so it may only be throttled when nobody is looking: visible if **any** watcher is, and
+     * when none are, at the fastest fps any of them asked for. Throttling on the first hidden
+     * watcher would starve the tab still watching the same preview beside it.
+     *
+     * Caller holds [lock] (the send happens under it so two flips can't land out of order).
+     */
+    fun syncVisibility() {
+      val current = watchers.toList()
+      val visible = current.isEmpty() || current.any { it.visible }
+      // `null` means "the daemon's default throttle" (1 fps) and is the slowest option, so an
+      // explicit fps only wins when every hidden watcher named one.
+      val fps =
+        if (visible) null
+        else
+          current
+            .map { it.fps }
+            .reduceOrNull { a, b -> if (a == null || b == null) null else maxOf(a, b) }
+      if (visible == upstreamVisible && fps == upstreamFps) return
+      upstreamVisible = visible
+      upstreamFps = fps
+      handle?.visibility(visible, fps)
+    }
+
+    /** Remove a watcher; returns the remaining count. Caller holds [lock]. */
+    fun removeWatcher(watcher: Watcher): Int {
+      watchers.remove(watcher)
+      return watchers.size
+    }
+  }
+
+  private companion object {
+    /** Same identity the snapshot cache uses, plus the stream-only knobs (codec, fps). */
+    fun keyOf(
+      previewId: String,
+      overrides: PreviewOverrides,
+      codec: StreamCodec?,
+      maxFps: Int?,
+    ): String =
+      "${ServeOverrides.cacheKey(previewId, overrides)}|c=${codec?.name ?: "-"}|f=${maxFps ?: "-"}"
+  }
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -1,0 +1,1027 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.bundle.AndroidBundleLaunch
+import ee.schimke.composeai.bundle.AndroidBundleResources
+import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.bundle.bundleSidecarSearchDescription
+import ee.schimke.composeai.bundle.coordinates.CoordinateResolver
+import ee.schimke.composeai.bundle.extractBundleClassesAndManifest
+import ee.schimke.composeai.bundle.extractBundleIrArtifacts
+import ee.schimke.composeai.bundle.locateBundleSidecarJars
+import ee.schimke.composeai.daemon.protocol.DaemonLaunchDescriptor
+import ee.schimke.composeai.io.SystemFileSystem
+import ee.schimke.composeai.io.composeAiCacheDir
+import ee.schimke.composeai.previewdata.PreviewManifest
+import java.io.File
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+/**
+ * Materialises a daemon-backed [ServeSessionState] straight from a **packed preview bundle** — no
+ * Gradle build, no worktree, no repo clone. This is the engine behind serving a `--catalogs`
+ * system's `liveBundle` ([ServeCatalogStore]): extract the bundle's `classes/app.jar` +
+ * `previews.json` (+ any embedded `libs/`), resolve its `maven` classpath entries via
+ * [CoordinateResolver], locate the CLI install's `lib-daemon-desktop`/`lib-renderer` sidecar jars
+ * (same lookup `bundle daemon` uses), and write a `daemon-launch.json` in the exact shape
+ * `SubprocessRenderSessions.open` reads. Writing it as a **file** (rather than constructing the
+ * descriptor purely in-memory, the way
+ * [ee.schimke.composeai.render.session.subprocess.SubprocessRenderSessions.openBundleDaemon] does)
+ * is what lets this session ride the existing `ServeSessionState → openHost → ServeRenderHost.open
+ * → registry.register` path unmodified — [ServeSessionRegistry] resumes a suspended session by
+ * re-opening the same descriptor path, so suspend/resume works for free.
+ *
+ * Backend-aware, mirroring `bundle daemon`'s two launches over the **same** `DaemonMain`
+ * entrypoint: a `desktop` bundle spawns the CMP/Skiko daemon (`lib-daemon-desktop` +
+ * `lib-renderer`), an `android` bundle spawns the Robolectric daemon (`lib-daemon-android` +
+ * `android.jar` + the required `--add-opens` + `robolectric.*` sysprops [AndroidBundleLaunch]
+ * supplies). Wiring the Android backend here is what gives an Android/Wear catalog (e.g. `wear-m3`)
+ * a live daemon session — and hence per-variant renders + the daemon-produced `compose/figma-svg`
+ * lane (`renderSvg` on [ServeCatalogLiveHost]) that a baked, per-slug `figma/<slug>.svg` can't
+ * match. Any other backend makes [materialize] return `null` (logging why) so the caller falls back
+ * to the catalog's baked PNGs or its Gradle `source` build.
+ *
+ * The `android` backend needs the ~150-200 MB `lib-daemon-android` sidecar (shipped separately as
+ * `compose-preview-android-daemon-<version>.zip`, not in the CLI tarball) unpacked and reachable
+ * via `-Dcomposeai.cli.libDaemonAndroidDir=…`, plus `android.jar` from a local SDK
+ * (`ANDROID_HOME`/`ANDROID_SDK_ROOT`); on its first render the Robolectric runtime fetches the
+ * `android-all-instrumented` jar (network + cold-start latency). Missing either → `null` + a clear
+ * log, same fail-soft as a missing desktop sidecar.
+ */
+public object ServeBundleDaemon {
+
+  /**
+   * Live-seat cost ([LiveSeatLimiter] permits) of an **Android/Robolectric** catalog daemon. It
+   * boots a sandbox fleet (each `wear-m3` daemon spins ~5 Robolectric sandboxes) and holds ~1.5–2
+   * GB RSS, versus ~0.5–1 GB for a desktop CMP daemon — so it consumes two permits where desktop
+   * takes one. Tuned for the reference 4 GB box's default budget; a bigger box's budget scales up
+   * (see `deploy/image/entrypoint.sh`), letting more of these run at once.
+   */
+  const val ANDROID_LIVE_SEAT_WEIGHT: Int = 2
+
+  /**
+   * Live-seat weight ([LiveSeatLimiter] permits) of an already-built daemon [descriptor] file — for
+   * the Gradle **source-build** catalog path ([ServeCommand.buildTrustedCatalogSource]), which has
+   * no bundle `manifest.backend` to read. Detects the Android/Robolectric backend by the
+   * `robolectric.*` JVM sysprops every Android daemon launch carries (see
+   * [AndroidPreviewClasspath]) and a desktop CMP daemon never does, so a source-served Android
+   * catalog is charged [ANDROID_LIVE_SEAT_WEIGHT] exactly like the bundle path — keeping the OOM
+   * protection intact in from-source deployments. Defaults to `1` (desktop) when the descriptor is
+   * missing or unreadable.
+   */
+  fun liveSeatWeightForDescriptor(descriptor: File): Int {
+    val text = descriptor.takeIf { it.isFile }?.let { runCatching { it.readText() }.getOrNull() }
+    val launch =
+      text?.let {
+        runCatching { overridesJson.decodeFromString(DaemonLaunchDescriptor.serializer(), it) }
+          .getOrNull()
+      } ?: return 1
+    val android =
+      launch.systemProperties.keys.any { it.startsWith("robolectric.") } ||
+        launch.jvmArgs.any { it.contains("robolectric.", ignoreCase = true) }
+    return if (android) ANDROID_LIVE_SEAT_WEIGHT else 1
+  }
+
+  /**
+   * Extract [bundleFile] into [destDir] and synthesise a working [ServeSessionState] for it, or
+   * `null` (logging a clear reason via [onLog]) on any failure — a bad/foreign bundle, an
+   * unsupported backend, missing sidecar jars (desktop or android), or an empty preview manifest.
+   * [offline] forces classpath resolution to skip the network (mirrors
+   * `-Dcomposeai.bundle.offline`); default `false` still honours that sysprop /
+   * `COMPOSE_PREVIEW_OFFLINE` via [CoordinateResolver]'s own default.
+   */
+  fun materialize(
+    bundleFile: File,
+    destDir: File,
+    system: String,
+    offline: Boolean = false,
+    /**
+     * Extra remote Maven repository base URLs the classpath resolver may fetch from, in addition to
+     * Maven Central + Google Maven ([CoordinateResolver.DEFAULT_REMOTE_REPOSITORIES]). A catalog
+     * whose module pulls deps from a non-default repo (e.g. `https://jitpack.io`, an
+     * Apollo/JetBrains snapshot repo) would otherwise have those coordinates skipped — leaving the
+     * live daemon's classpath incomplete, so a class that references them fails at bootstrap and
+     * the catalog silently falls back to baked PNGs. Empty by default (Central + Google only); the
+     * serve host passes its `--extra-maven-repos` / `SERVE_EXTRA_MAVEN_REPOS` list here.
+     */
+    extraMavenRepos: List<String> = emptyList(),
+    /**
+     * Extra classpath directories prepended after the bundle's own `classes/` — the rehydrated
+     * [BundleReader.Manifest.externalResources] pool (fonts lifted out of `classes/app.jar` by
+     * `bundle externalize`, materialized at their original resource paths so
+     * `getResourceAsStream("/fonts/…")` resolves). Empty for a self-contained bundle.
+     */
+    extraClasspathDirs: List<File> = emptyList(),
+    fileSystem: FileSystem = SystemFileSystem,
+    onLog: (String) -> Unit = { System.err.println("[serve bundle] $it") },
+  ): ServeSessionState? {
+    destDir.mkdirs()
+
+    val manifest =
+      try {
+        BundleReader.readMetadata(bundleFile).manifest
+      } catch (e: Exception) {
+        onLog("catalog $system: could not read bundle metadata (${e.message})")
+        return null
+      }
+    val backend = manifest.backend
+    if (backend != "desktop" && backend != "android") {
+      onLog(
+        "catalog $system: bundle backend '$backend' is not 'desktop' or 'android' — no live daemon " +
+          "for this backend"
+      )
+      return null
+    }
+
+    val zipBytes =
+      try {
+        BundleReader.extractZipBytes(bundleFile, fileSystem)
+      } catch (e: Exception) {
+        onLog("catalog $system: could not read bundle zip (${e.message})")
+        return null
+      }
+
+    val classesDir = File(destDir, "classes").apply { mkdirs() }
+    val libsDir = File(destDir, "libs").apply { mkdirs() }
+    val previewsJson = File(destDir, "previews.json")
+    // A fully IR-backed bundle (schema v5+) legitimately carries no classes/app.jar — its daemon
+    // replays the carried documents extracted below. A mixed bundle with at least one class-backed
+    // preview must still carry its jar.
+    val irPreviewIds = manifest.intermediateRepresentations.mapTo(mutableSetOf()) { it.previewId }
+    val requireAppJar = manifest.previewIds.any { it !in irPreviewIds }
+    try {
+      extractBundleClassesAndManifest(
+        zipBytes,
+        classesDir,
+        previewsJson,
+        bundleFile,
+        requireAppJar,
+        fileSystem,
+      )
+    } catch (e: Exception) {
+      onLog("catalog $system: bundle extraction failed (${e.message})")
+      return null
+    }
+
+    // v5+ IR replay: a Remote Compose preview has no consumer class to reflect. The Android
+    // daemon instead reads the captured document from `ir/` and resolves its descriptor through
+    // the carried bundle manifest. This is the same setup `compose-preview bundle daemon` uses;
+    // without it the public catalog path filtered IR previews out and falsely reported a daemon
+    // startup failure.
+    val hasIr = manifest.intermediateRepresentations.isNotEmpty()
+    val irDir = if (hasIr) File(destDir, "ir").apply { mkdirs() } else null
+    val bundleManifestFile = if (hasIr) File(destDir, "bundle.json") else null
+    if (hasIr) {
+      try {
+        extractBundleIrArtifacts(zipBytes, irDir!!, bundleManifestFile!!, bundleFile, fileSystem)
+      } catch (e: Exception) {
+        onLog("catalog $system: IR extraction failed (${e.message})")
+        return null
+      }
+    }
+
+    val libJars = BundleReader.extractEmbeddedLibs(zipBytes, libsDir, fileSystem)
+    val recordedCoords = manifest.classpath.filterIsInstance<BundleReader.ClasspathEntry.Maven>()
+    // A bundle records `skiko-awt` but not the `skiko-awt-runtime-<host>` its bindings link
+    // against — the platform native reaches a Gradle-resolved classpath as a transitive artifact,
+    // not as a coordinate. Promoted unpaired, those bindings link against the SERVER's older
+    // libskiko and every render dies with UnsatisfiedLinkError. See [SkikoNativePairing].
+    val skikoNativeRepair = SkikoNativePairing.missingHostRuntime(recordedCoords)
+    if (skikoNativeRepair != null) {
+      onLog("catalog $system: ${SkikoNativePairing.repairLog(skikoNativeRepair)}")
+    }
+    val mavenCoords = recordedCoords + listOfNotNull(skikoNativeRepair)
+    // (v9) The bundle names the repositories its own coordinates resolve from — a JitPack fork, an
+    // internal mirror, the androidx.dev snapshot build a Remote Compose catalog is built against.
+    // Consulted after the operator's `--extra-maven-repos`, so a box that pins a mirror still wins,
+    // and a pre-v9 bundle contributes nothing. The recorded `sha256` still decides whether the
+    // bytes that come back are the ones the producer packed.
+    val bundleRepositories = manifest.repositories.filter { it.isNotBlank() }
+    if (bundleRepositories.isNotEmpty()) {
+      onLog(
+        "catalog $system: bundle declares ${bundleRepositories.size} extra Maven " +
+          "repository(s) — ${bundleRepositories.joinToString()}"
+      )
+    }
+    val resolutions =
+      CoordinateResolver(
+          warn = { onLog("catalog $system: $it") },
+          networkEnabled = if (offline) false else CoordinateResolver.defaultNetworkEnabled(),
+          remoteRepositories =
+            CoordinateResolver.DEFAULT_REMOTE_REPOSITORIES +
+              extraMavenRepos.filter { it.isNotBlank() } +
+              bundleRepositories,
+        )
+        .resolveAll(mavenCoords)
+    val resolvedDependencies = resolutions.mapNotNull { resolution ->
+      resolution.file?.let { file -> ResolvedBundleDependency(resolution.coordinate, file) }
+    }
+    // A coordinate the resolver couldn't find is dropped with a per-coordinate warning and the
+    // daemon starts anyway — correct, because most misses are harmless (a dep nothing on the render
+    // path touches). What was missing is the *aggregate*: 13 unresolved coordinates read as 13
+    // unrelated warnings, and the consequence only surfaced later as an unattributable
+    // `NoClassDefFoundError` that tripped the breaker terminally (issues #4259 / #4265). Record the
+    // gap beside the launch descriptor so a linkage trip can name it — see [BundleClasspathGaps].
+    //
+    // A coordinate that resolved to the WRONG bytes is recorded the same way and for the same
+    // reason. The resolver warns and hands the artifact over regardless, so a hash mismatch reads
+    // as one more startup warning while the daemon links two builds of one library — which is how
+    // meshcore-mobile's lane died on `NoSuchFieldError: … RemoteClock … SYSTEM` with a breaker
+    // reason that named no cause at all (#187). Nothing was unresolved there, so only the mismatch
+    // list could have said so.
+    BundleClasspathGaps.record(
+      destDir = destDir,
+      unresolved = resolutions.filter { it.file == null }.map { it.coordinate },
+      total = mavenCoords.size,
+      system = system,
+      onLog = onLog,
+      mismatched = resolutions.filter { it.mismatch }.map { it.coordinate },
+      fileSystem = fileSystem,
+    )
+    // The resolver warns and returns null rather than throwing, so an unresolvable repair would
+    // otherwise be indistinguishable from one that was never needed — and the daemon would launch
+    // straight back into the split-Skiko classpath this repair exists to close.
+    if (
+      skikoNativeRepair != null && resolvedDependencies.none { it.coordinate == skikoNativeRepair }
+    ) {
+      onLog(
+        "catalog $system: could not resolve ${skikoNativeRepair.artifact}:" +
+          "${skikoNativeRepair.version} — the live lane will link Skiko ${skikoNativeRepair.version} " +
+          "bindings against this server's own libskiko and is likely to fail every render with " +
+          "UnsatisfiedLinkError. Republish the catalog against a Compose Multiplatform version " +
+          "whose Skiko this server ships, or give the server network access to Maven Central."
+      )
+    }
+    // Resolved before the partition below: which Remote Compose artifacts the sidecar ships decides
+    // whether the bundle's own are safe to promote ahead of it.
+    val backendLaunch =
+      when (backend) {
+        "android" -> androidBundleDaemonLaunch(system, onLog)
+        else -> desktopBundleDaemonLaunch(system, onLog)
+      } ?: return null
+    // `androidx.compose.remote:*` is a family compiled against itself, and the daemon's own IR
+    // replay connector calls into it. Promoting the bundle's copies ahead of the sidecar is right
+    // when the bundle carries the WHOLE family — the sidecar's line is then shadowed entire — and
+    // fatal when it carries only part of it: the rest falls through to the sidecar's pin and the
+    // first replay dies on `NoSuchFieldError: … RemoteClock … SYSTEM`, latching the lane for good
+    // (#187). On an IR bundle the sidecar is authoritative in that state, because it is the
+    // sidecar's replay code that links against the family and a replayed document has no consumer
+    // class of its own; demoting the bundle's partial line keeps its jars reachable (in the child
+    // loader, and on the parent behind the sidecar) while one coherent set answers.
+    //
+    // Gated on `hasIr` deliberately. A bundle with no IR is the opposite case — its previews ARE
+    // consumer bytecode compiled against the versions it records — so the catalog keeps its own
+    // Remote Compose versions there and the split is reported without being rearranged. Scoped to
+    // the groups actually split, too: the base and Wear lines version independently, so a bundle
+    // whose base family is coherent keeps it even when its Wear artifacts are not. See
+    // [RemoteComposePairing].
+    val remoteComposeLine =
+      RemoteComposePairing.Line(
+        bundle = RemoteComposePairing.bundleMembers(resolvedDependencies.map { it.coordinate }),
+        sidecar = RemoteComposePairing.sidecarMembers(backendLaunch.daemonClasspath),
+      )
+    val demotedRemoteComposeGroups =
+      if (hasIr) RemoteComposePairing.skewedGroups(remoteComposeLine) else emptySet()
+    val (parentOverlayDependencies, childDependencies) =
+      resolvedDependencies.partition {
+        overlaysDaemonSidecar(it.coordinate, demotedRemoteComposeGroups)
+      }
+    // Android app-resource carriage: a classic `@Preview` that calls `stringResource(R.string.…)`
+    // needs the app's own `0x7f` resource table at render time. Extract the bundle's carried
+    // `android/` payload and synthesize the Robolectric `test_config.properties` onto the daemon
+    // `-cp` — the same wiring `bundle daemon` uses — or Robolectric throws
+    // `Resources$NotFoundException`. Empty for a desktop bundle, or an Android bundle packed before
+    // this carriage existed (renders framework-resources-only, exactly as before).
+    val androidResourceClasspath =
+      if (backend == "android")
+        AndroidBundleResources.daemonClasspath(
+            zipBytes,
+            destDir,
+            manifest.androidResources?.applicationPackage,
+          )
+          .map { it.absolutePath }
+          .also {
+            if (it.isNotEmpty())
+              onLog("catalog $system: android resource carriage → ${it.size} classpath entry(s)")
+          }
+      else emptyList()
+
+    val classpaths =
+      bundleDaemonClasspaths(
+        classesDir = classesDir,
+        extraClasspathDirs = extraClasspathDirs,
+        embeddedLibJars = libJars,
+        parentOverlayJars = parentOverlayDependencies.map { it.file },
+        childDependencyJars = childDependencies.map { it.file },
+        daemonSidecarClasspath = backendLaunch.daemonClasspath,
+        androidResourceClasspath = androidResourceClasspath,
+        hasIr = hasIr,
+      )
+    if (parentOverlayDependencies.isNotEmpty()) {
+      onLog(
+        "catalog $system: ${parentOverlayDependencies.size} shared bundle dependency classpath " +
+          "entry(s) precede the daemon sidecar; ${childDependencies.size} app dependency " +
+          "entry(s) remain isolated"
+      )
+    }
+    // Backstop for every split-Skiko cause the repair above does not close (an offline box, a host
+    // with no published native, a bundle recording another platform's). Read off the assembled
+    // classpath rather than the coordinates, because order is what decides which pair loads.
+    SkikoNativePairing.classpathSkew(classpaths.daemonClasspath)?.let {
+      onLog("catalog $system: $it")
+    }
+    // The same "two artifacts must move together" property for Remote Compose, read off the two
+    // sides rather than the assembled `-cp`: a resolved `.aar` reaches the classpath as
+    // `extracted/<sha256>/classes.jar` and carries neither artifact nor version in its path. A
+    // bundle that records only part of the family leaves the rest at the sidecar's pin, and the
+    // first IR replay dies on `NoSuchFieldError: … RemoteClock … SYSTEM` (#187). Recorded beside
+    // the launch descriptor so the trip can name the seam — see [RemoteComposePairing].
+    RemoteComposePairing.record(
+      destDir = destDir,
+      bundle = remoteComposeLine.bundle,
+      sidecar = remoteComposeLine.sidecar,
+      system = system,
+      onLog = onLog,
+      demoted = demotedRemoteComposeGroups.isNotEmpty(),
+      fileSystem = fileSystem,
+    )
+
+    val descriptor =
+      DaemonLaunchDescriptor(
+        schemaVersion = DAEMON_LAUNCH_SCHEMA_VERSION,
+        modulePath = ":catalog",
+        variant = backendLaunch.variant,
+        enabled = true,
+        // Both backends speak the same JSON-RPC over stdio via the same `DaemonMain`; only the
+        // classpath / JVM args / sysprops differ (see [BackendDaemonLaunch]).
+        mainClass = DAEMON_MAIN_CLASS,
+        javaLauncher = null,
+        classpath = classpaths.daemonClasspath,
+        jvmArgs = backendLaunch.jvmArgs,
+        systemProperties =
+          buildMap {
+            put("composeai.daemon.userClassDirs", classpaths.userClassPath)
+            put("composeai.daemon.previewsJsonPath", previewsJson.absolutePath)
+            irDir?.let { put(IR_DIR_PROPERTY, it.absolutePath) }
+            bundleManifestFile?.let { put(BUNDLE_MANIFEST_PATH_PROPERTY, it.absolutePath) }
+            // Point the daemon's render output at `<destDir>/renders`. This is what makes
+            // `DaemonMain.dataRoot` non-null (`<destDir>/data`), which is the gate that *registers*
+            // the file-based data products — including `compose/figma-svg` (+ `-long`). Without it
+            // `dataRoot` is null, the figma-svg producer still writes its SVG (it has an
+            // independent
+            // fallback dir) but the product is never advertised, so an override-bearing `.svg`
+            // render fails `-32020 kind not advertised` and the SVG lane 404s (ServeRenderHost's
+            // `enableExtensions` gets it back in `unknown`). `RenderEngine.dataDir` resolves to the
+            // SAME `<destDir>/data` (`outputDir.parent/data`), so the registry reads exactly where
+            // the render wrote. Keep the key literal to avoid a `:daemon:desktop` compile dep.
+            put("composeai.render.outputDir", File(destDir, "renders").absolutePath)
+            // Opt in to the missing-resource placeholder fallback: this is the live/serve viewer,
+            // so
+            // an app-resource lookup absent from a stale or incompletely-packed bundle degrades to
+            // an
+            // obvious placeholder rather than throwing and showing a broken image. The pack-time
+            // semantics daemon leaves this off so a miss fails loudly instead of baking a
+            // placeholder
+            // into a published catalog sticker. Key kept literal to avoid a `:daemon:android` dep.
+            put("composeai.render.placeholderMissingResources", "true")
+            // Backend extras: the Robolectric `robolectric.*` flags for `android`; none for
+            // desktop.
+            putAll(backendLaunch.extraSystemProperties)
+          },
+        workingDirectory = destDir.absolutePath,
+        manifestPath = previewsJson.absolutePath,
+      )
+    val descriptorFile = File(destDir, "daemon-launch.json")
+    try {
+      fileSystem.write(descriptorFile.path.toPath()) {
+        writeUtf8(json.encodeToString(DaemonLaunchDescriptor.serializer(), descriptor))
+      }
+    } catch (e: Exception) {
+      onLog("catalog $system: could not write daemon-launch.json (${e.message})")
+      return null
+    }
+
+    // The author-declared knob sidecars ride alongside the PNGs in the bundle — the plain-Compose
+    // `previews/<id>.overrides.json` (`compose/overrides`) and the Remote Compose
+    // `previews/<id>.remotecompose.json` (`compose/remotecompose`) channels. Extract both so
+    // [readPreviews] can advertise each preview's editable knobs, which the viewer renders as live
+    // knob controls (and that ServeCatalogLiveHost grafts onto the baked browse surface).
+    // Best-effort: a bundle that carried none simply yields previews with no knobs.
+    val previewsDir = File(destDir, "previews").apply { mkdirs() }
+    extractKnobSidecars(zipBytes, previewsDir, fileSystem)
+
+    val previews = readPreviews(previewsJson, previewsDir, fileSystem)
+    if (previews.isEmpty()) {
+      onLog("catalog $system: bundle previews.json carried no previews")
+      return null
+    }
+
+    return ServeSessionState(
+      descriptor = descriptorFile,
+      workspaceRoot = destDir,
+      workspaceName = destDir.name.ifBlank { system },
+      previews = previews,
+      label = system,
+      // The catalog's app-declared @ThemeCatalog themes, read from the same carried previews.json —
+      // so a published catalog's live lane offers the App theme selector (its daemon applies the
+      // themeProvider override on demand). Empty when the app declares none.
+      declaredThemes = readDeclaredThemes(previewsJson, fileSystem),
+      // An Android/Robolectric daemon boots a sandbox fleet and is far heavier than a desktop CMP
+      // one, so it costs more of the live-seat budget (see [LiveSeatLimiter]); a desktop bundle
+      // keeps the default weight of 1.
+      liveSeatWeight = if (backend == "android") ANDROID_LIVE_SEAT_WEIGHT else 1,
+    )
+  }
+
+  /**
+   * Materialize a compiled **playground snippet** into a resumable live-session state — the Stage-2
+   * ([PlaygroundRedeemService]) counterpart of [materialize], but over a just-compiled snippet's
+   * own classes instead of a fetched bundle. Writes a `previews.json` (every `@Preview` the snippet
+   * declared, so the session can navigate between them) and a `daemon-launch.json` for the
+   * snippet's mode (desktop CMP / Android Robolectric) into the snippet's work dir, so the registry
+   * opens, resumes, seat-counts, and streams it through the exact same path a catalog uses — no new
+   * live-session machinery. Returns null (logged) when the mode's daemon backend (sidecar /
+   * `android.jar`) is unavailable, so redemption reports "unavailable" rather than standing up a
+   * dead session.
+   *
+   * [sandbox] is the per-session containment (PLAYGROUND.md §6, issue #3016): its jail argv and
+   * hard TTL ride the written descriptor, so the registry's ordinary descriptor→spawn path launches
+   * the snippet's daemon inside the jail and shoots it at the deadline. [PlaygroundSandbox.NONE]
+   * leaves the descriptor identical to the pre-sandbox one.
+   */
+  fun materializePlaygroundSnippet(
+    snippet: PlaygroundTokenStore.PlaygroundSnippet,
+    sandbox: PlaygroundSandbox = PlaygroundSandbox.NONE,
+    fileSystem: FileSystem = SystemFileSystem,
+    onLog: (String) -> Unit = { System.err.println("[playground live] $it") },
+  ): ServeSessionState? {
+    val label = "playground:${snippet.previewId.substringAfterLast('.').ifBlank { "snippet" }}"
+    val android = snippet.mode == PlaygroundMode.ANDROID
+    val backendLaunch =
+      (if (android) androidBundleDaemonLaunch(label, onLog)
+      else desktopBundleDaemonLaunch(label, onLog)) ?: return null
+
+    val workDir = File(snippet.workDir.toString())
+    val classesDir = File(snippet.classesDir.toString())
+    val previewsJson = File(workDir, "previews.json")
+    try {
+      fileSystem.write(previewsJson.path.toPath()) {
+        writeUtf8(PlaygroundPreviews.previewManifestJson(snippet))
+      }
+    } catch (e: Exception) {
+      onLog("$label: could not write previews.json (${e.message})")
+      return null
+    }
+
+    // Partition the resolved catalog jars exactly as the bundle path does: the namespaces
+    // UserClassLoaderHolder delegates to the daemon parent (androidx.*, kotlinx-coroutines,
+    // kotlinx-io) must *precede* the sidecar on the parent -cp, or the daemon loads its own
+    // (possibly older) sidecar
+    // versions and a snippet/catalog composable built against the catalog's newer AndroidX fails
+    // with NoSuchMethodError/NoSuchFieldError. Everything else — including the snippet's own
+    // classes
+    // (classesDir) — stays isolated on the user (child) classloader. We only have file paths here
+    // (not coordinates), so match the same groups by their Maven/Gradle cache path segment.
+    // classesDir
+    // lands in `child` (its temp path matches neither), and bundleDaemonClasspaths dedupes it
+    // against
+    // the explicit classesDir arg.
+    val (parentOverlayJars, childJars) =
+      snippet.classpath.map { File(it.toString()) }.partition { jarPrecedesDaemonSidecar(it) }
+    val classpaths =
+      bundleDaemonClasspaths(
+        classesDir = classesDir,
+        extraClasspathDirs = emptyList(),
+        embeddedLibJars = emptyList(),
+        parentOverlayJars = parentOverlayJars,
+        childDependencyJars = childJars,
+        daemonSidecarClasspath = backendLaunch.daemonClasspath,
+        androidResourceClasspath = emptyList(),
+        hasIr = false,
+      )
+    val descriptor =
+      DaemonLaunchDescriptor(
+        schemaVersion = DAEMON_LAUNCH_SCHEMA_VERSION,
+        modulePath = ":playground",
+        variant = backendLaunch.variant,
+        enabled = true,
+        mainClass = DAEMON_MAIN_CLASS,
+        javaLauncher = null,
+        classpath = classpaths.daemonClasspath,
+        // The sandbox's JVM caps come last so they win over any backend default: a snippet's daemon
+        // is bounded in heap and CPU even on a jail with no cgroup behind it.
+        jvmArgs = backendLaunch.jvmArgs + sandbox.jvmArgs(workDir),
+        systemProperties =
+          buildMap {
+            put("composeai.daemon.userClassDirs", classpaths.userClassPath)
+            put("composeai.daemon.previewsJsonPath", previewsJson.absolutePath)
+            put("composeai.render.outputDir", File(workDir, "renders").absolutePath)
+            put("composeai.render.placeholderMissingResources", "true")
+            putAll(
+              if (android) sandbox.robolectricSystemProperties(backendLaunch.extraSystemProperties)
+              else backendLaunch.extraSystemProperties
+            )
+          },
+        workingDirectory = workDir.absolutePath,
+        manifestPath = previewsJson.absolutePath,
+        jailCommand =
+          sandbox.command(
+            PlaygroundSandbox.Paths(
+              workDir = workDir,
+              // Everything the daemon reads: its own sidecar jars, the catalog classpath, and the
+              // snippet's compiled classes. Bound read-only; only workDir is writable.
+              readOnly =
+                (classpaths.daemonClasspath.map { File(it) } +
+                    snippet.classpath.map { File(it.toString()) } +
+                    classesDir)
+                  .distinct(),
+              javaHome = File(System.getProperty("java.home")),
+            )
+          ),
+        hardTtlSeconds = sandbox.ttlSeconds.takeIf { sandbox.isActive },
+      )
+    val descriptorFile = File(workDir, "daemon-launch.json")
+    try {
+      fileSystem.write(descriptorFile.path.toPath()) {
+        writeUtf8(json.encodeToString(DaemonLaunchDescriptor.serializer(), descriptor))
+      }
+    } catch (e: Exception) {
+      onLog("$label: could not write daemon-launch.json (${e.message})")
+      return null
+    }
+
+    val previews =
+      readPreviews(previewsJson, File(workDir, "previews").apply { mkdirs() }, fileSystem)
+    if (previews.isEmpty()) {
+      onLog("$label: synthesized previews.json carried no previews")
+      return null
+    }
+    return ServeSessionState(
+      descriptor = descriptorFile,
+      workspaceRoot = workDir,
+      workspaceName = workDir.name.ifBlank { "playground" },
+      previews = previews,
+      label = label,
+      liveSeatWeight = if (android) ANDROID_LIVE_SEAT_WEIGHT else 1,
+    )
+  }
+
+  /**
+   * Read the catalog's declared `@ThemeCatalog` themes from the carried `previews.json` (the
+   * synthetic `THEME_CATALOG` entries discovery emits). Module-global, so the whole catalog shares
+   * one theme set. Absent / unreadable previews.json → no themes.
+   */
+  private fun readDeclaredThemes(previewsJson: File, fileSystem: FileSystem): List<ServeTheme> {
+    val text =
+      try {
+        fileSystem.read(previewsJson.path.toPath()) { readUtf8() }
+      } catch (_: Exception) {
+        return emptyList()
+      }
+    val manifest =
+      runCatching { previewsManifestJson.decodeFromString(PreviewManifest.serializer(), text) }
+        .getOrNull() ?: return emptyList()
+    return declaredThemesFromPreviews(manifest.previews)
+  }
+
+  /**
+   * Read the bundle's extracted `previews.json` into the [ServePreview] shape serve expects,
+   * folding in each preview's author-declared knobs from its extracted
+   * `previews/<id>.overrides.json` sidecar (in [previewsDir]) so the daemon-backed session
+   * advertises what's editable.
+   */
+  public fun readPreviews(
+    previewsJson: File,
+    previewsDir: File,
+    fileSystem: FileSystem,
+  ): List<ServePreview> {
+    val text =
+      try {
+        fileSystem.read(previewsJson.path.toPath()) { readUtf8() }
+      } catch (_: Exception) {
+        return emptyList()
+      }
+    val manifest =
+      runCatching { previewsManifestJson.decodeFromString(PreviewManifest.serializer(), text) }
+        .getOrNull() ?: return emptyList()
+    return manifest.previews.map {
+      val (focus, gestures) = detectedFeaturesOf(it)
+      ServePreview(
+        id = it.id,
+        label = it.functionName.ifBlank { it.id },
+        dataProductKinds = it.dataProducts.mapTo(LinkedHashSet()) { product -> product.kind },
+        uiMode = it.params.uiMode,
+        showBackground = it.params.showBackground,
+        backgroundColor = it.params.backgroundColor,
+        deviceFrame =
+          ServeDeviceFrame.from(it.params.device, it.params.widthDp, it.params.heightDp),
+        overrides = readOverrideSidecar(previewsDir, it.id, fileSystem),
+        remoteComposeKnobs = readRemoteComposeSidecar(previewsDir, it.id, fileSystem),
+        supportsFocus = focus,
+        supportsGestures = gestures,
+        fixedTheme = it.fixedTheme,
+      )
+    }
+  }
+
+  /**
+   * Extract the per-preview knob sidecars (`previews/<id>.overrides.json` and
+   * `previews/<id>.remotecompose.json`) from [zipBytes] into [previewsDir] (zip-slip safe). Mirrors
+   * the PNG-side extraction in [ServeBundleStore]; other bundle entries are handled elsewhere
+   * ([extractBundleClassesAndManifest]).
+   */
+  public fun extractKnobSidecars(zipBytes: ByteArray, previewsDir: File, fileSystem: FileSystem) {
+    val root = previewsDir.canonicalFile.toPath()
+    java.util.zip.ZipInputStream(java.io.ByteArrayInputStream(zipBytes)).use { zin ->
+      while (true) {
+        val entry = zin.nextEntry ?: break
+        val name = entry.name.replace('\\', '/')
+        if (
+          !entry.isDirectory &&
+            name.startsWith("previews/") &&
+            (name.endsWith(OVERRIDES_SUFFIX) || name.endsWith(REMOTECOMPOSE_SUFFIX)) &&
+            ".." !in name.split("/")
+        ) {
+          // Strip the leading `previews/` so the file lands directly under previewsDir (keyed by
+          // id).
+          val target = File(previewsDir, name.removePrefix("previews/"))
+          if (target.canonicalFile.toPath().startsWith(root)) {
+            target.parentFile?.mkdirs()
+            val bytes = zin.readBytes()
+            fileSystem.write(target.path.toPath()) { write(bytes) }
+          }
+        }
+        zin.closeEntry()
+      }
+    }
+  }
+
+  /** Read [id]'s extracted `<id>.overrides.json` sidecar (the `compose/overrides` payload). */
+  private fun readOverrideSidecar(
+    previewsDir: File,
+    id: String,
+    fileSystem: FileSystem,
+  ): List<ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration> {
+    val sidecar = File(previewsDir, "$id$OVERRIDES_SUFFIX").path.toPath()
+    if (!fileSystem.exists(sidecar)) return emptyList()
+    return try {
+      val text = fileSystem.read(sidecar) { readUtf8() }
+      overridesJson
+        .decodeFromString(
+          ee.schimke.composeai.data.overrides.PreviewOverridesPayload.serializer(),
+          text,
+        )
+        .declarations
+    } catch (_: Exception) {
+      emptyList()
+    }
+  }
+
+  /**
+   * Read [id]'s extracted `<id>.remotecompose.json` sidecar (the `compose/remotecompose`
+   * declarations payload) into its declared knobs. Absent / unreadable ⇒ no knobs, so a bundle that
+   * carried none (or a non-RC catalog) just advertises an empty list.
+   */
+  private fun readRemoteComposeSidecar(
+    previewsDir: File,
+    id: String,
+    fileSystem: FileSystem,
+  ): List<ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration> {
+    val sidecar = File(previewsDir, "$id$REMOTECOMPOSE_SUFFIX").path.toPath()
+    if (!fileSystem.exists(sidecar)) return emptyList()
+    return try {
+      val text = fileSystem.read(sidecar) { readUtf8() }
+      overridesJson
+        .decodeFromString(
+          ee.schimke.composeai.data.remotecompose.RemoteComposeDeclarationsPayload.serializer(),
+          text,
+        )
+        .declarations
+    } catch (_: Exception) {
+      emptyList()
+    }
+  }
+
+  /**
+   * Suffix of the per-preview plain-Compose knob sidecar; lockstep with `PreviewBundleFormat`'s.
+   */
+  private const val OVERRIDES_SUFFIX = ".overrides.json"
+
+  /**
+   * Suffix of the per-preview Remote Compose knob sidecar; lockstep with `PreviewBundleFormat`'s.
+   */
+  private const val REMOTECOMPOSE_SUFFIX = ".remotecompose.json"
+
+  /** IR replay properties consumed by BundleIrReplayStore in the daemon. */
+  private const val IR_DIR_PROPERTY = "composeai.daemon.irDir"
+  private const val BUNDLE_MANIFEST_PATH_PROPERTY = "composeai.daemon.bundleManifestPath"
+
+  private val json = Json { encodeDefaults = true }
+
+  /**
+   * Read back a `daemon-launch.json` written by [materialize].
+   *
+   * Exists so the theme cache can fingerprint a generation from the launch the daemon will actually
+   * perform — the classpath it loads and the variant it renders as — rather than from a parallel
+   * description of it that someone would have to keep in step by hand.
+   *
+   * Null on anything unreadable, which the caller treats as "this generation has no durable
+   * identity" and therefore as "do not persist".
+   */
+  fun readLaunchDescriptor(descriptorFile: File): DaemonLaunchDescriptor? = runCatching {
+    launchDescriptorJson.decodeFromString(
+      DaemonLaunchDescriptor.serializer(),
+      descriptorFile.readText(),
+    )
+  }
+    .getOrNull()
+
+  private val launchDescriptorJson = Json { ignoreUnknownKeys = true }
+  private val overridesJson = Json { ignoreUnknownKeys = true }
+  private val previewsManifestJson = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+  }
+
+  /**
+   * Split a packed bundle's runtime into the daemon parent and disposable user child classpaths.
+   *
+   * Compose, AndroidX, Kotlin, and kotlinx packages deliberately delegate to the daemon parent
+   * loader so renderer and preview code share one class identity. Consequently, leaving the
+   * bundle's resolved Maven jars in `composeai.daemon.userClassDirs` cannot make those catalog
+   * versions win: [ee.schimke.composeai.daemon.UserClassLoaderHolder] delegates them straight to
+   * the server sidecar, producing `NoSuchMethodError` when the catalog was compiled against newer
+   * Material, Lifecycle, or coroutines APIs.
+   *
+   * Put the bundle's shared AndroidX/Compose and coroutines dependencies first on the parent `-cp`,
+   * ahead of the daemon sidecar. The JVM's left-to-right classpath order then selects the catalog's
+   * framework versions while retaining one parent-loaded copy for both renderer and app code. Keep
+   * ordinary app dependencies in the child loader. In particular, do not overlay
+   * kotlinx-serialization: the daemon's generated JSON-RPC serializers and its runtime must stay
+   * version-aligned.
+   */
+  public fun bundleDaemonClasspaths(
+    classesDir: File,
+    extraClasspathDirs: List<File>,
+    embeddedLibJars: List<File>,
+    parentOverlayJars: List<File>,
+    childDependencyJars: List<File>,
+    daemonSidecarClasspath: List<String>,
+    androidResourceClasspath: List<String>,
+    hasIr: Boolean,
+  ): BundleDaemonClasspaths {
+    // The carried r-classes.jar belongs to the catalog's AndroidX graph too. It must precede the
+    // sidecar's generated R.jar or newer Compose UI bytecode can resolve an older R$id class and
+    // fail with NoSuchFieldError.
+    val parentEntries =
+      (parentOverlayJars.map { it.absolutePath } +
+          androidResourceClasspath +
+          daemonSidecarClasspath +
+          // Parent-loaded IR replay connectors link the carried player/runtime libraries
+          // directly. Mirror BundleDaemonCommand.composeDaemonClasspath by making every carried
+          // dependency visible to the parent after the authoritative daemon sidecars. Shared ABI
+          // overlays above still precede the sidecar and retain their version priority.
+          (if (hasIr) (embeddedLibJars + childDependencyJars).map { it.absolutePath }
+          else emptyList()))
+        .distinct()
+    // The rehydrated external-resource dirs go right after the bundle's own classes so a lifted
+    // font resolves at the same `/fonts/…` path it did when carried inline.
+    val childEntries =
+      (listOf(classesDir) +
+          extraClasspathDirs.filter { it.isDirectory } +
+          embeddedLibJars +
+          childDependencyJars)
+        .map { it.absolutePath }
+        .distinct()
+    return BundleDaemonClasspaths(
+      daemonClasspath = parentEntries,
+      userClassPath = childEntries.joinToString(File.pathSeparator),
+    )
+  }
+
+  public data class BundleDaemonClasspaths(
+    val daemonClasspath: List<String>,
+    val userClassPath: String,
+  )
+
+  /**
+   * [shouldPrecedeDaemonSidecar] with the one exception the Remote Compose family earns: when an
+   * **IR-carrying** bundle covers only part of a Remote Compose group and the sidecar supplies the
+   * rest at another version ([demotedRemoteComposeGroups], from `hasIr` and
+   * [RemoteComposePairing.skewedGroups]), promoting the bundle's half of that group wins nothing
+   * and links the two halves together. Demoted, the group answers whole from the sidecar — the side
+   * whose IR replay code calls into it. A bundle with no IR never demotes: its previews are
+   * consumer bytecode compiled against the versions it records, which is exactly what
+   * [shouldPrecedeDaemonSidecar] protects. See [RemoteComposePairing].
+   */
+  internal fun overlaysDaemonSidecar(
+    coordinate: BundleReader.ClasspathEntry.Maven,
+    demotedRemoteComposeGroups: Set<String>,
+  ): Boolean =
+    shouldPrecedeDaemonSidecar(coordinate) &&
+      !RemoteComposePairing.isDemoted(coordinate, demotedRemoteComposeGroups)
+
+  /**
+   * Dependencies whose packages [ee.schimke.composeai.daemon.UserClassLoaderHolder] deliberately
+   * resolves from the parent and whose consumer ABI must therefore win over the baked sidecar.
+   */
+  public fun shouldPrecedeDaemonSidecar(coordinate: BundleReader.ClasspathEntry.Maven): Boolean =
+    coordinate.group.startsWith("androidx.") ||
+      // Compose Multiplatform artifacts are `org.jetbrains.compose.*` by GROUP but ship
+      // `androidx.compose.*` PACKAGES — the same overlap [ValidateComposePreviewClasspathTask]
+      // warns about. [UserClassLoaderHolder.mustDelegateToParent] keys on the package, so those
+      // classes are force-delegated to the parent; leaving the jars in the isolated child means
+      // the child copy is never consulted and the sidecar's own Compose answers instead. A
+      // consumer pinning a different version than the renderer ships then gets a hard
+      // `NoSuchMethodError` mid-render — meshcore-mobile on material3 1.10.0-alpha05 against a
+      // 1.11.x sidecar died on `AppBarKt.TopAppBar-gNPyAyM`. Group and package rule must agree.
+      //
+      // Skiko travels WITH Compose, and for the same reason: `org.jetbrains.skiko:skiko-awt`
+      // carries `org.jetbrains.skia.*` (bindings) as well as `org.jetbrains.skiko.*`, and
+      // `mustDelegateToParent` force-delegates `org.jetbrains.skia.`. Promoting Compose without it
+      // would pair the consumer's newer bindings with the sidecar's older native library — the
+      // `UnsatisfiedLinkError` on `skia.paragraph.TextStyleKt._nSetFontEdging` that
+      // [DesktopRendererGraphAlignmentFunctionalTest] documents (issue #1844). The two must move
+      // together or the graph is incoherent either way.
+      coordinate.group.startsWith("org.jetbrains.compose") ||
+      coordinate.group.startsWith("org.jetbrains.skiko") ||
+      (coordinate.group == "org.jetbrains.kotlinx" &&
+        (coordinate.artifact.startsWith("kotlinx-coroutines") ||
+          coordinate.artifact.startsWith("kotlinx-io")))
+
+  /**
+   * The [shouldPrecedeDaemonSidecar] rule applied to a resolved **jar path** rather than a
+   * coordinate — used by the playground live path ([materializePlaygroundSnippet]), which carries
+   * only the resolved files (the coordinates were dropped during catalog resolution). Both the
+   * Maven-local (`…/androidx/compose/…`) and Gradle-cache (`…/androidx.compose.material3/…`)
+   * layouts put the dotted/slashed group right after a path separator, so a `/androidx` segment
+   * identifies the AndroidX graph, `org.jetbrains.compose` the Compose Multiplatform graph (whose
+   * artifacts ship `androidx.compose.*` packages — see [shouldPrecedeDaemonSidecar]), and
+   * `kotlinx-coroutines` / `kotlinx-io` the kotlinx artifacts whose namespaces
+   * `UserClassLoaderHolder` delegates to the daemon parent.
+   */
+  public fun jarPrecedesDaemonSidecar(jar: File): Boolean {
+    val path = jar.path.replace('\\', '/')
+    return path.contains("/androidx") ||
+      JETBRAINS_COMPOSE_ARTIFACT_PATH.containsMatchIn(path) ||
+      KOTLINX_SHARED_ARTIFACT_PATH.containsMatchIn(path)
+  }
+
+  /**
+   * The `org.jetbrains.compose.*` and `org.jetbrains.skiko` graphs in either cache layout. Broader
+   * than the old `components-resources` check it replaces — every Compose Multiplatform artifact
+   * ships `androidx.compose.*` packages the child delegates to the parent, not just the resources
+   * one, and Skiko ships the `org.jetbrains.skia.*` bindings that are delegated too. Both must be
+   * promoted together so the bindings and the native library stay one coherent version.
+   */
+  private val JETBRAINS_COMPOSE_ARTIFACT_PATH =
+    Regex("/(?:org\\.jetbrains\\.(?:compose|skiko)|org/jetbrains/(?:compose|skiko))[./]")
+
+  /** Matches Gradle-cache and Maven-local group layouts without inspecting unrelated path parts. */
+  private val KOTLINX_SHARED_ARTIFACT_PATH =
+    Regex(
+      "/(?:org\\.jetbrains\\.kotlinx|org/jetbrains/kotlinx)/" +
+        "kotlinx-(?:coroutines|io)(?:-[^/]+)?(?:/|$)"
+    )
+
+  private data class ResolvedBundleDependency(
+    val coordinate: BundleReader.ClasspathEntry.Maven,
+    val file: File,
+  )
+
+  /**
+   * The backend-specific half of a bundle daemon launch: the daemon (parent `-cp`) classpath, the
+   * JVM args, and any extra `-D` system properties. Mirrors `BundleDaemonCommand.DaemonLaunch` but
+   * flattened for the descriptor path (which applies `jvmArgs` + `systemProperties` + `classpath`
+   * directly — see `SubprocessDaemonClientFactory.spawn`). The daemon's own classpath carries the
+   * renderer; the bundle's app classes ride the `composeai.daemon.userClassDirs` sysprop, so they
+   * are NOT in [daemonClasspath].
+   */
+  private data class BackendDaemonLaunch(
+    val variant: String,
+    val daemonClasspath: List<String>,
+    val jvmArgs: List<String>,
+    val extraSystemProperties: Map<String, String>,
+  )
+
+  /** Desktop (CMP/Skiko) launch: `lib-daemon-desktop` + `lib-renderer`, native-access opened. */
+  private fun desktopBundleDaemonLaunch(
+    system: String,
+    onLog: (String) -> Unit,
+  ): BackendDaemonLaunch? {
+    val daemonJars = locateBundleSidecarJars("lib-daemon-desktop")
+    if (daemonJars.isEmpty()) {
+      onLog(
+        "catalog $system: no daemon jars found (looked in " +
+          "${bundleSidecarSearchDescription("lib-daemon-desktop")}) — is this a " +
+          "`:cli:installDist` build?"
+      )
+      return null
+    }
+    val rendererJars = locateBundleSidecarJars("lib-renderer")
+    if (rendererJars.isEmpty()) {
+      onLog(
+        "catalog $system: no renderer jars found (looked in " +
+          "${bundleSidecarSearchDescription("lib-renderer")})"
+      )
+      return null
+    }
+    return BackendDaemonLaunch(
+      variant = "desktop",
+      daemonClasspath = (daemonJars + rendererJars).map { it.absolutePath },
+      // -Dapple.awt.UIElement=true runs the desktop daemon JVM as a macOS background agent
+      // (no Dock icon / focus steal). Launch -D so it lands before AWT inits; macOS-only.
+      jvmArgs = listOf("--enable-native-access=ALL-UNNAMED", "-Dapple.awt.UIElement=true"),
+      extraSystemProperties = desktopFontSystemProperties(),
+    )
+  }
+
+  /**
+   * Font-related props the desktop daemon needs, mirroring the Android launch's
+   * [AndroidBundleLaunch.robolectricSystemProperties]. The `compose/figma-svg` export embeds fonts
+   * by default, so the daemon fetches generic faces (e.g. Roboto) from Google Fonts; point it at
+   * the SAME shared cache the Android path and Gradle plugin use so those downloads are cached, and
+   * forward this process's `composeai.svg.embedFonts` / `composeai.fonts.offline` choices when set
+   * so a `-Dcomposeai.svg.embedFonts=false` opt-out reaches the child daemon.
+   */
+  private fun desktopFontSystemProperties(): Map<String, String> = buildMap {
+    put("composeai.fonts.cacheDir", composeAiCacheDir("fonts").absolutePath)
+    System.getProperty("composeai.fonts.offline")?.let { put("composeai.fonts.offline", it) }
+    System.getProperty("composeai.svg.embedFonts")?.let { put("composeai.svg.embedFonts", it) }
+    // The figma-svg background opt-in is read in the daemon, not here, so a
+    // `-Dcomposeai.svg.background=true` on this process only takes effect if it is forwarded.
+    System.getProperty("composeai.svg.background")?.let { put("composeai.svg.background", it) }
+  }
+
+  /**
+   * Android (Robolectric) launch: `lib-daemon-android` + `android.jar`, plus the required
+   * `--add-opens` args and `robolectric.*` mode sysprops [AndroidBundleLaunch] supplies (the same
+   * ones `bundle daemon`'s `androidDaemonLaunch` passes). `resolveAndroidJar(null)` falls back to
+   * `ANDROID_HOME`/`ANDROID_SDK_ROOT` since a module-less serve has no `local.properties`. Missing
+   * the sidecar or android.jar → `null` + an actionable log (caller falls back to baked PNGs).
+   */
+  private fun androidBundleDaemonLaunch(
+    system: String,
+    onLog: (String) -> Unit,
+  ): BackendDaemonLaunch? {
+    val daemonJars = locateBundleSidecarJars("lib-daemon-android")
+    if (daemonJars.isEmpty()) {
+      onLog(
+        "catalog $system: backend=android needs the Android daemon sidecar (`lib-daemon-android/`)," +
+          " which ships separately as `compose-preview-android-daemon-<version>.zip` (too large for" +
+          " the CLI tarball). Unpack it and set" +
+          " `-Dcomposeai.cli.libDaemonAndroidDir=<dir>/lib-daemon-android`. Looked in " +
+          "${bundleSidecarSearchDescription("lib-daemon-android")}."
+      )
+      return null
+    }
+    val androidJar =
+      AndroidBundleLaunch.resolveAndroidJar(localPropertiesFile = null)
+        ?: run {
+          onLog(
+            "catalog $system: backend=android needs android.jar — set ANDROID_HOME / " +
+              "ANDROID_SDK_ROOT."
+          )
+          return null
+        }
+    val launch = AndroidBundleLaunch()
+    return BackendDaemonLaunch(
+      variant = "android",
+      daemonClasspath = (daemonJars + listOf(androidJar)).map { it.absolutePath },
+      jvmArgs = launch.jvmArgs(),
+      extraSystemProperties =
+        launch.robolectricSystemProperties() + androidColdStartSystemProperties(),
+    )
+  }
+
+  /**
+   * Cold-start knobs for a serve-spawned Android/Robolectric daemon. Serve fronts the daemon with
+   * baked PNGs while it warms ([ServeCatalogLiveHost]'s warm-in-background lane), so nothing here
+   * needs the strict all-sandboxes-ready `initialize` contract the Gradle-plugin/VS Code launch
+   * keeps — opt into `RobolectricHost`'s background pool boot by default: `initialize` returns once
+   * ONE sandbox can render (~12 s warm-cache instead of N×), the rest of the pool boots off the
+   * request path, and each background slot gets a boot-time warm render. An explicit
+   * `-Dcomposeai.daemon.backgroundSandboxBoot=…` on the serve JVM (e.g. via `JAVA_TOOL_OPTIONS`)
+   * wins, so operators can opt a deployment out; `composeai.daemon.warmRenderOnBoot` is forwarded
+   * when set for the same reason. Command-line `-D`s land after `JAVA_TOOL_OPTIONS` on the child
+   * JVM, so the value emitted here is authoritative for the daemon.
+   */
+  private fun androidColdStartSystemProperties(): Map<String, String> = buildMap {
+    put(
+      "composeai.daemon.backgroundSandboxBoot",
+      System.getProperty("composeai.daemon.backgroundSandboxBoot") ?: "true",
+    )
+    System.getProperty("composeai.daemon.warmRenderOnBoot")?.let {
+      put("composeai.daemon.warmRenderOnBoot", it)
+    }
+  }
+
+  /**
+   * `ee.schimke.composeai.daemon.DaemonMain` — the daemon entrypoint a bundle spawns (both
+   * backends).
+   */
+  private const val DAEMON_MAIN_CLASS = "ee.schimke.composeai.daemon.DaemonMain"
+
+  /** Descriptor schema version — mirrors `SubprocessRenderSessions.openBundleDaemon`. */
+  private const val DAEMON_LAUNCH_SCHEMA_VERSION = 2
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeDegradation.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeDegradation.kt
@@ -1,0 +1,108 @@
+package ee.schimke.composeai.cli.serve
+
+/**
+ * A structured, human-readable reason a served session is **degraded** — i.e. a live/interactive
+ * lane the viewer would otherwise offer is unavailable and the server has fallen back to baked PNG
+ * snapshots. Recorded by [ServeCatalogStore] at catalog-load time (where the fallback is decided,
+ * and where it was previously only written to stderr), then surfaced by the viewer (a session-level
+ * banner) and `/api/previews` (a `degradations` array) so a visitor sees *why* a session is
+ * snapshot-only instead of guessing.
+ *
+ * [code] is a stable machine slug a programmatic client can switch on; [detail] is a one-sentence
+ * explanation shown in the UI. Keep [code] values in lockstep with any downstream consumer.
+ */
+data class ServeDegradation(val code: String, val detail: String) {
+  companion object {
+    /**
+     * The catalog publishes baked PNGs only — its delivery branch carries no `liveBundle` (and no
+     * source this server can build), so no device/theme/knob control can re-render. The common case
+     * for an app catalog that hasn't opted into the live tier yet.
+     */
+    const val CATALOG_BAKED_ONLY = "catalog-baked-only"
+
+    /**
+     * The catalog declared a `liveBundle` but the server couldn't stand a daemon up from it (the
+     * bundle or one of its externalized resources failed to fetch/verify, or the daemon didn't
+     * start), so it fell back to baked PNGs. [detail] carries the specific cause.
+     */
+    const val LIVEBUNDLE_UNAVAILABLE = "livebundle-unavailable"
+
+    /**
+     * The catalog offers a live lane (a `liveBundle` or a buildable source) but verified as
+     * `Unverified`, so the server refuses to re-render it (fail-closed) and serves baked PNGs. The
+     * trust badge already shows the amber verdict; this states the consequence.
+     */
+    const val UNVERIFIED_NO_RERENDER = "unverified-no-rerender"
+
+    /**
+     * The catalog declares live-only (`deferred[]`) coverage this session can't produce: those
+     * previews have no baked PNG by design, and without a live daemon there is nothing to render
+     * them from — so they are omitted from the grid rather than shown as broken cards. The count
+     * rides in [detail] so a visitor knows the sheet is thinner than the catalog claims.
+     */
+    const val DEFERRED_NOT_SERVED = "deferred-not-served"
+
+    /**
+     * The session HAD a working live lane and the server has since **switched it off**: its render
+     * circuit breaker tripped (a linkage/classpath fault that can never succeed on retry, or a
+     * sustained failure rate), so live renders are refused with the underlying reason rather than
+     * retried. Distinct from [LIVEBUNDLE_UNAVAILABLE], which is a daemon that never came up.
+     */
+    const val RENDER_LANE_BROKEN = "render-lane-broken"
+
+    /**
+     * The live render lane was disabled by its circuit breaker; [reason] is the breaker's text and
+     * [fatal] marks a linkage fault (needs a fixed bundle, not a retry). See
+     * [RenderCircuitBreaker].
+     */
+    fun renderLaneBroken(reason: String, fatal: Boolean): ServeDegradation =
+      ServeDegradation(
+        RENDER_LANE_BROKEN,
+        if (fatal) {
+          "This catalog's live render lane is disabled: it hit a non-recoverable error that no " +
+            "retry can clear, so device, theme and knob controls serve baked PNG snapshots until " +
+            "the catalog is republished. $reason"
+        } else {
+          "This catalog's live render lane is disabled after a sustained run of render failures — " +
+            "it serves baked PNG snapshots and retries periodically. $reason"
+        },
+      )
+
+    /**
+     * [count] live-only previews hidden because this session has no live lane. Paired with
+     * whichever reason explains the missing live lane (no live bundle / unverified / bundle
+     * unavailable).
+     */
+    fun deferredNotServed(count: Int): ServeDegradation =
+      ServeDegradation(
+        DEFERRED_NOT_SERVED,
+        "$count preview(s) in this catalog are published live-only (rendered on demand rather " +
+          "than baked), and this session has no live render lane — they're hidden rather than " +
+          "shown as broken images.",
+      )
+
+    /** A baked-only catalog with no live bundle on its delivery branch. */
+    fun catalogBakedOnly(): ServeDegradation =
+      ServeDegradation(
+        CATALOG_BAKED_ONLY,
+        "This catalog serves baked PNG snapshots only — its delivery branch publishes no live " +
+          "bundle, so device, theme and knob controls can't re-render on this server.",
+      )
+
+    /** A declared live bundle that couldn't be brought up; [cause] is the specific reason. */
+    fun liveBundleUnavailable(cause: String): ServeDegradation =
+      ServeDegradation(
+        LIVEBUNDLE_UNAVAILABLE,
+        "This catalog publishes a live bundle, but the server couldn't render from it ($cause) — " +
+          "falling back to baked PNG snapshots.",
+      )
+
+    /** A live-capable catalog that verified as unverified, so re-render is refused. */
+    fun unverifiedNoRerender(): ServeDegradation =
+      ServeDegradation(
+        UNVERIFIED_NO_RERENDER,
+        "This catalog is unverified, so the server won't re-render it (fail-closed) — showing " +
+          "baked PNG snapshots only.",
+      )
+  }
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeDesignAnnotations.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeDesignAnnotations.kt
@@ -1,0 +1,481 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsInsets
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsNode
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsTokens
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsTypography
+import ee.schimke.composeai.data.layoutinspector.LayoutInspectorBounds
+import ee.schimke.composeai.data.layoutinspector.LayoutInspectorGradient
+import ee.schimke.composeai.data.layoutinspector.LayoutInspectorNode
+import ee.schimke.composeai.data.layoutinspector.LayoutInspectorPayload
+import ee.schimke.composeai.data.layoutinspector.SlotBounds
+import ee.schimke.composeai.data.theme.ThemePayload
+
+/**
+ * Derive the viewer's **typography**, **theme** and **layout** inspection layers from a render's
+ * own capture.
+ *
+ * The compare page reads [DesignAnnotation]s a producer authored into a bundle
+ * ([ServeAnnotationStore]) — the spec side of a design ↔ code comparison. The viewer needs the same
+ * shape for the *code* side, and the daemon already captures it: every semantics node carries its
+ * resolved typographic identity ([ComposeSemanticsNode.typography] — the size, face, weight, line
+ * height, and variation axes the render actually resolved), while [ThemePayload.consumers]
+ * attributes that resolved style back to its Material typography role. Projecting those onto
+ * [DesignAnnotation] means the viewer draws them with exactly the numbered-box + legend idiom the
+ * compare page already uses, with no second overlay model to maintain.
+ *
+ * **Two trees, deliberately.** Typography exists only on `compose/semantics`, so that layer is
+ * walked there. The container layers read `layout/inspector` instead, because that is the tree the
+ * facts actually live in: `LayoutInspectorProduct` is the canonical home for
+ * [ComposeSemanticsTokens] (they are modifier-derived, and that product models the modifier chain;
+ * `compose/semantics` merely mirrors them), and it walks every `LayoutNode` rather than only the
+ * nodes that carry semantics. A `Column(Modifier.padding(16.dp), Arrangement.spacedBy(8.dp))`
+ * declares no semantics at all, so on the semantics tree the very padding and gap these layers
+ * advertise are invisible. A capture without the layout product falls back to the semantics tree's
+ * mirrored tokens — fewer boxes, same projection — rather than dropping the layers.
+ *
+ * The **layout** layer is the code-side counterpart of the producer-authored
+ * [AnnotationKind.LAYOUT] the compare page has always drawn on the reference side (issue #4328).
+ * Until it existed the viewer could only inspect *paint* — fill, radius, type — and the redline
+ * values a layout diff is actually argued in (the box's own size, its padding per edge, the
+ * arrangement gap, a `defaultMinSize` floor) had no surface at all. Those are the same tokens the
+ * published layout wireframe (`render-layout-wireframe-svg.mjs`) draws off the same tree, so the
+ * two agree by construction.
+ *
+ * No typography metrics are re-measured here, and no geometry is inferred: every number is one the
+ * capture already resolved. Material roles use the theme producer's resolved-value attribution and
+ * may therefore contain multiple honest candidates when two roles resolve identically. A node that
+ * resolved no typography (or no container tokens) simply contributes no annotation to that layer.
+ */
+object ServeDesignAnnotations {
+
+  /**
+   * The typography, theme and layout annotations for one render, in depth-first order (the order
+   * the legend numbers them in).
+   *
+   * Bounds are absolute-to-root **render pixels** — `boundsInRoot` on the semantics tree,
+   * [LayoutInspectorNode.bounds] on the layout tree, and the node's captured paint box where the
+   * theme layer has one. All are the space the served PNG is in, so the viewer scales one layer to
+   * the on-screen image and is done. A node with malformed or zero-area bounds is skipped; it can't
+   * be drawn and would only produce a legend row pointing at nothing.
+   *
+   * `enclosing` threads the nearest **annotated** layout box down the walk rather than the literal
+   * parent, so a chain of wrappers that all reproduce one box collapses to one rectangle instead of
+   * comparing each node only against the one directly above it and emitting the whole stack.
+   */
+  fun annotations(
+    payload: ComposeSemanticsPayload,
+    theme: ThemePayload? = null,
+    layout: LayoutInspectorPayload? = null,
+  ): List<DesignAnnotation> {
+    val out = mutableListOf<DesignAnnotation>()
+    val typographyTokensByNode = theme.typographyTokensByNode()
+    // The semantics walk always carries typography; it carries the container layers too only when
+    // there is no layout tree to take them from, so the two trees can never both describe one node.
+    val containersFromSemantics = layout == null
+    fun walkSemantics(node: ComposeSemanticsNode, enclosing: AnnotationBounds?) {
+      // An unplaced node was measured but never positioned, so it draws nothing and its bounds
+      // read as the frame's ORIGIN rather than as "nowhere" — the same rule the layout walk below
+      // applies, and the same reason. Wear's `AlertDialogContent` is the case that found this: it
+      // subcomposes a full trial copy of the dialog to decide whether the content has to scroll,
+      // and that copy reached the typography layer as a second title stacked in the top-left
+      // corner (yschimke/wear-m3-catalog#77). The whole subtree goes with it: nothing under a node
+      // that was never placed is on the frame either.
+      if (!node.placed) return
+      val bounds = SlotBounds.parse(node.boundsInRoot)?.takeIf { it.hasArea() }
+      var nextEnclosing = enclosing
+      if (bounds != null) {
+        typographyAnnotation(node, bounds, typographyTokensByNode[node.nodeId].orEmpty())
+          ?.let(out::add)
+        if (containersFromSemantics) {
+          val box = bounds.toAnnotationBounds()
+          val role = node.role ?: node.testTag ?: node.textSnippet()
+          themeAnnotation(node.tokens, box, role)?.let(out::add)
+          layoutAnnotation(node.tokens, box, enclosing, role)?.let {
+            out.add(it)
+            nextEnclosing = box
+          }
+        }
+      }
+      node.children.forEach { walkSemantics(it, nextEnclosing) }
+    }
+    walkSemantics(payload.root, null)
+
+    if (layout != null) {
+      fun walkLayout(node: LayoutInspectorNode, enclosing: AnnotationBounds?) {
+        // An unplaced node was measured but never positioned, so its bounds describe nowhere on
+        // the frame — and nothing beneath it is on the frame either, whatever its own `placed`
+        // says. Suppressing only this node's box left a descendant free to draw one.
+        if (!node.placed) return
+        val box = node.bounds.toAnnotationBounds()
+        var nextEnclosing = enclosing
+        if (box != null) {
+          val role = node.displayName ?: node.component
+          themeAnnotation(node.tokens, box, role)?.let(out::add)
+          layoutAnnotation(node.tokens, box, enclosing, role)?.let {
+            out.add(it)
+            nextEnclosing = box
+          }
+        }
+        node.children.forEach { walkLayout(it, nextEnclosing) }
+      }
+      walkLayout(layout.root, null)
+    }
+    return out
+  }
+
+  private fun SlotBounds.hasArea(): Boolean = right > left && bottom > top
+
+  private fun SlotBounds.toAnnotationBounds(): AnnotationBounds =
+    AnnotationBounds(x = left, y = top, width = right - left, height = bottom - top)
+
+  private fun LayoutInspectorBounds.toAnnotationBounds(): AnnotationBounds? =
+    if (right > left && bottom > top)
+      AnnotationBounds(x = left, y = top, width = right - left, height = bottom - top)
+    else null
+
+  /**
+   * `"14.0sp/20.0sp · Roboto · 500 · italic"` — the one-line spec a designer reads off a type ramp,
+   * dropping whatever the render left ambiguous. Null when the node resolved no size *and* no face:
+   * an annotation whose label would be empty is not worth a box.
+   */
+  private fun typographyAnnotation(
+    node: ComposeSemanticsNode,
+    bounds: SlotBounds,
+    materialThemeTokens: List<String>,
+  ): DesignAnnotation? {
+    val type = node.typography ?: return null
+    val size =
+      when {
+        type.fontSize != null && type.lineHeight != null -> "${type.fontSize}/${type.lineHeight}"
+        type.fontSize != null -> type.fontSize
+        else -> null
+      }
+    val face = type.fontFamily?.let(::shortFace)
+    val parts =
+      listOfNotNull(
+        materialThemeTokens
+          .takeIf { it.isNotEmpty() }
+          ?.joinToString(" / ") { "MaterialTheme.typography.$it" },
+        size,
+        face,
+        type.fontWeight?.toString(),
+        type.fontStyle?.takeIf { it != "normal" },
+        type.letterSpacing?.let { "tracking $it" },
+        type.textAlign?.takeIf { it != "start" },
+      )
+    if (parts.isEmpty()) return null
+    return DesignAnnotation(
+      kind = AnnotationKind.TYPOGRAPHY,
+      bounds = bounds.toAnnotationBounds(),
+      label = parts.joinToString(" · "),
+      role = node.textSnippet(),
+      detail = typographyDetail(type, node, materialThemeTokens),
+    )
+  }
+
+  private fun typographyDetail(
+    type: ComposeSemanticsTypography,
+    node: ComposeSemanticsNode,
+    materialThemeTokens: List<String>,
+  ): Map<String, String> = buildMap {
+    materialThemeTokens.takeIf { it.isNotEmpty() }?.let { put("token", it.joinToString(",")) }
+    type.fontSize?.let { put("fontSize", it) }
+    type.lineHeight?.let { put("lineHeight", it) }
+    type.letterSpacing?.let { put("letterSpacing", it) }
+    type.fontFamily?.let { put("fontFamily", it) }
+    type.fontWeight?.let { put("fontWeight", it.toString()) }
+    type.fontStyle?.let { put("fontStyle", it) }
+    type.fontVariationSettings?.let { put("fontVariationSettings", it) }
+    type.textAlign?.let { put("textAlign", it) }
+    node.textColor?.foreground?.let { put("color", it) }
+    node.textOverflow?.lineCount?.let { put("lines", it.toString()) }
+    node.textOverflow?.maxLines?.let { put("maxLines", it.toString()) }
+  }
+
+  /**
+   * Theme consumers contain colour, typography, and shape names in one flat list. Intersecting with
+   * the payload's resolved typography keys retains only type-scale roles while preserving the
+   * consumer's stable attribution order. Both products use the same Compose `SemanticsNode.id`.
+   */
+  private fun ThemePayload?.typographyTokensByNode(): Map<String, List<String>> {
+    if (this == null || resolvedTokens.typography.isEmpty()) return emptyMap()
+    val typographyNames = resolvedTokens.typography.keys
+    return consumers
+      .mapNotNull { consumer ->
+        consumer.tokens
+          .filter { it in typographyNames }
+          .takeIf { it.isNotEmpty() }
+          ?.let { consumer.nodeId to it }
+      }
+      .toMap()
+  }
+
+  /**
+   * `"fill #FF6750A4 · radius 12.0dp · border 1.0dp #FF79747E · elevation 6.0dp"` — the resolved
+   * theme attributes of a container. Null for the common node that declares none of them (pure
+   * layout / text nodes).
+   *
+   * Anchored to [ComposeSemanticsTokens.paintBox] when the capture read one, falling back to the
+   * node's placement bounds. The two differ whenever a `padding` sits before the paint modifiers in
+   * the chain (`padding(4.dp).clip(CircleShape).background(…)`), and the box being described is the
+   * one the fill and ring were actually drawn into — outlining the placement box instead reports a
+   * radius against geometry that was never painted.
+   */
+  private fun themeAnnotation(
+    tokens: ComposeSemanticsTokens?,
+    bounds: AnnotationBounds,
+    role: String?,
+  ): DesignAnnotation? {
+    if (tokens == null) return null
+    val parts =
+      listOfNotNull(
+        tokens.backgroundColor?.let { "fill $it" },
+        tokens.backgroundGradient?.let { "fill ${gradientText(it)}" },
+        tokens.shape,
+        radiusText(tokens),
+        borderText(tokens),
+        tokens.elevation?.let { "elevation $it" },
+        tokens.opacity?.takeIf { it < 1.0 }?.let { "alpha ${trimDouble(it)}" },
+        "clip".takeIf { tokens.clipsContent == true },
+      )
+    if (parts.isEmpty()) return null
+    val paintBox = tokens.paintBox?.toAnnotationBounds()?.takeIf { it != bounds }
+    return DesignAnnotation(
+      kind = AnnotationKind.THEME,
+      bounds = paintBox ?: bounds,
+      label = parts.joinToString(" · "),
+      role = role,
+      detail = themeDetail(tokens, paintBox != null),
+    )
+  }
+
+  /**
+   * `"120×48px · pad 16.0dp · gap 8.0dp"` — the box a layout diff is argued in.
+   *
+   * Every node with a drawable box contributes one, because a redline's value is the *nesting*: a
+   * component that measures 4px wider than the kit is only diagnosable when the slot boxes inside
+   * it are on screen too. The one exclusion is a node that exactly reproduces its nearest annotated
+   * ancestor's box **and** declares no layout tokens of its own — a wrapper that adds nothing but a
+   * second rectangle on the same pixels and a legend row pointing at the row above it.
+   */
+  private fun layoutAnnotation(
+    tokens: ComposeSemanticsTokens?,
+    bounds: AnnotationBounds,
+    enclosing: AnnotationBounds?,
+    role: String?,
+  ): DesignAnnotation? {
+    val shapesLayout =
+      tokens != null &&
+        (tokens.padding != null ||
+          tokens.paintInset != null ||
+          tokens.gap != null ||
+          tokens.minWidth != null ||
+          tokens.minHeight != null)
+    if (bounds == enclosing && !shapesLayout) return null
+    val parts =
+      listOfNotNull(
+        "${bounds.width}×${bounds.height}px",
+        tokens?.padding?.let { insetsText("pad", it) },
+        tokens?.paintInset?.let { insetsText("paint inset", it) },
+        tokens?.gap?.let { "gap $it" },
+        minSizeText(tokens),
+      )
+    return DesignAnnotation(
+      kind = AnnotationKind.LAYOUT,
+      bounds = bounds,
+      label = parts.joinToString(" · "),
+      role = role,
+      detail = layoutDetail(bounds, tokens),
+    )
+  }
+
+  /** `"radius 12.0dp"`, or the pixel corners a dp radius can't express, or both when both exist. */
+  private fun radiusText(tokens: ComposeSemanticsTokens): String? {
+    val dp = tokens.cornerRadius?.let { "radius $it" }
+    val px = tokens.cornerRadiusPx?.let { "radius $it" }
+    return when {
+      dp != null && px != null -> "$dp ($px)"
+      // A shape none of the corner tokens could describe (an `Outline.Generic` morph/star): say so
+      // rather than print a radius the render does not have.
+      else -> dp ?: px ?: "custom shape".takeIf { tokens.shapePath != null }
+    }
+  }
+
+  private fun borderText(tokens: ComposeSemanticsTokens): String? {
+    val colour = tokens.borderColor
+    val width = tokens.borderWidth
+    val gradient = tokens.borderGradient
+    return when {
+      width != null && colour != null -> "border $width $colour"
+      width != null && gradient != null -> "border $width ${gradientText(gradient)}"
+      colour != null -> "border $colour"
+      width != null -> "border $width"
+      gradient != null -> "border ${gradientText(gradient)}"
+      else -> null
+    }
+  }
+
+  /**
+   * `"gradient #FF6750A4→#FF625B71"` — a linear brush named by its endpoints rather than the bare
+   * word "gradient" the layer used to print, which told a reader nothing they couldn't already see.
+   * More than two stops keep the ends and count the middle.
+   */
+  private fun gradientText(gradient: LayoutInspectorGradient): String {
+    val colours = gradient.colors
+    return when (colours.size) {
+      0 -> "gradient"
+      1 -> "gradient ${colours[0]}"
+      2 -> "gradient ${colours[0]}→${colours[1]}"
+      else -> "gradient ${colours.first()}→${colours.last()} (${colours.size} stops)"
+    }
+  }
+
+  /**
+   * `"pad 16.0dp"` when every edge agrees, `"pad 8.0dp/16.0dp"` for the symmetric vertical/
+   * horizontal case, else all four edges in CSS order (top, end, bottom, start) so an asymmetric
+   * inset stays readable on one line. Null for an inset that pads nothing.
+   */
+  private fun insetsText(prefix: String, insets: ComposeSemanticsInsets): String? {
+    val edges = listOf(insets.top, insets.end, insets.bottom, insets.start)
+    if (edges.all { it == null }) return null
+    val (top, end, bottom, start) = edges.map { it ?: "0.0dp" }
+    return when {
+      top == end && end == bottom && bottom == start -> "$prefix $top"
+      top == bottom && end == start -> "$prefix $top/$end"
+      else -> "$prefix $top $end $bottom $start"
+    }
+  }
+
+  private fun minSizeText(tokens: ComposeSemanticsTokens?): String? {
+    val width = tokens?.minWidth
+    val height = tokens?.minHeight
+    return when {
+      width != null && height != null -> "min ${width}×${height}"
+      width != null -> "min width $width"
+      height != null -> "min height $height"
+      else -> null
+    }
+  }
+
+  /**
+   * The whole resolved container token set, not the eight fields this used to carry (issue #4328).
+   * The hover card and any machine consumer read this map, so a token the capture resolved and the
+   * label had no room for — the gradient's stops, the shadow, the effective alpha, the clip — is
+   * dropped here or nowhere.
+   */
+  private fun themeDetail(
+    tokens: ComposeSemanticsTokens,
+    paintBoxAnchored: Boolean,
+  ): Map<String, String> = buildMap {
+    tokens.backgroundColor?.let { put("background", it) }
+    tokens.backgroundGradient?.let { put("backgroundGradient", gradientDetail(it)) }
+    tokens.borderColor?.let { put("borderColor", it) }
+    tokens.borderWidth?.let { put("borderWidth", it) }
+    tokens.borderGradient?.let { put("borderGradient", gradientDetail(it)) }
+    tokens.cornerRadius?.let { put("cornerRadius", it) }
+    tokens.cornerRadiusPx?.let { put("cornerRadiusPx", it) }
+    tokens.shape?.let { put("shape", it) }
+    tokens.shapePath?.let { put("shapePath", it) }
+    tokens.elevation?.let { put("elevation", it) }
+    tokens.opacity?.let { put("opacity", trimDouble(it)) }
+    tokens.clipsContent?.let { put("clipsContent", it.toString()) }
+    tokens.minWidth?.let { put("minWidth", it) }
+    tokens.minHeight?.let { put("minHeight", it) }
+    tokens.padding?.let { insets -> insetsDetail(insets)?.let { put("padding", it) } }
+    tokens.paintInset?.let { insets -> insetsDetail(insets)?.let { put("paintInset", it) } }
+    tokens.gap?.let { put("gap", it) }
+    // Which rectangle the numbered box is on, present only when it is NOT the node's placement box
+    // — otherwise every ordinary container would carry a `box placement` row saying nothing. The
+    // padded paint chain this exists for is exactly the case where the label's radius and the
+    // Layout layer's size describe two different rectangles, and nothing else says so.
+    if (paintBoxAnchored) put("box", "paint")
+  }
+
+  /** Geometry first — the layout layer's whole point — then the tokens that shaped it. */
+  private fun layoutDetail(
+    bounds: AnnotationBounds,
+    tokens: ComposeSemanticsTokens?,
+  ): Map<String, String> = buildMap {
+    put("width", "${bounds.width}px")
+    put("height", "${bounds.height}px")
+    put("x", "${bounds.x}px")
+    put("y", "${bounds.y}px")
+    tokens?.padding?.let { insets -> insetsDetail(insets)?.let { put("padding", it) } }
+    tokens?.paintInset?.let { insets -> insetsDetail(insets)?.let { put("paintInset", it) } }
+    tokens?.gap?.let { put("gap", it) }
+    tokens?.minWidth?.let { put("minWidth", it) }
+    tokens?.minHeight?.let { put("minHeight", it) }
+    tokens?.paintBox?.let { put("paintBox", "${it.left},${it.top},${it.right},${it.bottom}") }
+  }
+
+  /** `"top 8.0dp, end 16.0dp, bottom 8.0dp, start 16.0dp"`; null when no edge resolved. */
+  private fun insetsDetail(insets: ComposeSemanticsInsets): String? {
+    val parts =
+      listOfNotNull(
+        insets.top?.let { "top $it" },
+        insets.end?.let { "end $it" },
+        insets.bottom?.let { "bottom $it" },
+        insets.start?.let { "start $it" },
+      )
+    return parts.takeIf { it.isNotEmpty() }?.joinToString(", ")
+  }
+
+  /**
+   * All the gradient's stops (the label only had room for its endpoints) **and its direction**.
+   *
+   * The direction is not decoration: two brushes with identical colours and stops paint visibly
+   * differently when one runs left-to-right and the other top-to-bottom, so a detail map that
+   * serialised only the colours could not tell them apart — and this map is what a machine consumer
+   * diffs. Named where the axis is one of the three obvious ones, and given as its unit-space
+   * endpoints otherwise.
+   */
+  private fun gradientDetail(gradient: LayoutInspectorGradient): String {
+    val stops = gradient.stops
+    val colours =
+      gradient.colors.mapIndexed { index, colour ->
+        val at = stops?.getOrNull(index)
+        if (at == null) colour else "$colour@${trimDouble(at.toDouble())}"
+      }
+    return "${colours.joinToString(" → ")} (${gradientDirection(gradient)})"
+  }
+
+  private fun gradientDirection(gradient: LayoutInspectorGradient): String {
+    val dx = gradient.endX - gradient.startX
+    val dy = gradient.endY - gradient.startY
+    val endpoints =
+      "${trimDouble(gradient.startX.toDouble())},${trimDouble(gradient.startY.toDouble())}" +
+        " → ${trimDouble(gradient.endX.toDouble())},${trimDouble(gradient.endY.toDouble())}"
+    return when {
+      dx != 0f && dy == 0f -> if (dx > 0) "horizontal" else "horizontal, reversed"
+      dy != 0f && dx == 0f -> if (dy > 0) "vertical" else "vertical, reversed"
+      else -> endpoints
+    }
+  }
+
+  /** `1.0` → `"1"`, `0.5` → `"0.5"` — a token value, not a float dump. */
+  private fun trimDouble(value: Double): String {
+    val rounded = Math.round(value * 1000.0) / 1000.0
+    return if (rounded == Math.floor(rounded)) rounded.toLong().toString() else rounded.toString()
+  }
+
+  /**
+   * The node's drawn text, trimmed to a legend-sized handle. The legend shows this as the
+   * annotation's title, so a whole paragraph would push the spec — the thing being inspected — off
+   * the row.
+   */
+  private fun ComposeSemanticsNode.textSnippet(): String? {
+    val raw = (text ?: layoutText ?: label)?.trim()?.replace(Regex("\\s+"), " ") ?: return null
+    if (raw.isEmpty()) return null
+    return if (raw.length <= 32) raw else raw.take(31) + "…"
+  }
+
+  /**
+   * A resolved face identity is whatever handle the platform exposes — a generic name
+   * (`"sans-serif"`), but on desktop routinely an absolute font-file path. Show the file's own name
+   * so the legend reads `Roboto-Medium.ttf` rather than 90 characters of directory.
+   */
+  private fun shortFace(family: String): String =
+    family.substringAfterLast('/').substringAfterLast('\\').ifBlank { family }
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeDesignPages.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeDesignPages.kt
@@ -1,0 +1,204 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.designpages.DesignPage
+import ee.schimke.composeai.designpages.DesignPagesJson
+import ee.schimke.composeai.designpages.DesignPagesManifest
+import ee.schimke.composeai.designpages.PageImage
+import ee.schimke.composeai.designpages.PageNode
+import ee.schimke.composeai.designpages.PageNodeLink
+import ee.schimke.composeai.io.SystemFileSystem
+import java.io.File
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toOkioPath
+import okio.Path.Companion.toPath
+
+/**
+ * The serve host's view of the catalog's **design pages** — whole specimen sheets from the design
+ * file, cached as SVG, with the node id of every component on them.
+ *
+ * Where [ServeDesignReferenceStore] answers the per-component question ("does this Button match its
+ * Figma node?"), this answers the sheet-level one: *here is the kit's own Shape page — which of
+ * these 35 shapes do we implement, and does our render sit right where the design drew it?* The
+ * shapes nothing implements are the point: an unlinked node is a finding, not an omission.
+ *
+ * ## Why the SVG is sanitized here and not at publish time
+ *
+ * Because *here* is the trust boundary. The markup is inlined into a served page — that is what
+ * lets the viewer hide the design's own drawing of a node and put our render in its place — and a
+ * catalog is third-party data all the way down ([ServeCatalogStore] stages one on that assumption).
+ * A publish-time check would protect only the catalogs this repo happens to publish; the server
+ * reads branches it did not write. [SvgSanitizer] runs once at load rather than per request: a
+ * specimen sheet is hundreds of kilobytes, and parsing it on every open would be the surface's
+ * whole cost.
+ *
+ * ## Failure posture
+ *
+ * Fail-soft throughout, like [ServeDesignReferenceStore] and [ServeParityActivityStore]: a missing
+ * file, an unsupported version, a malformed page, a traversing image path or an export that does
+ * not survive sanitizing drops that page — or the whole manifest — and the catalog serves its grid
+ * exactly as before. A page view is an enhancement; it must never cost a catalog its previews.
+ *
+ * A manifest carries **free text authored in the design tool**: layer names like `Shape=Circle`.
+ * Nothing here is trusted. Every string is HTML-escaped at render time by [ServeWeb], and the
+ * outbound Figma deep link is *reassembled* from a validated file key and node id against a literal
+ * origin ([ServeFigmaSpec]) rather than taken from the file, so a manifest declaring `javascript:…`
+ * yields no link instead of an attacker-chosen href.
+ */
+class ServeDesignPageStore
+private constructor(
+  val pages: List<DesignPage>,
+  /** Sanitized markup per page id, ready to inline. Built at load; see the class comment. */
+  private val markup: Map<String, String>,
+  private val manifest: DesignPagesManifest? = null,
+) {
+  private val byId: Map<String, DesignPage> = pages.associateBy { it.id }
+
+  /** The Figma file the pages came from, or empty when the manifest named no well-formed one. */
+  val fileKey: String = manifest?.fileKey?.takeIf(::isSafeFileKey).orEmpty()
+
+  fun page(pageId: String): DesignPage? = byId[pageId]
+
+  /**
+   * Sanitized SVG for a previously advertised page, or null.
+   *
+   * The same string backs both the inline stage and the `/pages/<id>.svg` asset route. Serving the
+   * *sanitized* bytes on the asset route as well is deliberate: a consumer that fetched the raw
+   * export from the catalog branch would get markup this server has already judged unsafe to
+   * inline, and shipping two different answers for one URL is how a check gets bypassed.
+   */
+  fun svg(pageId: String): String? = markup[pageId]
+
+  /**
+   * The design ref for [node] — the producer's own, or the one it would have written.
+   *
+   * Delegates to [DesignPagesManifest.refFor] rather than reading [PageNode.ref] directly, so a
+   * node with no ref can still deep-link back into the design tool. That matters most for an
+   * *unlinked* node, where the design-tool link is the only one there is.
+   */
+  fun refFor(node: PageNode): String = manifest?.refFor(node) ?: node.ref.orEmpty()
+
+  companion object {
+    /** Directory (bundle-relative) the manifest and its cached SVGs live in. */
+    const val DIRECTORY = "pages"
+
+    const val INDEX_FILE = "index.json"
+
+    /**
+     * How many nodes one page may carry. The kit's densest definition sheet — `Buttons` — holds a
+     * few hundred component nodes; this is above that and far below anything that would turn one
+     * page into an enormous response. Every node becomes a list row and a hotspot.
+     */
+    const val MAX_NODES_PER_PAGE = 500
+
+    private val SAFE_ID = Regex("[A-Za-z0-9._-]{1,160}")
+
+    /** Suffixes that name something ABOUT a page on its own route. See [isDrawable]. */
+    private val RESERVED_SUFFIXES = listOf(".svg", ".json")
+
+    private val SVG_SIGNATURE =
+      Regex("""\A\s*(?:<\?xml[^>]*\?>\s*)?(?:<!--.*?-->\s*)*<svg\b""", RegexOption.DOT_MATCHES_ALL)
+
+    /** An empty store — the state every host without a page manifest is in. */
+    fun empty(): ServeDesignPageStore = ServeDesignPageStore(emptyList(), emptyMap())
+
+    fun load(bundleDir: File, fileSystem: FileSystem = SystemFileSystem): ServeDesignPageStore {
+      val root = bundleDir.toOkioPath()
+      val manifestPath = root / DIRECTORY / INDEX_FILE
+      val manifest =
+        runCatching {
+          if (!fileSystem.exists(manifestPath)) return@runCatching null
+          DesignPagesJson.decodeFromString<DesignPagesManifest>(
+            fileSystem.read(manifestPath) { readUtf8() }
+          )
+        }
+          .getOrNull()
+          ?.takeIf { it.isSupported } ?: return empty()
+
+      // Sanitize at load, and drop a page whose export doesn't survive it. Checked here rather than
+      // at draw time so the viewer is never offered a page that can only paint an empty stage.
+      val markup = LinkedHashMap<String, String>()
+      for (page in drawablePages(manifest)) {
+        val svg = readSvg(root, page, fileSystem) ?: continue
+        markup[page.id] = svg
+      }
+      return ServeDesignPageStore(
+        pages = drawablePages(manifest).filter { markup.containsKey(it.id) },
+        markup = markup,
+        manifest = manifest,
+      )
+    }
+
+    private fun readSvg(root: Path, page: DesignPage, fileSystem: FileSystem): String? {
+      if (!ServeDesignReferenceStore.isSafeRelativePath(page.image.uri)) return null
+      val path = root / DIRECTORY / page.image.uri.toPath()
+      if (!fileSystem.exists(path)) return null
+      val text = runCatching { fileSystem.read(path) { readUtf8() } }.getOrNull() ?: return null
+      // Cheap shape check before the DOM parse, for the same reason the PNG lane checked its
+      // signature: a file that isn't an SVG at all should cost a regex, not a parser.
+      if (!SVG_SIGNATURE.containsMatchIn(text)) return null
+      return SvgSanitizer.sanitize(text)
+    }
+
+    /**
+     * The pages of [manifest] this server is willing to draw, in the producer's order.
+     *
+     * Shared with [ServeCatalogStore]'s staging path so a malformed page is rejected *before* it is
+     * written into the staging tree, not only when it is read back — the same split
+     * [ServeParityActivityStore.sanitize] uses.
+     */
+    fun drawablePages(manifest: DesignPagesManifest): List<DesignPage> {
+      if (!manifest.isSupported) return emptyList()
+      val seen = HashSet<String>()
+      return manifest.pages
+        .filter { page -> isDrawable(page) && seen.add(page.id) }
+        .map { page -> page.copy(nodes = page.nodes.filter(::isDrawable).take(MAX_NODES_PER_PAGE)) }
+    }
+
+    /** A Figma file key is URL-safe alphanumerics; anything else is not a key we will link to. */
+    fun isSafeFileKey(value: String): Boolean = Regex("[A-Za-z0-9_-]{1,64}").matches(value)
+
+    /**
+     * `.svg` and `.json` are **reserved**, because the export and the page's data come off the same
+     * route as the view with those suffixes. A page legitimately id'd `shape.svg` would be
+     * unreachable — `/pages/shape.svg` reads as "the export of the page `shape`" — so it is refused
+     * here rather than published and half-broken. Reserving the suffixes keeps the URL shape; a
+     * separate asset path would only move the ambiguity.
+     */
+    private fun isDrawable(page: DesignPage): Boolean =
+      SAFE_ID.matches(page.id) &&
+        RESERVED_SUFFIXES.none { page.id.endsWith(it, ignoreCase = true) } &&
+        page.id != "." &&
+        page.id != ".." &&
+        page.image.format.equals(PageImage.SVG, ignoreCase = true) &&
+        page.frame.width.isPositiveFinite() &&
+        page.frame.height.isPositiveFinite() &&
+        ServeDesignReferenceStore.isSafeRelativePath(page.image.uri)
+
+    /**
+     * A node is drawable when it can be *found*: the node id is the only geometry this contract
+     * carries, so a blank one names nothing in the export and could never be hidden, swapped or
+     * pointed at.
+     */
+    private fun isDrawable(node: PageNode): Boolean = node.nodeId.isNotBlank() && node.depth >= 0
+
+    private fun Double.isPositiveFinite(): Boolean = isFinite() && this > 0.0
+  }
+}
+
+/**
+ * The contract's own spelling of a link method — `code-connect`, `manifest`, … — for the places the
+ * *value* has to leave Kotlin: a `data-link` attribute the stylesheet colours on, and the legend
+ * beside it. Taken from the enum's `@SerialName` rather than `name.lowercase()` so the CSS and the
+ * wire can never drift apart on a hyphen.
+ */
+// Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
+// and the `:server` call sites are in a different module now. Not a widened API by intent.
+val PageNodeLink.wire: String
+  get() =
+    when (this) {
+      PageNodeLink.CODE_CONNECT -> "code-connect"
+      PageNodeLink.MANIFEST -> "manifest"
+      PageNodeLink.CONVENTION -> "convention"
+      PageNodeLink.UNLINKED -> "unlinked"
+    }

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeDesignReferences.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeDesignReferences.kt
@@ -1,0 +1,274 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.io.SystemFileSystem
+import java.io.File
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.decodeFromJsonElement
+import okio.ByteString.Companion.toByteString
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toOkioPath
+import okio.Path.Companion.toPath
+
+/**
+ * Provider-neutral design references attached to exact preview ids.
+ *
+ * A producer may start from PNG, SVG, HTML, Figma, or another design tool, but it must include a
+ * canonical PNG raster for comparison. Keeping normalization at import time makes serving
+ * reproducible and prevents the preview server from executing arbitrary HTML or fetching private
+ * design URLs.
+ */
+@Serializable
+data class DesignReferenceManifest(
+  val schema: String = SCHEMA,
+  val references: List<DesignReference> = emptyList(),
+) {
+  companion object {
+    const val SCHEMA = "compose-preview-references/v1"
+  }
+}
+
+/** One independently-authored design reference mapped to an exact [previewId]. */
+@Serializable
+data class DesignReference(
+  /** Route-safe identity, unique within one served session. */
+  val id: String,
+  /** Exact serve/catalog preview id; theme/state/props selection is never inferred. */
+  val previewId: String,
+  /** Human label shown when a preview carries more than one reference. */
+  val label: String = id,
+  /** Canonical PNG used by the scorer, relative to the bundle/catalog root. */
+  val raster: DesignReferenceRaster,
+  /** Where this reference came from (Figma, a checked-in PNG, an HTML mock, …). */
+  val source: DesignReferenceSource = DesignReferenceSource(),
+  /** Original inert artifact retained by the producer for provenance/download. */
+  val artifact: DesignReferenceArtifact? = null,
+  /**
+   * How close the published render is to this reference, scored at publish time.
+   *
+   * The catalog exists to answer this, and until it was carried here no page answered it at rest: a
+   * visitor had to enter the spec lane and wait for two rasters to decode before a number appeared.
+   * Published, it goes on the design-spec chip on first paint.
+   *
+   * Absent on every catalog published before the producer existed, and on any run whose driver had
+   * no browser to score with — so it is a strict enhancement. The lane still computes the same
+   * numbers live on entry, which is what a chip with no verdict falls back to and what an
+   * override-bearing render needs regardless (the baked score describes the PUBLISHED pixels, and a
+   * knob has moved them).
+   */
+  val match: DesignReferenceMatch? = null,
+)
+
+/**
+ * A published render/reference comparison, in the units the viewer's readout already prints:
+ * [percent] is the structural match `ComposePreviewCompare.scoreImages` reports, [changedPercent]
+ * the share of pixels the delta map marks, and [geometry] the content-box proportion difference —
+ * carried only when it is above the threshold at which it describes the design rather than the
+ * rasteriser, which is why it is nullable rather than zero.
+ *
+ * The producer computes these by driving that same asset in a headless page, so the baked numbers
+ * and the lane's live ones come from one implementation and cannot disagree.
+ */
+@Serializable
+data class DesignReferenceMatch(
+  val percent: Double,
+  val changedPercent: Double? = null,
+  val geometry: Double? = null,
+  /**
+   * Which pixel path minted these numbers, mirrored from `SCORE_VERSION` in
+   * `cli/serve-web/src/scorer/tuning.ts` and checked against it by a test.
+   *
+   * A match that does not carry [SCORE_VERSION] is dropped rather than printed. The scorer's kernel
+   * changed once, deliberately — `drawImage`'s implementation-defined smoothing gave way to the
+   * portable area average both engines run — and every published number moved with it. A delivery
+   * branch is regenerated on its own schedule, so a viewer will inevitably meet a catalog baked
+   * before the change; printing that chip would put a number from the old kernel beside a readout
+   * the lane computes with the new one, and the two disagreeing at a glance is the exact failure a
+   * baked number cannot survive. Dropped, the lane scores live on entry — which is what a chip with
+   * no verdict has always fallen back to.
+   *
+   * Null on every catalog published before the version existed, which is the same case and is
+   * treated the same way.
+   */
+  val scoreVersion: Int? = null,
+)
+
+@Serializable
+data class DesignReferenceRaster(
+  val path: String,
+  val width: Int? = null,
+  val height: Int? = null,
+  /** Optional lowercase SHA-256. When present, ingestion verifies it before advertising the ref. */
+  val sha256: String? = null,
+)
+
+@Serializable
+data class DesignReferenceSource(
+  /** `figma`, `png`, `svg`, `html`, or another provider-defined token. */
+  val provider: String = "file",
+  /** Informational only. The serve host never fetches this URI. */
+  val uri: String? = null,
+  val revision: String? = null,
+  /** Provider metadata such as Figma node/page/component ids. */
+  val attributes: Map<String, String> = emptyMap(),
+)
+
+@Serializable data class DesignReferenceArtifact(val kind: String, val path: String? = null)
+
+/**
+ * Validated, read-only view of a bundle/catalog's `references/index.json`.
+ *
+ * All failures are fail-soft: malformed, missing, traversing, duplicate, or hash-mismatched records
+ * are omitted while the rest of the preview bundle continues to serve normally.
+ */
+class ServeDesignReferenceStore
+private constructor(
+  private val root: Path,
+  references: List<DesignReference>,
+  private val fileSystem: FileSystem,
+) {
+  private val byId: Map<String, DesignReference> = references.associateBy { it.id }
+  private val byPreview: Map<String, List<DesignReference>> = references.groupBy { it.previewId }
+
+  val all: List<DesignReference> = references
+
+  fun forPreview(previewId: String): List<DesignReference> = byPreview[previewId].orEmpty()
+
+  fun raster(referenceId: String): ByteArray? {
+    val reference = byId[referenceId] ?: return null
+    val path = containedPath(reference.raster.path) ?: return null
+    return runCatching { fileSystem.read(path) { readByteArray() } }.getOrNull()
+  }
+
+  private fun containedPath(relative: String): Path? {
+    if (!isSafeRelativePath(relative)) return null
+    val candidate = root / relative.toPath()
+    return candidate.takeIf { fileSystem.exists(it) }
+  }
+
+  /**
+   * The manifest as read from disk, with its records left as raw JSON.
+   *
+   * [DesignReferenceManifest] is the schema producers write against; this is what a fail-soft
+   * READER needs, and they differ in exactly one way that matters: decoding a `List<JsonElement>`
+   * cannot fail on the contents of any one record, so [load] can decode them individually and drop
+   * only what it cannot read.
+   */
+  @Serializable
+  private data class RawManifest(
+    val schema: String = DesignReferenceManifest.SCHEMA,
+    val references: List<JsonElement> = emptyList(),
+  )
+
+  companion object {
+    const val DIRECTORY = "references"
+    const val INDEX_FILE = "index.json"
+
+    /**
+     * The pixel path this build's scorer implements — mirrored from `SCORE_VERSION` in
+     * `cli/serve-web/src/scorer/tuning.ts`, which is where the rationale for the number lives, and
+     * pinned to it by `ServeDesignReferenceStoreTest`.
+     *
+     * Two copies of a constant are fine while something fails when they disagree, and this is the
+     * pair that has to agree: the browser mints the number and the host decides whether to print
+     * it, so a host reading the wrong version would either discard every current match or trust
+     * every stale one.
+     */
+    const val SCORE_VERSION = 3
+    private val SAFE_ID = Regex("[A-Za-z0-9._-]{1,160}")
+    private val SHA256 = Regex("[a-f0-9]{64}")
+    private val PNG_SIGNATURE = byteArrayOf(0x89.toByte(), 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a)
+    private val JSON = Json { ignoreUnknownKeys = true }
+
+    fun load(
+      bundleDir: File,
+      fileSystem: FileSystem = SystemFileSystem,
+    ): ServeDesignReferenceStore {
+      val root = bundleDir.toOkioPath()
+      val manifestPath = root / DIRECTORY / INDEX_FILE
+      val manifest = runCatching {
+        if (!fileSystem.exists(manifestPath)) return@runCatching null
+        JSON.decodeFromString<RawManifest>(fileSystem.read(manifestPath) { readUtf8() })
+      }
+        .getOrNull()
+        ?.takeIf { it.schema == DesignReferenceManifest.SCHEMA }
+      if (manifest == null) return ServeDesignReferenceStore(root, emptyList(), fileSystem)
+
+      val seen = HashSet<String>()
+      val valid =
+        manifest.references
+          // Decoded ONE RECORD AT A TIME, so a record this reader cannot understand costs only
+          // itself. Decoding the whole array in one call makes any single malformed entry — a
+          // `"match": {}` from a half-written producer, a null where a number belongs — throw while
+          // parsing the envelope, which lands in the `runCatching` above and returns an EMPTY
+          // store: one bad record and the catalog's entire design-spec lane goes dark, on every
+          // page, silently. That is the opposite of this class's stated contract, and the
+          // per-record validation below (ids, paths, hashes, [isSaneMatch]) never gets to run.
+          .mapNotNull {
+            runCatching { JSON.decodeFromJsonElement<DesignReference>(it) }.getOrNull()
+          }
+          .filter { reference ->
+            if (!hasValidMetadata(reference)) return@filter false
+            val rasterPath = root / reference.raster.path.toPath()
+            if (!fileSystem.exists(rasterPath)) return@filter false
+            val bytes =
+              runCatching { fileSystem.read(rasterPath) { readByteArray() } }.getOrNull()
+                ?: return@filter false
+            hasValidRaster(reference, bytes) && seen.add(reference.id)
+          }
+          .map { it.copy(match = it.match?.takeIf(::isSaneMatch)) }
+      return ServeDesignReferenceStore(root, valid, fileSystem)
+    }
+
+    /**
+     * Whether a published match is a number a chip can print — minted by the kernel this build
+     * scores with, and in range.
+     *
+     * Dropped rather than clamped, and dropped WITHOUT taking the reference with it: a nonsense
+     * percentage is a producer bug, and the lane's live scoring still answers the same question on
+     * entry — so the cost of ignoring it is a chip with no verdict, where the cost of trusting it
+     * is a chip stating a falsehood and the cost of dropping the record is a page with no design
+     * spec at all.
+     */
+    private fun isSaneMatch(match: DesignReferenceMatch): Boolean =
+      match.scoreVersion == SCORE_VERSION &&
+        match.percent.isFinite() &&
+        match.percent in 0.0..100.0 &&
+        (match.changedPercent?.let { it.isFinite() && it in 0.0..100.0 } ?: true) &&
+        (match.geometry?.let { it.isFinite() && it >= 0.0 } ?: true)
+
+    // Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
+    // and the `:server` call sites are in a different module now. Not a widened API by intent.
+    fun isSafeRelativePath(value: String): Boolean {
+      if (value.isBlank() || value.startsWith('/') || value.startsWith('\\')) return false
+      if (Regex("^[A-Za-z]:").containsMatchIn(value)) return false
+      return value.replace('\\', '/').split('/').none { it.isBlank() || it == "." || it == ".." }
+    }
+
+    // Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
+    // and the `:server` call sites are in a different module now. Not a widened API by intent.
+    fun isValid(reference: DesignReference, bytes: ByteArray): Boolean =
+      hasValidMetadata(reference) && hasValidRaster(reference, bytes)
+
+    private fun hasValidMetadata(reference: DesignReference): Boolean =
+      SAFE_ID.matches(reference.id) &&
+        reference.previewId.isNotBlank() &&
+        isSafeRelativePath(reference.raster.path) &&
+        reference.raster.width?.let { it > 0 } != false &&
+        reference.raster.height?.let { it > 0 } != false
+
+    private fun hasValidRaster(reference: DesignReference, bytes: ByteArray): Boolean {
+      if (
+        bytes.size < PNG_SIGNATURE.size ||
+          PNG_SIGNATURE.indices.any { bytes[it] != PNG_SIGNATURE[it] }
+      ) {
+        return false
+      }
+      val expected = reference.raster.sha256?.lowercase() ?: return true
+      if (!SHA256.matches(expected)) return false
+      return bytes.toByteString().sha256().hex() == expected
+    }
+  }
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvg.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvg.kt
@@ -1,0 +1,195 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.bundle.MAX_FIGMA_RASTER_EDGE_PX
+import ee.schimke.composeai.bundle.downscaleRaster
+import java.util.Base64
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+
+/**
+ * Shared helpers for serving a catalog's baked `compose/figma-svg` exports. A hybrid export
+ * references its per-node raster crops as **external** hrefs (`figma-raster/<node>.png`, or the
+ * delivery branch's slug-prefixed `<slug>.figma-raster/<node>.png`), so both fetching (enumerate
+ * the crops to download) and serving (inline them so the SVG is self-contained, since Figma's
+ * importer can't resolve external hrefs) walk those hrefs. Used by both the daemon path
+ * ([ServeRenderHost]) and the static catalog path ([ServeCatalogStore] / [ServeBundleHost]).
+ */
+
+/**
+ * `<image href="…figma-raster/<node>.png">` refs a hybrid figma-svg carries (bare or
+ * slug-prefixed).
+ */
+private val FIGMA_RASTER_HREF = Regex("href=\"([^\"]*figma-raster/[^\"]+)\"")
+
+/**
+ * The figma-raster hrefs a hybrid SVG references (external crop paths, relative to the SVG's dir).
+ */
+// Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
+// and the `:server` call sites are in a different module now. Not a widened API by intent.
+fun figmaRasterHrefs(svg: String): List<String> =
+  FIGMA_RASTER_HREF.findAll(svg).map { it.groupValues[1] }.toList()
+
+/**
+ * Longest-edge cap (px) for a raster crop inlined into a self-contained figma-svg. A hybrid
+ * sticker's crop is captured at device resolution, so a full-screen photo/`TextField` region can
+ * run to megabytes — and the base64 embedding adds a third on top, ballooning the "paste into
+ * Figma" SVG. A crop whose longest edge exceeds this is downscaled (aspect preserved) before
+ * embedding; the SVG's `<image x y width height>` box is unchanged, so the bitmap still fills the
+ * layer exactly, just at a bounded density.
+ *
+ * Aliases the shared [MAX_FIGMA_RASTER_EDGE_PX], which `bundle pack` now applies when it *writes* a
+ * crop — the two must stay equal or the pack-time bound would either discard pixels this path still
+ * wanted, or leave bytes it is about to throw away.
+ */
+internal const val MAX_INLINE_RASTER_EDGE_PX: Int = MAX_FIGMA_RASTER_EDGE_PX
+
+/**
+ * Inline an SVG's `figma-raster/<node>.png` crops as `data:image/png;base64` URIs, reading each
+ * crop (relative to [dir], where its href resolves) via [fileSystem], so the served SVG is
+ * self-contained. A crop whose longest edge exceeds [maxEdgePx] is downscaled before embedding (see
+ * [MAX_INLINE_RASTER_EDGE_PX]); pass [Int.MAX_VALUE] to embed full-resolution bytes. A vector-only
+ * SVG passes through; a crop missing on disk is left as a plain ref.
+ */
+// Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
+// and the `:server` call sites are in a different module now. Not a widened API by intent.
+fun inlineFigmaRasters(
+  fileSystem: FileSystem,
+  dir: Path,
+  svg: String,
+  maxEdgePx: Int = MAX_INLINE_RASTER_EDGE_PX,
+): String {
+  if (!svg.contains("figma-raster/")) return svg
+  val root = dir.normalized()
+  return FIGMA_RASTER_HREF.replace(svg) { match ->
+    val href = match.groupValues[1]
+    // Resolve + contain: an untrusted catalog SVG must not read outside `dir` via `..`/absolute
+    // hrefs — a crop that would escape is left as a plain ref, never followed.
+    val cropPath = "$dir/$href".toPath().normalized()
+    if (!cropPath.isUnder(root) || !fileSystem.exists(cropPath)) return@replace match.value
+    val crop = fileSystem.read(cropPath) { readByteArray() }
+    val bounded = downscaleRaster(crop, maxEdgePx)
+    "href=\"data:image/png;base64,${Base64.getEncoder().encodeToString(bounded)}\""
+  }
+}
+
+/**
+ * Rewrite an SVG's `figma-raster/<node>.png` hrefs to absolute URLs under [baseUrl] (the crops'
+ * public home — e.g. the catalog's delivery branch on `raw.githubusercontent.com`), so a
+ * web/document-served SVG *links* its rasters instead of carrying their bytes. The href's own
+ * relative path is preserved under the base, mirroring how it resolves next to the SVG on disk. A
+ * traversing href (`..` / absolute) is left untouched, exactly like [inlineFigmaRasters]'s
+ * containment. A vector-only SVG passes through.
+ */
+// Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
+// and the `:server` call sites are in a different module now. Not a widened API by intent.
+fun linkFigmaRasters(svg: String, baseUrl: String): String {
+  if (!svg.contains("figma-raster/")) return svg
+  val base = baseUrl.trimEnd('/')
+  return FIGMA_RASTER_HREF.replace(svg) { match ->
+    val href = match.groupValues[1]
+    if (href.startsWith("/") || href.contains("..") || href.contains(":"))
+      return@replace match.value
+    "href=\"$base/$href\""
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Web mode (`?mode=web`)
+//
+// The default served figma-svg is self-contained: fonts base64-embedded as `@font-face`, rasters
+// inlined as `data:` URIs — right for pasting into Figma (its importer resolves fonts by family
+// name and can't fetch external hrefs) but heavy, and it duplicates the font bytes into every
+// sticker. A **web/document** viewer that opens the `.svg` URL directly (not as an `<img>`, where
+// browsers block external refs in secure-static mode) can instead pull the faces from Google Fonts.
+//
+// [webModeSvg] rewrites an embedded SVG for that context: it strips the base64 `@font-face` blocks
+// and injects a single `@import url('https://fonts.googleapis.com/css2?family=…')` covering exactly
+// the families/weights/italics the SVG uses (the `<text>` still carry those family names, so the
+// browser resolves them from the imported sheet). Rasters are left as-is (still inlined) for now —
+// referencing the per-node crops needs an HTTP route to serve them, a separate step.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** One `@font-face` the SVG embeds, reduced to what a Google Fonts `css2` request needs. */
+internal data class WebFontFace(val family: String, val weight: Int, val italic: Boolean)
+
+private val FONT_FACE_BLOCK = Regex("@font-face\\{[^}]*\\}")
+
+/**
+ * Rewrite an embedded figma-svg for web/document viewing: replace the base64 `@font-face` blocks
+ * with an external Google Fonts `@import`, so the browser fetches the faces instead of the SVG
+ * carrying their bytes. A vector-only SVG, or one with no parseable `@font-face`, passes through
+ * unchanged. Rasters are untouched (still inlined). Pure — unit-testable without a served host.
+ */
+// Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
+// and the `:server` call sites are in a different module now. Not a widened API by intent.
+fun webModeSvg(svg: String): String {
+  val faces = FONT_FACE_BLOCK.findAll(svg).mapNotNull { parseWebFontFace(it.value) }.toList()
+  if (faces.isEmpty()) return svg
+  val importUrl = googleFontsImportUrl(faces) ?: return svg
+  // The URL's `&` separators (`&family=`, `&display=swap`) are XML entity starts inside the
+  // `<style>` text of an `image/svg+xml` document, so escape them — the XML parser decodes `&amp;`
+  // back to `&` before the CSS parser sees the `@import`, keeping the served SVG well-formed.
+  val importUrlXml = importUrl.replace("&", "&amp;")
+  // Drop every embedded face, then put the @import at the head of the first <style> (CSS requires
+  // `@import` before other rules; the base64 bytes are what bloated the sticker, so this is the
+  // win).
+  val stripped = FONT_FACE_BLOCK.replace(svg, "")
+  return stripped.replaceFirst("<style>", "<style>@import url('$importUrlXml');")
+}
+
+/**
+ * Parse `@font-face{font-family:'X';font-style:normal;font-weight:N;src:…}` into a [WebFontFace].
+ */
+private fun parseWebFontFace(block: String): WebFontFace? {
+  val family =
+    Regex("font-family:'([^']*)'").find(block)?.groupValues?.get(1)?.takeIf { it.isNotBlank() }
+      ?: return null
+  val weight = Regex("font-weight:(\\d+)").find(block)?.groupValues?.get(1)?.toIntOrNull() ?: 400
+  val italic = block.contains("font-style:italic")
+  return WebFontFace(family, weight, italic)
+}
+
+/**
+ * Build a single Google Fonts `css2` URL for [faces], grouped by family with sorted, de-duplicated
+ * weights (and the `ital,wght` axis when a family carries any italic). Generic families
+ * (`sans-serif` / `serif` / `monospace` / …) are skipped — they aren't Google Fonts. Null when
+ * nothing references a real family.
+ */
+internal fun googleFontsImportUrl(faces: List<WebFontFace>): String? {
+  val generics = setOf("sans-serif", "serif", "monospace", "cursive", "fantasy", "system-ui")
+  val byFamily =
+    faces.filter { it.family.lowercase() !in generics }.groupBy { it.family }.toSortedMap()
+  if (byFamily.isEmpty()) return null
+  val families = byFamily.map { (family, fs) ->
+    val enc = family.trim().replace(" ", "+")
+    if (fs.any { it.italic }) {
+      val tuples =
+        fs
+          .map { (if (it.italic) 1 else 0) to googleFontsWeight(it.weight) }
+          .distinct()
+          .sortedWith(compareBy({ it.first }, { it.second }))
+      "family=$enc:ital,wght@" + tuples.joinToString(";") { "${it.first},${it.second}" }
+    } else {
+      "family=$enc:wght@" +
+        fs.map { googleFontsWeight(it.weight) }.distinct().sorted().joinToString(";")
+    }
+  }
+  return "https://fonts.googleapis.com/css2?" + families.joinToString("&") + "&display=swap"
+}
+
+/** CSS2 static-family instances use conventional 100-step weights, unlike Compose's 1..1000. */
+private fun googleFontsWeight(weight: Int): Int =
+  (((weight.coerceIn(1, 1000) + 50) / 100) * 100).coerceIn(100, 900)
+
+/**
+ * True when this path is [root] or a descendant of it (both normalized) — traversal containment.
+ */
+private fun Path.isUnder(root: Path): Boolean {
+  var p: Path? = this
+  while (p != null) {
+    if (p == root) return true
+    p = p.parent
+  }
+  return false
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -1,0 +1,855 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.RemoteComposePlayerKind
+import ee.schimke.composeai.daemon.protocol.StreamCodec
+import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+import ee.schimke.composeai.daemon.protocol.UiMode
+
+/**
+ * A servable preview session behind the multi-tenant registry + HTTP layer. Two implementations:
+ * - [ServeRenderHost] — live daemon-backed snapshot renders + a streaming lane;
+ * - [ServeBundleHost] — a static, pre-rendered portable bundle (no daemon), for the shared/public
+ *   "host bundles, don't build" mode.
+ *
+ * The HTTP routes and the registry only need this surface, so either kind can be served at
+ * `?session=<id>` uniformly.
+ */
+interface ServeHost : AutoCloseable {
+  /** The whole servable preview set for this session. */
+  val previews: List<ServePreview>
+
+  /** One same-origin asset from a preview's portable spatial scene, or null when unavailable. */
+  fun spatialAsset(previewId: String, relativePath: String): ServeSpatialAsset? = null
+
+  /** Whether the server can return a self-contained executable bundle for this preview. */
+  fun canDownloadExecutableBundle(previewId: String): Boolean = false
+
+  /** A hydrated, self-contained PNG+ZIP preview bundle, or null when this host has no such lane. */
+  fun executableBundle(previewId: String): ByteArray? = null
+
+  /** Independently-authored design references mapped to [previewId], if this host carries any. */
+  fun designReferencesFor(previewId: String): List<DesignReference> = emptyList()
+
+  /** Canonical PNG bytes for a previously advertised design [referenceId]. */
+  fun designReferenceRaster(referenceId: String): ByteArray? = null
+
+  /**
+   * Design pages this session publishes (`pages/index.json`), or empty when it publishes none — the
+   * common case, and the one every host defaults to. See [ServeDesignPages].
+   */
+  fun designPages(): ServeDesignPageStore = ServeDesignPageStore.empty()
+
+  /** Sanitized SVG markup for a previously advertised page. */
+  fun designPageSvg(pageId: String): String? = designPages().svg(pageId)
+
+  /**
+   * Typography / layout annotations over this preview's *rendered* frame, if the session carries
+   * any. Empty by default — a host with no annotation manifest serves the compare page unchanged.
+   */
+  fun annotationsForPreview(previewId: String): List<DesignAnnotation> = emptyList()
+
+  /** Typography / layout annotations over a design reference's raster. */
+  fun annotationsForReference(referenceId: String): List<DesignAnnotation> = emptyList()
+
+  /**
+   * The **published** tag index for [previewId] — `testTag → {count, bounds}`, the element identity
+   * a scoped parity acceptance resolves against. Empty by default and for any host that publishes
+   * none.
+   *
+   * This is the *static* half of the pair: a published catalog's renders happened in CI, so its
+   * index is computed there and read back by [ServeBundleHost] from `tags/index.json`. A
+   * daemon-backed [ServeRenderHost] instead projects the same shape live, per render, inside its
+   * `.annotations` response ([ServeSemanticsTags]) — where it can be keyed to the frame it came
+   * from. Two producers, one projection, deliberately not one code path: only one of them has a
+   * daemon.
+   */
+  fun tagIndexForPreview(previewId: String): Map<String, ServeSemanticsTags.TagEntry> = emptyMap()
+
+  /**
+   * The design-parity activity feed this catalog published (`parity/activity.json`), or null when
+   * it publishes none — the common case, and the one every host defaults to. Drives the
+   * `/<system>/parity` view's code / Figma feeds; the coverage half of that page is derived from
+   * [previews] + [designReferencesFor] and needs no feed at all.
+   */
+  fun parityActivity(): ParityActivity? = null
+
+  /** The validated GitHub issue snapshot this catalog published. */
+  fun parityIssues(): ParityIssues? = null
+
+  /**
+   * The parity **verdict** this catalog published for one comparison (`parity/findings.json`) — the
+   * accessibility, i18n, token and layout findings a parity run concluded about this preview read
+   * against [referenceId]. Empty by default and for any catalog that publishes none.
+   *
+   * Keyed by the PAIR rather than by the preview alone because that is what a finding describes;
+   * see [ServeParityFindingStore.forComparison] for what an unscoped set means.
+   */
+  fun parityFindingsFor(previewId: String, referenceId: String): List<ParityFindingSet> =
+    emptyList()
+
+  /**
+   * This catalog's committed known-difference document, **verbatim**, or null when it publishes
+   * none — the common case, and the one every host defaults to.
+   *
+   * Raw text on purpose. Unlike every other carried artifact, the host does not parse this one:
+   * `compose-preview-known-differences/v1`'s verdicts belong to the engine, which runs from one
+   * shared implementation in the browser and in `design-parity`, and a host that pre-parsed it
+   * would be a third implementation of the same rules with no conformance suite behind it. See
+   * [ServeKnownDifferences].
+   */
+  fun knownDifferences(): ServeKnownDifferences.Document? = null
+
+  /**
+   * One of that document's artifacts, addressed as the document addresses it (`<id>/<path>`).
+   *
+   * The default is [ServeKnownDifferences.Artifact.Unreadable] rather than a null, because a host
+   * with no artifact tree and a path that resolves to no file are the same answer to the consumer:
+   * the record's bytes could not be read.
+   */
+  fun knownDifferenceArtifact(relativePath: String): ServeKnownDifferences.Artifact =
+    ServeKnownDifferences.Artifact.Unreadable
+
+  /**
+   * The app's declared `@ThemeCatalog` themes — module-global, so the viewer's Theme selector can
+   * offer "render this preview under Brand Dark". Non-empty only for a daemon-backed host
+   * ([ServeRenderHost]) whose module declares them; a static bundle carries no theme-apply lane
+   * (`themeProvider` needs the daemon to load the provider off the app classpath), so it stays
+   * empty and the selector shows only the built-in light/dark axis.
+   */
+  val declaredThemes: List<ServeTheme>
+    get() = emptyList()
+
+  /**
+   * Structured reasons this session is **degraded** — an interactive/live lane the viewer would
+   * otherwise offer is unavailable, so the server falls back to baked PNG snapshots. Recorded at
+   * catalog-load time by [ServeCatalogStore] (the point the fallback is decided, where it was
+   * previously only logged to stderr) so the viewer + `/api/previews` can explain *why* a session
+   * is snapshot-only rather than leaving the visitor to guess. Empty for a fully-live session (a
+   * daemon-backed module, or a catalog served live from a carried bundle) — a non-empty list is the
+   * signal the viewer shows its "why snapshot-only" banner. Defaults to empty; only
+   * [ServeBundleHost] (the baked host [ServeCatalogStore] terminally registers) carries a populated
+   * list.
+   */
+  val degradations: List<ServeDegradation>
+    get() = emptyList()
+
+  /**
+   * The previews this session lists that have **no baked pixels** — the catalog's `deferred[]`
+   * records (issue #2965): coverage a spec declared `priority: "deferred"` (or thinned out of the
+   * palette with `modePriority`), which CI deliberately didn't rasterise. They are registered only
+   * when the session has a live lane to produce them on request, so an id in here always has a
+   * daemon twin; a baked-only session omits them entirely rather than showing a card that can only
+   * render a broken image.
+   *
+   * The live composites read this to route such an id to the daemon even for an override-free
+   * browse (there is no baked PNG to replay — see [CatalogLiveRouting.daemonIdForRender]), and the
+   * viewer can badge the card as live-only. Empty for every ordinary session.
+   */
+  val liveOnlyPreviewIds: Set<String>
+    get() = emptySet()
+
+  /**
+   * The light/dark mode [previewId]'s **baked** pixels are drawn in, or null when this session
+   * cannot name one — see [ServeBakedTheme].
+   *
+   * The routing predicates ask the host rather than the id alone, because only the session knows
+   * what its catalog publishes: an untagged sticker is the light half of a folded pair exactly when
+   * the `__dark` twin is published beside it, and that is a fact about the manifest, not about the
+   * string. A host that carries no such manifest keeps the id-only answer, which is the
+   * conservative one — an unnamed theme routes a `uiMode` request to a real render rather than
+   * replaying a sticker whose mode nothing established.
+   */
+  fun bakedTheme(previewId: String): UiMode? = ServeBakedTheme.token(previewId)
+
+  /**
+   * The Remote Compose player [previewId]'s **baked** pixels were drawn with, or null when this
+   * session cannot name one.
+   *
+   * Both the routing predicates ([CatalogLiveRouting.overridesAffectRender]) and the
+   * published-parity shortcut in the HTTP layer need this: when a request names the player that
+   * already drew the baked PNG, the snapshot answers it exactly and the parameter is a no-op, which
+   * is what lets a default link stop carrying one. Naming any OTHER player is a genuine re-render.
+   *
+   * It is a question put to the host because the answer is a fact about the session's **manifest**,
+   * not about the id. A capture goes through `RemoteOverridablePreview`, which defaults to
+   * [RemoteComposePlayerKind.EMBEDDED] — but a preview pinning the view-backed lane with
+   * `@PreviewWrapper(RemoteViewPreviewWrapper::class)` does not, and only whoever holds the
+   * manifest knows which this is.
+   *
+   * **The default is null: not "no player", but "this session cannot say".** Both unknowns fail the
+   * same safe way — every `rcPlayer` survives as a genuine, refusable override, exactly as a null
+   * [bakedTheme] keeps every `uiMode` routing to a real render — and the cost is a redundant query
+   * parameter rather than another player's pixels under a confident 200. Guessing the common answer
+   * here is precisely the mistake this seam exists to stop: it is right for every catalog we
+   * publish today and silently wrong for the one preview shape that matters.
+   *
+   * [ServeBundleHost] overrides it, because it holds the two manifests that can answer — a bundle's
+   * root `previews.json` (which records the pin) and a published catalog's
+   * [ServeCatalogStore.PreviewParamsMeta.capturePlayer] (which records the player outright, once an
+   * exporter carries it). A catalog published before that field existed reads back null and keeps
+   * naming its player, which is the behaviour that predates this seam.
+   */
+  fun bakedRcPlayer(previewId: String): RemoteComposePlayerKind? = null
+
+  /** Human label for the tenant (module Gradle path, `module@rev`, or a bundle name). */
+  val label: String
+
+  /**
+   * Whether editing an override actually re-renders. `true` for a daemon-backed host
+   * ([ServeRenderHost]); `false` for a static pre-rendered bundle ([ServeBundleHost]) that can only
+   * replay the baked PNGs — the viewer then shows the preview's declared knobs as disabled,
+   * informational controls.
+   */
+  val canApplyOverrides: Boolean
+    get() = false
+
+  /**
+   * Whether the host can produce a **freshly rendered** snapshot when an override is supplied —
+   * even if the *default* (override-free) snapshot lane is baked. Governs whether the viewer offers
+   * the author-declared knob controls as live (an edit re-renders via `/render`) rather than
+   * disabled, informational ones. It defaults to [canApplyOverrides], so a plain daemon host (both
+   * true) and a plain static bundle (both false) are unchanged. A trusted-catalog live session
+   * ([ServeCatalogLiveHost]) is the exception: `canApplyOverrides = false` (browsing stays baked
+   * and instant) but `canRenderOverrides = true` — an override-bearing `/render` re-renders through
+   * the carried daemon on demand, so a `?knob.<key>=…` (or display-axis) URL returns fresh pixels.
+   */
+  val canRenderOverrides: Boolean
+    get() = canApplyOverrides
+
+  /**
+   * Per-preview refinement of [canRenderOverrides]: whether *this* preview can be re-rendered with
+   * an override. Defaults to the host-wide [canRenderOverrides] (true for every preview on a plain
+   * daemon host, false on a static bundle). A trusted-catalog live session ([ServeCatalogLiveHost])
+   * overrides it: only previews with a daemon twin can re-render, so an unaliased (e.g.
+   * Android-only) variant returns false — the viewer then shows its override controls (knobs, App
+   * theme) as disabled/informational rather than enabled-but-dead (an override on such a preview
+   * falls back to the baked PNG, which ignores it).
+   */
+  fun canRenderOverridesFor(previewId: String): Boolean = canRenderOverrides
+
+  /**
+   * The **named-value overrides that apply a declared theme to an already-recorded document** —
+   * `<name>` to a colour literal (`#RRGGBB`), keyed by the document's own state names.
+   *
+   * This is what lets a theme reach a preview whose composable is gone. A Remote Compose document
+   * emits the roles it draws through as named state (`USER:WearM3.primary` and friends) rather than
+   * folding them into constants, so the player's `setNamedColorOverride` can re-theme a *replayed*
+   * document with no recomposition. Seeding these is that operation, and it is the only route a
+   * theme has on a session that cannot recompose — a published catalog whose module bytecode was
+   * dropped at pack time.
+   *
+   * Empty (the default) means this host publishes no such mapping for [providerFqn], and a
+   * `themeProvider` render of a replayed preview stays the terminal refusal it is today. That is
+   * deliberate: applying nothing and answering `200` would be the #3449 failure — a render that
+   * claims a theme it never applied, indistinguishable from one where the theme changed nothing.
+   *
+   * Only consulted for previews that replay. A session that can recompose applies the provider by
+   * re-running the composable, which reaches everything a theme does — including the typeface,
+   * which has no named value to carry it.
+   */
+  fun themeReplayColors(providerFqn: String): Map<String, String> = emptyMap()
+
+  /**
+   * The declared themes a **replayed** preview can actually be rendered under — those this host
+   * publishes a [themeReplayColors] mapping for.
+   *
+   * Per theme, not per host: a catalog may publish mappings for some of its themes and not others,
+   * and a theme that moves only typography legitimately has no colours to seed at all. Offering the
+   * whole declared set because *one* of them is mapped puts the unmapped ones back on the terminal
+   * 409 the gate exists to prevent.
+   */
+  fun replayableThemes(): List<ServeTheme> = declaredThemes.filter {
+    themeReplayColors(it.providerFqn).isNotEmpty()
+  }
+
+  /**
+   * Maximum browser-side concurrency a short-lived themed-thumbnail burst may request. A plain
+   * daemon has one render lock, so the default remains serial. A composite backed by independent
+   * per-preview daemons may opt into a larger temporary burst; the HTTP server still clamps it to
+   * its render slots and shares that burst across every active page for the same catalog.
+   */
+  val themeRenderBurstCapacity: Int
+    get() = 1
+
+  /**
+   * Return an already-materialised PNG without entering the HTTP render admission queue. Hosts with
+   * no cache return null. [render] remains the authoritative path and must recheck its cache after
+   * admission to close the lookup/render race.
+   */
+  fun cachedRender(previewId: String, overrides: PreviewOverrides): RenderOutcome.Ok? = null
+
+  /**
+   * Serve [previewId] from pixels **already on this box** — a baked PNG on disk — or null when
+   * answering would need work: a daemon render, or a fetch for a preview whose pixels haven't
+   * arrived yet.
+   *
+   * This is what keeps a busy, mostly-browsing box responsive. Every `/render` request otherwise
+   * competes for the same small pool of global render slots, so a handful of cold daemon renders —
+   * which can take a minute each — head-of-line block dozens of readers whose answer is a local
+   * file, and those readers eventually 503. A host that can answer from disk says so here and is
+   * served without ever entering admission.
+   *
+   * Must be cheap and non-blocking: no daemon, no network, no waiting. Returning null is always
+   * safe — the caller falls back to the admitted [render] path.
+   */
+  fun bakedRender(previewId: String, overrides: PreviewOverrides): RenderOutcome.Ok? = null
+
+  /**
+   * Make [previewId]'s published pixels local, if this host can fetch them and has not already.
+   *
+   * The write half of [bakedRender]'s read: that one is local-only by design, so a preview whose
+   * PNG has never been fetched answers null and its card falls back to the full-resolution
+   * `/render/` URL. Calling this is what lets a *later* [bakedRender] — and therefore
+   * [ServeHeroImages.gridThumbFor] — succeed.
+   *
+   * **Blocking, and never to be called on a request thread.** It performs the delivery-branch fetch
+   * that `bakedRender` exists to avoid doing there; [ServeThumbWarmer] is what calls it, off a
+   * bounded background pool.
+   *
+   * Fetches published bytes only — it must never render, and never wake a suspended daemon.
+   * Best-effort throughout: an unknown id, a deferred (live-only) preview, a host with no fetch
+   * source, or a failed fetch are all silent no-ops, and a failure is not remembered, so the next
+   * attempt retries. Default does nothing, which is right for every host with no published bytes
+   * behind it.
+   */
+  fun warmBakedRender(previewId: String) {}
+
+  /**
+   * [previewId]'s baked render size in pixels, read from the PNG header alone — no decode, no
+   * fetch, no daemon — or null when the pixels aren't already on this box.
+   *
+   * Exists so a page can advertise `og:image:width`/`height` (see [ServeWeb.UnfurlMetadata]) for
+   * free. The dimensions are 8 bytes of a PNG's IHDR chunk, so the alternative — reading the whole
+   * render through [bakedRender] just to measure it — would pull ~90 KB off disk on every page
+   * build to learn two integers. Null is always safe: the page then omits the dimensions and the
+   * unfurler measures the image itself.
+   */
+  fun bakedRenderSize(previewId: String): Pair<Int, Int>? = null
+
+  /**
+   * The bytes of one published animated capture, or null when this host has none to serve.
+   *
+   * Defaults to null so every host that isn't a published catalog — a daemon, a plain bundle —
+   * simply has no motion lane rather than needing to say so. [extension] is part of the request
+   * because the two formats aren't interchangeable to a browser, and it is validated against what
+   * the catalog declared rather than trusted, so a request can't choose its own content type.
+   */
+  /**
+   * One published capture, with the reason a failure failed.
+   *
+   * The reason is the point: a host that cannot distinguish a capture the catalog never published
+   * from one the delivery branch is currently refusing to serve leaves the route with nothing to
+   * say but 404, and the reader with "could not be loaded" for both. Defaults to
+   * [BranchFetch.NotFound] — a host with no branch behind it publishes no captures.
+   */
+  fun motionRead(motionId: String, extension: String): BranchFetch = BranchFetch.NotFound
+
+  /**
+   * A visitor is present on this session's pages right now (see `POST /api/presence`) — get its
+   * live render lane ready, if it has one and isn't ready already.
+   *
+   * Leasing the session is what keeps it from being reaped; this is the other half, for the common
+   * case where the visitor has only browsed **prebaked** pixels and so has never woken a daemon at
+   * all. Their first live render — picking a declared theme, opening a knob — would otherwise pay a
+   * cold start (~68 s on Android) that no page-level retry outlasts. Warming while they read the
+   * grid turns that into the warm path (~350 ms).
+   *
+   * Best-effort, non-blocking and idempotent: called every few minutes by every open tab, so an
+   * implementation must return immediately and do nothing at all once its lane is ready. Hosts with
+   * no live lane (a static baked bundle) keep the default no-op.
+   */
+  fun keepLiveWarm() {}
+
+  /**
+   * Aggregate render-performance counters for this host's live render lane, surfaced on `/status`
+   * + `/status.json` (`runningServers[].renderStats`). Null when the host has no live render lane
+   *   to measure — a static baked bundle never renders. Daemon-backed hosts ([ServeRenderHost])
+   *   record every serve-side render round-trip; composites ([ServeCatalogLiveHost]) forward their
+   *   carried daemon's stats.
+   */
+  fun renderPerfStats(): RenderPerfSnapshot? = null
+
+  /**
+   * This lane's open render breaker, or null while it is rendering normally (the healthy case, and
+   * the default for a host with no live lane to break). A non-null value means the host has
+   * **stopped attempting renders** — a linkage fault it can never recover from, or a sustained
+   * failure rate — and is answering requests with [RenderBreakerSnapshot.reason] instead. Callers
+   * that schedule background render work must consult it and stand down: feeding a broken renderer
+   * is what burned 275s of render gate and a ~7h ETA in issue #3448.
+   */
+  fun renderBreaker(): RenderBreakerSnapshot? = null
+
+  /**
+   * Bounded child-daemon pools owned by this host, surfaced on `/status.json` so production
+   * monitors can distinguish "one catalog daemon is up" from "a catalog daemon plus N per-preview
+   * daemons are resident". Empty for ordinary hosts.
+   */
+  fun daemonPoolStats(): List<DaemonPoolSnapshot> = emptyList()
+
+  /** Server-side catalog theme optimization progress, or null for hosts without that cache. */
+  fun themeOptimizationSnapshot(): ThemeOptimizationSnapshot? = null
+
+  /** Memory occupancy of this catalog generation's durable rendered-preview cache. */
+  fun catalogRenderCacheSnapshot(): CatalogRenderCacheSnapshot? = null
+
+  /** True while low-priority work still needs this host resident. */
+  val backgroundWorkActive: Boolean
+    get() = false
+
+  /**
+   * Whether this session's daemon can actually apply the **one-handed gesture** override
+   * (`overrides.gestures`) — i.e. the daemon advertises `"gestures"` in its capabilities. Only the
+   * Android (Robolectric) backend does; the desktop backend behind a CMP `serve` / the published
+   * catalogs silently ignores it. The viewer gates the "Show gesture hints" control on this so a
+   * `@GestureHintPreview` component doesn't show a toggle that would do nothing on a desktop-backed
+   * session. Defaults false (a static bundle has no daemon; a desktop daemon doesn't support it).
+   */
+  val gesturesRenderable: Boolean
+    get() = false
+
+  /**
+   * Whether [renderSvg] can actually produce a `compose/figma-svg` export for this session's
+   * previews — a daemon-backed host always can, a static bundle only when it carried baked
+   * `figma/<slug>.svg` vectors (a design catalog). Drives whether the viewer offers a copyable SVG
+   * download URL alongside the PNG one. Defaults to false (a plain bundle 404s the `.svg` lane).
+   */
+  val hasSvgExport: Boolean
+    get() = false
+
+  /**
+   * Whether [renderSvg] can produce a `compose/figma-svg` export for **this specific** [previewId]
+   * — a per-preview refinement of [hasSvgExport]. A static catalog advertises SVG globally as soon
+   * as it carries a `figma/` dir, but an individual preview whose component slug has no baked
+   * `figma/<slug>.svg` still 404s the `.svg` lane; the viewer gates its SVG control on this so it
+   * isn't offered on a preview that would then render "failed" (issue #2352). Defaults to the
+   * session-wide [hasSvgExport] — a daemon-backed host exports any of its previews.
+   */
+  fun hasSvgExportFor(previewId: String): Boolean = hasSvgExport
+
+  /** Whether this host can produce the tall raster `render/scroll/long` export. */
+  val hasScrollExport: Boolean
+    get() = false
+
+  /** Per-preview refinement of [hasScrollExport]. */
+  fun hasScrollExportFor(previewId: String): Boolean = hasScrollExport
+
+  /**
+   * Whether a **live daemon stream** ("Live (stream)") is available for this session — distinct
+   * from [canApplyOverrides], which governs whether the *snapshot* lane re-renders on override
+   * edits. The two usually coincide (a plain [ServeRenderHost] has both; a static [ServeBundleHost]
+   * neither), so this defaults to [canApplyOverrides]. A trusted-catalog live session
+   * ([ServeCatalogLiveHost]) is the exception: its snapshots stay baked (so browsing is instant and
+   * stays on the published pixels) while the live stream is still offered on demand —
+   * `canApplyOverrides = false` but `hasLiveStream = true`.
+   */
+  /**
+   * How many render subprocesses this host is actually carrying right now.
+   *
+   * Distinct from [daemonStarted], which is a host-level "is anything up" used to keep `/status`
+   * from listing catalogs that own no process. This is a count, and a host with no daemon lane at
+   * all — a static baked bundle — must report 0 rather than inherit a truthy default, or the page
+   * would tell a visitor a purely static catalog has a render server connected.
+   */
+  val daemonProcessCount: Int
+    get() = 0
+
+  /**
+   * Whether this host's daemon subprocess actually exists yet.
+   *
+   * A daemon-backed host opens its session on first real use, so a *registered* catalog is not a
+   * *running* daemon — and `/status` must not conflate them, or the running count stays pinned to
+   * the catalog count and says nothing about what the box is really carrying. Defaults to true for
+   * every host with nothing to defer (baked bundles, and daemon hosts handed an already-open
+   * session), so their reporting is unchanged.
+   */
+  val daemonStarted: Boolean
+    get() = true
+
+  val hasLiveStream: Boolean
+    get() = canApplyOverrides
+
+  /** Render [previewId] at [overrides] (cached where possible). */
+  fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome
+
+  /**
+   * Why this host has permanently given up on rendering [previewId] at [overrides], or null while
+   * the render may still succeed. Lets the HTTP layer answer a repeat request with a **terminal**
+   * status instead of the retryable one a transient [RenderOutcome.Busy] earns — a preview whose
+   * live render always fails (a `painterResource` whose drawable never made it into the bundle,
+   * say) otherwise reads to the browser as "try again", forever. Hosts with no such memory report
+   * null and behave exactly as before.
+   */
+  fun renderFailureLatch(previewId: String, overrides: PreviewOverrides): String? = null
+
+  /**
+   * Close daemon subprocesses this host has held idle for [idleMillis] without closing the host
+   * itself, returning how many were closed. Default: nothing to shed.
+   *
+   * A **pinned** session (a registered bundle/catalog) is deliberately never suspended by
+   * [ServeSessionRegistry.suspendIdle] — it must stay listed and instantly resumable. That
+   * protection was reaching further than intended: it also kept every daemon process hanging off
+   * the host alive for the life of the server, so a catalog that once served a burst sat on its
+   * replica and per-preview pools forever. This is the narrower action — shed the processes, keep
+   * the host.
+   */
+  fun releaseIdleDaemons(idleMillis: Long): Int = 0
+
+  /**
+   * Render a request admitted by the server's short-lived catalog theme lease. Hosts that cannot
+   * parallelise keep the ordinary [render] behaviour. A catalog backed by a replica pool overrides
+   * this to borrow an independent shared daemon, so only explicitly leased batches grow the pool.
+   */
+  fun renderLeased(previewId: String, overrides: PreviewOverrides): RenderOutcome =
+    render(previewId, overrides)
+
+  /**
+   * The captured Remote Compose document bytes for [previewId] — the bundle's `ir/<id>.rc` sidecar
+   * — or null when this host carries none. Served over `GET /render/<id>.rc` so an in-browser
+   * Remote Compose player can render the document client-side (the browser counterpart of the
+   * daemon render). Defaults to null: only a bundle host that carries the `ir/` sidecars returns
+   * bytes; a daemon-only host has none.
+   */
+  fun remoteComposeDoc(previewId: String): ByteArray? = null
+
+  /**
+   * Whether [previewId] carries a captured Remote Compose document ([remoteComposeDoc]) the viewer
+   * can render client-side in its `<canvas>` lane. Drives whether the viewer offers the "RC
+   * (browser)" toggle and its live-in-browser knob controls for this preview. Defaults to reading
+   * [remoteComposeDoc]; a bundle host overrides it with a cheap existence check so the per-preview
+   * page render doesn't read the whole doc just to know it's there.
+   */
+  fun hasRemoteComposeDoc(previewId: String): Boolean = remoteComposeDoc(previewId) != null
+
+  /**
+   * The **published** Remote Compose player comparison this catalog carries — every player's render
+   * of every `ir/<id>.rc` document plus the build-time pixel diffs, as the offline `rc-compare`
+   * pipeline computed them (see [ServeRcCompare]). Drives the `?format=rc` half of the compare
+   * page, which replays these instead of rendering documents in the visitor's browser: one player
+   * runs in a browser, five ran offline, and replaying costs a few `<img>` loads.
+   *
+   * Null for every host but a catalog whose delivery branch published one — a plain uploaded
+   * bundle, or a system that ships no `ir/<id>.rc`, keeps the client-rendered lane.
+   */
+  fun rcCompare(): RcCompareManifest? = null
+
+  /**
+   * Bytes for one staged rc-compare lane image ([RcCompareCell.render] / [RcCompareCell.diff]),
+   * served over `GET /<system>/rc-compare/<lane>/<slot>.png`. Null for anything the host didn't
+   * stage — the name vocabulary is fixed, so this is never a general file read.
+   */
+  fun rcCompareImage(name: String): ByteArray? = null
+
+  /**
+   * The **published** render of [previewId] by [backend], from this catalog's `rc-compare` staging
+   * — or null when nothing was staged for that pair.
+   *
+   * The offline parity pipeline draws every `ir/<id>.rc` document with every player, so these bytes
+   * already exist for exactly the browse a viewer performs when it opens on its default player.
+   * Serving them makes that page cost what an override-free browse costs: a map lookup and a file
+   * read, with no daemon, no render slot and no admission.
+   *
+   * Only ever an answer to a **bare** player selection. A request that also carries a font scale, a
+   * knob or a theme is asking for pixels the parity run never drew, and the caller must route it to
+   * the renderer as before — see [ServeHttpServer]'s use, which checks that before calling.
+   */
+  /**
+   * The backends [previewId] has a **published** render for — the parity run's staging, in
+   * [RcPlayerBackend.UNIVERSE] order.
+   *
+   * Folded into [enabledRcPlayersFor] so the picker offers exactly what the host can produce.
+   * Without it the capability list and the render lane disagreed: a static bundle carrying staged
+   * rasters would answer a hand-typed `?rcPlayer=cmp-android` perfectly well while showing that
+   * option greyed, and Catalog mode would open on JS because its preferred embedded default was not
+   * in the enabled set.
+   *
+   * Reads the manifest, not the images: this runs per preview while building a page, and whether a
+   * lane was staged is a field on the row.
+   */
+  fun stagedRcPlayers(previewId: String): List<RcPlayerBackend> {
+    val row = rcCompare()?.rows?.firstOrNull { it.previewId == previewId } ?: return emptyList()
+    return RcPlayerBackend.UNIVERSE.filter { backend ->
+      val cell = backend.rcCompareLane?.let { row.lanes[it] }
+      cell != null && cell.rendered && cell.render.isNotEmpty()
+    }
+  }
+
+  fun publishedRcPlayerRender(previewId: String, backend: RcPlayerBackend): ByteArray? {
+    val lane = backend.rcCompareLane ?: return null
+    val cell = rcCompare()?.rows?.firstOrNull { it.previewId == previewId }?.lanes?.get(lane)
+    val name = cell?.takeIf { it.rendered }?.render?.takeIf { it.isNotEmpty() } ?: return null
+    return rcCompareImage(name)
+  }
+
+  /**
+   * True while the published comparison may still be arriving — the catalog's background staging
+   * lane has not reported an outcome yet, so [rcCompare] returning null does not yet mean "this
+   * catalog has none".
+   *
+   * The compare page reads this to decide whether it may be cached. Its shape (player wall vs the
+   * in-browser lane) is decided by [rcCompare], and a short-lived edge cache would otherwise pin
+   * the pre-manifest shape for minutes after the lanes had landed. False everywhere else: a host
+   * with no staging lane is never provisional.
+   */
+  fun rcComparePending(): Boolean = false
+
+  /**
+   * The pixel size and density a **cmp-jvm** render of [previewId] should use — matched to the
+   * baked View-player capture so the desktop-player PNG lands at the same size the viewer shows the
+   * other lanes at. Null when this host cannot supply one (no captured doc, or size metadata
+   * missing), in which case the cmp-jvm chip stays disabled. Only a bundle/catalog host that
+   * carries both the `ir/<id>.rc` sidecar and the baked `previews/<id>.png` returns a spec.
+   */
+  fun remoteComposeRenderSpec(previewId: String): RcJvmRenderSpec? = null
+
+  /**
+   * Whether the server-side **cmp-jvm** lane can render [previewId]: the host carries the captured
+   * document and a render spec, and the isolated desktop-player subprocess is installed
+   * ([RcJvmServerRenderer.isAvailable]). Hosts fold this into [enabledRcPlayersFor].
+   */
+  fun supportsCmpJvm(previewId: String): Boolean =
+    hasRemoteComposeDoc(previewId) &&
+      remoteComposeRenderSpec(previewId) != null &&
+      RcJvmServerRenderer.isAvailable()
+
+  /**
+   * The Remote Compose render backends the viewer may offer for [previewId] as **enabled** options
+   * — the subset of the fixed [RcPlayerBackend.UNIVERSE] this host can actually produce pixels
+   * through. The viewer renders every backend as a chip and enables the ones returned here; the
+   * rest (e.g. [RcPlayerBackend.CMP_JVM] when its sidecar is not installed) are shown disabled, so
+   * an unavailable lane remains visible without pretending it works.
+   *
+   * Empty for a non–Remote Compose preview (the viewer then shows no backend selector at all).
+   * Defaults to the client-side [RcPlayerBackend.JS] lane whenever [hasRemoteComposeDoc] is true —
+   * the in-browser player needs only the `.rc` bytes, so any host that carries the document
+   * supports it. A daemon-backed Android host ([ServeRenderHost]) adds the server-side
+   * [RcPlayerBackend.JAVA] / [RcPlayerBackend.CMP_ANDROID] lanes (they ride
+   * `remoteCompose.player`).
+   */
+  /**
+   * [bakedRcPlayer] as the backend that names it, or null when this session cannot say.
+   *
+   * Every `enabledRcPlayersFor` must union this in, including the two that override the default: a
+   * bare URL serves those pixels, so the picker has to offer that lane even when the parity run
+   * staged no column for it — and it never does for [RcPlayerBackend.JAVA], whose `rcCompareLane`
+   * is null. A host that has just established which player drew its snapshot, and then greys out
+   * that exact chip while the snapshot sits on the stage, is disagreeing with itself.
+   *
+   * Factored here rather than spelled out at each site, because three copies of one fact drifting
+   * apart is the bug this whole seam exists to stop.
+   */
+  fun bakedRcPlayerBackend(previewId: String): RcPlayerBackend? =
+    bakedRcPlayer(previewId)?.let { kind ->
+      RcPlayerBackend.entries.firstOrNull { it.playerKind == kind }
+    }
+
+  fun enabledRcPlayersFor(previewId: String): List<RcPlayerBackend> =
+    if (hasRemoteComposeDoc(previewId)) {
+      buildList {
+        add(RcPlayerBackend.JS)
+        // The desktop embedded player renders the same `.rc` server-side via an isolated
+        // subprocess; enable it wherever the sidecar player is installed and a render spec exists.
+        if (supportsCmpJvm(previewId)) add(RcPlayerBackend.CMP_JVM)
+        // …and every player the parity run already drew. Those need no renderer at all, so a host
+        // that carries the staging can offer them however little else it can do.
+        // cmp-wasm is an interactive iframe lane, not a staged-raster lane. Advertising it from
+        // parity output alone makes the viewer open /rc-wasm/ even when no Wasm distribution is
+        // installed; the published raster remains available to the comparison surface.
+        addAll(
+          stagedRcPlayers(previewId).filterNot { it == RcPlayerBackend.CMP_WASM || it in this }
+        )
+        // …and the player the BAKED artifact already is ([bakedRcPlayerBackend]).
+        bakedRcPlayerBackend(previewId)?.let { if (it !in this) add(it) }
+      }
+        .sortedBy { RcPlayerBackend.UNIVERSE.indexOf(it) }
+    } else {
+      emptyList()
+    }
+
+  /**
+   * Whether this host's live render lane honours the Remote Compose **player** override
+   * (`remoteCompose.player`) — i.e. a daemon carrying the Android Remote Compose runtime, the only
+   * backend where selecting the server-side VIEW ([RcPlayerBackend.JAVA]) vs EMBEDDED
+   * ([RcPlayerBackend.CMP_ANDROID]) player actually changes pixels. The desktop backend has no
+   * Remote Compose runtime and silently ignores it; a static bundle has no daemon at all. Gates
+   * whether [enabledRcPlayersFor] offers the server-side lanes, so the viewer never shows a backend
+   * chip that would re-render to the same image. Defaults false.
+   */
+  val remoteComposePlayerSelectable: Boolean
+    get() = false
+
+  /**
+   * Render [previewId] at [overrides] and return its figma-svg export, or [SvgOutcome.NotFound]
+   * when this host can't produce SVG. Defaults to `NotFound`: only the daemon-backed
+   * [ServeRenderHost] overrides this — a static [ServeBundleHost] has no daemon to export one.
+   */
+  fun renderSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome = SvgOutcome.NotFound
+
+  /**
+   * The figma-svg export tailored for **web/document** viewing (`?mode=web`): where possible the
+   * hybrid raster crops are *linked* (an `<image href>` to the crop's public home — the catalog's
+   * delivery branch) instead of base64-embedded, so the served SVG stays kilobytes. Defaults to the
+   * self-contained [renderSvg]: a host with no public raster home (a live daemon render whose crops
+   * exist only on its disk, a plain uploaded bundle) keeps embedding — the HTTP layer's
+   * font-`@import` rewrite still applies on top either way. Only the catalog-backed
+   * [ServeBundleHost] (which knows the `repo@branch` its crops were published to) overrides this.
+   */
+  fun renderSvgForWeb(previewId: String, overrides: PreviewOverrides): SvgOutcome =
+    renderSvg(previewId, overrides)
+
+  /**
+   * Render [previewId]'s **full-page** figma-svg export (`compose/figma-svg-long`) at [overrides] —
+   * the whole scrollable screen as one editable SVG (a virtualised `LazyColumn` rendered at an
+   * expanded viewport so every row composes), or [SvgOutcome.NotFound] when this host can't produce
+   * it. Defaults to `NotFound`: only the daemon-backed [ServeRenderHost] overrides it (the tall
+   * re-render needs a daemon; a static bundle has none). A non-scrolling preview yields its
+   * ordinary viewport SVG. See [docs/design/SCROLLING_SVG.md].
+   */
+  fun renderScrollSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome =
+    SvgOutcome.NotFound
+
+  /**
+   * Render [previewId]'s full-page raster scroll capture (`render/scroll/long`) at [overrides], or
+   * [RenderOutcome.NotFound] when this host has no daemon-backed scroll producer.
+   */
+  fun renderScrollPng(previewId: String, overrides: PreviewOverrides): RenderOutcome =
+    RenderOutcome.NotFound
+
+  /**
+   * Render [previewId] at [overrides] and return its declared preview slots as JSON, or
+   * [SlotsOutcome.NotFound] when this host can't extract them. Defaults to `NotFound`: only the
+   * daemon-backed [ServeRenderHost] overrides this — a static [ServeBundleHost] has no daemon to
+   * capture a semantics tree.
+   */
+  fun renderSlots(previewId: String, overrides: PreviewOverrides): SlotsOutcome =
+    SlotsOutcome.NotFound
+
+  /**
+   * Whether this host can produce the accessibility products the viewer's overlay + legend draw
+   * from (`a11y/hierarchy`, plus `a11y/atf` / `a11y/touchTargets` where the backend has them).
+   * Defaults to false — only the daemon-backed [ServeRenderHost] carries an a11y producer, and a
+   * static bundle has no daemon to walk a semantics tree.
+   */
+  val hasA11yOverlay: Boolean
+    get() = false
+
+  /** Per-preview accessibility availability; composite hosts may only map part of a catalog. */
+  fun hasA11yOverlayFor(previewId: String): Boolean = hasA11yOverlay
+
+  /**
+   * Fetch [previewId]'s merged accessibility products at [overrides] as JSON (`{previewId, nodes,
+   * findings, touchTargets}`), or [A11yOutcome.NotFound] when this host can't produce them. See
+   * [ServeRenderHost.renderA11y].
+   */
+  fun renderA11y(previewId: String, overrides: PreviewOverrides): A11yOutcome = A11yOutcome.NotFound
+
+  /**
+   * Whether this host can derive the viewer's typography, theme and layout inspection layers from a
+   * render's `compose/semantics` tree ([renderAnnotations]). Tracks [canApplyOverrides]: capturing
+   * a semantics tree needs a daemon, exactly like [renderSlots].
+   */
+  val hasDesignAnnotations: Boolean
+    get() = canApplyOverrides
+
+  /**
+   * Per-preview annotation availability, the twin of [hasA11yOverlayFor]: a composite host may
+   * front a whole catalog while only part of it has a daemon twin to capture semantics from, and
+   * offering the Typography / Theme / Layout layers on a preview whose fetch can only 404 is
+   * exactly the dead control [hasDesignAnnotations] exists to avoid.
+   */
+  fun hasDesignAnnotationsFor(previewId: String): Boolean = hasDesignAnnotations
+
+  /**
+   * Whether this host can answer `.annotations` for [previewId] from the catalog's **published**
+   * annotations rather than from a daemon-captured semantics tree — see
+   * [ServeBundleHost.renderAnnotations].
+   *
+   * Separate from [hasDesignAnnotationsFor] because the two lanes carry different layers, and the
+   * viewer offers a checkbox per layer. A published bundle's preview annotations are typography (a
+   * producer measures them off the frame); the theme attributes are projected live from a semantics
+   * tree and nothing authors them into a bundle. Folding the two together would either hide the
+   * Typography layer on a catalog that published it, or offer a Theme checkbox with nothing behind
+   * it. Defaults to false — a host with no published annotation manifest has neither.
+   */
+  fun hasPublishedTypographyFor(previewId: String): Boolean = false
+
+  /**
+   * Render [previewId] at [overrides] and return its typography + theme inspection layers as JSON
+   * (`{previewId, annotations, tags}`), or [AnnotationsOutcome.NotFound] when this host has no
+   * daemon. See [ServeRenderHost.renderAnnotations].
+   *
+   * `tags` is [ServeSemanticsTags]' `testTag → {count, bounds}` index over the same semantics
+   * payload the annotations are projected from — the element identity a scoped parity acceptance
+   * targets. Sharing this response is what keeps the two projections describing one frame; it does
+   * *not* couple either of them to the PNG a client already fetched. See
+   * [ServeRenderHost.renderAnnotations] for what that still owes.
+   *
+   * [layers] names the inspect layers the caller will actually draw ([AnnotationKind.KNOWN]), or
+   * null for "all of them" — the pre-`layers=` behaviour every unscoped caller still gets. It is a
+   * routing hint, not a filter contract: a host may return a superset (the daemon projects all
+   * three off one capture, so narrowing would cost a second render and save nothing), but must
+   * never return a payload missing a layer that was named. What it buys is
+   * [AnnotationKind.publishedLayersSuffice] — a typography-only request can be answered off a
+   * published bundle without a daemon, which is worth 16-22s on an idle catalog.
+   */
+  fun renderAnnotations(
+    previewId: String,
+    overrides: PreviewOverrides,
+    layers: Set<String>? = null,
+  ): AnnotationsOutcome = AnnotationsOutcome.NotFound
+
+  /**
+   * Whether [renderAnnotations] describes the **same frame** an override-free `/render/<id>.png`
+   * replays, rather than one produced for the annotations request itself.
+   *
+   * True only for a host whose annotations lane is a pure replay of published data
+   * ([ServeBundleHost]). False by default, and deliberately so: getting this wrong the safe way
+   * costs an affordance, and getting it wrong the other way records a region from a frame the
+   * reporter never saw as an acceptance's authoring-time baseline.
+   *
+   * **It is not implied by `canApplyOverrides == false`.** That names the PNG lane, and both live
+   * catalog wrappers keep the PNG baked for an override-free browse while asking their daemon for
+   * annotations *first*, falling back to published only on `NotFound`. A baked frame with live
+   * annotations is exactly the mismatch, so those hosts leave this false and the focused comparison
+   * withholds annotation-box selection on them — the layers still draw, since being a render out of
+   * date costs a reading aid nothing.
+   */
+  val annotationsFollowBakedFrame: Boolean
+    get() = false
+
+  /**
+   * Join the shared live stream for [previewId], or `null` when this host has no live lane (the
+   * snapshot fallback is used instead — always the case for [ServeBundleHost]).
+   *
+   * [onUnavailable] is invoked (once, before the `null` return) with a short human-readable reason
+   * when the live lane can't be opened — the daemon's original failure (e.g. `interactive session
+   * already held`, `previewSpecResolver returned null`, a `stream/start` timeout) or "no live
+   * daemon twin for this variant". The caller surfaces it so the viewer shows *why* it fell back to
+   * re-rendered snapshots instead of the opaque "input requires a live stream". Not called on
+   * success (a non-null return).
+   */
+  fun subscribeStream(
+    previewId: String,
+    overrides: PreviewOverrides,
+    codec: StreamCodec?,
+    maxFps: Int?,
+    onUnavailable: ((String) -> Unit)? = null,
+    onFrame: (StreamFrameParams) -> Unit,
+  ): StreamHandle?
+
+  /** Count of live upstream streams (0 for hosts without a live lane). */
+  fun activeStreamCount(): Int
+}
+
+/**
+ * [ServeHost.motionRead]'s bytes, for callers that only care whether there are any.
+ *
+ * An **extension**, deliberately, rather than a second interface member: with both on the interface
+ * an implementor could override this one, see its override silently ignored (every caller goes
+ * through [ServeHost.motionRead]), and ship a host that serves no captures — which is the shape of
+ * the bug that made the Motion lane 404 in the first place, where `ServeCatalogLiveHost`
+ * implemented a pair and missed a member of it. An extension cannot be overridden, so there is one
+ * place to implement and no way to implement the wrong one.
+ */
+fun ServeHost.motionBytes(motionId: String, extension: String): ByteArray? =
+  motionRead(motionId, extension).bytesOrNull

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeKnownDifferences.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeKnownDifferences.kt
@@ -1,0 +1,398 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toOkioPath
+import okio.Path.Companion.toPath
+
+/**
+ * A catalog's committed known differences — the `compose-preview-known-differences/v1` document and
+ * the mask / accepted-candidate rasters it names.
+ *
+ * [docs/design/COMPONENT_PARITY_WORKFLOW.md](../../../../../../../../docs/design/COMPONENT_PARITY_WORKFLOW.md)
+ * §4 is the contract. This class is **not** an implementation of it, and the distinction is the
+ * whole design of the file:
+ *
+ * ## The host carries; it does not decide
+ *
+ * Every other carried artifact here — [ServeParityIssuesStore], [ServeTagIndexStore] — parses,
+ * validates and drops what it cannot use. This one deliberately does none of that. The document's
+ * verdicts belong to the engine, which runs in the browser and in `design-parity` from
+ * [one shared implementation](../../../../../../../../scripts/design-artifacts/known-differences.mjs),
+ * and a host that pre-parsed it would become a **third** implementation of the same rules — with no
+ * conformance suite behind it, disagreeing about exactly the cases the contract spends its length
+ * on. `document-unreadable`, `document-too-large`, a duplicated id, a schema token from the future:
+ * all of those are answers the engine must be able to reach, and it can only reach them if the
+ * bytes arrive intact.
+ *
+ * So the document is served **verbatim**, as text, and the only thing this class refuses is what a
+ * *reader* must refuse. §4 names three obligations no lexical rule inside the engine can discharge,
+ * and they are discharged here:
+ *
+ * 1. **Size before allocation.** The reader must not hand over more than the ceiling so the caller
+ *    can measure it; a document or artifact past its cap is refused from the file's length, before
+ *    its bytes exist in memory.
+ * 2. **Containment, resolved rather than lexical.** The path grammar cannot see a symlink inside an
+ *    acceptance directory. Whether a resolved path stays inside **that acceptance's own** `<id>/`
+ *    directory — not merely somewhere under the artifact root — is a fact about the filesystem, and
+ *    the narrower bound is the load-bearing one: a link from one acceptance's directory into
+ *    another's stays under the root while letting a record read bytes it does not own, and the hash
+ *    it is then checked against is the *other* record's.
+ * 3. **Exact case, including the `<id>` directory.** A document spelling `MASK.png` for a committed
+ *    `mask.png` opens on a case-insensitive filesystem and is `artifact-unreadable` on a Linux
+ *    checkout — the same host-versus-checkout divergence the portable path grammar closes from the
+ *    other side, and one no lexical rule can see, because it is a fact about which bytes the reader
+ *    actually opened.
+ *
+ * ## Where the files live
+ *
+ * Published beside the issue index, under `parity/`, because they are the same kind of thing and
+ * batch 02 already established that a file-only commit on the delivery branch reaches serving hosts
+ * within one refresh tick without a re-render:
+ * ```
+ * parity/known-differences.json
+ * parity/known-differences/<id>/mask.png
+ * parity/known-differences/<id>/accepted-candidate.png
+ * ```
+ *
+ * The source repo commits them under `.design-parity/`; `@design-parity/catalog-export` is what
+ * carries them across.
+ */
+object ServeKnownDifferences {
+  const val DIRECTORY = "parity"
+  const val DOCUMENT_FILE = "known-differences.json"
+  const val ARTIFACT_DIRECTORY = "known-differences"
+
+  /**
+   * The producer's own list of the artifacts it published, beside the document.
+   *
+   * Written by `@design-parity/catalog-export`, which knows exactly which files it wrote. It exists
+   * so the staging path can *copy a list* rather than interpret the contract to derive one — see
+   * [ServeCatalogStore.knownDifferenceArtifactPaths] for what deriving it costs.
+   *
+   * A **sibling** of the document rather than `known-differences/index.json`, because a record `id`
+   * is a portable segment and `index.json` is one: a record so named owns the directory
+   * `known-differences/index.json/`, which an index file of that name could not coexist with.
+   *
+   * Not part of `compose-preview-known-differences/v1` and not read by any engine. It is a
+   * transport convenience between a producer and a host, which is why a catalog without it still
+   * works.
+   */
+  const val ARTIFACT_INDEX_FILE = "known-differences-index.json"
+
+  /** The index's schema token; a document declaring another is ignored rather than guessed at. */
+  const val ARTIFACT_INDEX_SCHEMA = "compose-preview-known-difference-artifacts/v1"
+
+  /**
+   * The document's schema token, mirrored for the same one job the record cap is: the staging path
+   * has to know whether the engine will read *anything* before it fetches a document's artifacts,
+   * and a document declaring another schema is one the engine refuses whole.
+   *
+   * Not a licence to interpret the document — nothing here decides a record's verdict. Pinned to
+   * the contract by [ServeKnownDifferencesTest] like the ceilings beside it.
+   */
+  const val SCHEMA = "compose-preview-known-differences/v1"
+
+  /**
+   * The two ceilings, versioned with the schema and **not** per-catalog settings.
+   *
+   * Restated from the contract rather than imported, because Kotlin cannot import a JavaScript
+   * constant and a host that guessed them would refuse what the engine calls legal. They are
+   * checked by [ServeKnownDifferencesTest] against `known-differences.mjs`'s `BUDGET`, which is the
+   * same device the scorer's tuning mirror uses: two copies are fine while something fails when
+   * they disagree.
+   */
+  const val MAX_DOCUMENT_BYTES = 1024 * 1024
+  const val MAX_ARTIFACT_BYTES = 8 * 1024 * 1024
+
+  /**
+   * The record cap, mirrored for the one job the host has that needs it: the staging path
+   * enumerates a document's artifact paths to fetch them, and a document past this cap is one the
+   * engine rejects wholesale — so reading further would fetch bytes no consumer will ever evaluate.
+   *
+   * It bounds a fetch list, never a verdict. Checked against `BUDGET.maxAcceptances` by the same
+   * mirror test the two byte ceilings use.
+   */
+  const val MAX_ACCEPTANCES = 256
+
+  /**
+   * §4's portable path grammar, restated: the character class, the length, and the three shapes a
+   * *checkout* cannot express.
+   *
+   * The class alone is not the grammar, and the gap is where a traversal lives: `.` and `..` are
+   * spelled entirely in permitted characters. The rest are the host-versus-checkout divergences the
+   * grammar exists to close — a Windows device name, which commits fine and cannot be created under
+   * that name at all; a trailing dot or space, which Windows silently strips so two committed names
+   * collapse onto one file; and a segment past what any filesystem allows as a *component*, which a
+   * URL-backed consumer fetches happily and `git checkout` cannot create.
+   *
+   * Mirrors `isPortableSegment` in `known-differences.mjs`. Two copies again, and again the reason
+   * is that Kotlin cannot import one — a host that accepted what the engine refuses would serve
+   * bytes for a record the engine then discards, which is only wasted work, but a host that
+   * *refused* what the engine accepts is a catalog that evaluates differently here and there.
+   */
+  private val SAFE_SEGMENT = Regex("[A-Za-z0-9._-]{1,255}")
+
+  private val RESERVED_SEGMENTS = buildSet {
+    addAll(listOf("con", "prn", "aux", "nul"))
+    for (i in 1..9) {
+      add("com$i")
+      add("lpt$i")
+    }
+  }
+
+  private fun isPortableSegment(segment: String): Boolean {
+    if (!SAFE_SEGMENT.matches(segment)) return false
+    if (segment == "." || segment == "..") return false
+    if (segment.endsWith(".") || segment.endsWith(" ")) return false
+    return segment.substringBefore('.').lowercase() !in RESERVED_SEGMENTS
+  }
+
+  /**
+   * What a read produced. The three failures are the reader's own tokens from §4 — the engine turns
+   * them into the record's verdict, and inventing a fourth here would be a rule with no conformance
+   * case behind it.
+   */
+  sealed interface Artifact {
+    class Bytes(val bytes: ByteArray) : Artifact
+
+    /** The path resolves outside the acceptance's own directory. */
+    data object NotContained : Artifact
+
+    /** The file is past [MAX_ARTIFACT_BYTES], refused from its length rather than read. */
+    data object TooLarge : Artifact
+
+    /** No file, a directory, or a spelling the filesystem resolved case-insensitively. */
+    data object Unreadable : Artifact
+  }
+
+  /**
+   * The document's raw text, or null when the catalog publishes none.
+   *
+   * Null is "this catalog has no known differences", which is every catalog until it has some. A
+   * document past the byte ceiling is **not** null — it is refused as text the engine will reject,
+   * because "absent" and "too large" are different answers and a consumer that cannot tell them
+   * apart cannot report the second one. It is refused *here* rather than handed over, so nothing
+   * allocates a hostile document to discover its size.
+   */
+  fun document(bundleDir: File, fileSystem: FileSystem = FileSystem.SYSTEM): Document? =
+    document(bundleDir.toOkioPath(), fileSystem)
+
+  fun document(bundleRoot: Path, fileSystem: FileSystem): Document? {
+    val path = bundleRoot / DIRECTORY.toPath() / DOCUMENT_FILE.toPath()
+    val metadata = runCatching { fileSystem.metadataOrNull(path) }.getOrNull() ?: return null
+    if (metadata.isDirectory) return null
+    val size = metadata.size ?: return null
+    if (size > MAX_DOCUMENT_BYTES) return Document.TooLarge
+    val text = runCatching { fileSystem.read(path) { readUtf8() } }.getOrNull() ?: return null
+    // A second check, on the decoded bytes: `size` is the file's length and the ceiling is in UTF-8
+    // bytes, which agree — but only while nothing between them re-encodes. Cheap, and it keeps the
+    // rule stated where it is enforced.
+    if (text.encodeToByteArray().size > MAX_DOCUMENT_BYTES) return Document.TooLarge
+    return Document.Text(text)
+  }
+
+  sealed interface Document {
+    data class Text(val text: String) : Document
+
+    data object TooLarge : Document
+  }
+
+  /**
+   * One artifact, addressed the way the document addresses it: `<id>/<path>`, relative to the fixed
+   * `known-differences/` root.
+   *
+   * The `<id>` is the first segment and is a path segment in its own right, which is why a record's
+   * `id` is grammar-checked at all — it names a directory on every consumer's disk.
+   */
+  fun artifact(
+    bundleDir: File,
+    relativePath: String,
+    fileSystem: FileSystem = FileSystem.SYSTEM,
+  ): Artifact = artifact(bundleDir.toOkioPath(), relativePath, fileSystem)
+
+  /**
+   * The **lexical** half of [artifact]: a path this consumer will look up at all.
+   *
+   * Exposed because the catalog staging path needs the same answer *before* it writes a byte — a
+   * producer's document names where its artifacts live, and a path the reader would refuse is a
+   * path that must never reach the staging tree either. Deliberately the same predicate rather than
+   * a second one: a stager stricter than the reader silently drops records the engine calls legal,
+   * and a stager looser than it writes files nothing will ever open.
+   *
+   * The filesystem half — containment inside the record's own directory, exact case, the byte cap —
+   * stays in [artifact], where there is a resolved path to ask about.
+   */
+  fun isLookupPath(relativePath: String): Boolean {
+    val segments = relativePath.split('/')
+    if (segments.size < 2) return false
+    return segments.all { isPortableSegment(it) }
+  }
+
+  fun artifact(bundleRoot: Path, relativePath: String, fileSystem: FileSystem): Artifact {
+    val segments = relativePath.split('/')
+    // Lexical first, and cheaply: an absolute path, a backslash, a `..`, an over-long segment or a
+    // Windows-reserved name never reaches the filesystem. The engine refuses these too — this is
+    // the
+    // host declining to *look up* what it would refuse anyway, which is what keeps a traversal from
+    // being a filesystem question at all.
+    if (segments.size < 2) return Artifact.NotContained
+    if (segments.any { !isPortableSegment(it) }) return Artifact.NotContained
+
+    val acceptanceRoot = bundleRoot / DIRECTORY.toPath() / ARTIFACT_DIRECTORY.toPath() / segments[0]
+    var path = acceptanceRoot
+    for (segment in segments.drop(1)) path /= segment
+
+    val canonical =
+      runCatching { fileSystem.canonicalize(path) }.getOrNull() ?: return Artifact.Unreadable
+    val root =
+      runCatching { fileSystem.canonicalize(acceptanceRoot) }.getOrNull()
+        ?: return Artifact.Unreadable
+    // Contained in **this acceptance's** directory, not merely under the artifact root. A symlink
+    // from `a/link` into `b/` resolves inside the root, so a root-only check would let record `a`
+    // read `b`'s bytes and be hashed against `a`'s recorded digest. Walked as parents rather than
+    // compared as strings, so `…/id-two` cannot pass as a child of `…/id`.
+    if (generateSequence(canonical) { it.parent }.none { it == root }) return Artifact.NotContained
+    // Exact case. `canonicalize` reports the on-disk spelling, so comparing the resolved tail
+    // against the requested segments is the check — and it costs nothing where the filesystem is
+    // already case-sensitive, which is also why CI does not exercise it. Recorded rather than
+    // claimed as covered.
+    if (canonical.segments.takeLast(segments.size) != segments) return Artifact.Unreadable
+
+    val metadata =
+      runCatching { fileSystem.metadataOrNull(canonical) }.getOrNull() ?: return Artifact.Unreadable
+    if (metadata.isDirectory) return Artifact.Unreadable
+    val size = metadata.size ?: return Artifact.Unreadable
+    // From the length, before the bytes exist. Handing back an oversized file so the caller can
+    // measure `.length` exhausts the process through the guard meant to prevent that.
+    if (size > MAX_ARTIFACT_BYTES) return Artifact.TooLarge
+    val bytes = runCatching { fileSystem.read(canonical) { readByteArray() } }.getOrNull()
+    return if (bytes == null) Artifact.Unreadable else Artifact.Bytes(bytes)
+  }
+}
+
+/**
+ * Everything the browser engine needs to evaluate this catalog's acceptances against one
+ * comparison.
+ *
+ * Handed over as one JSON payload rather than a scatter of `data-` attributes, for the reason the
+ * annotation layers are: `overrides` and `tagIndex` are maps, and a map flattened into attributes
+ * is a serialisation format two sides have to agree on for no benefit.
+ *
+ * **The scope fields are the locator's, and must be the same values `ServeIssueReport` writes.** An
+ * acceptance matches on *every* recorded field — `system` and `component` included, which a
+ * comparison-shaped mental model quietly drops, because served preview and reference ids are unique
+ * only within a system and one source repo can publish several. A page that derived them
+ * independently from the report would be two spellings of one identity, and the acceptance would
+ * miss the very comparison it was authored on.
+ */
+@Serializable
+data class KnownDifferenceContext(
+  val documentUrl: String,
+  /**
+   * Prefix and suffix an artifact URL is built from: `artifactBase + "<id>/<file>" +
+   * artifactQuery`.
+   *
+   * Two fields rather than one, because the path segment goes **between** them and the credential
+   * lives in the query. A single "base" would either lose the query or force the client to splice a
+   * path into a URL it did not build, which is where a hand-rolled query loses its token.
+   */
+  val artifactBase: String,
+  val artifactQuery: String,
+  val referenceUrl: String,
+  val candidateUrl: String,
+  val scope: KnownDifferenceScope,
+  /** Positive issue-state evidence for the lifecycle join; an absent row remains `unknown`. */
+  val issues: List<KnownDifferenceIssue> = emptyList(),
+)
+
+@Serializable
+data class KnownDifferenceIssue(
+  val repository: String,
+  val number: Int,
+  val state: String,
+)
+
+/**
+ * The comparison's identity, as the page knows it — everything except the URLs.
+ *
+ * Separate from [KnownDifferenceContext] because the two are decided in different places, and the
+ * split follows the rule the tag-index URL already follows: the *handler* knows the identity, the
+ * *page* builds URLs, so that every link goes through one query builder. A hand-rolled query in a
+ * handler is how the element picker once lost its credential on a header-authorized page and
+ * silently withheld itself from a catalog publishing a perfectly good index.
+ */
+@Serializable
+data class KnownDifferenceScope(
+  val system: String,
+  val component: String,
+  val previewId: String,
+  val referenceId: String,
+  val variant: String,
+  val overrides: Map<String, String> = emptyMap(),
+  /**
+   * The served reference's digest, when it publishes one.
+   *
+   * Null is not a missing check that degrades to "compare anyway": an acceptance targeting a
+   * reference with no `sha256` is **refused**, because the fingerprint gate has nothing to compare
+   * against and a gate that cannot have fired must not be reported as having passed.
+   */
+  val referenceSha256: String? = null,
+  /**
+   * The published tag index for this preview, or **empty when it does not describe this frame**.
+   *
+   * Empty is load-bearing and is why this is passed rather than fetched: an element-scoped
+   * acceptance whose gate cannot run suppresses **nothing**. Handing over an index measured on a
+   * different render would be worse than handing over none — it reports an element that never moved
+   * as moved, with a plausible explanation attached.
+   */
+  val tagIndex: Map<String, WireTagEntry> = emptyMap(),
+)
+
+private val CONTEXT_JSON = Json { encodeDefaults = true }
+
+/** As an inline `application/json` payload, with `<` escaped so it cannot close the script tag. */
+fun encodeKnownDifferenceContext(context: KnownDifferenceContext): String =
+  CONTEXT_JSON.encodeToString(context).replace("<", "\\u003c")
+
+/**
+ * Everything the browser engine needs to audit this catalog's acceptances **without a comparison**.
+ *
+ * The comparison band ([KnownDifferenceContext]) can only ever judge records scoped into the page
+ * it is on, and that leaves one finding structurally unreachable: an acceptance naming a preview,
+ * reference, component or variant the catalog no longer has is scoped into *no* comparison, so it
+ * stays invisible in the browser while `design-parity` reports `orphaned-target` for the same
+ * record. The dashboard is where the whole document can be walked, so the walk is mounted there.
+ *
+ * [previews] is the catalog inventory the walk resolves targets against, and its fields are the
+ * **locator's**, spelled exactly as the comparison page spells them ([ServeIssueReport.Context]) —
+ * an acceptance matches on every recorded field, so a second derivation of `system`, `component` or
+ * `variant` here would report every acceptance in the catalog as an orphan.
+ */
+@Serializable
+data class KnownDifferenceAuditContext(
+  val documentUrl: String,
+  val artifactBase: String,
+  val artifactQuery: String,
+  val previews: List<KnownDifferenceCatalogPreview> = emptyList(),
+  /** Positive issue-state evidence for the lifecycle join; an absent row remains `unknown`. */
+  val issues: List<KnownDifferenceIssue> = emptyList(),
+)
+
+/** One served preview, as an acceptance's scope names it. */
+@Serializable
+data class KnownDifferenceCatalogPreview(
+  val system: String,
+  val id: String,
+  /** Null when the preview declares no component — it can then match no acceptance. */
+  val component: String? = null,
+  val variant: String = "",
+  val referenceIds: List<String> = emptyList(),
+)
+
+/** As an inline `application/json` payload, with `<` escaped so it cannot close the script tag. */
+fun encodeKnownDifferenceAuditContext(context: KnownDifferenceAuditContext): String =
+  CONTEXT_JSON.encodeToString(context).replace("<", "\\u003c")

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
@@ -1,0 +1,803 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.FocusOverride
+import ee.schimke.composeai.daemon.protocol.GestureKindOverride
+import ee.schimke.composeai.daemon.protocol.GestureOverride
+import ee.schimke.composeai.daemon.protocol.Orientation
+import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.RemoteComposeOverride
+import ee.schimke.composeai.daemon.protocol.RemoteComposeProfile
+import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
+import ee.schimke.composeai.daemon.protocol.UiMode
+import java.security.MessageDigest
+
+/**
+ * How a preview is delivered to the browser. The `compose-preview serve` surface (URLs, token,
+ * override controls) is identical across modes; only the transport behind the viewer changes.
+ *
+ * Modelled now even though only [SNAPSHOT] is implemented, so the URL scheme and the
+ * `/api/previews` payload can advertise per-preview mode support from day one and the future
+ * in-browser [LIVE] transport (CMP→JS) slots into the same `/p/{id}` surface instead of a parallel
+ * one. See the plan's "design both now, build PNG first" decision.
+ */
+enum class PreviewMode(val wire: String) {
+  /** Daemon renders server-side; the browser shows PNG bytes. Universal (Android + Desktop). */
+  SNAPSHOT("snapshot"),
+  /** Composable compiled to Kotlin/Wasm and run live in the browser. CMP-only; not yet built. */
+  LIVE("live");
+
+  companion object {
+    fun parse(raw: String?): PreviewMode? =
+      raw?.lowercase()?.let { v -> entries.firstOrNull { it.wire == v } }
+  }
+}
+
+/** Outcome of parsing query-string overrides — either a typed [PreviewOverrides] or a reason. */
+sealed interface OverrideParse {
+  data class Ok(val overrides: PreviewOverrides) : OverrideParse
+
+  data class Invalid(val message: String) : OverrideParse
+}
+
+/**
+ * Pure mapping from `/render` query parameters to a typed [PreviewOverrides], plus a stable cache
+ * key over the pixel-affecting fields. No IO — unit-tested directly. The accepted keys mirror the
+ * `render-matrix` axes ([ee.schimke.composeai.mcp.MatrixCell]) plus the extra display knobs the
+ * daemon already honours, so behaviour matches the rest of the CLI.
+ */
+object ServeOverrides {
+
+  /** Query keys `/render` understands. Unknown keys are ignored (forward-compatible). */
+  val SUPPORTED_KEYS: Set<String> =
+    setOf(
+      "uiMode",
+      "device",
+      "localeTag",
+      "fontScale",
+      "density",
+      "widthPx",
+      "heightPx",
+      // Wrapped-axis content-size bounds (the Max / Min / Within size modes). Fixed size uses
+      // widthPx/heightPx above; these constrain a wrapping preview's intrinsic measure instead.
+      "minWidthPx",
+      "minHeightPx",
+      "maxWidthPx",
+      "maxHeightPx",
+      "orientation",
+      "inspectionMode",
+      "slotMode",
+      // Content-loading placeholder state (#2646): `placeholderActive=true` renders a placeholdered
+      // preview in its loading state, `false` in the loaded one. Boolean, like slotMode; opt-in on
+      // the preview's side (it must read `placeholderActive(...)` into its `PlaceholderState`).
+      "placeholderActive",
+      // Live-only overlay toggles (held-session / recording features). The daemon composites these
+      // onto the streamed frames; a baked snapshot never carries them, so the viewer offers them
+      // only while a Live Compose session is active. Booleans, like inspectionMode/slotMode.
+      "talkBack",
+      "touchOverlay",
+      // FQN of an app-declared @ThemeCatalog `PreviewWrapperProvider` to render this preview under
+      // (the discrete-theme axis). Daemon-only — a baked bundle has no provider to load.
+      "themeProvider",
+      // Detected-feature: keyboard focus. `focus=<tabIndex>` lands focus on the n-th focusable and
+      // draws the focus overlay (`FocusOverride(tabIndex, overlay=true)`). Offered only for a
+      // `@FocusedPreview`-detected preview; daemon-only (the desktop daemon honours it).
+      "focus",
+      // Detected-feature: one-handed (wear) gesture hints. `gestures=true` force-shows the gesture
+      // hint affordance (`GestureOverride(showHints=true)`). Offered only for a
+      // `@GestureHintPreview`-detected preview on an Android-backed session (the desktop daemon
+      // ignores it).
+      "gestures",
+      // Detected-feature: FIRE a one-handed gesture (`GestureOverride(invoke=…)`, issue #5102). The
+      // double pinch and the wrist turn are sensor events — no pointer stands in for them, and off
+      // a watch there is no gesture source at all — so a gesture-aware preview could play its hint
+      // and then never be taken up. `gestureInvoke=primary|dismiss|scroll|page` names the gesture
+      // to fire; the daemon runs the matching handler once composition has settled. Same audience
+      // and same lane as `gestures`: an Android-backed daemon session.
+      "gestureInvoke",
+      // "crisp outline" toggle. Friendly `background=clear` (aliases below) or the raw
+      // `clearBackground=true`; both map to `PreviewOverrides.clearBackground`.
+      "background",
+      "clearBackground",
+      // Remote Compose platform profile (`RcPlatformProfiles` variant) the daemon compiles the
+      // remote document against. Wire names match `RemoteComposeProfile` (androidx, androidx7…,
+      // widgetsV6/V7, wearWidgets). Daemon-only + Android-only — a desktop/static session ignores
+      // it. The per-name seeds ride the dynamic `rc.<name>=…` prefix ([RC_NAMED_PREFIX]), like the
+      // `knob.` knobs.
+      "rcProfile",
+      // Remote Compose render backend (the viewer's per-preview backend selector). Selects which
+      // *server-side* player draws the replayed `ir/<id>.rc` document: `java`/`view` →
+      // `RemoteComposePlayerKind.VIEW`, `cmp-android`/`embedded` → `EMBEDDED`. The client-side `js`
+      // canvas lane and the not-yet-renderable `cmp-jvm` lane never ride this param (js replays the
+      // doc in-browser; cmp-jvm has no draw path), so those values are rejected. Daemon-only +
+      // Android-only — a desktop/static session has no Remote Compose runtime and ignores it.
+      "rcPlayer",
+    )
+
+  /**
+   * Prefix for author-declared named-override knobs: `knob.<wireKey>=<value>`, e.g. `knob.label=Tap
+   * me` or `knob.count=3`. `wireKey` is the declaration key (indexed knobs use `key[index]`). The
+   * value's **type is inferred from the preview's declaration** (the `knobKinds` map passed to
+   * [parse]) — a viewer never has to spell it. An explicit `<kind>:<value>` prefix
+   * (`knob.count=int:3`, `kind` one of string/int/float/bool/color) is still honoured for older
+   * shared links and keys the server has no declaration for; absent a declaration and a recognised
+   * prefix, a bare value parses as a string. The daemon's named-override planner seeds the
+   * preview's declared knobs from these, so editing one re-renders the composable (only on a
+   * daemon-backed session — a static bundle / the Wasm tier ignore them). Dynamic keys, so not
+   * listed in [SUPPORTED_KEYS].
+   *
+   * **`knob.<key>=` with no value is a value, for a string knob.** Clearing a label is an edit a
+   * viewer has to be able to express, and an `@OverrideVariant` can seed one deliberately (`strings
+   * = ["label="]`, which discovery preserves). For any other kind there is nothing to parse out of
+   * it, so it is skipped rather than rejected — the viewer builds these URLs itself and a
+   * half-typed number field must not 400 the page it came from.
+   */
+  const val KNOB_PREFIX = "knob."
+
+  /**
+   * Prefix for Remote Compose named-value seeds: `rc.<name>=<value>`, e.g. `rc.label=Tap me` or
+   * `rc.stopColor=color:%23FF8800`. These feed `PreviewOverrides.remoteCompose.namedValues` (the
+   * `RemoteComposeOverride` facet the `:data-remotecompose-connector` bridges into the running
+   * `RemoteDocumentPlayer`'s `StateUpdater`), which is a **separate channel** from the generic
+   * `knob.` overrides — a Remote Compose sticker's `rememberNamedRemote*` binding is reachable only
+   * through this facet, never the `compose/overrides` knob map. Unlike `knob.`, there is no
+   * per-preview declaration to infer the type from, so the value carries its own `<kind>:<value>`
+   * tag ([RC_KNOWN_KINDS], default `string`). Daemon-only + Android-only — a desktop/static session
+   * has no Remote Compose runtime and ignores it. Dynamic keys, so not listed in [SUPPORTED_KEYS].
+   */
+  const val RC_NAMED_PREFIX = "rc."
+
+  /**
+   * True when [key] is a param [parse] consumes — a fixed [SUPPORTED_KEYS] axis, an author-declared
+   * `knob.` knob, or an `rc.` Remote Compose seed. The HTTP `GET /render` handlers filter the query
+   * string through this so a dynamic knob/rc edit reaches [parse] instead of being dropped, while
+   * an unrelated param (a cache-buster, an analytics tag) never does. The `message.overrides` map
+   * the WebSocket live/stream sessions send is already scoped, so it is passed to [parse]
+   * wholesale.
+   */
+  fun isOverrideParam(key: String): Boolean =
+    key in SUPPORTED_KEYS || key.startsWith(KNOB_PREFIX) || key.startsWith(RC_NAMED_PREFIX)
+
+  /**
+   * The Remote Compose `rc.<name>=<value>` seeds in [params], parsed **leniently** — a malformed
+   * typed value is skipped rather than failing. Used by the cmp-jvm render lane, which renders the
+   * captured document server-side and is best-effort (a bad seed drops to the authored default
+   * rather than 400ing the whole render). The strict counterpart lives inline in [parse], which
+   * returns [OverrideParse.Invalid] for the daemon lanes. Both read the same `<kind>:` grammar
+   * ([RC_KNOWN_KINDS], default `string`).
+   */
+  fun rcNamedValueSeeds(params: Map<String, String>): Map<String, RemoteNamedValue> {
+    val seeds = mutableMapOf<String, RemoteNamedValue>()
+    for ((rawKey, raw) in params) {
+      if (!rawKey.startsWith(RC_NAMED_PREFIX)) continue
+      val name = rawKey.removePrefix(RC_NAMED_PREFIX)
+      if (name.isBlank() || raw.isBlank()) continue
+      val sep = raw.indexOf(':')
+      val kind = if (sep > 0) raw.substring(0, sep).takeIf { it in RC_KNOWN_KINDS } else null
+      val value = if (kind != null) raw.substring(sep + 1) else raw
+      val seed =
+        when (kind ?: "string") {
+          "string" -> RemoteNamedValue.StringValue(value)
+          "int" -> value.toIntOrNull()?.let { RemoteNamedValue.IntValue(it) }
+          "float" -> value.toFloatOrNull()?.let { RemoteNamedValue.FloatValue(it) }
+          "dp" -> value.toFloatOrNull()?.let { RemoteNamedValue.DpValue(it) }
+          "bool" ->
+            RemoteNamedValue.BooleanValue(value.equals("true", ignoreCase = true) || value == "1")
+          "color" -> RemoteNamedValue.ColorValue(value)
+          else -> null
+        }
+      if (seed != null) seeds[name] = seed
+    }
+    return seeds
+  }
+
+  /**
+   * The `<kind>` tags an explicit `knob.<key>=<kind>:<value>` may carry (legacy /
+   * declaration-less).
+   */
+  private val KNOWN_KINDS: Set<String> = setOf("string", "int", "float", "bool", "color")
+
+  /**
+   * The bare value a `knob.<key>=<raw>` param holds, with a legacy `<kind>:` prefix stripped when
+   * [parse] would strip it — i.e. when the prefix is a known kind AND matches the knob's
+   * [declaredKind].
+   *
+   * For the viewer's *controls*, which hold the bare value while the wire may carry the tag. A
+   * `?knob.count=int:3` seeded verbatim puts `int:3` in a number input, which the browser sanitizes
+   * to empty; `?knob.enabled=bool:true` reads as unchecked, since the checkbox tests the whole
+   * string. Either way the control ends up disagreeing with the render the same URL produced, and
+   * the next query built from that control drops or inverts the value.
+   *
+   * The prefix rule is deliberately NOT re-spelled at the call site: a declared *string* knob may
+   * legitimately hold text beginning `int:` / `color:` (the type-free viewer submits it verbatim),
+   * so what may be stripped is exactly what [parse] treats as a type tag, and the two must agree
+   * for the control and the pixels to.
+   */
+  fun knobControlValue(raw: String, declaredKind: String?): String? {
+    val sep = raw.indexOf(':')
+    val prefix =
+      if (sep > 0) {
+        raw
+          .substring(0, sep)
+          .takeIf { it in KNOWN_KINDS }
+          ?.takeIf { declaredKind == null || it == declaredKind }
+      } else null
+    val value = if (prefix != null) raw.substring(sep + 1) else raw
+    val kind = prefix ?: declaredKind ?: "string"
+    // `knob.count=` / `knob.count=int:` — an EMPTY value on a non-string knob. [parse] skips it (it
+    // has nothing to parse), so the render keeps the declaration; blanking the number field beside
+    // those pixels would show a value the picture isn't. An empty STRING is a real value there and
+    // a real one here.
+    return value.takeUnless { it.isEmpty() && kind != "string" }
+  }
+
+  /**
+   * The bare value an `rc.<name>=<raw>` param puts on a **declared** Remote Compose control, or
+   * null when the seed does not apply to it and the declaration should stand.
+   *
+   * Stricter than [knobControlValue], because [parse] types the two differently. A plain knob takes
+   * its type from the DECLARATION, so a bare `knob.count=3` is an int on an int knob. An RC seed
+   * carries its own tag and defaults to `string` with no declaration lookup at all — so a bare
+   * `rc.count=3` parses as `StringValue("3")` and leaves a declared *int* knob on its authored
+   * value. Showing `3` on that control would contradict the pixels it was rendered beside, and the
+   * next query built from it serialises `rc.count=int:3`, quietly turning a request the renderer
+   * ignored into one it obeys.
+   *
+   * So a seed is taken only when the kind it will actually parse as matches the declared one: an
+   * explicit tag that agrees, or no tag at all on a `string` knob. Anything else — a bare value on
+   * a typed knob, a `float:` on an `int` — leaves the control showing what the render used.
+   */
+  fun rcControlValue(raw: String, declaredKind: String): String? {
+    // A blank `rc.<name>=` is skipped wholesale by [parse] — unlike a knob, not even a string RC
+    // seed accepts one — so the declaration stands and the control has to keep showing it.
+    if (raw.isBlank()) return null
+    val sep = raw.indexOf(':')
+    val wireKind = if (sep > 0) raw.substring(0, sep).takeIf { it in RC_KNOWN_KINDS } else null
+    val value = if (wireKind != null) raw.substring(sep + 1) else raw
+    return value.takeIf { (wireKind ?: "string") == declaredKind }
+  }
+
+  /**
+   * The `<kind>` tags an `rc.<name>=<kind>:<value>` seed may carry. Superset of [KNOWN_KINDS] with
+   * `dp` — Remote Compose distinguishes a density-independent measure ([RemoteNamedValue.DpValue])
+   * from a raw float, matching the connector's `setUserLocalFloat` (dp) vs `setUserLocalFloat`
+   * (float) bind. A bare value with no recognised prefix is a `string`.
+   */
+  private val RC_KNOWN_KINDS: Set<String> = setOf("string", "int", "float", "dp", "bool", "color")
+
+  /**
+   * Map a `compose/overrides` declaration `type` to the [PreviewOverrideValue] wire kind. Shared
+   * with the viewer's control rendering so the inferred type always matches the widget shown.
+   */
+  fun knobKind(type: String): String =
+    when (type.lowercase()) {
+      "int" -> "int"
+      "float",
+      "dp" -> "float"
+      "bool",
+      "boolean" -> "bool"
+      "color" -> "color"
+      else -> "string"
+    }
+
+  /**
+   * The `wireKey → kind` map [parse] uses to type a bare `knob.<key>=<value>`, built from a
+   * preview's declared knobs (keyed by
+   * [ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration.seedKey]). Empty when the
+   * preview is unknown or declares no knobs — a bare value then falls back to string.
+   */
+  fun declaredKnobKinds(preview: ServePreview?): Map<String, String> =
+    preview?.overrides?.associate { it.seedKey to knobKind(it.type) } ?: emptyMap()
+
+  /**
+   * Parse [params] (one value per key — the ktor layer collapses multi-values to the first) into a
+   * [PreviewOverrides]. Returns [OverrideParse.Invalid] with a human reason on malformed values
+   * (bad number, unknown enum) rather than rendering with a silent default. Absent / blank keys
+   * leave the corresponding field null (the preview's discovery-time value).
+   *
+   * [knobKinds] maps a knob's `wireKey` to its declared kind so a bare `knob.<key>=<value>` is
+   * typed without the caller spelling it (see [declaredKnobKinds]); an explicit `<kind>:<value>`
+   * prefix still wins, and an undeclared key with a bare value falls back to a string.
+   *
+   * [declaredThemeFqns] is the session's `@ThemeCatalog` provider FQNs
+   * ([ServeHost.declaredThemes]). A `themeProvider` outside that set is rejected here rather than
+   * passed down: the renderer's `loadWrapperByFqnOrNull` logs to stderr and returns null on a class
+   * it can't load, so a misspelled or stale FQN used to come back HTTP 200 with a
+   * **default-themed** PNG — visually indistinguishable from a theme that genuinely renders the
+   * same, and therefore the kind of failure a caller can stare straight through. `null` (the
+   * default) means "the caller doesn't know this session's themes" and skips the check; an **empty
+   * set** means the session declares none, so any `themeProvider` is rejected — nothing could apply
+   * it.
+   */
+  fun parse(
+    params: Map<String, String>,
+    knobKinds: Map<String, String> = emptyMap(),
+    declaredThemeFqns: Set<String>? = null,
+  ): OverrideParse {
+    fun blank(key: String): Boolean = params[key]?.isBlank() ?: true
+
+    val uiMode =
+      params["uiMode"]
+        ?.takeIf { it.isNotBlank() }
+        ?.let {
+          when (it.lowercase()) {
+            "light" -> UiMode.LIGHT
+            "dark" -> UiMode.DARK
+            else -> return OverrideParse.Invalid("uiMode must be 'light' or 'dark', got '$it'")
+          }
+        }
+
+    val orientation =
+      params["orientation"]
+        ?.takeIf { it.isNotBlank() }
+        ?.let {
+          when (it.lowercase()) {
+            "portrait" -> Orientation.PORTRAIT
+            "landscape" -> Orientation.LANDSCAPE
+            else ->
+              return OverrideParse.Invalid(
+                "orientation must be 'portrait' or 'landscape', got '$it'"
+              )
+          }
+        }
+
+    val fontScale =
+      if (blank("fontScale")) null
+      else
+        params.getValue("fontScale").toFloatOrNull()?.takeIf { it > 0f }
+          ?: return OverrideParse.Invalid(
+            "fontScale must be a positive number, got '${params["fontScale"]}'"
+          )
+
+    val density =
+      if (blank("density")) null
+      else
+        params.getValue("density").toFloatOrNull()?.takeIf { it > 0f }
+          ?: return OverrideParse.Invalid(
+            "density must be a positive number, got '${params["density"]}'"
+          )
+
+    val widthPx =
+      if (blank("widthPx")) null
+      else
+        params.getValue("widthPx").toIntOrNull()?.takeIf { it > 0 }
+          ?: return OverrideParse.Invalid(
+            "widthPx must be a positive integer, got '${params["widthPx"]}'"
+          )
+
+    val heightPx =
+      if (blank("heightPx")) null
+      else
+        params.getValue("heightPx").toIntOrNull()?.takeIf { it > 0 }
+          ?: return OverrideParse.Invalid(
+            "heightPx must be a positive integer, got '${params["heightPx"]}'"
+          )
+
+    // Wrapped-axis content-size bounds (Max / Min / Within). Same positive-integer grammar as the
+    // fixed widthPx/heightPx; a malformed value is a hard Invalid rather than a silently-dropped
+    // bound. A `min > max` on the same axis is rejected below — it can't be satisfied.
+    val minWidthPx =
+      if (blank("minWidthPx")) null
+      else
+        params.getValue("minWidthPx").toIntOrNull()?.takeIf { it > 0 }
+          ?: return OverrideParse.Invalid(
+            "minWidthPx must be a positive integer, got '${params["minWidthPx"]}'"
+          )
+
+    val minHeightPx =
+      if (blank("minHeightPx")) null
+      else
+        params.getValue("minHeightPx").toIntOrNull()?.takeIf { it > 0 }
+          ?: return OverrideParse.Invalid(
+            "minHeightPx must be a positive integer, got '${params["minHeightPx"]}'"
+          )
+
+    val maxWidthPx =
+      if (blank("maxWidthPx")) null
+      else
+        params.getValue("maxWidthPx").toIntOrNull()?.takeIf { it > 0 }
+          ?: return OverrideParse.Invalid(
+            "maxWidthPx must be a positive integer, got '${params["maxWidthPx"]}'"
+          )
+
+    val maxHeightPx =
+      if (blank("maxHeightPx")) null
+      else
+        params.getValue("maxHeightPx").toIntOrNull()?.takeIf { it > 0 }
+          ?: return OverrideParse.Invalid(
+            "maxHeightPx must be a positive integer, got '${params["maxHeightPx"]}'"
+          )
+
+    if (minWidthPx != null && maxWidthPx != null && minWidthPx > maxWidthPx) {
+      return OverrideParse.Invalid(
+        "minWidthPx ($minWidthPx) must not exceed maxWidthPx ($maxWidthPx)"
+      )
+    }
+    if (minHeightPx != null && maxHeightPx != null && minHeightPx > maxHeightPx) {
+      return OverrideParse.Invalid(
+        "minHeightPx ($minHeightPx) must not exceed maxHeightPx ($maxHeightPx)"
+      )
+    }
+
+    val inspectionMode =
+      params["inspectionMode"]
+        ?.takeIf { it.isNotBlank() }
+        ?.let {
+          when (it.lowercase()) {
+            "true",
+            "1" -> true
+            "false",
+            "0" -> false
+            else -> return OverrideParse.Invalid("inspectionMode must be a boolean, got '$it'")
+          }
+        }
+
+    val slotMode =
+      params["slotMode"]
+        ?.takeIf { it.isNotBlank() }
+        ?.let {
+          when (it.lowercase()) {
+            "true",
+            "1" -> true
+            "false",
+            "0" -> false
+            else -> return OverrideParse.Invalid("slotMode must be a boolean, got '$it'")
+          }
+        }
+
+    val placeholderActive =
+      params["placeholderActive"]
+        ?.takeIf { it.isNotBlank() }
+        ?.let {
+          when (it.lowercase()) {
+            "true",
+            "1" -> true
+            "false",
+            "0" -> false
+            else -> return OverrideParse.Invalid("placeholderActive must be a boolean, got '$it'")
+          }
+        }
+
+    // Live-only overlay flags (daemon composites onto the held session's frames). Parsed like the
+    // other booleans; a malformed value is a hard Invalid rather than a silently-dropped toggle.
+    val talkBack =
+      params["talkBack"]
+        ?.takeIf { it.isNotBlank() }
+        ?.let {
+          when (it.lowercase()) {
+            "true",
+            "1" -> true
+            "false",
+            "0" -> false
+            else -> return OverrideParse.Invalid("talkBack must be a boolean, got '$it'")
+          }
+        }
+
+    val touchOverlay =
+      params["touchOverlay"]
+        ?.takeIf { it.isNotBlank() }
+        ?.let {
+          when (it.lowercase()) {
+            "true",
+            "1" -> true
+            "false",
+            "0" -> false
+            else -> return OverrideParse.Invalid("touchOverlay must be a boolean, got '$it'")
+          }
+        }
+
+    // Detected-feature: keyboard focus. `focus=<tabIndex>` lands focus on the n-th focusable in tab
+    // order and draws the post-capture focus overlay (stroke + label). A non-negative integer; a
+    // malformed value is a hard Invalid. Absent → no focus override (discovery-time behaviour).
+    val focus: FocusOverride? =
+      params["focus"]
+        ?.takeIf { it.isNotBlank() }
+        ?.let {
+          val tabIndex =
+            it.toIntOrNull()?.takeIf { n -> n >= 0 }
+              ?: return OverrideParse.Invalid(
+                "focus must be a non-negative integer tab index, got '$it'"
+              )
+          FocusOverride(tabIndex = tabIndex, overlay = true)
+        }
+
+    // Detected-feature: one-handed gesture hints. `gestures=true` (or `1`) force-shows the gesture
+    // hint affordance; `false`/`0` clears it. A malformed value is a hard Invalid.
+    val showGestureHints: Boolean? =
+      params["gestures"]
+        ?.takeIf { it.isNotBlank() }
+        ?.let {
+          when (it.lowercase()) {
+            "true",
+            "1" -> true
+            "false",
+            "0" -> false
+            else -> return OverrideParse.Invalid("gestures must be a boolean, got '$it'")
+          }
+        }
+
+    // Detected-feature: fire a gesture (issue #5102). `gestureInvoke=<kind>` names which of the
+    // wearer's gestures to run — `primary` is the double pinch, `dismiss` the wrist turn — and the
+    // daemon invokes the matching registered handler once composition has settled. Spelled as the
+    // wire kind rather than as a label, because the label is authored per handler and a viewer
+    // offering "Double pinch" must not have to know what this preview called it.
+    val invokeGesture: GestureKindOverride? =
+      params["gestureInvoke"]
+        ?.takeIf { it.isNotBlank() }
+        ?.let {
+          when (it.lowercase()) {
+            "primary" -> GestureKindOverride.PRIMARY
+            "dismiss" -> GestureKindOverride.DISMISS
+            "scroll" -> GestureKindOverride.SCROLL
+            "page" -> GestureKindOverride.PAGE
+            else ->
+              return OverrideParse.Invalid(
+                "gestureInvoke must be primary, dismiss, scroll or page, got '$it'"
+              )
+          }
+        }
+
+    // One override carries both halves, so hints and an invocation compose: a viewer can show the
+    // hint and fire the gesture in the same render, which is what "play the hint, then take it up"
+    // looks like. Absent from both ⇒ null, i.e. no gesture override at all rather than an empty
+    // one.
+    val gestures: GestureOverride? =
+      if (showGestureHints == null && invokeGesture == null) null
+      else GestureOverride(showHints = showGestureHints, invoke = invokeGesture)
+
+    // Cleared background ("crisp outline"). Two spellings: the friendly `background=clear`
+    // (aliases `transparent` / `none` / `off`; `default` / `show` mean "keep the preview's
+    // background") and the raw boolean `clearBackground=true`. A present `background` key wins over
+    // `clearBackground`. Absent → null (discovery-time background).
+    val clearBackground: Boolean? =
+      when {
+        !blank("background") ->
+          when (params.getValue("background").lowercase()) {
+            "clear",
+            "transparent",
+            "none",
+            "off" -> true
+            "default",
+            "show",
+            "on" -> false
+            else ->
+              return OverrideParse.Invalid(
+                "background must be 'clear' or 'default', got '${params["background"]}'"
+              )
+          }
+        !blank("clearBackground") ->
+          when (params.getValue("clearBackground").lowercase()) {
+            "true",
+            "1" -> true
+            "false",
+            "0" -> false
+            else ->
+              return OverrideParse.Invalid(
+                "clearBackground must be a boolean, got '${params["clearBackground"]}'"
+              )
+          }
+        else -> null
+      }
+
+    // Named-override knobs (`knob.<key>=<value>`, type inferred from the declaration; a legacy
+    // `<kind>:<value>` prefix still wins). A malformed typed value is a hard Invalid (mirrors the
+    // numeric fields) rather than a silently-dropped edit.
+    val namedOverrides = mutableMapOf<String, PreviewOverrideValue>()
+    for ((rawKey, raw) in params) {
+      if (!rawKey.startsWith(KNOB_PREFIX)) continue
+      val wireKey = rawKey.removePrefix(KNOB_PREFIX)
+      if (wireKey.isBlank()) continue
+      // Type the value. A bare value takes its type from the preview's declaration (default
+      // string). A legacy `<kind>:<value>` prefix is honoured ONLY when the knob is undeclared or
+      // the prefix matches its declared kind — otherwise a declared *string* knob could never hold
+      // a value that happens to start with `int:` / `color:` / … (the type-free viewer submits such
+      // text verbatim), which would silently mistype the seed or strip a legitimate prefix.
+      val declaredKind = knobKinds[wireKey]
+      val sep = raw.indexOf(':')
+      val prefix = if (sep > 0) raw.substring(0, sep).takeIf { it in KNOWN_KINDS } else null
+      val explicitKind = prefix?.takeIf { declaredKind == null || it == declaredKind }
+      val kind = explicitKind ?: declaredKind ?: "string"
+      val value = if (explicitKind != null) raw.substring(sep + 1) else raw
+      // `knob.label=` — an EMPTY value. For a string knob that is a real value, not a missing one:
+      // clearing a label is an edit a viewer must be able to express, and an `@OverrideVariant` may
+      // seed one deliberately (`strings = ["label="]`). Dropping it (as a blanket blank-skip did)
+      // silently rendered the author default instead — the seeded variant's whole point inverted.
+      // Whitespace is likewise a real string, so this tests isEmpty rather than isBlank.
+      //
+      // For every other kind there is nothing to parse out of "", and a viewer legitimately
+      // produces it (an emptied number input). That stays a skipped no-op rather than a hard
+      // Invalid, which would 400 a URL the viewer itself built.
+      if (value.isEmpty() && kind != "string") continue
+      namedOverrides[wireKey] =
+        when (kind) {
+          "string" -> PreviewOverrideValue.StringValue(value)
+          "int" ->
+            value.toIntOrNull()?.let { PreviewOverrideValue.IntValue(it) }
+              ?: return OverrideParse.Invalid(
+                "knob '$wireKey' int must be an integer, got '$value'"
+              )
+          "float" ->
+            value.toFloatOrNull()?.let { PreviewOverrideValue.FloatValue(it) }
+              ?: return OverrideParse.Invalid(
+                "knob '$wireKey' float must be a number, got '$value'"
+              )
+          "bool" ->
+            PreviewOverrideValue.BooleanValue(
+              value.equals("true", ignoreCase = true) || value == "1"
+            )
+          "color" -> PreviewOverrideValue.ColorValue(value)
+          else -> return OverrideParse.Invalid("knob '$wireKey' has unknown kind '$kind'")
+        }
+    }
+
+    // Remote Compose profile (`rcProfile=<wire name>`). Absent → null (the connector's default
+    // ANDROIDX). An unknown value is a hard Invalid rather than a silently-ignored profile.
+    val rcProfile: RemoteComposeProfile? =
+      params["rcProfile"]
+        ?.takeIf { it.isNotBlank() }
+        ?.let {
+          when (it.lowercase()) {
+            "androidx" -> RemoteComposeProfile.ANDROIDX
+            "androidx7" -> RemoteComposeProfile.ANDROIDX7
+            "androidx8" -> RemoteComposeProfile.ANDROIDX8
+            "androidx9" -> RemoteComposeProfile.ANDROIDX9
+            "widgetsv6" -> RemoteComposeProfile.WIDGETS_V6
+            "widgetsv7" -> RemoteComposeProfile.WIDGETS_V7
+            "wearwidgets" -> RemoteComposeProfile.WEAR_WIDGETS
+            else ->
+              return OverrideParse.Invalid(
+                "rcProfile must be one of androidx/androidx7/androidx8/androidx9/widgetsV6/" +
+                  "widgetsV7/wearWidgets, got '$it'"
+              )
+          }
+        }
+
+    // Remote Compose named-value seeds (`rc.<name>=<value>`, own `<kind>:<value>` tag, default
+    // string). A malformed typed value is a hard Invalid, mirroring the `knob.` block.
+    val rcNamedValues = mutableMapOf<String, RemoteNamedValue>()
+    for ((rawKey, raw) in params) {
+      if (!rawKey.startsWith(RC_NAMED_PREFIX)) continue
+      val name = rawKey.removePrefix(RC_NAMED_PREFIX)
+      if (name.isBlank() || raw.isBlank()) continue
+      val sep = raw.indexOf(':')
+      val kind = if (sep > 0) raw.substring(0, sep).takeIf { it in RC_KNOWN_KINDS } else null
+      val value = if (kind != null) raw.substring(sep + 1) else raw
+      rcNamedValues[name] =
+        when (kind ?: "string") {
+          "string" -> RemoteNamedValue.StringValue(value)
+          "int" ->
+            value.toIntOrNull()?.let { RemoteNamedValue.IntValue(it) }
+              ?: return OverrideParse.Invalid("rc '$name' int must be an integer, got '$value'")
+          "float" ->
+            value.toFloatOrNull()?.let { RemoteNamedValue.FloatValue(it) }
+              ?: return OverrideParse.Invalid("rc '$name' float must be a number, got '$value'")
+          "dp" ->
+            value.toFloatOrNull()?.let { RemoteNamedValue.DpValue(it) }
+              ?: return OverrideParse.Invalid("rc '$name' dp must be a number, got '$value'")
+          "bool" ->
+            RemoteNamedValue.BooleanValue(value.equals("true", ignoreCase = true) || value == "1")
+          // Color carries the raw `#AARRGGBB` string; the connector strips `#` and skips a value it
+          // can't parse (a panel typo must not crash the render), so accept any string here.
+          "color" -> RemoteNamedValue.ColorValue(value)
+          else -> return OverrideParse.Invalid("rc '$name' has unknown kind '$kind'")
+        }
+    }
+
+    // Remote Compose render backend (`rcPlayer=<backend>`). Maps a server-side backend id onto the
+    // daemon's `RemoteComposePlayerKind` (`java`/`view` → VIEW, `cmp-android`/`embedded` →
+    // EMBEDDED).
+    // The client-side `js` canvas and the not-yet-renderable `cmp-jvm` lane never ride the PNG
+    // render param, so those (and any other value) are a hard Invalid rather than a silent default.
+    val rcPlayer =
+      params["rcPlayer"]
+        ?.takeIf { it.isNotBlank() }
+        ?.let {
+          RcPlayerBackend.serverSideFromParam(it)?.playerKind
+            ?: return OverrideParse.Invalid(
+              "rcPlayer must be one of java/view or cmp-android/embedded, got '$it'"
+            )
+        }
+
+    val themeProvider = params["themeProvider"]?.takeIf { it.isNotBlank() }
+    if (themeProvider != null && declaredThemeFqns != null && themeProvider !in declaredThemeFqns) {
+      return OverrideParse.Invalid(
+        if (declaredThemeFqns.isEmpty()) {
+          "themeProvider '$themeProvider' cannot be applied: this catalog declares no " +
+            "@ThemeCatalog providers"
+        } else {
+          "unknown themeProvider '$themeProvider'; this catalog declares " +
+            declaredThemeFqns.sorted().joinToString(", ")
+        }
+      )
+    }
+
+    // Fold the two Remote Compose facets into one override, or leave null when neither is present
+    // so
+    // an rc-free render carries no `remoteCompose` payload (identical wire shape to before).
+    val remoteCompose: RemoteComposeOverride? =
+      if (rcProfile == null && rcNamedValues.isEmpty() && rcPlayer == null) null
+      else
+        RemoteComposeOverride(profile = rcProfile, namedValues = rcNamedValues, player = rcPlayer)
+
+    return OverrideParse.Ok(
+      PreviewOverrides(
+        widthPx = widthPx,
+        heightPx = heightPx,
+        minWidthPx = minWidthPx,
+        minHeightPx = minHeightPx,
+        maxWidthPx = maxWidthPx,
+        maxHeightPx = maxHeightPx,
+        density = density,
+        localeTag = params["localeTag"]?.takeIf { it.isNotBlank() },
+        fontScale = fontScale,
+        uiMode = uiMode,
+        orientation = orientation,
+        device = params["device"]?.takeIf { it.isNotBlank() },
+        inspectionMode = inspectionMode,
+        slotMode = slotMode,
+        placeholderActive = placeholderActive,
+        talkBack = talkBack,
+        touchOverlay = touchOverlay,
+        themeProvider = themeProvider,
+        focus = focus,
+        gestures = gestures,
+        clearBackground = clearBackground,
+        namedOverrides = namedOverrides.ifEmpty { null },
+        remoteCompose = remoteCompose,
+      )
+    )
+  }
+
+  /**
+   * Stable cache key for one rendered preview + its overrides. Built from the pixel-affecting
+   * fields in a fixed order (independent of query-param order) and hashed, so identical overrides
+   * coalesce to one render and the key is safe as a map key. Only the fields tier 1 supports
+   * participate; adding a field here is the one place to keep in lockstep with [parse].
+   */
+  fun cacheKey(previewId: String, o: PreviewOverrides): String {
+    val canonical = buildString {
+      append(previewId).append(' ')
+      append("w=").append(o.widthPx).append('|')
+      append("h=").append(o.heightPx).append('|')
+      append("minw=").append(o.minWidthPx).append('|')
+      append("minh=").append(o.minHeightPx).append('|')
+      append("maxw=").append(o.maxWidthPx).append('|')
+      append("maxh=").append(o.maxHeightPx).append('|')
+      append("d=").append(o.density).append('|')
+      append("loc=").append(o.localeTag).append('|')
+      append("fs=").append(o.fontScale).append('|')
+      append("ui=").append(o.uiMode).append('|')
+      append("or=").append(o.orientation).append('|')
+      append("dev=").append(o.device).append('|')
+      append("insp=").append(o.inspectionMode).append('|')
+      append("slot=").append(o.slotMode).append('|')
+      append("ph=").append(o.placeholderActive).append('|')
+      append("talk=").append(o.talkBack).append('|')
+      append("touch=").append(o.touchOverlay).append('|')
+      append("theme=").append(o.themeProvider).append('|')
+      append("focus=").append(o.focus).append('|')
+      append("gestures=").append(o.gestures).append('|')
+      append("clearbg=").append(o.clearBackground).append('|')
+      // Named overrides participate so a knob edit isn't coalesced onto the prior render. Sorted by
+      // key for order-independence; the value data classes have stable toString.
+      append("named=")
+      o.namedOverrides?.toSortedMap()?.forEach { (k, v) ->
+        append(k).append('=').append(v).append(';')
+      }
+      // Remote Compose facet participates for the same reason — an `rc.` seed / profile edit must
+      // re-render. Named values sorted for order-independence; the value/profile toStrings are
+      // stable. acceptedHostActions is never set from the serve query path, so it is omitted.
+      append("|rcProfile=").append(o.remoteCompose?.profile)
+      // The render backend participates so switching the RC player (java ⇄ cmp-android) re-renders
+      // rather than serving the prior backend's cached pixels under a shared key.
+      append("|rcPlayer=").append(o.remoteCompose?.player)
+      append("|rc=")
+      o.remoteCompose?.namedValues?.toSortedMap()?.forEach { (k, v) ->
+        append(k).append('=').append(v).append(';')
+      }
+    }
+    return MessageDigest.getInstance("SHA-256")
+      .digest(canonical.toByteArray(Charsets.UTF_8))
+      .joinToString("") { "%02x".format(it) }
+  }
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParameterRows.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParameterRows.kt
@@ -1,0 +1,92 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.io.SystemFileSystem
+import ee.schimke.composeai.previewdata.PreviewInfo
+import ee.schimke.composeai.previewdata.PreviewParameterFanout
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+
+/**
+ * Expands a parameterized `@PreviewParameter` preview into the **row ids** the daemon can address,
+ * by reading the fan-out the render pass already wrote to disk (issue #3749 follow-up).
+ *
+ * **Why disk and not discovery.** `previews.json` carries one entry per parameterized function —
+ * discovery reads bytecode and can't instantiate a `PreviewParameterProvider`, so it has no idea
+ * how many values there are. The *renderer* does: it writes `<stem>_<label>.png` /
+ * `<stem>_PARAM_<idx>.png` per value (docs/RENDER_FILENAMES.md). `serve`'s Gradle path runs a full
+ * render before it starts the server, so those files are sitting there — and the daemon now accepts
+ * exactly those `<baseId>_<row>` ids. Reading them back is what turns "the daemon *can* render row
+ * 3" into "the viewer lists row 3", with no new protocol surface.
+ *
+ * **Which files, and what each row is called, is not decided here** — [PreviewParameterFanout] owns
+ * that rule, and `PreviewResultBuilder` reads the same fan-out through it for `show` / `list` /
+ * `render` (issue #3819). This class contributes the manifest evidence (who claims which output)
+ * and the directory listing; sharing the rest is what stops `serve` and the result-shaped commands
+ * from disagreeing about what row `Foo_Dark_Alice` is — a disagreement that doesn't merely
+ * misreport, it hands you a different row than the one you selected.
+ *
+ * A preview with no provider, or one whose fan-out isn't on disk (a `serve` run that didn't render
+ * — a bundle-backed session, or a render that failed), expands to nothing and keeps its bare id, so
+ * this only ever adds rows that genuinely exist.
+ */
+object ServeParameterRows {
+
+  /** One row of a parameterized preview: the addressable id plus the token that names it. */
+  data class Row(val id: String, val label: String)
+
+  /**
+   * The rows of [preview] found under [moduleDir]`/build/compose-previews/`, in the fan-out's own
+   * order (numeric `PARAM_<idx>` by index first, then labels alphabetically — matching how the CLI
+   * orders a fan-out elsewhere). Empty when [preview] declares no provider or nothing matched.
+   *
+   * [siblingOutputs] must be every *other* preview's capture outputs, used to reject files this
+   * preview doesn't own.
+   */
+  fun rowsFor(
+    preview: PreviewInfo,
+    moduleDir: Path,
+    siblingOutputs: Set<String>,
+    fileSystem: FileSystem = SystemFileSystem,
+  ): List<Row> {
+    if (preview.params.previewParameterProviderClassName.isNullOrBlank()) return emptyList()
+    val template =
+      preview.captures.firstOrNull { it.renderOutput.isNotBlank() } ?: return emptyList()
+    val rel = template.renderOutput
+    val dirPart = rel.substringBeforeLast('/', "")
+
+    val root = moduleDir / "build" / "compose-previews"
+    val dir = if (dirPart.isEmpty()) root else dirPart.split('/').fold(root) { acc, p -> acc / p }
+    val entries = runCatching {
+      fileSystem.list(dir)
+    }
+      .getOrElse {
+        return emptyList()
+      }
+
+    return PreviewParameterFanout.rowsOf(
+        baseId = preview.id,
+        templateOutput = rel,
+        fileNames = entries.map { it.name },
+        siblingOutputs = siblingOutputs,
+      )
+      .map { Row(id = it.id, label = it.token) }
+  }
+
+  /**
+   * Every capture output claimed by [previews], as `renderOutput`-relative paths — the exclusion
+   * set [rowsFor] needs so one preview's render can't be read as another's row.
+   */
+  fun claimedOutputs(previews: List<PreviewInfo>): Set<String> =
+    previews.flatMapTo(mutableSetOf()) { p ->
+      p.captures.map { it.renderOutput }.filter { it.isNotBlank() }
+    }
+
+  /** Convenience for callers holding a `java.io.File` project dir (the Tooling API's shape). */
+  fun rowsFor(
+    preview: PreviewInfo,
+    moduleDir: java.io.File,
+    siblingOutputs: Set<String>,
+    fileSystem: FileSystem = SystemFileSystem,
+  ): List<Row> = rowsFor(preview, moduleDir.path.toPath(), siblingOutputs, fileSystem)
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParityActivity.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParityActivity.kt
@@ -1,0 +1,354 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.io.SystemFileSystem
+import java.io.File
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path.Companion.toOkioPath
+import okio.Path.Companion.toPath
+
+/**
+ * The **design-parity activity feed** a producer publishes alongside its catalog — recent code
+ * commits, recent Figma file versions, recent Figma comments, and the mapping gaps only the
+ * producer can see.
+ *
+ * ## Why this is published data rather than a live query
+ *
+ * The serve host holds **no Figma credential and never talks to Figma** — the same rule that keeps
+ * `source.uri` on a [DesignReference] informational (see [ServeFigmaSpec] and
+ * `docs/public-preview-server.md`). A dashboard that called `GET /v1/files/:key/comments` at
+ * request time would put a write-capable design-file token on a public box and make every page load
+ * depend on Figma's rate limit. So the *pipeline* — which already holds `FIGMA_TOKEN` to rasterize
+ * references (`emit-design-references.mjs`) — snapshots the activity at publish time into
+ * `activity.json`, and the server only reads and renders it. That also makes the page reproducible:
+ * the feed is a property of the published catalog, identical for every visitor, and diffable on the
+ * delivery branch like everything else there.
+ *
+ * The same argument applies to the code lane: `git log` needs a checkout, which the publish job has
+ * and the server does not.
+ *
+ * ## Failure posture
+ *
+ * Fail-soft, exactly like [ServeDesignReferenceStore]: a missing file, a wrong schema token, a
+ * malformed record, or an out-of-range field drops that record (or the whole feed) and the catalog
+ * serves normally. A parity dashboard is an enhancement; it must never cost a catalog its grid.
+ *
+ * ## Trust
+ *
+ * A catalog is third-party data and this file carries **free text written by other people** —
+ * commit subjects and Figma comment bodies. Nothing here is trusted: every string is HTML-escaped
+ * at render time by [ServeWeb], and the two outbound link shapes ([CodeEvent.url], Figma node deep
+ * links) are *reassembled* from validated parts against literal origins rather than taken from the
+ * file, so a catalog declaring `javascript:…` produces no link instead of an attacker-chosen href.
+ */
+@Serializable
+data class ParityActivity(
+  val schema: String = SCHEMA,
+  /** ISO-8601 instant the feed was snapshotted. Shown as the feed's "as of". */
+  val generatedAt: String? = null,
+  /** How far back the producer looked, in days. Informational; drives the header wording only. */
+  val windowDays: Int? = null,
+  val code: CodeLane? = null,
+  val figma: FigmaLane? = null,
+  /** Gaps only the producer can see — the server derives preview-side coverage itself. */
+  val gaps: List<MappingGap> = emptyList(),
+) {
+  companion object {
+    const val SCHEMA = "compose-preview-activity/v1"
+    const val DIRECTORY = "parity"
+    const val FILE = "activity.json"
+  }
+}
+
+/** Recent commits to the code side of the parity pair. */
+@Serializable
+data class CodeLane(
+  /** `owner/name` of the source repo, used to rebuild commit URLs. */
+  val repo: String? = null,
+  /** Branch or ref the commits were read from. */
+  val ref: String? = null,
+  val events: List<CodeEvent> = emptyList(),
+)
+
+/** One commit that touched a file backing at least one catalog preview. */
+@Serializable
+data class CodeEvent(
+  val sha: String,
+  val subject: String,
+  /** ISO-8601 author date. */
+  val at: String,
+  val author: String? = null,
+  /**
+   * Preview ids this commit touched, resolved by the producer from the changed source files. Empty
+   * is legal (a commit to a shared file) and simply renders with no inbound links.
+   */
+  val previewIds: List<String> = emptyList(),
+  /** Catalog component ids (`Button/Filled`) the commit touched, for display. */
+  val components: List<String> = emptyList(),
+)
+
+/** Recent activity on the Figma file the catalog is specified by. */
+@Serializable
+data class FigmaLane(
+  /** Figma file key. Validated before any deep link is built from it. */
+  val fileKey: String? = null,
+  val fileName: String? = null,
+  val versions: List<FigmaVersionEvent> = emptyList(),
+  val comments: List<FigmaCommentEvent> = emptyList(),
+)
+
+/** One named version / autosave checkpoint in the Figma file's history. */
+@Serializable
+data class FigmaVersionEvent(
+  val id: String,
+  /** ISO-8601. */
+  val at: String,
+  val label: String? = null,
+  val description: String? = null,
+  val author: String? = null,
+)
+
+/**
+ * One Figma comment, anchored to a node when the commenter pinned it to one.
+ *
+ * [previewIds] is the payoff: the producer resolves the pinned node back through `design-map.json`
+ * to the previews it specifies, so "a designer commented on this" becomes a link straight to that
+ * preview's reference-vs-render comparison.
+ */
+@Serializable
+data class FigmaCommentEvent(
+  val id: String,
+  /** ISO-8601. */
+  val at: String,
+  val message: String,
+  val author: String? = null,
+  val resolved: Boolean = false,
+  /** `51592:4768` — the pinned node, when the comment is anchored. */
+  val nodeId: String? = null,
+  val previewIds: List<String> = emptyList(),
+  val components: List<String> = emptyList(),
+)
+
+/**
+ * A mapping gap the **producer** found. Preview-side coverage ("this preview has no design
+ * reference") is derived by the server from data it already has, so it is deliberately NOT a kind
+ * here — publishing it would let a stale `activity.json` contradict the live catalog.
+ */
+@Serializable
+data class MappingGap(
+  /** One of [Kind]; an unknown token drops the record rather than rendering as a mystery row. */
+  val kind: String,
+  /** Human summary — what is missing, in the producer's own words. */
+  val detail: String,
+  /** The design-map `code` locator (`path/Foo.kt#Bar`), when the gap has a code side. */
+  val code: String? = null,
+  /** The design-map `ref` (`figma:<key>/<node>`), when the gap has a design side. */
+  val ref: String? = null,
+  /** The preview id the gap concerns, when it names one. */
+  val previewId: String? = null,
+  val component: String? = null,
+) {
+  /** The gap kinds the dashboard groups and explains. */
+  object Kind {
+    /** `design-map.json` names a preview id the published catalog does not contain. */
+    const val DANGLING_MAPPING = "dangling-mapping"
+
+    /** A mapped Figma node exists but its reference raster could not be published. */
+    const val UNRENDERED_REFERENCE = "unrendered-reference"
+
+    /** A component published in the Figma file that no code entry maps to. */
+    const val UNMAPPED_DESIGN_NODE = "unmapped-design-node"
+
+    val ALL = setOf(DANGLING_MAPPING, UNRENDERED_REFERENCE, UNMAPPED_DESIGN_NODE)
+  }
+}
+
+/**
+ * Validated, read-only view of a catalog's `parity/activity.json`.
+ *
+ * Validation is per-record and permissive about *absence* but strict about *shape*: an event with
+ * no parseable timestamp is dropped (the feed is ordered by time, so an undated row has nowhere to
+ * go), an over-long free-text field is truncated rather than dropped (the text is display-only),
+ * and a gap with an unknown [MappingGap.Kind] is dropped.
+ */
+object ServeParityActivityStore {
+
+  /** Feed rows kept per lane. A catalog cannot make a page arbitrarily large. */
+  private const val MAX_EVENTS = 100
+
+  /** Gap rows kept. Same reasoning as [MAX_EVENTS]. */
+  private const val MAX_GAPS = 200
+
+  /** Free text is display-only; longer than this is truncated with an ellipsis. */
+  private const val MAX_TEXT = 400
+
+  /** Figma file keys are URL-safe alphanumerics — same rule [ServeFigmaSpec] links by. */
+  private val FILE_KEY = Regex("[A-Za-z0-9_-]{1,64}")
+
+  /** `73:6` (API/handle form) or `73-6` (URL form). */
+  private val NODE_ID = Regex("[0-9]+[:-][0-9]+")
+
+  /** A full commit sha; short forms are rejected because the URL is rebuilt from it. */
+  private val SHA = Regex("[a-f0-9]{7,40}")
+
+  /** `owner/name`, the only shape a github.com commit URL is assembled from. */
+  private val REPO = Regex("[A-Za-z0-9_.-]{1,100}/[A-Za-z0-9_.-]{1,100}")
+
+  private val JSON = Json { ignoreUnknownKeys = true }
+
+  /**
+   * The catalog's activity feed, or null when it publishes none (the common case) or publishes one
+   * that does not parse. Never throws.
+   */
+  fun load(bundleDir: File, fileSystem: FileSystem = SystemFileSystem): ParityActivity? {
+    val path = bundleDir.toOkioPath() / ParityActivity.DIRECTORY.toPath() / ParityActivity.FILE
+    val raw =
+      runCatching {
+        if (!fileSystem.exists(path)) return@runCatching null
+        JSON.decodeFromString<ParityActivity>(fileSystem.read(path) { readUtf8() })
+      }
+        .getOrNull() ?: return null
+    return sanitize(raw)
+  }
+
+  /**
+   * Drop every record that cannot be rendered honestly and clamp the rest. Exposed (rather than
+   * private to [load]) because it is the whole of the trust boundary and is what the unit tests
+   * exercise — no filesystem needed.
+   */
+  fun sanitize(raw: ParityActivity): ParityActivity? {
+    if (raw.schema != ParityActivity.SCHEMA) return null
+    val code =
+      raw.code?.let { lane ->
+        CodeLane(
+          repo = lane.repo?.trim()?.takeIf { REPO.matches(it) },
+          ref = lane.ref?.trim()?.takeIf { it.isNotEmpty() }?.let { clamp(it, 120) },
+          events =
+            lane.events
+              .filter { SHA.matches(it.sha.trim().lowercase()) && isTimestamp(it.at) }
+              .map { event ->
+                CodeEvent(
+                  sha = event.sha.trim().lowercase(),
+                  subject = clamp(event.subject.trim(), MAX_TEXT),
+                  at = event.at.trim(),
+                  author = event.author?.trim()?.takeIf { it.isNotEmpty() }?.let { clamp(it, 120) },
+                  previewIds = event.previewIds.filter { it.isNotBlank() }.distinct().take(50),
+                  components = event.components.filter { it.isNotBlank() }.distinct().take(50),
+                )
+              }
+              .sortedByDescending { it.at }
+              .take(MAX_EVENTS),
+        )
+      }
+    val figma =
+      raw.figma?.let { lane ->
+        FigmaLane(
+          fileKey = lane.fileKey?.trim()?.takeIf { FILE_KEY.matches(it) },
+          fileName = lane.fileName?.trim()?.takeIf { it.isNotEmpty() }?.let { clamp(it, 160) },
+          versions =
+            lane.versions
+              .filter { it.id.isNotBlank() && isTimestamp(it.at) }
+              .map { version ->
+                FigmaVersionEvent(
+                  id = clamp(version.id.trim(), 80),
+                  at = version.at.trim(),
+                  label = version.label?.trim()?.takeIf { it.isNotEmpty() }?.let { clamp(it, 160) },
+                  description =
+                    version.description
+                      ?.trim()
+                      ?.takeIf { it.isNotEmpty() }
+                      ?.let { clamp(it, MAX_TEXT) },
+                  author =
+                    version.author?.trim()?.takeIf { it.isNotEmpty() }?.let { clamp(it, 120) },
+                )
+              }
+              .sortedByDescending { it.at }
+              .take(MAX_EVENTS),
+          comments =
+            lane.comments
+              .filter { it.id.isNotBlank() && isTimestamp(it.at) && it.message.isNotBlank() }
+              .map { comment ->
+                FigmaCommentEvent(
+                  id = clamp(comment.id.trim(), 80),
+                  at = comment.at.trim(),
+                  message = clamp(comment.message.trim(), MAX_TEXT),
+                  author =
+                    comment.author?.trim()?.takeIf { it.isNotEmpty() }?.let { clamp(it, 120) },
+                  resolved = comment.resolved,
+                  nodeId = comment.nodeId?.trim()?.takeIf { NODE_ID.matches(it) },
+                  previewIds = comment.previewIds.filter { it.isNotBlank() }.distinct().take(50),
+                  components = comment.components.filter { it.isNotBlank() }.distinct().take(50),
+                )
+              }
+              .sortedByDescending { it.at }
+              .take(MAX_EVENTS),
+        )
+      }
+    val gaps =
+      raw.gaps
+        .filter { it.kind in MappingGap.Kind.ALL && it.detail.isNotBlank() }
+        .map { gap ->
+          MappingGap(
+            kind = gap.kind,
+            detail = clamp(gap.detail.trim(), MAX_TEXT),
+            code = gap.code?.trim()?.takeIf { it.isNotEmpty() }?.let { clamp(it, 300) },
+            ref = gap.ref?.trim()?.takeIf { it.isNotEmpty() }?.let { clamp(it, 300) },
+            previewId = gap.previewId?.trim()?.takeIf { it.isNotEmpty() }?.let { clamp(it, 300) },
+            component = gap.component?.trim()?.takeIf { it.isNotEmpty() }?.let { clamp(it, 160) },
+          )
+        }
+        .take(MAX_GAPS)
+    val sanitized =
+      ParityActivity(
+        generatedAt = raw.generatedAt?.trim()?.takeIf { isTimestamp(it) },
+        windowDays = raw.windowDays?.takeIf { it in 1..3650 },
+        code = code?.takeIf { it.events.isNotEmpty() },
+        figma = figma?.takeIf { it.versions.isNotEmpty() || it.comments.isNotEmpty() },
+        gaps = gaps,
+      )
+    // An empty feed is indistinguishable from no feed, and rendering an empty dashboard is worse
+    // than not offering the tab at all.
+    val empty = sanitized.code == null && sanitized.figma == null && sanitized.gaps.isEmpty()
+    return sanitized.takeIf { !empty }
+  }
+
+  /**
+   * The github.com commit URL for [sha] in [repo], or null when either is not the exact shape the
+   * URL is built from. Assembled from a literal origin, never taken from the catalog.
+   */
+  fun commitUrl(repo: String?, sha: String): String? {
+    val owner = repo?.trim()?.takeIf { REPO.matches(it) } ?: return null
+    val id = sha.trim().lowercase().takeIf { SHA.matches(it) } ?: return null
+    return "https://github.com/$owner/commit/$id"
+  }
+
+  /**
+   * The figma.com deep link for [nodeId] in [fileKey], or null when either is malformed. Figma's
+   * URL form spells a node id `73-6` where the API and the design map use `73:6`.
+   */
+  fun nodeUrl(fileKey: String?, nodeId: String?): String? {
+    val key = fileKey?.trim()?.takeIf { FILE_KEY.matches(it) } ?: return null
+    val node = nodeId?.trim()?.takeIf { NODE_ID.matches(it) } ?: return null
+    return "https://www.figma.com/design/$key?node-id=${node.replace(':', '-')}"
+  }
+
+  /** The figma.com file URL for [fileKey], or null when it is not a key. */
+  fun fileUrl(fileKey: String?): String? {
+    val key = fileKey?.trim()?.takeIf { FILE_KEY.matches(it) } ?: return null
+    return "https://www.figma.com/design/$key"
+  }
+
+  /**
+   * Whether [value] is an ISO-8601 instant we can both sort and display. Deliberately a shape check
+   * rather than a full parse: the feed is sorted as text (ISO-8601 sorts chronologically) and
+   * displayed through the same `prettyDate` the provenance strip uses, so anything that matches is
+   * safe on both paths and anything that doesn't has nowhere sensible to go.
+   */
+  private fun isTimestamp(value: String?): Boolean =
+    value != null &&
+      Regex("""^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?""").containsMatchIn(value.trim())
+
+  private fun clamp(value: String, max: Int): String =
+    if (value.length <= max) value else value.take(max - 1).trimEnd() + "…"
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParityFindings.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParityFindings.kt
@@ -1,0 +1,553 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.io.SystemFileSystem
+import java.io.File
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.decodeFromJsonElement
+import okio.FileSystem
+import okio.Path.Companion.toOkioPath
+import okio.Path.Companion.toPath
+
+/**
+ * The parity **verdict** behind a comparison — what a parity run concluded about a render and its
+ * design reference, in the categories a designer asks about: accessibility and i18n, token
+ * compliance, layout drift, and whether the two frames were comparable at all.
+ *
+ * ## Why this is a third manifest and not a field on the other two
+ *
+ * The compare page already transports two producer-authored artifacts, and this is deliberately
+ * neither of them:
+ *
+ * - [DesignReference] carries how far apart the two pictures are — one number, scored off pixels.
+ *   It says a comparison is 64% matched and cannot say why.
+ * - [DesignAnnotation] carries what each side *is* — the padding, the type style — anchored to a
+ *   region. It describes one panel at a time and asserts nothing about the pair.
+ *
+ * A finding is the sentence between them: a claim about the PAIR, with a severity, that a reader
+ * acts on. "spacing.padding: 24 vs spec 12" is not derivable from either manifest — the annotation
+ * layer reports both numbers without knowing which one the spec asserts, and the score reports a
+ * percentage that a padding change and a colour change move identically.
+ *
+ * ## Anchors are bounds, not labels
+ *
+ * design-parity's own HTML report ties a layout finding back to a node by matching its LABEL
+ * against the semantics tree, which works there because the report renders the tree it matched
+ * against, in the same process, moments later. Here the two are separated by a publish, a branch
+ * and a server: the render can be re-rendered, the reference re-exported, and a label ("Label
+ * text") is neither unique nor stable. So a finding names its regions in the same pixel space
+ * [DesignAnnotation.bounds] uses — the annotated image's own — and the page draws them with the
+ * placement code it already has. A finding with no anchors is still a finding; it simply reads as
+ * prose rather than lighting up a box.
+ *
+ * ## Scoped to a reference, when the producer knows which
+ *
+ * A preview may carry several references (a component's `ideal` and `layout` boards, a variant
+ * set), and the compare page shows exactly one at a time. A flat list per preview would print the
+ * `ideal` board's token drift under the `layout` board's panels, which is a wrong claim rather than
+ * a missing one. [ParityFindingSet.referenceId] scopes a set; an absent one applies to every
+ * reference, which is the correct reading for a check that describes the render alone (a touch
+ * target, a contrast ratio) and the only shape a producer with one reference per preview has to
+ * think about.
+ *
+ * Fail-soft throughout, like [ServeAnnotationStore] and [ServeDesignReferenceStore]: a parity
+ * verdict is an enhancement over a comparison that already works, and a producer bug in it must
+ * cost the reader the panel it describes, never the comparison.
+ */
+@Serializable
+data class ParityFindings(
+  val schema: String = SCHEMA,
+  val generatedAt: String? = null,
+  /** Finding sets over a preview's rendered frame, keyed by exact serve/catalog preview id. */
+  val previews: Map<String, List<ParityFindingSet>> = emptyMap(),
+) {
+  companion object {
+    const val SCHEMA = "compose-preview-parity-findings/v1"
+    const val DIRECTORY = "parity"
+    const val FILE = "findings.json"
+  }
+}
+
+/** One run's conclusion about one (preview, reference) pair. */
+@Serializable
+data class ParityFindingSet(
+  /** The [DesignReference.id] this verdict compared against; null ⇒ it applies to any of them. */
+  val referenceId: String? = null,
+  /** `pass` / `warn` / `fail`, as the run concluded. Unknown values are dropped, not defaulted. */
+  val status: String? = null,
+  /** Where the producing run's own report lives, when it published one. */
+  val reportUrl: String? = null,
+  val findings: List<ParityFinding> = emptyList(),
+)
+
+/** One observation, in the diff engine's own vocabulary. */
+@Serializable
+data class ParityFinding(
+  /**
+   * One of [ParityFindingKind.KNOWN]. An unknown kind is dropped rather than shown uncategorised.
+   */
+  val kind: String,
+  /** One of [ParityFindingSeverity.KNOWN]. */
+  val severity: String,
+  /** Human-readable, one line — the sentence the reader acts on. */
+  val message: String,
+  /**
+   * Structured payload behind the sentence. Rendered as a delta row when it carries
+   * `expected`/`actual`, and as the finding's title otherwise, so a producer's extra keys are
+   * transported rather than dropped.
+   */
+  val detail: Map<String, String> = emptyMap(),
+  /** Where on the two panels this finding is. Empty ⇒ the finding reads as prose. */
+  val anchors: List<ParityAnchor> = emptyList(),
+)
+
+/** A region of one panel a finding points at, in that panel image's own pixel space. */
+@Serializable
+data class ParityAnchor(
+  /** `reference` or `actual`; anything else is dropped. */
+  val side: String,
+  val bounds: AnnotationBounds,
+  /** Optional caption for the highlight, e.g. the node the finding is about. */
+  val label: String? = null,
+)
+
+/**
+ * The categories a finding can be about, mirroring `@design-parity/core`'s `FindingKind`.
+ *
+ * Kept as strings rather than an enum because this is a wire type read from a file a different
+ * repository writes: an enum would make a kind this build has not heard of a DECODE failure for the
+ * whole record, and the point of the fail-soft posture is that a newer producer costs this reader
+ * only the rows it cannot place.
+ */
+object ParityFindingKind {
+  const val A11Y = "a11y"
+  const val I18N = "i18n"
+  const val CONTRAST = "contrast"
+  const val TOKEN = "token"
+  const val LAYOUT = "layout"
+  const val SEMANTIC = "semantic"
+  const val VISUAL = "visual"
+  const val PAIRING = "pairing"
+
+  val KNOWN = setOf(A11Y, I18N, CONTRAST, TOKEN, LAYOUT, SEMANTIC, VISUAL, PAIRING)
+}
+
+object ParityFindingSeverity {
+  const val INFO = "info"
+  const val WARN = "warn"
+  const val ERROR = "error"
+
+  val KNOWN = setOf(INFO, WARN, ERROR)
+
+  /** Worst-first, so a group leads with the row that decides its status. */
+  fun rank(value: String): Int =
+    when (value) {
+      ERROR -> 0
+      WARN -> 1
+      else -> 2
+    }
+}
+
+/**
+ * The groups the compare page prints, in the order it prints them.
+ *
+ * Ordered by what a reader can act on, which is design-parity's own reporting order (Principle 2:
+ * a11y and i18n first, then tokens, then pixels) rather than by severity: a `warn` that a label
+ * will truncate in German is a bug in the component, while an `error` on 35% of pixels differing is
+ * usually the two frames being different sizes.
+ */
+enum class ParityFindingGroup(val id: String, val title: String, val kinds: Set<String>) {
+  ACCESSIBILITY(
+    "a11y",
+    "Accessibility & i18n",
+    setOf(ParityFindingKind.A11Y, ParityFindingKind.I18N, ParityFindingKind.CONTRAST),
+  ),
+  TOKENS("tokens", "Token compliance", setOf(ParityFindingKind.TOKEN)),
+  LAYOUT("layout", "Layout", setOf(ParityFindingKind.LAYOUT, ParityFindingKind.SEMANTIC)),
+  PAIRING("pairing", "Pairing", setOf(ParityFindingKind.PAIRING)),
+  VISUAL("visual", "Visual", setOf(ParityFindingKind.VISUAL));
+
+  companion object {
+    fun of(kind: String): ParityFindingGroup? = entries.firstOrNull { kind in it.kinds }
+  }
+}
+
+/**
+ * The compare page's client payload: every anchored finding's regions, keyed by the id the
+ * server-rendered row carries.
+ *
+ * Only the ANCHORS ride here. The findings themselves are rendered into the page as HTML, because
+ * they are prose a reader needs with or without script — a parity verdict that only appears once a
+ * bundle has downloaded and upgraded is one the reader cannot cite, quote or find with the
+ * browser's own search. The geometry is the half that is useless without script, so it is the half
+ * that travels as data.
+ */
+@Serializable
+data class ParityAnchorPayload(val findings: Map<String, List<ParityAnchor>> = emptyMap())
+
+private val PARITY_FINDINGS_JSON = Json { encodeDefaults = false }
+
+/**
+ * Encode for embedding in a `<script type="application/json">` block, exactly as
+ * [encodeAnnotationPayload] does and for the same reason: entities are not decoded inside a script
+ * element, so HTML-escaping would reach `JSON.parse` verbatim and throw, while an unescaped
+ * `</script>` inside a label would end the block early.
+ */
+fun encodeParityAnchorPayload(payload: ParityAnchorPayload): String =
+  PARITY_FINDINGS_JSON.encodeToString(payload).replace("<", "\\u003c")
+
+/**
+ * Validated, read-only view of a bundle/catalog's `parity/findings.json`.
+ *
+ * Every record is decoded ONE AT A TIME, through raw [JsonElement]s, for the reason
+ * [ServeDesignReferenceStore] does the same: decoding the whole document in one call makes any
+ * single malformed record — a finding with no `message`, a number where a detail string belongs, a
+ * `bounds` missing a field — throw while parsing the envelope, and the whole catalog's verdict goes
+ * dark on every page. That is the opposite of the per-record salvage this class promises, and the
+ * validation below never gets to run.
+ *
+ * Every cap exists because this file is authored by another repository and rendered into a page: an
+ * unbounded finding list is a page nobody can scroll, and an unbounded message is a layout break
+ * rather than information. The per-preview aggregates are the ones that bind — nested ceilings
+ * multiply, so twenty sets of two hundred findings is four thousand rows and a browser that stops
+ * responding while the anchors are placed.
+ */
+class ServeParityFindingStore
+private constructor(private val byPreview: Map<String, List<ParityFindingSet>>) {
+
+  val isEmpty: Boolean = byPreview.isEmpty()
+
+  /** Every set published for [previewId], scoped and unscoped alike. */
+  fun forPreview(previewId: String): List<ParityFindingSet> = byPreview[previewId].orEmpty()
+
+  /**
+   * The sets that describe the comparison on screen: those naming [referenceId], plus the unscoped
+   * ones that describe the render whichever reference it is being read against.
+   *
+   * The page budgets are spent HERE, not at load, because they describe a page and only this
+   * selection is one. Reference-scoped sets are mutually exclusive on screen — a preview with three
+   * boards shows one of them at a time — so charging them against a shared allowance let the first
+   * two exhaust it and left the third comparison with no verdict at all, for a page that was never
+   * going to render the other two.
+   */
+  fun forComparison(previewId: String, referenceId: String): List<ParityFindingSet> =
+    spendPageBudget(
+      forPreview(previewId).filter { it.referenceId == null || it.referenceId == referenceId }
+    )
+
+  companion object {
+    private const val MAX_PREVIEWS = 5000
+    private const val MAX_SETS_PER_PREVIEW = 20
+    private const val MAX_FINDINGS_PER_SET = 200
+
+    /**
+     * What ONE comparison may put on a page, across every set it shows.
+     *
+     * The per-set ceiling alone is not a limit on anything a reader meets: the page renders every
+     * set for a preview at once, so twenty of them is twenty times whatever that ceiling says. This
+     * is the number that describes the page — beyond it a verdict has stopped being something
+     * anyone reads and become something that has to be scrolled past.
+     */
+    private const val MAX_FINDINGS_PER_PREVIEW = 300
+    private const val MAX_ANCHORS_PER_FINDING = 40
+
+    /**
+     * And what one comparison may DRAW, which is the tighter constraint of the two.
+     *
+     * A finding row is a few hundred bytes of HTML; an anchor is an element the client creates,
+     * positions on every reflow, and repositions on every resize. The page stays readable long
+     * after it has stopped being responsive, so the boxes get their own budget rather than riding
+     * the row count.
+     */
+    private const val MAX_ANCHORS_PER_PREVIEW = 600
+
+    /**
+     * What one preview may KEEP, across every reference it publishes a verdict for.
+     *
+     * A second budget, because it bounds a different thing. The page allowance above has to be
+     * spent at READ time — reference-scoped sets are mutually exclusive on screen, so charging them
+     * against one allowance at load blanks boards a page was never going to show together — and
+     * that leaves the store itself unbounded. The store is not free: it is held in memory by
+     * `ServeBundleHost` and reserialized into the staging tree by `ServeCatalogStore`, so the
+     * nested ceilings alone let one preview keep four thousand findings and a hundred and sixty
+     * thousand anchors no page can ever reach.
+     *
+     * Deliberately far above the page budget: several boards' worth of a real verdict passes
+     * untouched, since which of them a reader asks for is not known here. This bounds disk and
+     * heap, not what anyone reads.
+     */
+    private const val MAX_STORED_FINDINGS_PER_PREVIEW = 1000
+    private const val MAX_STORED_ANCHORS_PER_PREVIEW = 2000
+    private const val MAX_DETAIL_KEYS = 24
+    private const val MAX_MESSAGE = 400
+
+    /** An anchor caption names an element; anything longer is not a name. */
+    private const val MAX_LABEL = 120
+    private const val MAX_DETAIL_VALUE = 200
+    private val STATUSES = setOf("pass", "warn", "fail")
+    private val ID = Regex("[^\\p{Cc}]{1,300}")
+    private val JSON = Json { ignoreUnknownKeys = true }
+
+    /** Empty store — a catalog that publishes no parity verdict at all. */
+    val EMPTY = ServeParityFindingStore(emptyMap())
+
+    /**
+     * The document as read from disk, with its records left as raw JSON.
+     *
+     * [ParityFindings] is the schema producers write against; this is what a fail-soft READER
+     * needs. Raw at EVERY level, because a producer can be wrong at any of them and the blast
+     * radius has to stop at the record that is wrong: a preview whose value is not a list must not
+     * cost the catalog its other previews, a malformed SET must not cost the preview its other
+     * sets, a malformed FINDING must not cost the set, and a malformed ANCHOR must not cost the
+     * finding its sentence. Typing `previews` as `Map<String, List<JsonElement>>` looks tolerant
+     * and is not — one entry holding a string throws while the map is decoded, which is the whole
+     * document again.
+     */
+    @Serializable
+    private data class RawManifest(
+      val schema: String = ParityFindings.SCHEMA,
+      val previews: Map<String, JsonElement> = emptyMap(),
+    )
+
+    @Serializable
+    private data class RawSet(
+      val referenceId: JsonElement? = null,
+      val status: String? = null,
+      val reportUrl: String? = null,
+      val findings: List<JsonElement> = emptyList(),
+    )
+
+    @Serializable
+    private data class RawFinding(
+      val kind: String = "",
+      val severity: String = "",
+      val message: String = "",
+      /**
+       * Values as raw JSON, then coerced. A producer that emits `"expected": 16` rather than `"16"`
+       * is writing the same fact; refusing it would drop the delta row over a type the wire format
+       * never needed to be strict about.
+       */
+      val detail: Map<String, JsonElement> = emptyMap(),
+      val anchors: List<JsonElement> = emptyList(),
+    )
+
+    fun load(
+      bundleDir: File,
+      fileSystem: FileSystem = SystemFileSystem,
+    ): ServeParityFindingStore {
+      val path =
+        bundleDir.toOkioPath() / ParityFindings.DIRECTORY.toPath() / ParityFindings.FILE.toPath()
+      val text =
+        runCatching {
+          if (!fileSystem.exists(path)) return@runCatching null
+          fileSystem.read(path) { readUtf8() }
+        }
+          .getOrNull() ?: return EMPTY
+      val document = sanitizeDocument(text) ?: return EMPTY
+      return ServeParityFindingStore(document.previews)
+    }
+
+    /**
+     * Parse and validate a manifest, returning the cleaned document or null when nothing survives.
+     *
+     * Shared with [ServeCatalogStore]'s staging path so a published catalog is validated by the
+     * very code that will later read it: staging writes what this returns, not what the branch
+     * said, and a manifest that could not survive the reader never reaches the staged tree at all.
+     */
+    fun sanitizeDocument(text: String): ParityFindings? {
+      val raw = runCatching { JSON.decodeFromString<RawManifest>(text) }.getOrNull() ?: return null
+      if (raw.schema != ParityFindings.SCHEMA) return null
+      val previews =
+        raw.previews.entries
+          .asSequence()
+          .filter { (previewId, _) -> ID.matches(previewId) }
+          .take(MAX_PREVIEWS)
+          .mapNotNull { (previewId, value) ->
+            val sets = value as? JsonArray ?: return@mapNotNull null
+            sanitizePreview(sets)?.let { previewId to it }
+          }
+          .toMap()
+      if (previews.isEmpty()) return null
+      return ParityFindings(previews = previews)
+    }
+
+    /**
+     * One preview's sets, each validated on its own. The page budgets are spent in [forComparison],
+     * which is the only place that knows what one page will show.
+     */
+    private fun sanitizePreview(sets: JsonArray): List<ParityFindingSet>? {
+      val kept =
+        sets
+          .take(MAX_SETS_PER_PREVIEW)
+          .mapNotNull { element ->
+            runCatching { JSON.decodeFromJsonElement<RawSet>(element) }.getOrNull()
+          }
+          .mapNotNull(::sanitizeSet)
+      return spendBudget(kept, MAX_STORED_FINDINGS_PER_PREVIEW, MAX_STORED_ANCHORS_PER_PREVIEW)
+        .takeIf { it.isNotEmpty() }
+    }
+
+    private fun sanitizeSet(raw: RawSet): ParityFindingSet? {
+      // A supplied id that does not validate is NOT the same as an absent one, and treating it as
+      // one is the worst reading available: `forComparison` takes null as "describes the render
+      // whichever reference it is read against", so a producer's malformed scope would print this
+      // verdict under every other reference's panels — a plausible, wrong claim rather than a
+      // missing one. Absent stays unscoped; present-and-broken drops the set.
+      val referenceId =
+        when (val supplied = raw.referenceId) {
+          null,
+          JsonNull -> null
+          else -> {
+            val text = (supplied as? JsonPrimitive)?.takeIf { it.isString }?.content?.trim()
+            if (text == null || !ID.matches(text)) return null
+            text
+          }
+        }
+      val findings =
+        raw.findings
+          .take(MAX_FINDINGS_PER_SET)
+          .mapNotNull { element ->
+            runCatching { JSON.decodeFromJsonElement<RawFinding>(element) }.getOrNull()
+          }
+          .mapNotNull(::sanitizeFinding)
+          .sortedBy { ParityFindingSeverity.rank(it.severity) }
+      val status = raw.status?.trim()?.lowercase()?.takeIf(STATUSES::contains)
+      // A set with no findings is KEPT when it declares a status, and it is not an empty record: a
+      // run that looked and found nothing is a different fact from a catalog nobody ran, and only
+      // the first can say "Pass". Dropping it made the two indistinguishable on the page. With
+      // neither findings nor a status there is nothing to say, and the set goes.
+      // …but only when the producer's array was ALSO empty. A set whose findings were all
+      // rejected here — a message this reader could not use, a kind it does not know — has a
+      // report behind it that this build cannot show, and printing "Pass · No findings." over it
+      // would turn a manifest we failed to read into a reassuring clean verdict. That is the one
+      // direction this panel must never fail in: silence says "unknown", a green chip says
+      // "checked".
+      if (findings.isEmpty() && (status == null || raw.findings.isNotEmpty())) return null
+      return ParityFindingSet(
+        referenceId = referenceId,
+        status = status,
+        // Only an absolute https link, and only as a link: this string is written by another
+        // repository and lands in an `href`, so a `javascript:` or a protocol-relative host would
+        // be a stored redirect out of the catalog on a page the reader trusts.
+        reportUrl =
+          raw.reportUrl?.trim()?.takeIf { it.startsWith("https://") && it.length <= 2000 },
+        findings = findings,
+      )
+    }
+
+    private fun sanitizeFinding(raw: RawFinding): ParityFinding? {
+      val kind =
+        raw.kind.trim().lowercase().takeIf(ParityFindingKind.KNOWN::contains) ?: return null
+      val severity =
+        raw.severity.trim().lowercase().takeIf(ParityFindingSeverity.KNOWN::contains) ?: return null
+      val message =
+        raw.message.trim().takeIf { it.isNotEmpty() }?.let { clamp(it, MAX_MESSAGE) } ?: return null
+      return ParityFinding(
+        kind = kind,
+        severity = severity,
+        message = message,
+        detail =
+          raw.detail.entries
+            .asSequence()
+            .filter { (key, _) -> key.isNotBlank() && key.length <= 80 }
+            .mapNotNull { (key, value) -> detailValue(value)?.let { key.trim() to it } }
+            .take(MAX_DETAIL_KEYS)
+            .toMap(),
+        anchors =
+          raw.anchors
+            .take(MAX_ANCHORS_PER_FINDING)
+            .mapNotNull { runCatching { JSON.decodeFromJsonElement<ParityAnchor>(it) }.getOrNull() }
+            .filter(::isUsable)
+            // Clamped like a message and a detail value, and for a sharper reason than either:
+            // this string is serialized into every comparison page AND drawn by the client as a
+            // `white-space: nowrap` caption, so an unbounded one is both a multi-megabyte response
+            // and a label wider than the screen it is meant to annotate.
+            .map { anchor ->
+              anchor.copy(
+                label =
+                  anchor.label?.trim()?.takeIf { it.isNotEmpty() }?.let { clamp(it, MAX_LABEL) }
+              )
+            },
+      )
+    }
+
+    /**
+     * A detail value as text, or null when it is not a value at all.
+     *
+     * Primitives are printed as written — a number stays `16`, not `16.0` — and an object or array
+     * is dropped rather than stringified: a hover card is a readout, and JSON in it is noise the
+     * reader cannot act on.
+     */
+    private fun detailValue(value: JsonElement): String? {
+      val primitive = value as? JsonPrimitive ?: return null
+      if (primitive is JsonNull) return null
+      return clamp(primitive.content.trim(), MAX_DETAIL_VALUE).takeIf { it.isNotEmpty() }
+    }
+
+    /**
+     * Hold one comparison's sets to what a page can show and draw, worst-severity-first.
+     *
+     * Trimmed rather than dropped: the budget is spent in the order the producer wrote, and a
+     * verdict past it has already said far more than a reader will get through. Findings are
+     * severity-ordered within a set before this runs, so what survives is the worst of what was
+     * published rather than whatever happened to be written first.
+     */
+    private fun spendPageBudget(sets: List<ParityFindingSet>): List<ParityFindingSet> =
+      spendBudget(sets, MAX_FINDINGS_PER_PREVIEW, MAX_ANCHORS_PER_PREVIEW)
+
+    /** Hold a list of sets to a finding and anchor allowance, worst-severity-first. */
+    private fun spendBudget(
+      sets: List<ParityFindingSet>,
+      maxFindings: Int,
+      maxAnchors: Int,
+    ): List<ParityFindingSet> {
+      var findingsLeft = maxFindings
+      var anchorsLeft = maxAnchors
+      // Nothing to spend against: the common shape, and worth not rebuilding every set for.
+      if (
+        sets.sumOf { it.findings.size } <= findingsLeft &&
+          sets.sumOf { set -> set.findings.sumOf { it.anchors.size } } <= anchorsLeft
+      ) {
+        return sets
+      }
+      return sets.mapNotNull { set ->
+        val findings =
+          set.findings.take(findingsLeft.coerceAtLeast(0)).map { finding ->
+            val room = anchorsLeft.coerceAtLeast(0)
+            anchorsLeft -= finding.anchors.size.coerceAtMost(room)
+            if (finding.anchors.size <= room) finding
+            else finding.copy(anchors = finding.anchors.take(room))
+          }
+        findingsLeft -= findings.size
+        // A set this budget emptied is DROPPED, never trimmed to a status-only record. It reached
+        // here carrying findings, so its "Pass" would be printed over a report that exists and
+        // that this build then discarded — the same false-clean verdict a rejected findings array
+        // produces, arriving one level up. Only a set the producer wrote empty may say "Pass" with
+        // nothing under it, and such a set is empty before this runs rather than because of it.
+        if (findings.isEmpty() && set.findings.isNotEmpty()) null else set.copy(findings = findings)
+      }
+    }
+
+    /**
+     * A box with no area cannot be drawn and a negative origin paints outside the panel — the same
+     * rule [ServeAnnotationStore] applies, for the same reason: both indicate a producer bug rather
+     * than something to render badly.
+     */
+    private fun isUsable(anchor: ParityAnchor): Boolean =
+      (anchor.side == SIDE_REFERENCE || anchor.side == SIDE_ACTUAL) &&
+        anchor.bounds.width > 0 &&
+        anchor.bounds.height > 0 &&
+        anchor.bounds.x >= 0 &&
+        anchor.bounds.y >= 0
+
+    const val SIDE_REFERENCE = "reference"
+    const val SIDE_ACTUAL = "actual"
+
+    private fun clamp(value: String, max: Int): String =
+      if (value.length <= max) value else value.take(max - 1) + "…"
+  }
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParityIssues.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParityIssues.kt
@@ -1,0 +1,113 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.io.SystemFileSystem
+import java.io.File
+import java.time.Instant
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path.Companion.toOkioPath
+import okio.Path.Companion.toPath
+
+/** Source-compatible names for the wire types now owned by compose-preview-contracts. */
+typealias ParityIssues = ee.schimke.composeai.parityissues.protocol.ParityIssues
+
+typealias ParityIssue = ee.schimke.composeai.parityissues.protocol.ParityIssue
+
+/** Fail-soft trust boundary for `parity/issues.json`. */
+object ServeParityIssuesStore {
+  const val MAX_ISSUES = 2000
+  private const val MAX_TEXT = 300
+  private val REPOSITORY = Regex("[A-Za-z0-9_.-]{1,100}/[A-Za-z0-9_.-]{1,100}")
+  private val ID = Regex("[^\\p{Cc}]{1,300}")
+  private val AREAS = setOf("spec", "component", "preview", "renderer", "comparison")
+  /**
+   * The `parity:` vocabulary this index accepts, kept in step with `parity-issues.mjs`'s own set —
+   * a value only one end knows is a classification the round trip drops without saying so.
+   * `upstream` and `catalog` are the two answers the report form's "Where does it belong?" control
+   * offers beside the `verification-needed` it already had.
+   */
+  private val PARITY =
+    setOf("regression", "known-difference", "verification-needed", "upstream", "catalog")
+  private val JSON = Json { ignoreUnknownKeys = true }
+
+  fun load(bundleDir: File, fileSystem: FileSystem = SystemFileSystem): ParityIssues? {
+    val path = bundleDir.toOkioPath() / ParityIssues.DIRECTORY.toPath() / ParityIssues.FILE
+    val raw =
+      runCatching {
+        if (!fileSystem.exists(path)) return@runCatching null
+        JSON.decodeFromString<ParityIssues>(fileSystem.read(path) { readUtf8() })
+      }
+        .getOrNull() ?: return null
+    return sanitize(raw)
+  }
+
+  fun sanitize(raw: ParityIssues): ParityIssues? {
+    if (raw.schema != ParityIssues.SCHEMA || raw.issues.size > MAX_ISSUES) return null
+    val generatedAt = raw.generatedAt?.trim()?.takeIf(::isTimestamp)
+    // Identity is repository + number + **component**, not repository + number. One issue may name
+    // several components — an umbrella report covering three Elevated stickers files one issue and
+    // the producer emits a row each — and deduping by issue alone collapsed those to an arbitrary
+    // one of them at load time, so the report reached one component page and silently missed the
+    // rest. Two rows that agree on all three are still a duplicate and still collapse.
+    val issues =
+      raw.issues.mapNotNull(::sanitizeIssue).distinctBy {
+        Triple(it.repository, it.number, it.component)
+      }
+    if (issues.isEmpty()) return null
+    return ParityIssues(generatedAt = generatedAt, issues = issues)
+  }
+
+  private fun sanitizeIssue(raw: ParityIssue): ParityIssue? {
+    val repository = raw.repository.trim().lowercase().takeIf(REPOSITORY::matches) ?: return null
+    if (raw.number < 1) return null
+    val expected = "https://github.com/$repository/issues/${raw.number}"
+    val claimed = canonicalIssueUrl(raw.url) ?: return null
+    if (claimed != expected) return null
+    val state =
+      raw.state.trim().lowercase().takeIf { it == "open" || it == "closed" } ?: return null
+    val title =
+      raw.title.trim().takeIf { it.isNotEmpty() }?.let { clamp(it, MAX_TEXT) } ?: return null
+    val scope =
+      raw.scope.trim().lowercase().takeIf { it == "component" || it == "variant" } ?: return null
+    return ParityIssue(
+      repository = repository,
+      number = raw.number,
+      title = title,
+      url = expected,
+      state = state,
+      area = raw.area?.removePrefix("area:")?.lowercase()?.takeIf(AREAS::contains),
+      parity = raw.parity?.removePrefix("parity:")?.lowercase()?.takeIf(PARITY::contains),
+      system = raw.system.cleanId(),
+      component = raw.component.cleanId(),
+      scope = scope,
+      previewIds = raw.previewIds.mapNotNull { it.cleanId() }.distinct().take(100),
+      referenceIds = raw.referenceIds.mapNotNull { it.cleanId() }.distinct().take(100),
+      acceptanceId = raw.acceptanceId.cleanId(),
+    )
+  }
+
+  private fun String?.cleanId(): String? =
+    this?.trim()?.takeIf { ID.matches(it) }?.let { clamp(it, MAX_TEXT) }
+
+  private fun canonicalIssueUrl(value: String): String? {
+    val match =
+      Regex(
+          "https://(?:www\\.)?github\\.com/([^/]+)/([^/]+)/issues/([0-9]+)/?",
+          RegexOption.IGNORE_CASE,
+        )
+        .matchEntire(value.trim()) ?: return null
+    val repository = "${match.groupValues[1]}/${match.groupValues[2]}".lowercase()
+    if (!REPOSITORY.matches(repository)) return null
+    val number = match.groupValues[3].toIntOrNull()?.takeIf { it > 0 } ?: return null
+    return "https://github.com/$repository/issues/$number"
+  }
+
+  private fun isTimestamp(value: String): Boolean = runCatching {
+    Instant.parse(value)
+    true
+  }
+    .getOrDefault(false)
+
+  private fun clamp(value: String, max: Int): String =
+    if (value.length <= max) value else value.take(max - 1) + "…"
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRcCompare.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRcCompare.kt
@@ -1,0 +1,485 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.io.SystemFileSystem
+import java.io.File
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toOkioPath
+
+/**
+ * The **published** Remote Compose player comparison, served from a catalog's delivery branch.
+ *
+ * The offline `rc-compare` pipeline (`scripts/design-artifacts/rc-compare.mjs`) already renders
+ * every `ir/<id>.rc` document through every player it can reach — the vendored TypeScript
+ * `RC.RcdPlayer`, AndroidX's Compose-embedded `RcPlayer`, the Compose Desktop / Skiko player, the
+ * CMP/Wasm player — pixel-diffs each against the baked render, and publishes the lot beside the
+ * catalog: one PNG per lane per preview plus `rc-compare-summary.json`. That is the same data
+ * `rc-compare.html` is built from.
+ *
+ * The serve page reuses it rather than re-deriving it. Rendering a document in the visitor's
+ * browser is the slow path (one `.rc` fetch + a canvas render per preview, and only for the one
+ * player that runs in a browser); replaying the published renders is a handful of `<img>` loads and
+ * shows **every** player, with the build-time `pixelmatch` numbers already computed.
+ *
+ * ## Shape
+ *
+ * [RcCompareManifest] is what [ServeCatalogStore] stages into `<catalog>/rc-compare/index.json`
+ * after fetching the lane PNGs, and what [ServeWeb] inlines into the compare page for the client
+ * script. It is **catalog-keyed**: the published summary keys rows by the daemon preview id
+ * (`…CatalogPreviewsKt.AppCardRemote_width_320dp…`), the served routes by the catalog id
+ * (`appcard__ideal__default__compact`), so staging re-keys through the catalog's alias exactly like
+ * [ServeCatalogStore.extractCatalogRcDocs] does for the documents themselves.
+ *
+ * Staged image names are `<lane-id>/<slot>.png` — a fixed lane vocabulary and an integer slot, so
+ * no published id ever reaches the filesystem or a URL and there is nothing to escape. Slots are
+ * per *daemon* id, so two catalog ids sharing a source preview share one set of files.
+ */
+@Serializable
+data class RcCompareManifest(
+  val schema: String = SCHEMA,
+  /**
+   * The pixelmatch threshold the build-time diffs used, carried so the client-side player↔player
+   * diff (which nothing precomputed can answer) scores on the same scale.
+   */
+  val threshold: Double = DEFAULT_THRESHOLD,
+  /** The player columns this catalog actually has, in display order. `baked` is always first. */
+  val lanes: List<RcCompareLane> = emptyList(),
+  val rows: List<RcCompareRow> = emptyList(),
+) {
+  companion object {
+    const val SCHEMA = "compose-preview-rc-compare/v1"
+    const val DEFAULT_THRESHOLD = 0.1
+  }
+}
+
+/** One player column. [short] is the compact label used on the per-row score chips. */
+@Serializable data class RcCompareLane(val id: String, val label: String, val short: String)
+
+/** One preview's row: the published renders keyed by lane id. */
+@Serializable
+data class RcCompareRow(
+  /** Served catalog preview id — the same id `/p/<id>` and `/render/<id>.png` use. */
+  val previewId: String,
+  val width: Int = 0,
+  val height: Int = 0,
+  /**
+   * The baked render carries no opaque pixel at all, so it is no reference: a player that also drew
+   * nothing would score a perfect 0%. Such a row is shown but reads `no reference` whenever the
+   * baked lane is the selected reference (two *player* renders still compare normally).
+   */
+  val referenceBlank: Boolean = false,
+  val lanes: Map<String, RcCompareCell> = emptyMap(),
+)
+
+/** One lane's published result for one preview. */
+@Serializable
+data class RcCompareCell(
+  val rendered: Boolean = false,
+  /**
+   * Staged image name (`<lane>/<slot>.png`), served under `/<system>/rc-compare/`. Empty ⇒ none.
+   */
+  val render: String = "",
+  /** The build-time pixel diff against the baked render. Empty for that lane itself. */
+  val diff: String = "",
+  /** Build-time mismatch against the baked render. Null when unrendered or unscorable. */
+  val mismatchPct: Double? = null,
+  val mismatchPx: Long? = null,
+  /** Why this lane has no render, when it doesn't (the player's own reason). */
+  val note: String = "",
+)
+
+/**
+ * A player lane as it exists **on the delivery branch**: which directories hold its renders and its
+ * build-time diffs, and how to read its fields out of a published summary row.
+ *
+ * This mirrors `render-rc-compare-html.mjs`'s `LANES` — the same columns in the same order, so the
+ * serve page and the published `rc-compare.html` show the same thing. `baked` is not a player (it
+ * is the reference everything was scored against) but it is a first-class column and a first-class
+ * reference choice, so it lives in the same list.
+ */
+// Public with `ServeRcCompare` above, which exposes `LANES: List<RcLaneSource>`: `internal` is
+// module-scoped and the `:server` call sites moved out of this module.
+data class RcLaneSource(
+  val id: String,
+  val label: String,
+  val short: String,
+  /** Branch dir holding this lane's renders. */
+  val renderDir: String,
+  /** Branch dir holding its build-time diff against the baked render; null for that lane. */
+  val diffDir: String?,
+  /** Whether this lane ran at all for a given row — null ⇒ the lane was not part of the run. */
+  val rendered: (RcSummaryRow) -> Boolean?,
+  val mismatchPct: (RcSummaryRow) -> Double?,
+  val mismatchPx: (RcSummaryRow) -> Long?,
+  val note: (RcSummaryRow) -> String?,
+)
+
+// Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
+// and the `:server` call sites are in a different module now. Not a widened API by intent.
+object ServeRcCompare {
+  /** Staged subdir under the served catalog root, and the URL segment it is served at. */
+  const val DIRECTORY = "rc-compare"
+  const val INDEX_FILE = "index.json"
+
+  /**
+   * The manifest a catalog with nothing to show writes anyway — no lanes, no rows.
+   *
+   * It is the *settled* marker: it says the background lane ran and this catalog has no published
+   * comparison, which is a different state from "the lane hasn't finished yet". Only the second one
+   * makes the compare page's shape provisional, and only that one must stay out of caches.
+   */
+  val NONE = RcCompareManifest()
+
+  /**
+   * Whether the staging lane runs for a session whose catalog-id → daemon-id bridge is [alias].
+   *
+   * The whole view is re-keyed through that bridge, so a catalog with an empty one publishes
+   * nothing and the lane is never scheduled. Two callers must agree on this — the scheduler, which
+   * would otherwise do a pointless fetch, and the host, whose "still pending" answer is only
+   * meaningful when a lane is actually coming — so they share this one expression rather than each
+   * spelling it out.
+   */
+  fun stagesFor(alias: Map<String, String>): Boolean = alias.isNotEmpty()
+
+  /** The published summary, branch-relative — the source this whole view is derived from. */
+  const val SUMMARY_FILE = "rc-compare-summary.json"
+
+  val LANES: List<RcLaneSource> =
+    listOf(
+      RcLaneSource(
+        id = "baked",
+        // The catalog's own capture, rendered offline under Robolectric/Skiko. Named for the
+        // player rather than for the file it arrives as: "baked PNG" said how it got here, not
+        // what drew it, which is the only thing a reader comparing it against four other players
+        // cares about.
+        // That player is now the embedded `RcPlayer`: `RemoteOverridablePreview` defaults to
+        // `RemoteComposePlayerKind.EMBEDDED`, so a capture goes through it unless the preview pins
+        // the view-backed lane with `RemoteViewPreviewWrapper`. [ServeHost.bakedRcPlayer] is where
+        // that question is now asked, and a bundle answers it from its `previews.json` pin — but
+        // `rc-compare-summary.json` still records no per-row renderer, and a published catalog's
+        // inline `previewParams` does not carry the wrapper either. So a *catalog* whose previews
+        // mix the two is still mislabelled in this column rather than detected: carry the player
+        // per row into the published catalog before scoring such a catalog.
+        label = "AndroidX Embedded · baked",
+        short = "baked",
+        renderDir = "rc-baked",
+        diffDir = null,
+        // The driver writes a baked copy for every row it processes, rendered or not.
+        rendered = { true },
+        mismatchPct = { null },
+        mismatchPx = { null },
+        note = { null },
+      ),
+      RcLaneSource(
+        id = "js",
+        label = "RC · JS player",
+        short = "js",
+        renderDir = "rc",
+        diffDir = "rc-diff",
+        rendered = { it.rendered },
+        mismatchPct = { it.mismatchPct },
+        mismatchPx = { it.mismatchPx },
+        note = { it.note },
+      ),
+      RcLaneSource(
+        id = "embedded",
+        label = "AndroidX Embedded · vendored Android",
+        short = "vendored",
+        renderDir = "rc-embedded",
+        diffDir = "rc-embedded-diff",
+        rendered = { it.embeddedRendered },
+        mismatchPct = { it.embeddedMismatchPct },
+        mismatchPx = { it.embeddedMismatchPx },
+        note = { it.embeddedNote },
+      ),
+      RcLaneSource(
+        id = "androidx-embedded",
+        label = "AndroidX Embedded · androidx.dev",
+        short = "androidx.dev",
+        renderDir = "rc-androidx-embedded",
+        diffDir = "rc-androidx-embedded-diff",
+        rendered = { it.androidxEmbeddedRendered },
+        mismatchPct = { it.androidxEmbeddedMismatchPct },
+        mismatchPx = { it.androidxEmbeddedMismatchPx },
+        note = { it.androidxEmbeddedNote },
+      ),
+      RcLaneSource(
+        id = "cmp-jvm",
+        label = "RC · cmp-jvm player",
+        short = "cmp-jvm",
+        renderDir = "rc-embedded-jvm",
+        diffDir = "rc-embedded-jvm-diff",
+        rendered = { it.embeddedJvmRendered },
+        mismatchPct = { it.embeddedJvmMismatchPct },
+        mismatchPx = { it.embeddedJvmMismatchPx },
+        note = { it.embeddedJvmNote },
+      ),
+      RcLaneSource(
+        id = "cmp-wasm",
+        label = "RC · cmp-wasm player",
+        short = "cmp-wasm",
+        renderDir = "rc-cmp-wasm",
+        diffDir = "rc-cmp-wasm-diff",
+        rendered = { it.cmpWasmRendered },
+        mismatchPct = { it.cmpWasmMismatchPct },
+        mismatchPx = { it.cmpWasmMismatchPx },
+        note = { it.cmpWasmNote },
+      ),
+    )
+
+  /** Lane ids, for validating a served image path against the fixed vocabulary. */
+  private val LANE_IDS = LANES.map { it.id }.toSet()
+
+  private val JSON = Json { ignoreUnknownKeys = true }
+
+  /**
+   * The row model the compare page's client script diffs over, inlined as `application/json`.
+   *
+   * Keeping it as data — rather than having the script scrape the DOM — is what lets the client
+   * pick the *build-time* diff whenever the selected reference is the baked lane (exact
+   * `pixelmatch` numbers, zero work) and fall back to a canvas diff only for the player↔player
+   * question nothing precomputed can answer.
+   */
+  @Serializable
+  data class ClientModel(
+    val threshold: Double,
+    val lanes: List<RcCompareLane>,
+    val rows: List<ClientRow>,
+  )
+
+  /** One row as the browser sees it: [RcCompareCell]s whose paths have been resolved to URLs. */
+  @Serializable
+  data class ClientRow(
+    val label: String,
+    val referenceBlank: Boolean,
+    val lanes: Map<String, RcCompareCell>,
+  )
+
+  private val MODEL_JSON = Json { encodeDefaults = true }
+
+  /** Encode a [ClientModel] for inlining — `<` escaped so a player note can't close the script. */
+  fun encodeClientModel(model: ClientModel): String =
+    MODEL_JSON.encodeToString(ClientModel.serializer(), model).replace("<", "\\u003c")
+
+  fun parseSummary(bytes: ByteArray): RcSummary? = runCatching {
+    JSON.decodeFromString<RcSummary>(bytes.decodeToString())
+  }
+    .getOrNull()
+    ?.takeIf { it.rows.isNotEmpty() }
+
+  /**
+   * Turn a published summary + the catalog's `catalog-id → daemon-id` alias into the manifest to
+   * stage and the branch assets to fetch for it. Pure, so the re-keying and the lane arithmetic are
+   * testable without a network or a filesystem.
+   *
+   * Only lanes that actually ran are kept: a catalog whose run had no cmp-wasm player simply has no
+   * cmp-wasm column, rather than a column of empty cells. Only *rendered* cells plan a fetch, so a
+   * player that choked on a document costs no round-trip — its note is shown in place of the image.
+   *
+   * Returns null when nothing published matches this catalog, which is the common case (most
+   * systems ship no `ir/<id>.rc` at all).
+   */
+  fun plan(summary: RcSummary, alias: Map<String, String>): RcComparePlan? {
+    val byDaemonId = summary.rows.associateBy { it.id }
+    val matched = alias.mapNotNull { (catalogId, daemonId) ->
+      byDaemonId[daemonId]?.let { catalogId to it }
+    }
+    if (matched.isEmpty()) return null
+
+    // A lane is present when the run recorded a verdict for it on any row — the same test
+    // `render-rc-compare-html.mjs` applies before it emits the column.
+    val lanes = LANES.filter { lane -> matched.any { (_, row) -> lane.rendered(row) != null } }
+    val slots = LinkedHashMap<String, Int>()
+    val assets = LinkedHashMap<String, String>()
+
+    fun stage(dir: String, daemonId: String, laneId: String, suffix: String, slot: Int): String {
+      val staged = "$laneId$suffix/$slot.png"
+      assets["$dir/$daemonId.png"] = staged
+      return staged
+    }
+
+    val rows = matched.map { (catalogId, row) ->
+      val slot = slots.getOrPut(row.id) { slots.size }
+      val cells = LinkedHashMap<String, RcCompareCell>()
+      for (lane in lanes) {
+        val rendered = lane.rendered(row) == true
+        val scorable = !row.referenceBlank
+        cells[lane.id] =
+          RcCompareCell(
+            rendered = rendered,
+            render = if (rendered) stage(lane.renderDir, row.id, lane.id, "", slot) else "",
+            diff =
+              if (rendered && scorable && lane.diffDir != null)
+                stage(lane.diffDir, row.id, lane.id, "-diff", slot)
+              else "",
+            mismatchPct = if (scorable) lane.mismatchPct(row) else null,
+            mismatchPx = if (scorable) lane.mismatchPx(row) else null,
+            note = lane.note(row).orEmpty(),
+          )
+      }
+      RcCompareRow(
+        previewId = catalogId,
+        width = row.width ?: 0,
+        height = row.height ?: 0,
+        referenceBlank = row.referenceBlank,
+        lanes = cells,
+      )
+    }
+
+    return RcComparePlan(
+      manifest =
+        RcCompareManifest(
+          threshold = summary.threshold ?: RcCompareManifest.DEFAULT_THRESHOLD,
+          lanes = lanes.map { RcCompareLane(it.id, it.label, it.short) },
+          rows = rows,
+        ),
+      assets = assets,
+    )
+  }
+
+  /**
+   * Narrow a planned manifest to the images that actually landed. A lane whose render didn't arrive
+   * reads as unrendered with a plain reason rather than a broken `<img>`; a lane that rendered but
+   * lost its diff simply has no diff, and the page falls back to diffing it in the browser.
+   *
+   * Returns null when nothing survived — there is no page worth publishing then, and the absent
+   * manifest is what makes the compare page keep its client-rendered lane.
+   */
+  fun retainStaged(manifest: RcCompareManifest, staged: Set<String>): RcCompareManifest? {
+    val rows =
+      manifest.rows.map { row ->
+        row.copy(
+          lanes =
+            row.lanes.mapValues { (_, cell) ->
+              val render = cell.render.takeIf { it in staged }.orEmpty()
+              cell.copy(
+                rendered = cell.rendered && render.isNotEmpty(),
+                render = render,
+                diff = cell.diff.takeIf { render.isNotEmpty() && it in staged }.orEmpty(),
+                note =
+                  if (cell.rendered && render.isEmpty()) "render was not published" else cell.note,
+              )
+            }
+        )
+      }
+    if (rows.none { row -> row.lanes.values.any { it.render.isNotEmpty() } }) return null
+    return manifest.copy(rows = rows)
+  }
+
+  /**
+   * Whether [name] is a staged image this catalog could have written —
+   * `<known-lane>[-diff]/<n>.png` and nothing else. The fixed vocabulary is what keeps the route
+   * from being a file-read primitive: a request that isn't literally of this shape never reaches
+   * the filesystem.
+   */
+  fun isStagedImageName(name: String): Boolean {
+    val (dir, file) = name.split('/').takeIf { it.size == 2 } ?: return false
+    val lane = dir.removeSuffix("-diff")
+    if (lane !in LANE_IDS) return false
+    val slot = file.removeSuffix(".png")
+    return file.endsWith(".png") && slot.isNotEmpty() && slot.all { it.isDigit() }
+  }
+}
+
+/** The manifest to stage plus the branch assets (`source path → staged name`) it references. */
+// Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
+// and the `:server` call sites are in a different module now. Not a widened API by intent.
+data class RcComparePlan(val manifest: RcCompareManifest, val assets: Map<String, String>)
+
+/**
+ * A published `rc-compare-summary.json`, cut down to the per-row verdicts the serve page replays.
+ * Extra fields (the coverage split, the cmp-wasm frame-pacing numbers, the CI gate) are ignored:
+ * they belong to the parity gate, not to a side-by-side viewer.
+ */
+@Serializable
+data class RcSummary(val threshold: Double? = null, val rows: List<RcSummaryRow> = emptyList())
+
+/** One preview as the offline run scored it, keyed by the **daemon** preview id. */
+@Serializable
+data class RcSummaryRow(
+  val id: String = "",
+  val width: Int? = null,
+  val height: Int? = null,
+  val referenceBlank: Boolean = false,
+  val rendered: Boolean? = null,
+  val mismatchPct: Double? = null,
+  val mismatchPx: Long? = null,
+  val note: String? = null,
+  val embeddedRendered: Boolean? = null,
+  val embeddedMismatchPct: Double? = null,
+  val embeddedMismatchPx: Long? = null,
+  val embeddedNote: String? = null,
+  val androidxEmbeddedRendered: Boolean? = null,
+  val androidxEmbeddedMismatchPct: Double? = null,
+  val androidxEmbeddedMismatchPx: Long? = null,
+  val androidxEmbeddedNote: String? = null,
+  val embeddedJvmRendered: Boolean? = null,
+  val embeddedJvmMismatchPct: Double? = null,
+  val embeddedJvmMismatchPx: Long? = null,
+  val embeddedJvmNote: String? = null,
+  val cmpWasmRendered: Boolean? = null,
+  val cmpWasmMismatchPct: Double? = null,
+  val cmpWasmMismatchPx: Long? = null,
+  val cmpWasmNote: String? = null,
+)
+
+/**
+ * Read-only view of a staged `rc-compare/index.json` + its images.
+ *
+ * Loaded **lazily and re-checked while absent**, unlike the reference/annotation manifests: the
+ * lane PNGs are fetched on the catalog's background lane (they are an enrichment, not the catalog),
+ * so a host built the moment `catalog.json` landed would otherwise cache "no rc-compare" forever
+ * and only pick the page up on the next refresh. Once a manifest has been read it is kept — a
+ * published comparison is a snapshot, and a refresh rebuilds the host anyway.
+ */
+class ServeRcCompareStore
+private constructor(private val root: Path, private val fileSystem: FileSystem) {
+
+  @Volatile private var settled: RcCompareManifest? = null
+
+  fun manifest(): RcCompareManifest? = read()?.takeIf { it.rows.isNotEmpty() }
+
+  /**
+   * True while the background staging lane has yet to write anything — so this catalog's compare
+   * page is showing a shape that may still change.
+   *
+   * The page is assembled from published metadata and is normally short-cached at the edge, which
+   * would pin the pre-manifest shape in place for minutes after the lanes landed. A pending
+   * catalog's page is served uncacheable instead; once the lane settles (with a comparison or with
+   * [ServeRcCompare.NONE]) the page is stable and caches like every other one.
+   */
+  fun pending(): Boolean = read() == null
+
+  private fun read(): RcCompareManifest? {
+    settled?.let {
+      return it
+    }
+    val path = root / ServeRcCompare.DIRECTORY / ServeRcCompare.INDEX_FILE
+    val manifest =
+      runCatching {
+        if (!fileSystem.exists(path)) return null
+        JSON.decodeFromString<RcCompareManifest>(fileSystem.read(path) { readUtf8() })
+      }
+        .getOrNull()
+        ?.takeIf { it.schema == RcCompareManifest.SCHEMA } ?: return null
+    settled = manifest
+    return manifest
+  }
+
+  /** Bytes for a staged lane image, or null for anything this catalog didn't stage. */
+  fun image(name: String): ByteArray? {
+    if (!ServeRcCompare.isStagedImageName(name)) return null
+    val path = root / ServeRcCompare.DIRECTORY / name
+    if (!fileSystem.exists(path)) return null
+    return runCatching { fileSystem.read(path) { readByteArray() } }.getOrNull()
+  }
+
+  companion object {
+    private val JSON = Json { ignoreUnknownKeys = true }
+
+    fun load(bundleDir: File, fileSystem: FileSystem = SystemFileSystem): ServeRcCompareStore =
+      ServeRcCompareStore(bundleDir.toOkioPath(), fileSystem)
+  }
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -1,0 +1,2043 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.devices.DeviceDimensions
+import ee.schimke.composeai.daemon.devices.frameDpOverriddenBy
+import ee.schimke.composeai.daemon.protocol.DataFetchParams
+import ee.schimke.composeai.daemon.protocol.ExtensionsEnableResult
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.StreamCodec
+import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+import ee.schimke.composeai.data.layoutinspector.ComposeFigmaSvgProduct
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsProduct
+import ee.schimke.composeai.data.layoutinspector.LayoutInspectorPayload
+import ee.schimke.composeai.data.layoutinspector.LayoutInspectorProduct
+import ee.schimke.composeai.data.layoutinspector.PreviewSlots
+import ee.schimke.composeai.data.layoutinspector.PreviewSlotsPayload
+import ee.schimke.composeai.data.theme.Material3ThemeProduct
+import ee.schimke.composeai.data.theme.ThemePayload
+import ee.schimke.composeai.io.SystemFileSystem
+import ee.schimke.composeai.render.session.RenderSession
+import ee.schimke.composeai.render.session.RenderSessionConfig
+import ee.schimke.composeai.render.session.RenderSessionException
+import ee.schimke.composeai.render.session.RenderSessionFactory
+import ee.schimke.composeai.render.session.subprocess.SubprocessRenderSessions
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+/**
+ * A live daemon-backed frame stream. Forward input into the held composition via [input]; [close]
+ * tears the stream down. Obtained from [ServeRenderHost.startStream].
+ */
+interface StreamHandle : AutoCloseable {
+  fun input(
+    kind: InteractiveInputKind,
+    pixelX: Int? = null,
+    pixelY: Int? = null,
+    pointerId: Int? = null,
+    scrollDeltaY: Float? = null,
+    keyCode: String? = null,
+    /** The character a `keyDown` typed, when it produced one (issue #3491). */
+    text: String? = null,
+    /** `"mouse"` / `"touch"` / `"pen"`; absent means touch (issue #3491). */
+    pointerType: String? = null,
+  )
+
+  /**
+   * Tell the daemon whether this watcher is still looking at the stream (tab visible, card in
+   * viewport). A hidden watcher keeps its held session warm but the daemon drops to [fps] (default
+   * 1) for both the emit gate *and* the render loop behind it, and repaints from a keyframe as soon
+   *    as visibility comes back.
+   *
+   * Default no-op so a handle from a backend without the notification (an older daemon, a test
+   * double) degrades to "always visible" rather than failing the socket.
+   */
+  fun visibility(visible: Boolean, fps: Int? = null) = Unit
+}
+
+/** One servable preview: its id, a human label, and which delivery modes it supports. */
+/**
+ * One animated capture a preview can offer instead of its still.
+ *
+ * Motion answers a question a screenshot cannot: whether a component's own interaction plumbing
+ * actually drives its transition, and how that transition is shaped. It is also not what most
+ * readers came for — so the viewer surfaces this as a control beside the still rather than playing
+ * it by default, and a preview carrying none is presented exactly as it was before.
+ */
+data class ServeMotion(
+  /** The route the bytes are served under (`/motion/<id><extension>`). */
+  val id: String,
+  /** `"interaction"` (a scripted gesture) or `"animation"` (a self-running animation). */
+  val kind: String? = null,
+  /**
+   * The caption the annotation declared — which property the reader is being shown. Without it a
+   * capture tells someone only that *something* moved, so the viewer shows it alongside.
+   */
+  val caption: String? = null,
+  /** `.apng` or `.gif`. Not interchangeable: an APNG typed as a GIF renders one frame and stops. */
+  val extension: String = ".apng",
+)
+
+/**
+ * One production-composable value parameter published with a catalog component. [type] is the
+ * producer's short Kotlin rendering (`Dp`, `RowScope.() -> Unit`, …), intended for display rather
+ * than source generation. [composableSlot] distinguishes content slots from ordinary callbacks and
+ * values; [hasDefault] tells the reader which API surface is optional.
+ */
+@Serializable
+data class ServeComponentParameter(
+  val name: String,
+  val type: String,
+  val hasDefault: Boolean = false,
+  val composableSlot: Boolean = false,
+)
+
+data class ServePreview(
+  val id: String,
+  val label: String,
+  /** Delivery transports available for this preview. Tier 1 is always [PreviewMode.SNAPSHOT]. */
+  val modes: List<PreviewMode> = listOf(PreviewMode.SNAPSHOT),
+  /** Data products declared for this preview in `previews.json`. */
+  val dataProductKinds: Set<String> = emptySet(),
+  /**
+   * The author-declared editable knobs this preview exposed via `previewOverride*` (the
+   * `compose/overrides` payload). Populated from a bundle's `previews/<id>.overrides.json` sidecar
+   * so the viewer can present editable controls (label / list length / per-item indexed values).
+   * Empty when the preview declared none (or the host doesn't carry them).
+   */
+  val overrides: List<ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration> = emptyList(),
+  /**
+   * The Remote Compose named-value knobs this preview declared during its render (the
+   * `compose/remotecompose` editable surface). Populated from a bundle's
+   * `previews/<id>.remotecompose.json` sidecar so the viewer can present a control per knob (text
+   * field / colour swatch / slider) whose edits round-trip through the `rc.<name>=…` serve
+   * override. Empty when the preview binds no named values through the declaring
+   * `rememberOverridableRemote*` wrappers (or the host doesn't carry them). Distinct from
+   * [overrides], which is the plain-Compose `previewOverride*` surface.
+   */
+  val remoteComposeKnobs:
+    List<ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration> =
+    emptyList(),
+  /**
+   * Whether this preview supports **keyboard focus** — it carries `@FocusedPreview` (discovery
+   * emits a `focus` capture). Lets the viewer offer a "Keyboard focus" control *only* for previews
+   * that actually have something focusable, rather than as a dead control everywhere. Applied live
+   * via the `focus` override (daemon-only); the desktop daemon honours it.
+   */
+  val supportsFocus: Boolean = false,
+  /**
+   * Whether this preview supports **one-handed (wear) gestures** — it carries `@GestureHintPreview`
+   * (discovery emits a `gestureHint` capture). Surfaced for detection, but the gesture *override*
+   * is Android-only (the desktop daemon behind `serve` ignores `overrides.gestures`), so the viewer
+   * gates the control to Android-backed sessions.
+   */
+  val supportsGestures: Boolean = false,
+  /**
+   * Whether this preview's **subject is a theme** — it carries `@FixedTheme`, or discovery
+   * synthesised it from a `@ThemeCatalog` / `@WearThemeCatalog`. Re-rendering such a card under a
+   * `themeProvider` override destroys the very thing it documents, so the landing keeps its baked
+   * pixels for the theme axis (the same "no themed base" path a card with no daemon twin takes).
+   *
+   * The catalog-wide counterpart is [section] == `"Themes"`, which speaks for a whole tab; this is
+   * the per-preview signal for a specimen that lives outside such a tab.
+   */
+  val fixedTheme: Boolean = false,
+  /**
+   * Whether this render is a **second-tier** variant cell: it renders, it keeps its own URL and its
+   * design-kit pairing, but it is not listed in the component's variant tree or in the viewer's
+   * subtree. From `@OverrideVariant(secondary = true)` by way of `previews/variants.json`.
+   *
+   * The tree has always had two tiers — `state` and `props` in it, theme / breakpoint / font scale
+   * / locale out of it, because those are a different rendering of one thing rather than a
+   * different thing to look at. This lets a state cell say the same about itself, which is what a
+   * catalog that draws a kit set exhaustively needs: 90 cells of one progress indicator are 90 real
+   * comparisons and one menu nobody can read.
+   */
+  val secondary: Boolean = false,
+  /**
+   * The baked component **state** this preview render represents — `"unchecked"`, `"pressed"`,
+   * `"disabled"`, `"unselected"`, … — or `null`/`"default"` for the default render (and for plain
+   * bundles / app screens that carry no state). Carried from the catalog's `previews/variants.json`
+   * manifest so the grid can fold non-default states into one card and the viewer can offer a state
+   * switcher. Null keeps the current behaviour everywhere.
+   */
+  val state: String? = null,
+  /**
+   * The baked **theme** this preview render represents — `"light"`/`"dark"` — or `null` when the
+   * render is unthemed (or a plain bundle). Also from `previews/variants.json`; used to scope the
+   * viewer's state switcher to same-theme siblings.
+   */
+  val theme: String? = null,
+  /**
+   * The i18n / content / a11y **variant axis** this render represents — `{"locale":"ar-XB"}`,
+   * `{"direction":"rtl"}`, `{"fontScale":"2.0"}`, `{"content":"icon+label"}`, … — or `null`/empty
+   * for the component's default render. From the catalog's `previews/variants.json`; lets the grid
+   * fold these variants onto the component's one card (like [state], rather than a tile each) and
+   * the viewer offer a variant switcher. Null keeps the current behaviour everywhere.
+   */
+  val props: JsonObject? = null,
+  /**
+   * The declared **breakpoint** this render was captured at — `"192dp"`, `"compact"`,
+   * `"smallRound"`, … — from the catalog's `previews/variants.json`, which carries the `size` name
+   * the spec's `breakpoints` table declares. Null when the catalog declares no breakpoints (or for
+   * a plain bundle), which is every catalog that had no size axis before.
+   *
+   * A size is a different *rendering* of one component rather than a different component, so the
+   * grid folds the non-primary sizes onto that component's one card — the same treatment [state]
+   * and [props] get — and the viewer offers them as a size switcher. Without this the axis is
+   * invisible to the server: five breakpoints publish five identically-named cards, which is what a
+   * five-size Wear catalog actually did (wear-m3-catalog#41).
+   */
+  val size: String? = null,
+  /**
+   * The top-level **section** (tab) this preview belongs to — `"Themes"`, `"Components"`,
+   * `"Screens"`, `"Animations"`, … — from the catalog's `previews/variants.json`. Drives the
+   * landing page's tab bar: a catalog whose previews carry sections renders tabbed, one tab per
+   * distinct section, with [group] as a sub-heading inside a tab. Null for a plain (untabbed)
+   * catalog / uploaded bundle, which stays a flat grid.
+   */
+  val section: String? = null,
+  /**
+   * The sub-heading **group** within a [section] (e.g. `"Foundation"`, `"Contacts"`), from
+   * `previews/variants.json`. Rendered as a labelled sub-group inside its section's tab panel. Null
+   * ⇒ the section's cards are ungrouped.
+   */
+  val group: String? = null,
+  /**
+   * The preview's position in the catalog's **authored** component order, from
+   * `previews/variants.json`. [ServeBundleHost] lists previews sorted by id, so the landing uses
+   * this to order tabs, sub-groups, and cards by authoring intent (Themes before Components before
+   * Screens, …) rather than alphabetically. Null for a plain bundle (no ordering metadata).
+   */
+  val catalogOrder: Int? = null,
+  /**
+   * Module-relative source path of the file this preview was authored in
+   * (`src/main/kotlin/…/Foo.kt`), from the bundle's `previews.json` manifest
+   * ([ee.schimke.composeai.previewdata.PreviewInfo.sourceFile]). Lets the viewer link the preview
+   * to its source on GitHub when the session carries delivery provenance (repo + branch). Null for
+   * a bundle without a manifest, a preview whose manifest entry recorded no source path, or a
+   * live/local session with no published source to point at.
+   */
+  val sourceFile: String? = null,
+  /**
+   * Gradle project path that owns [sourceFile]. Repository-wide catalogs set this per preview;
+   * older single-module catalogs use their catalog-wide source module instead.
+   */
+  val sourceModule: String? = null,
+  /**
+   * A 1-based line inside this preview's function body within [sourceFile], from the bundle's
+   * `previews.json` ([ee.schimke.composeai.previewdata.PreviewInfo.bodyLine]).
+   *
+   * Lets the playground handoff seed the editor with the one declaration that was clicked rather
+   * than the whole file it shares with its group — a section file is one *group*, so opening
+   * `Button/Filled` otherwise hands over four other components too. Null for a bundle without a
+   * manifest, or one produced before discovery recorded it; the seed is then whole-file, as it
+   * always was.
+   */
+  val bodyLine: Int? = null,
+  /** Discovery-time `@Preview(uiMode=…)`; used to identify the baked Day/Night default. */
+  val uiMode: Int = 0,
+  /**
+   * Discovery-time `@Preview(showBackground = …)` / `@Preview(backgroundColor = …)`.
+   *
+   * Carried for one reason: they are the two rungs where the *preview itself* states the ground it
+   * wants, and without them a page can only infer one from the catalog's stage or from a variant
+   * name — which is how a catalog full of `showBackground = false` stickers and one deliberately
+   * white specimen ended up presented identically. Fed to `PreviewBackdrop`; see [ServeWeb]'s
+   * backdrop resolution. Both default to the annotation's own defaults, so a host with no
+   * `previews.json` behind it (a plain uploaded bundle) simply contributes no opinion and the
+   * catalog stage answers, exactly as before.
+   */
+  val showBackground: Boolean = false,
+  /** See [showBackground]. `0` means unset — the annotation's own default. */
+  val backgroundColor: Long = 0L,
+  /**
+   * The catalog's original component identifier (`SessionDetails`, `Button/Filled`, …). Unlike
+   * [id], this retains word boundaries and casing after the image path is flattened into a
+   * route-safe slug. Null for ordinary uploaded bundles and live discovery previews.
+   */
+  val componentId: String? = null,
+  /**
+   * The one-line description the catalog authored for this preview's component — what it is FOR, in
+   * the design system's own words (`@CatalogComponent(caption = …)`). Surfaced by the viewer under
+   * the component's name and as the component drawer's tooltip, so a reader who does not already
+   * know what "Button Loading" means can find out without opening the source. Null for a catalog
+   * that authors none, and for a plain uploaded bundle.
+   */
+  val caption: String? = null,
+  /** Published render failure for a catalog card that has no PNG. */
+  val renderFailure: CatalogRenderFailure? = null,
+  /**
+   * Animated captures published for this preview. Empty for the overwhelming majority — a still is
+   * the whole artifact for most components — so a viewer treats this as opt-in extra surface and
+   * never as a replacement for the baked pixels.
+   *
+   * Last in the parameter list deliberately: several callers construct a [ServePreview]
+   * positionally, so a new field anywhere earlier silently rebinds their arguments.
+   */
+  val motion: List<ServeMotion> = emptyList(),
+  /**
+   * The device frame this preview renders into, when it names one — the raw material for the
+   * device-frame clip. Null for the ordinary case: a preview with no `device =` renders into a
+   * plain rectangle and every pixel of it is screen.
+   *
+   * Also last in the parameter list, for the reason [motion] is.
+   */
+  val deviceFrame: ServeDeviceFrame? = null,
+  /**
+   * Whether this preview carries a portable `scene.json` plus panel textures for the browser's
+   * spatial/WebXR viewer. Last for positional-call compatibility; see [motion].
+   */
+  val spatial: Boolean = false,
+  /**
+   * The production composable's ordered value parameters, recovered by compose-ai-tools discovery
+   * and published on the catalog component. Empty for plain bundles and older catalogs. Last for
+   * positional-call compatibility; see [motion].
+   */
+  val componentParameters: List<ServeComponentParameter> = emptyList(),
+)
+
+/**
+ * What a preview's `@Preview(device = …)` resolves to, reduced to what a clip needs.
+ *
+ * Resolved once here rather than carried as the raw device string, because working out whether a
+ * device is round is a real lookup — a catalog id, a `spec:` term, a `parent=` that supplies the
+ * shape it doesn't restate — and every surface that re-derived it from a name would get the
+ * `parent=` case wrong.
+ */
+@Serializable
+data class ServeDeviceFrame(
+  val widthDp: Double? = null,
+  val heightDp: Double? = null,
+  val isRound: Boolean = false,
+) {
+  companion object {
+
+    /**
+     * The frame for a preview's `@Preview` params, or null when it names no device.
+     *
+     * Dimensions go through [frameDpOverriddenBy], which is the repo's one answer to "do the
+     * annotation's dp displace the device catalog?" — **both axes or neither**, because that is
+     * what the renderer that produced the PNG did, and Studio ignores a single-axis hint on a
+     * device frame too. Deciding it per axis here would put a 120×227 clip over a 227×227 render
+     * and crop live screen, and the helper exists precisely so the places making this call cannot
+     * drift apart on it.
+     *
+     * **Roundness always comes from the device string**, separately, and that split is not
+     * cosmetic: [DeviceDimensions.resolve] returns early with `isRound = false` the moment it is
+     * handed explicit dimensions, so asking it for both at once reports every sized Wear preview as
+     * square, which is exactly the whole set this feature is for.
+     */
+    fun from(device: String?, widthDp: Int?, heightDp: Int?): ServeDeviceFrame? {
+      val named = device?.takeIf { it.isNotBlank() } ?: return null
+      val resolved = DeviceDimensions.resolve(named)
+      val (w, h) = resolved.frameDpOverriddenBy(widthDp, heightDp)
+      return ServeDeviceFrame(
+        widthDp = w.toDouble(),
+        heightDp = h.toDouble(),
+        isRound = resolved.isRound,
+      )
+    }
+  }
+}
+
+/** Structured, catalog-published render failure. Additive to `design-parity-catalog/v1`. */
+@Serializable
+data class CatalogRenderFailure(
+  val id: String = "",
+  val componentId: String? = null,
+  val preview: String? = null,
+  val phase: String = "render",
+  val errorClass: String = "RenderError",
+  val message: String = "",
+  val stackTrace: String? = null,
+  val topAppFrame: RenderFailureFrame? = null,
+  val mode: String? = null,
+  val state: String? = null,
+  val props: JsonObject? = null,
+  val section: String? = null,
+  val group: String? = null,
+  val sourceFile: String? = null,
+)
+
+@Serializable
+data class RenderFailureFrame(val file: String = "", val line: Int = 0, val function: String = "")
+
+/**
+ * Detected per-preview feature support, folded across a discovery
+ * [ee.schimke.composeai.previewdata.PreviewInfo]'s captures: keyboard focus (`@FocusedPreview` → a
+ * `focus`/`focusGif` capture) and one-handed gestures (`@GestureHintPreview` → a `gestureHint`
+ * capture). Returns the two booleans the viewer gates its feature controls on. A preview with
+ * neither annotation yields `(false, false)`.
+ */
+fun detectedFeaturesOf(
+  preview: ee.schimke.composeai.previewdata.PreviewInfo
+): Pair<Boolean, Boolean> {
+  val focus = preview.captures.any { it.focus != null || it.focusGif != null }
+  val gestures = preview.captures.any { it.gestureHint != null }
+  return focus to gestures
+}
+
+/**
+ * One app-declared `@ThemeCatalog` theme this session can render an arbitrary preview under — the
+ * discrete-theme counterpart of the built-in light/dark axis. Discovered as a module-global set (a
+ * theme applies to every preview, not one), so it hangs off [ServeHost.declaredThemes] rather than
+ * [ServePreview]. [providerFqn] is the `PreviewWrapperProvider` FQN sent verbatim as the
+ * `themeProvider` override; [name] is the human label; [group] buckets related themes (a brand).
+ */
+data class ServeTheme(
+  val name: String,
+  val providerFqn: String,
+  val group: String? = null,
+  /** Light/dark mode implied by this theme, when its name or provider is unambiguous. */
+  val mode: String? = inferredThemeMode(name, providerFqn),
+)
+
+internal fun inferredThemeMode(name: String, providerFqn: String): String? {
+  val words =
+    "$name $providerFqn"
+      .replace(Regex("([a-z])([A-Z])"), "$1 $2")
+      .split(Regex("[^A-Za-z]+"))
+      .map { it.lowercase() }
+      .toSet()
+  val light = "light" in words
+  val dark = "dark" in words
+  return when {
+    light && !dark -> "light"
+    dark && !light -> "dark"
+    else -> null
+  }
+}
+
+/**
+ * Extract the module's declared `@ThemeCatalog` / `@WearThemeCatalog` themes from a discovery
+ * manifest's preview list. Discovery materializes each annotated `PreviewWrapperProvider` as a
+ * synthetic `THEME_CATALOG` / `WEAR_THEME_CATALOG` preview carrying the provider FQN on
+ * `params.wrapperClassName` plus its `name` / `group`; this lifts those into [ServeTheme]s (the
+ * module-global theme options) without disturbing the ordinary preview cards. Both kinds feed the
+ * same switcher — the platform only decides which specimen *sheet* gets rendered, while applying a
+ * theme to some other preview is just `Wrap`, which is platform-agnostic. Entries missing a
+ * provider FQN are skipped (nothing to apply). Deduped by FQN.
+ */
+fun declaredThemesFromPreviews(
+  previews: List<ee.schimke.composeai.previewdata.PreviewInfo>
+): List<ServeTheme> =
+  previews
+    .filter { it.params.kind == "THEME_CATALOG" || it.params.kind == "WEAR_THEME_CATALOG" }
+    .mapNotNull { p ->
+      val fqn = p.params.wrapperClassName?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+      ServeTheme(
+        name = p.params.name?.takeIf { it.isNotBlank() } ?: p.functionName.ifBlank { p.id },
+        providerFqn = fqn,
+        group = p.params.group?.takeIf { it.isNotBlank() },
+        mode =
+          inferredThemeMode(
+            p.params.name?.takeIf { it.isNotBlank() } ?: p.functionName.ifBlank { p.id },
+            fqn,
+          ) ?: if (p.params.kind == "WEAR_THEME_CATALOG") "dark" else null,
+      )
+    }
+    .distinctBy { it.providerFqn }
+
+/** Result of a snapshot render request. */
+sealed interface RenderOutcome {
+  data class Ok(
+    val png: ByteArray,
+    /** How these bytes were produced, exposed on HTTP responses for remote diagnosis. */
+    val generation: Generation = Generation.DAEMON,
+  ) : RenderOutcome
+
+  enum class Generation(val wire: String) {
+    /** Read directly from a published bundle; no renderer was involved in this request. */
+    BAKED("baked"),
+    /** Reused from the catalog host's theme cache, which survives per-preview daemon eviction. */
+    CATALOG_CACHE("catalog-cache"),
+    /** Reused from the daemon host's in-memory override cache. */
+    DAEMON_CACHE("daemon-cache"),
+    /** Produced by a daemon render during this request. */
+    DAEMON("daemon"),
+    /**
+     * A **player's published render**, read off the catalog's `rc-compare` staging — the offline
+     * parity pipeline already drew every `ir/<id>.rc` document with every player, so a bare
+     * `?rcPlayer=<wire>` browse is answerable from published bytes exactly as an override-free
+     * browse is answerable from the baked PNG.
+     *
+     * Its own generation rather than [BAKED] because the two make different claims: BAKED means "no
+     * renderer was involved and the request's overrides are NOT reflected", which is what turns an
+     * override-bearing request into a refusal. These bytes *are* the requested player's output, so
+     * reporting them as baked would refuse the very request they answer.
+     */
+    RC_PUBLISHED("rc-published"),
+  }
+
+  /** No such preview id in this session's module. */
+  data object NotFound : RenderOutcome
+
+  /** The render was attempted but rejected / failed / timed out. [reason] is human-readable. */
+  data class Failed(val reason: String) : RenderOutcome
+
+  /**
+   * The per-daemon render lock was held by another in-flight render (a cold Android render can hold
+   * it for up to `renderTimeoutSeconds`, minutes on a public host), so this request **backed off**
+   * rather than block a shared HTTP render slot on that wait. NOT an error: the caller should serve
+   * the baked fallback immediately (or retry). See [ServeRenderHost.DAEMON_BUSY_WAIT_MS].
+   */
+  data object Busy : RenderOutcome
+}
+
+/** Result of a figma-svg render request — the SVG counterpart of [RenderOutcome]. */
+sealed interface SvgOutcome {
+  data class Ok(
+    val svg: ByteArray,
+    /**
+     * How these bytes were produced, exposed on HTTP responses for remote diagnosis — the same
+     * ladder [RenderOutcome.Ok] reports. [RenderOutcome.Generation.BAKED] means the vector was read
+     * from a published bundle with no renderer involved, which is what lets the HTTP layer notice
+     * that an override-bearing request was answered with pixels (well, paths) that ignore it.
+     */
+    val generation: RenderOutcome.Generation = RenderOutcome.Generation.DAEMON,
+  ) : SvgOutcome
+
+  /** No such preview id, or this host can't produce SVG (a static bundle has no daemon). */
+  data object NotFound : SvgOutcome
+
+  /** The render or SVG export was attempted but failed. [reason] is human-readable. */
+  data class Failed(val reason: String) : SvgOutcome
+}
+
+/**
+ * Result of a preview-slots request — the [PreviewSlotsPayload] JSON counterpart of
+ * [RenderOutcome].
+ */
+sealed interface SlotsOutcome {
+  data class Ok(val json: ByteArray) : SlotsOutcome
+
+  /** No such preview id, or this host can't extract slots (a static bundle has no daemon). */
+  data object NotFound : SlotsOutcome
+
+  /** The render or semantics fetch was attempted but failed. [reason] is human-readable. */
+  data class Failed(val reason: String) : SlotsOutcome
+}
+
+/**
+ * Result of a design-annotation request — the typography + theme inspection layers derived from a
+ * render's own `compose/semantics` tree ([ServeDesignAnnotations]).
+ */
+sealed interface AnnotationsOutcome {
+  data class Ok(val json: ByteArray) : AnnotationsOutcome
+
+  /** No such preview id, or this host has no daemon to capture a semantics tree. */
+  data object NotFound : AnnotationsOutcome
+
+  /** The render or semantics fetch was attempted but failed. [reason] is human-readable. */
+  data class Failed(val reason: String) : AnnotationsOutcome
+}
+
+/**
+ * Result of an accessibility-overlay request — the merged `a11y/hierarchy` + `a11y/atf` +
+ * `a11y/touchTargets` JSON the viewer draws its overlay boxes and legend from.
+ */
+sealed interface A11yOutcome {
+  data class Ok(val json: ByteArray) : A11yOutcome
+
+  /** No such preview id, or this host has no daemon to produce a11y data products. */
+  data object NotFound : A11yOutcome
+
+  /** The a11y re-render / fetch was attempted but failed. [reason] is human-readable. */
+  data class Failed(val reason: String) : A11yOutcome
+}
+
+/**
+ * Long-lived, thread-safe wrapper around **one** [RenderSession], fronting it for the
+ * `compose-preview serve` HTTP server. The long-lived sibling of
+ * [ee.schimke.composeai.cli.MatrixRenderFetcher]: same `renderNow` + await-`renderFinished` +
+ * read-PNG sequence, but the session is held for the server's lifetime and shared across all
+ * connected clients.
+ *
+ * ## Multi-client + serialisation
+ *
+ * The host holds **no per-client state** — any number of browsers can hit it concurrently. The
+ * daemon renders one-at-a-time per session and [RenderSession] is not promised thread-safe, so all
+ * renders funnel through one [renderLock]; a [cache] keyed by `(previewId, overrides)` means
+ * identical concurrent requests coalesce to a single render and every later request is a cache hit.
+ *
+ * ## Preview switching
+ *
+ * Bound to a module, not a single preview: [previews] is the whole servable set and [render] takes
+ * any id in it, so switching previews is just a different request — no session churn.
+ */
+class ServeRenderHost
+internal constructor(
+  /**
+   * Opens the daemon session — called **once, on first use**, not at construction.
+   *
+   * Spawning here rather than in [Companion.open] is what keeps a registered catalog from costing a
+   * JVM nobody asked for. Every catalog registers its live host at startup and again on each
+   * republish, so an eager spawn meant ~18 daemons resident on the public box with zero active
+   * streams and the live-seat budget reading fully free. Everything the browse surface needs
+   * ([previews], [label], [declaredThemes]) comes from the module manifest via the constructor, so
+   * a visitor can browse a catalog end-to-end without waking anything; the first request that
+   * genuinely needs the daemon forces it.
+   */
+  openSession: () -> RenderSession,
+  override val previews: List<ServePreview>,
+  /** Human label for this tenant (e.g. the module's Gradle path); shown in the served pages. */
+  override val label: String = "",
+  /** App-declared `@ThemeCatalog` themes discovered for this module (module-global). */
+  override val declaredThemes: List<ServeTheme> = emptyList(),
+  private val fileSystem: FileSystem = SystemFileSystem,
+  private val onLog: (String) -> Unit = {},
+  private val renderTimeoutSeconds: Long = RENDER_TIMEOUT_SECONDS,
+  private val frameRenderTimeoutSeconds: Long = FRAME_RENDER_TIMEOUT_SECONDS,
+  /**
+   * True when the caller handed over a session that is already open, so there is a live subprocess
+   * from the moment this host exists even though [sessionDelegate] has not been touched. Only the
+   * deferred [Companion.open] path leaves this false.
+   */
+  private val sessionAlreadyOpen: Boolean = false,
+  /**
+   * One extra sentence appended to a **fatal** breaker trip, given the failure text — see
+   * [RenderCircuitBreaker]'s parameter of the same name. The [Companion.open] path supplies the
+   * daemon's own launch descriptor, so a Skia link error is answered with the Skiko pair that
+   * classpath resolves (#4220) rather than leaving the symbol name to speak for itself.
+   */
+  private val linkageDiagnosis: (String) -> String? = { null },
+) : ServeHost {
+
+  /**
+   * Wrap an already-open session. Nothing is deferred — the session exists — but the lazies below
+   * are shared with the deferred path, so their RPCs fire on first access rather than here.
+   */
+  // `public`, unlike the deferred primary constructor above: `:cli`'s `BundleRenderKnobTest` wraps
+  // a
+  // fake session to exercise `bundle render --knob` without a daemon subprocess, and `serve` is its
+  // own
+  // module now, so `internal` no longer reaches it. Wrapping a session the caller already owns is a
+  // reasonable thing to expose; spawning one is not, which is why only this half opens up.
+  public constructor(
+    session: RenderSession,
+    previews: List<ServePreview>,
+    label: String = "",
+    declaredThemes: List<ServeTheme> = emptyList(),
+    fileSystem: FileSystem = SystemFileSystem,
+    onLog: (String) -> Unit = {},
+    renderTimeoutSeconds: Long = RENDER_TIMEOUT_SECONDS,
+    frameRenderTimeoutSeconds: Long = FRAME_RENDER_TIMEOUT_SECONDS,
+  ) : this(
+    { session },
+    previews,
+    label,
+    declaredThemes,
+    fileSystem,
+    onLog,
+    renderTimeoutSeconds,
+    frameRenderTimeoutSeconds,
+    sessionAlreadyOpen = true,
+  )
+
+  /**
+   * Registered inside [sessionDelegate]'s initializer rather than as its own lazy, so it is always
+   * hooked up before any caller can issue a render — a `renderFinished` that arrived before the
+   * listener existed would strand that render waiting for an event already delivered.
+   */
+  private var notificationHandle: AutoCloseable? = null
+
+  /**
+   * Guards opening against [close]. Both take it, so a `close()` that lands while `openSession()`
+   * is still handshaking either waits for the session to be published and then tears it down, or
+   * lets the initializer below notice `closed` and tear it down itself. Without a shared lock the
+   * `isInitialized()` check in [close] reads false during the handshake, returns, and the
+   * subprocess that appears a moment later is never reaped — the exact race a catalog refresh runs
+   * into, since it closes the old host while requests may be waking it.
+   */
+  private val sessionLock = Any()
+
+  /**
+   * Set the instant [openSession] is entered, before the handshake completes.
+   *
+   * `Lazy.isInitialized()` stays false for the whole of a cold open — tens of seconds on an
+   * Android/Robolectric backend — even though the subprocess is already launched and consuming the
+   * box. Reporting "no daemon" across exactly that window would hide the single largest resource
+   * spike the lazy open is meant to make visible.
+   */
+  private val sessionOpening = AtomicBoolean(false)
+
+  private val sessionDelegate =
+    lazy(sessionLock) {
+      sessionOpening.set(true)
+      val opened = openSession()
+      if (closed.get()) {
+        // Lost the race: [close] already ran and found nothing to reap. Tear the subprocess down
+        // here instead of leaking it. The dead session is still published rather than thrown from,
+        // because callers that merely read a capability flag off a host being retired should not
+        // eat an exception for it — anything that goes on to actually use it gets the session's own
+        // closed-transport error, which is the honest answer.
+        runCatching { opened.close() }
+      } else {
+        notificationHandle = opened.onNotification(::onDaemonNotification)
+      }
+      opened
+    }
+
+  private val session: RenderSession by sessionDelegate
+
+  /**
+   * Whether the daemon subprocess has actually been started. Lets `/status` and [close] reason
+   * about a host that is registered but never woken, without waking it to find out.
+   */
+  /** One subprocess, once it exists. */
+  override val daemonProcessCount: Int
+    get() = if (daemonStarted) 1 else 0
+
+  override val daemonStarted: Boolean
+    get() = sessionAlreadyOpen || sessionOpening.get() || sessionDelegate.isInitialized()
+
+  // A daemon backs this host, so an override edit actually re-renders (unlike a static bundle).
+  override val canApplyOverrides: Boolean = true
+
+  // The daemon registers its export and inspection data products **inactive**, so fetching SVG,
+  // accessibility, semantics, or theme data before enabling their extensions fails with `-32020
+  // kind not advertised`. Enable them together once on open; gate
+  // `hasSvgExport` on whether the daemon actually has them (a backend without figma-svg reports
+  // them in `unknown`), so a non-figma backend cleanly offers no SVG rather than dead-ending in a
+  // 500. Best-effort: an enable RPC failure disables these optional surfaces, it doesn't break the
+  // host.
+  private val extensionEnableResult: ExtensionsEnableResult by lazy {
+    // Resolve the session OUTSIDE the runCatching. A failure to open the daemon is not the same
+    // fact as "this backend advertises no exports", but folding them together cached the latter
+    // forever: a transient open failure on the first capability lookup left `hasSvgExport` /
+    // `hasScrollExport` false for the host's lifetime, so every export 404'd even after a later
+    // render brought the daemon up fine. Letting it propagate leaves the lazy uninitialized, so the
+    // next caller retries.
+    val opened = session
+    runCatching {
+      opened.enableExtensions(
+        listOf(
+          ComposeFigmaSvgProduct.KIND,
+          ComposeFigmaSvgProduct.KIND_LONG,
+          SCROLL_EXTENSION_ID,
+          A11Y_EXTENSION_ID,
+          ComposeSemanticsProduct.KIND,
+          LayoutInspectorProduct.KIND,
+          THEME_EXTENSION_ID,
+        )
+      )
+    }
+      .getOrElse { e ->
+        onLog("export and inspection data unavailable: enable failed: ${e.message}")
+        ExtensionsEnableResult(
+          unknown =
+            listOf(
+              ComposeFigmaSvgProduct.KIND,
+              ComposeFigmaSvgProduct.KIND_LONG,
+              SCROLL_EXTENSION_ID,
+              A11Y_EXTENSION_ID,
+              ComposeSemanticsProduct.KIND,
+              LayoutInspectorProduct.KIND,
+              THEME_EXTENSION_ID,
+            )
+        )
+      }
+  }
+
+  override val hasSvgExport: Boolean by lazy {
+    ComposeFigmaSvgProduct.KIND !in extensionEnableResult.unknown
+  }
+
+  override val hasScrollExport: Boolean by lazy {
+    SCROLL_EXTENSION_ID !in extensionEnableResult.unknown &&
+      extensionEnableResult.dataProducts.any { it.kind == SCROLL_LONG_KIND }
+  }
+
+  // The a11y extension is registered inactive like the exports above, so it rides the same
+  // `extensions/enable` call. A backend that doesn't carry it reports it in `unknown`, which is
+  // what makes the viewer omit the Accessibility overlay control rather than offer one whose fetch
+  // would 500 on `kind not advertised`.
+  override val hasA11yOverlay: Boolean by lazy {
+    A11Y_EXTENSION_ID !in extensionEnableResult.unknown
+  }
+
+  override fun hasScrollExportFor(previewId: String): Boolean =
+    hasScrollExport &&
+      previews.firstOrNull { it.id == previewId }?.dataProductKinds?.contains(SCROLL_LONG_KIND) ==
+        true
+
+  /**
+   * Run the one-shot `extensions/enable` ([extensionEnableResult]) before any data-product fetch.
+   *
+   * The daemon registers its export and inspection products **inactive**, so a `data/fetch` that
+   * reaches a session nobody enabled fails `-32020 kind not advertised` — the enable is a
+   * precondition of every fetch lane, not a detail of the capability flags. Until this existed the
+   * only thing that ran it was a lane that happened to read a capability on the way past
+   * ([renderSvg] reads [hasSvgExport], [renderAnnotations] reads [THEME_EXTENSION_ID]);
+   * [renderA11y] and [renderScrollPng] read none, so on a host whose capabilities nobody ever asked
+   * for they fetched against an un-enabled session and 500'd.
+   *
+   * That host is not hypothetical: [ServeCatalogLiveHost] answers `hasA11yOverlayFor` from the
+   * SHARED daemon while routing `renderA11y` to the **per-preview** one, so the viewer offered the
+   * Accessibility layer on a catalog page whose fetch could only fail — until some unrelated
+   * request (an SVG export, a scroll capture) happened to enable that daemon's extensions, at which
+   * point the same URL started working. Hence the intermittency.
+   *
+   * Returns null on success, or the reason the daemon could not be opened at all. That open is
+   * deliberately outside [extensionEnableResult]'s own `runCatching` (so a transient failure leaves
+   * the lazy uninitialized and the next caller retries), which means it throws straight through the
+   * capability read. Every lane that forces the enable therefore has to turn it into its own
+   * failure outcome: these lanes used to reach the session only from inside a `try` that answered
+   * `Failed`, and an exception escaping instead would skip the route's 500-with-reason and its log
+   * line. Reporting it here keeps the retry — nothing was cached — while keeping the lane's
+   * contract.
+   */
+  private fun ensureExtensionsEnabled(): String? =
+    try {
+      extensionEnableResult
+      null
+    } catch (e: Exception) {
+      "inspection data unavailable: ${e.message}".also(onLog)
+    }
+
+  // The one-handed gesture override is honoured only by the Android (Robolectric) backend — the
+  // desktop backend ignores `overrides.gestures`. Read the daemon's advertised capabilities so the
+  // viewer offers the "Show gesture hints" control only when it would actually re-render.
+  override val gesturesRenderable: Boolean by lazy {
+    "gestures" in session.initializeResult.capabilities.supportedOverrides
+  }
+
+  // The Remote Compose `player` override (VIEW ⇄ EMBEDDED server-side player) is meaningful only on
+  // the Android backend, which is the only one carrying the Remote Compose runtime — the desktop
+  // backend has no runtime and ignores it. Read the daemon's declared backend so the viewer offers
+  // the server-side java / cmp-android backend chips only where they actually re-render.
+  override val remoteComposePlayerSelectable: Boolean by lazy {
+    session.initializeResult.capabilities.backend ==
+      ee.schimke.composeai.daemon.protocol.BackendKind.ANDROID
+  }
+
+  /**
+   * A daemon-backed host offers the server-side [RcPlayerBackend.JAVA] /
+   * [RcPlayerBackend.CMP_ANDROID] lanes for a Remote Compose preview when its backend honours the
+   * player override ([remoteComposePlayerSelectable]); the client-side [RcPlayerBackend.JS] lane
+   * rides on top whenever the host can also hand back the `.rc` document. RC-ness is taken from the
+   * preview's declared Remote Compose knobs (populated for a Remote Compose preview) or a carried
+   * `.rc` doc.
+   */
+  override fun enabledRcPlayersFor(previewId: String): List<RcPlayerBackend> {
+    val isRemoteCompose =
+      hasRemoteComposeDoc(previewId) ||
+        previews.firstOrNull { it.id == previewId }?.remoteComposeKnobs?.isNotEmpty() == true
+    if (!isRemoteCompose) return emptyList()
+    return buildList {
+      if (hasRemoteComposeDoc(previewId)) add(RcPlayerBackend.JS)
+      if (remoteComposePlayerSelectable) {
+        add(RcPlayerBackend.JAVA)
+        add(RcPlayerBackend.CMP_ANDROID)
+      }
+      // Inert today — a daemon-only host carries no baked artifact to name a player for — but
+      // stated so this override cannot drift from the other two if it ever gains one.
+      bakedRcPlayerBackend(previewId)?.let { if (it !in this) add(it) }
+    }
+  }
+
+  private val previewIds: Set<String> = previews.map { it.id }.toHashSet()
+
+  // Decodes streamFrame notification params for the live-stream lane (startStream).
+  private val streamJson = Json { ignoreUnknownKeys = true }
+
+  // Bounded LRU of rendered PNGs keyed by ServeOverrides.cacheKey. A dev-facing server fronting one
+  // module won't accumulate many distinct (preview × overrides) combos, so a small cap is plenty.
+  private val cache = LruByteCache(MAX_CACHE_ENTRIES)
+
+  // The figma-svg counterpart of [cache], keyed the same way (previewId × overrides).
+  private val svgCache = LruByteCache(MAX_CACHE_ENTRIES)
+
+  // The full-page (scrolling) figma-svg counterpart of [svgCache], keyed the same way.
+  private val scrollSvgCache = LruByteCache(MAX_CACHE_ENTRIES)
+
+  // The full-page raster counterpart of [scrollSvgCache], keyed by preview id + overrides.
+  private val scrollPngCache = LruByteCache(MAX_CACHE_ENTRIES)
+
+  // The preview-slots counterpart of [cache], keyed the same way (previewId × overrides).
+  private val slotsCache = LruByteCache(MAX_CACHE_ENTRIES)
+
+  // The accessibility-overlay counterpart of [cache], keyed the same way (previewId × overrides).
+  private val a11yCache = LruByteCache(MAX_CACHE_ENTRIES)
+
+  // The typography/theme inspection-layer counterpart of [cache], keyed the same way.
+  private val annotationsCache = LruByteCache(MAX_CACHE_ENTRIES)
+
+  // Decodes a fetched compose/semantics payload and encodes the slots response; tolerant of the
+  // schema's additive fields (a v7 file read by this v-agnostic slot extractor).
+  private val dataJson = Json { ignoreUnknownKeys = true }
+
+  // Fair (FIFO) so a waiter can't be starved and the longest-waiting render — an interactive
+  // browse — wins the daemon when it frees, ahead of the background prewarm re-acquiring the lock
+  // for the next warm render.
+  private val renderLock = ReentrantLock(/* fair= */ true)
+
+  // Serve-side render-latency accounting for `/status` (`renderStats`) — see [RenderPerfStats].
+  private val perfStats = RenderPerfStats()
+
+  /**
+   * Stops this host re-attempting renders it has proved it cannot serve — a linkage fault on the
+   * first occurrence, an unclassified sustained failure rate on the backstop. See
+   * [RenderCircuitBreaker] and issue #3448 (3794 retries of one `UnsatisfiedLinkError` in 14
+   * minutes).
+   */
+  private val breaker = RenderCircuitBreaker(linkageDiagnosis = linkageDiagnosis)
+
+  override fun renderPerfStats(): RenderPerfSnapshot =
+    perfStats.snapshot().copy(breaker = breaker.snapshot())
+
+  override fun renderBreaker(): RenderBreakerSnapshot? = breaker.snapshot()
+
+  /**
+   * An open breaker is host-wide, so it latches EVERY preview: the fault is in the daemon's
+   * classpath, not in one composition. This is what turns the `503 render busy; retry shortly` into
+   * a terminal 409 naming the linkage error — the HTTP layer consults the latch before it takes a
+   * render slot.
+   */
+  override fun renderFailureLatch(previewId: String, overrides: PreviewOverrides): String? =
+    breaker.peekReason()
+
+  /**
+   * A host whose breaker is open has no working live lane, so it must stop advertising one — the
+   * `/status` `live` / `running` columns and the viewer's stream toggle both read this. Reported
+   * from the breaker alone; no session is touched, so a registered-but-unopened catalog is
+   * unaffected.
+   */
+  override val hasLiveStream: Boolean
+    get() = breaker.peekReason() == null
+
+  /** Publishes the open breaker as a session degradation, so `/status` says WHY it went dark. */
+  override val degradations: List<ServeDegradation>
+    get() =
+      breaker.snapshot()?.let { listOf(ServeDegradation.renderLaneBroken(it.reason, it.fatal)) }
+        ?: emptyList()
+
+  /** Record a failed render against both the perf counters and the breaker. */
+  private fun recordFailure(durationMs: Long, timeout: Boolean, reason: String) {
+    perfStats.recordFailed(durationMs, timeout = timeout, reason = reason)
+    breaker.recordFailure(reason)
+  }
+
+  // Set under renderLock immediately before each renderNow; the (single) in-flight render's
+  // renderFinished notification fills pngPath and trips the latch. Safe because the lock guarantees
+  // exactly one render in flight at a time.
+  private val pendingLatch = AtomicReference<CountDownLatch?>(null)
+  private val pendingPreviewId = AtomicReference<String?>(null)
+  private val pendingPngPath = AtomicReference<String?>(null)
+
+  // Set (instead of [pendingPngPath]) when the in-flight render's terminal event is
+  // `renderFailed` — the render body threw, e.g. a preview whose composition NPEs. Carrying the
+  // failure through the same latch turns "broken preview" into an immediate
+  // [RenderOutcome.Failed] instead of a full render-budget sleep under [renderLock].
+  private val pendingFailure = AtomicReference<String?>(null)
+
+  // Count of timed-out renders per preview id whose `renderFinished` is still outstanding. A render
+  // that timed out releases the lock, but the daemon still emits that render's `renderFinished`
+  // later; since the notification carries only the preview id (no per-render correlation id), a
+  // stale event for the same id would otherwise complete the *next* same-id render's latch and
+  // cache
+  // the wrong PNG under the new override key. The daemon delivers `renderFinished` reliably and in
+  // order per session (the S4 harness tests assert none are lost / reordered), so we drain exactly
+  // one outstanding event per timed-out render here before honouring a fresh one.
+  private val staleRenders = ConcurrentHashMap<String, Int>()
+
+  // The first render after the session opens pays Skiko/JVM cold start, so it gets the generous
+  // [renderTimeoutSeconds] budget; once one render has succeeded, each subsequent frame is capped
+  // at
+  // [frameRenderTimeoutSeconds] so a single wedged render can't hold the only render slot.
+  private val warmedUp = AtomicBoolean(false)
+
+  // An override-bearing render (a `?knob.…=` edit, device/locale/theme override, …) forces a real
+  // recomposition and is much slower than a plain re-emit — its first occurrence is effectively
+  // cold even when [warmedUp] is already set by a background prewarm (a throwaway default render
+  // that flips [warmedUp] without ever exercising the override path). Without a separate gate the
+  // very first override render on `preview.coo.ee` — where `warmInBackground` prewarms — is charged
+  // the tight [frameRenderTimeoutSeconds] cap and times out (the public `?knob.…` 500). Give the
+  // first override render the generous [renderTimeoutSeconds] budget too; subsequent override
+  // frames
+  // are capped like any other so a wedged one can't pin the slot.
+  private val overridesWarmedUp = AtomicBoolean(false)
+
+  // Fans one upstream daemon stream out to all watchers of the same preview/overrides/codec/fps, so
+  // many browsers cost one held session instead of one each. Built on [startStream]; shared because
+  // there's one host per server.
+  private val broadcast = ServeBroadcastHub(::startStream)
+
+  private val closed = AtomicBoolean(false)
+
+  /**
+   * Daemon render lifecycle events. A method rather than an inline lambda so [sessionDelegate] can
+   * register it the instant the session opens — see [notificationHandle].
+   */
+  private fun onDaemonNotification(method: String, params: JsonObject?) {
+    if (params == null) return
+    val isFinished = method == "renderFinished"
+    val isFailed = method == "renderFailed"
+    if (!isFinished && !isFailed) return
+    val id = params["id"]?.jsonPrimitive?.contentOrNull ?: return
+    // Drain the late event of a previously timed-out render (FIFO: it arrives before the current
+    // render's own event) so it can't complete a fresh same-id render's latch with a stale PNG.
+    // Either terminal event drains — the daemon owes exactly one (finished OR failed) per render.
+    if ((staleRenders[id] ?: 0) > 0) {
+      staleRenders.compute(id) { _, v -> ((v ?: 0) - 1).takeIf { it > 0 } }
+      return
+    }
+    if (id != pendingPreviewId.get()) return
+    if (isFinished) {
+      // `unchanged` renders still carry a (re-used) pngPath, so this captures bytes either way.
+      params["pngPath"]?.jsonPrimitive?.contentOrNull?.let { pendingPngPath.set(it) }
+    } else {
+      // `renderFailed` must complete the wait too. Without this the render body's failure (a
+      // preview whose composition throws) left the latch untouched and [render] slept out its
+      // ENTIRE cold budget — 900s on the public server — holding [renderLock] for a render the
+      // daemon had already reported dead seconds in. Profiled on the confetti-mobile bundle: a
+      // broken preview failed in ~4s and the host still burned the full 180s CLI budget per
+      // render of it, which read as "cold Android renders take minutes".
+      pendingFailure.set(
+        params["error"]?.jsonObject?.get("message")?.jsonPrimitive?.contentOrNull
+          ?: "daemon reported renderFailed"
+      )
+    }
+    pendingLatch.get()?.countDown()
+  }
+
+  /** Render [previewId] at [overrides], serving a cached result when one exists. Thread-safe. */
+  override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
+    check(!closed.get()) { "ServeRenderHost is closed" }
+    if (previewId !in previewIds) return RenderOutcome.NotFound
+
+    val key = ServeOverrides.cacheKey(previewId, overrides)
+    cache.get(key)?.let {
+      perfStats.recordCacheHit()
+      return RenderOutcome.Ok(it, RenderOutcome.Generation.DAEMON_CACHE)
+    }
+
+    // The daemon has already proved it cannot serve this (a linkage fault, or a sustained failure
+    // rate) — answer with that reason instead of asking it again. Ahead of the lock acquire, so a
+    // broken daemon neither holds the render lock nor pushes other callers into a Busy back-off
+    // that reads to the browser as "the server is busy, retry" (issue #3448). A rate-tripped
+    // breaker lets one probe render through per cooldown, so a transient wave still heals.
+    breaker.blockedReason()?.let {
+      perfStats.recordShortCircuit()
+      return RenderOutcome.Failed(it)
+    }
+
+    // Perf accounting for `/status` (`renderStats`): the round-trip clock starts at the cache
+    // miss, and "cold" is judged before the render — a render issued while this host has never
+    // completed one is the cold-start population the boot/warm work targets.
+    val perfStartNs = System.nanoTime()
+    val coldAtEntry = !warmedUp.get()
+    fun perfElapsedMs(): Long = (System.nanoTime() - perfStartNs) / 1_000_000
+
+    // Bounded acquire (Fix 4): a cold render holds [renderLock] for up to renderTimeoutSeconds
+    // (minutes); don't pin the caller's HTTP render slot on that wait — back off to Busy so the
+    // caller serves baked instead. Waiting the [DAEMON_BUSY_WAIT_MS] window still rides out a fast
+    // warm re-emit.
+    if (!renderLock.tryLock(DAEMON_BUSY_WAIT_MS, TimeUnit.MILLISECONDS)) {
+      perfStats.recordBusy()
+      return RenderOutcome.Busy
+    }
+    try {
+      // Double-check: another request may have filled the cache while we waited for the lock.
+      cache.get(key)?.let {
+        perfStats.recordCacheHit()
+        return RenderOutcome.Ok(it, RenderOutcome.Generation.DAEMON_CACHE)
+      }
+
+      // The daemon coalesces an override-bearing `renderNow` whose previewId already has one in
+      // flight, expecting the client to resubmit once it clears. Because the daemon clears that
+      // flag
+      // on (just after) `renderFinished`, the very next serialised render here can momentarily race
+      // the not-yet-cleared flag and get rejected. Honour the daemon's retry contract with a
+      // bounded
+      // backoff instead of surfacing it to the browser as a 500.
+      var attempt = 0
+      while (true) {
+        val latch = CountDownLatch(1)
+        pendingLatch.set(latch)
+        pendingPreviewId.set(previewId)
+        pendingPngPath.set(null)
+        pendingFailure.set(null)
+
+        val ack =
+          try {
+            session.renderNow(
+              previewIds = listOf(previewId),
+              reason = "serve",
+              overrides = overrides,
+              timeout = RENDER_ACK_TIMEOUT,
+            )
+          } catch (e: RenderSessionException) {
+            val reason = "renderNow failed: ${e.message}"
+            onLog(reason)
+            recordFailure(perfElapsedMs(), timeout = false, reason = reason)
+            return RenderOutcome.Failed(reason)
+          }
+
+        val rejected = ack.rejected.firstOrNull { it.id == previewId }
+        if (rejected != null) {
+          if (rejected.reason.startsWith("coalesced") && attempt++ < MAX_COALESCED_RETRIES) {
+            Thread.sleep(COALESCED_RETRY_BACKOFF_MS)
+            continue
+          }
+          val reason = "render rejected: ${rejected.reason}"
+          onLog(reason)
+          recordFailure(perfElapsedMs(), timeout = false, reason = reason)
+          return RenderOutcome.Failed(reason)
+        }
+
+        // Cold start gets the generous budget; every frame after the first is capped so a wedged
+        // render can't pin the slot. An override-bearing render's *first* occurrence is cold too
+        // (real recompose, and prewarm may have flipped [warmedUp] without ever paying it), so it
+        // keeps the generous budget until one override render has succeeded.
+        val hasOverrides = overrides != PreviewOverrides()
+        val warmForThisRender = warmedUp.get() && (!hasOverrides || overridesWarmedUp.get())
+        val budget = if (warmForThisRender) frameRenderTimeoutSeconds else renderTimeoutSeconds
+        val completed =
+          try {
+            latch.await(budget, TimeUnit.SECONDS)
+          } catch (_: InterruptedException) {
+            // A caller may impose a tighter foreground bound than this host's cold-render budget.
+            // The daemon still owes a terminal event, so quarantine it exactly like a timeout
+            // before releasing the render lock; otherwise it can complete the next same-id render.
+            // CountDownLatch checks interruption before its completed state. If the terminal event
+            // won that race it has already been consumed, so recording it as outstanding would
+            // discard the next legitimate same-preview event instead.
+            if (latch.count > 0) staleRenders.merge(previewId, 1, Int::plus)
+            Thread.currentThread().interrupt()
+            perfStats.recordBusy()
+            return RenderOutcome.Busy
+          }
+        if (!completed) {
+          // The daemon still owes this queued render a `renderFinished`; record it so the late
+          // event
+          // is drained instead of completing a future same-id render with a stale PNG.
+          staleRenders.merge(previewId, 1, Int::plus)
+          val reason = "timed out after ${budget}s waiting for render"
+          onLog(reason)
+          recordFailure(perfElapsedMs(), timeout = true, reason = reason)
+          return RenderOutcome.Failed(reason)
+        }
+        // The latch also trips on `renderFailed` — the daemon reported the render body threw.
+        // Fail immediately: sleeping out the budget here (the pre-fix behaviour, since only
+        // `renderFinished` completed the latch) held [renderLock] for minutes per broken preview
+        // and is what read as "cold Android renders take minutes" in the serve 503 investigation.
+        // No [staleRenders] entry — the daemon already delivered this render's terminal event —
+        // and [warmedUp] stays as-is: a failed render proves nothing about engine warmth.
+        pendingFailure.get()?.let { failure ->
+          val reason = "render failed: $failure"
+          onLog(reason)
+          recordFailure(perfElapsedMs(), timeout = false, reason = reason)
+          return RenderOutcome.Failed(reason)
+        }
+        warmedUp.set(true)
+        if (hasOverrides) overridesWarmedUp.set(true)
+        break
+      }
+
+      val path = pendingPngPath.get()
+      val bytes =
+        path
+          ?.toPath()
+          ?.takeIf { fileSystem.exists(it) }
+          ?.let { p -> fileSystem.read(p) { readByteArray() } }
+      if (bytes == null) {
+        val reason = "render produced no PNG"
+        onLog(reason)
+        recordFailure(perfElapsedMs(), timeout = false, reason = reason)
+        return RenderOutcome.Failed(reason)
+      }
+
+      cache.put(key, bytes)
+      perfStats.recordOk(perfElapsedMs(), cold = coldAtEntry)
+      breaker.recordOk()
+      return RenderOutcome.Ok(bytes)
+    } finally {
+      renderLock.unlock()
+    }
+  }
+
+  /**
+   * Render [previewId] at [overrides] and return its **figma-svg** export (`compose/figma-svg`),
+   * serving a cached result when one exists. Thread-safe.
+   *
+   * The daemon writes the SVG to a per-preview path as a side effect of the *same* render that
+   * produces the PNG, so this renders (reusing [render] and its retry/timeout handling) and then
+   * fetches the just-written SVG. Both happen under [renderLock] with the PNG cache entry evicted
+   * first: the SVG file is shared per preview and overwritten by every render, so it must be
+   * fetched in the same critical section as the render that produced it — a PNG cache hit would
+   * otherwise skip the render and leave a prior render's (stale) SVG on disk.
+   */
+  override fun renderSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome {
+    check(!closed.get()) { "ServeRenderHost is closed" }
+    if (previewId !in previewIds) return SvgOutcome.NotFound
+    // A daemon without the figma-svg producer ([hasSvgExport] false) can't export it — fetchData
+    // would fail `-32020 kind not advertised`. Short-circuit to NotFound (a clean 404) instead, so
+    // a direct/stale `/render/<id>.svg` matches the "no SVG lane" this host already advertises.
+    if (!hasSvgExport) return SvgOutcome.NotFound
+
+    val key = ServeOverrides.cacheKey(previewId, overrides)
+    svgCache.get(key)?.let {
+      return SvgOutcome.Ok(it, RenderOutcome.Generation.DAEMON_CACHE)
+    }
+
+    return renderLock.withLock {
+      svgCache.get(key)?.let {
+        return@withLock SvgOutcome.Ok(it, RenderOutcome.Generation.DAEMON_CACHE)
+      }
+
+      // Force a fresh render of these overrides so the shared per-preview SVG file on disk is
+      // theirs; the held lock keeps any other render from overwriting it before the fetch below.
+      cache.remove(key)
+      when (val pngOutcome = render(previewId, overrides)) {
+        RenderOutcome.NotFound -> return@withLock SvgOutcome.NotFound
+        is RenderOutcome.Failed -> return@withLock SvgOutcome.Failed(pngOutcome.reason)
+        // Unreachable in practice — render() re-enters the lock we already hold — but the caller
+        // falls back to the baked vector on any non-Ok, so a busy signal degrades gracefully.
+        RenderOutcome.Busy -> return@withLock SvgOutcome.Failed("daemon busy")
+        is RenderOutcome.Ok -> {} // rendered; the SVG for these overrides is now on disk
+      }
+
+      val svgPath =
+        try {
+          session.fetchData(previewId, ComposeFigmaSvgProduct.KIND).path?.toPath()
+        } catch (e: Exception) {
+          val reason = "figma-svg fetch failed: ${e.message}"
+          onLog(reason)
+          return@withLock SvgOutcome.Failed(reason)
+        }
+      val raw =
+        svgPath
+          ?.takeIf { fileSystem.exists(it) }
+          ?.let { p -> fileSystem.read(p) { readByteArray() } }
+      if (raw == null) {
+        val reason = "render produced no SVG"
+        onLog(reason)
+        return@withLock SvgOutcome.Failed(reason)
+      }
+
+      // Inline any hybrid figma-raster crops so the served SVG is self-contained (a vector-only SVG
+      // passes through untouched); Figma's importer can't resolve external hrefs.
+      val bytes = inlineRasters(svgPath, raw)
+      svgCache.put(key, bytes)
+      SvgOutcome.Ok(bytes)
+    }
+  }
+
+  /**
+   * Render [previewId]'s **full-page** figma-svg (`compose/figma-svg-long`) at [overrides], serving
+   * a cached result when one exists. Thread-safe.
+   *
+   * Unlike [renderSvg] this fetches the `requiresRerender = true` long kind directly:
+   * `session.fetchData` drives the daemon's `figma-svg-long` re-render (an expanded-viewport /
+   * slice- stitched render that composes the whole list) and returns the written SVG path — so
+   * there's no separate PNG render to force first. Still serialised through [renderLock] with the
+   * fetch reading the file the re-render just wrote.
+   *
+   * **Override-aware.** The full-page SVG file is shared per preview, so serving it at non-default
+   * overrides needs a fresh render: the [overrides] ride the fetch's kind-agnostic `params` bag
+   * ([DataFetchParams.PARAM_OVERRIDES]) — the daemon threads them into the `figma-svg-long`
+   * re-render — and [DataFetchParams.PARAM_FORCE_RERENDER] makes the file-backed registry re-render
+   * even though a prior (differently-themed) file exists. The cache is keyed by
+   * [ServeOverrides.cacheKey] so themed and default capsules don't collide; the held [renderLock]
+   * keeps the shared file from being overwritten between the re-render and the read, mirroring the
+   * viewport [renderSvg] lane.
+   */
+  override fun renderScrollSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome {
+    check(!closed.get()) { "ServeRenderHost is closed" }
+    if (previewId !in previewIds) return SvgOutcome.NotFound
+    // No figma-svg producer ⇒ no export; NotFound (404) rather than a `-32020` fetch 500. See
+    // [renderSvg].
+    if (!hasSvgExport) return SvgOutcome.NotFound
+
+    val key = ServeOverrides.cacheKey(previewId, overrides)
+    scrollSvgCache.get(key)?.let {
+      return SvgOutcome.Ok(it, RenderOutcome.Generation.DAEMON_CACHE)
+    }
+
+    return renderLock.withLock {
+      scrollSvgCache.get(key)?.let {
+        return@withLock SvgOutcome.Ok(it, RenderOutcome.Generation.DAEMON_CACHE)
+      }
+
+      // Force a fresh full-page render at these overrides (the shared per-preview file may hold a
+      // different theme's export) and read it under the held lock.
+      val fetchParams = buildJsonObject {
+        put(DataFetchParams.PARAM_FORCE_RERENDER, JsonPrimitive(true))
+        put(
+          DataFetchParams.PARAM_OVERRIDES,
+          Json.encodeToJsonElement(PreviewOverrides.serializer(), overrides),
+        )
+      }
+      val svgPath =
+        try {
+          session
+            .fetchData(previewId, ComposeFigmaSvgProduct.KIND_LONG, params = fetchParams)
+            .path
+            ?.toPath()
+        } catch (e: Exception) {
+          val reason = "figma-svg-long fetch failed: ${e.message}"
+          onLog(reason)
+          return@withLock SvgOutcome.Failed(reason)
+        }
+      val raw =
+        svgPath
+          ?.takeIf { fileSystem.exists(it) }
+          ?.let { p -> fileSystem.read(p) { readByteArray() } }
+      if (raw == null) {
+        val reason = "render produced no full-page SVG"
+        onLog(reason)
+        return@withLock SvgOutcome.Failed(reason)
+      }
+
+      val bytes = inlineRasters(svgPath, raw)
+      scrollSvgCache.put(key, bytes)
+      SvgOutcome.Ok(bytes)
+    }
+  }
+
+  /**
+   * Fetch the daemon's tall raster scroll product at [overrides]. Like [renderScrollSvg], the
+   * product is a shared per-preview file, so every cache miss forces an override-aware re-render
+   * and reads the resulting bytes while [renderLock] is held.
+   */
+  override fun renderScrollPng(previewId: String, overrides: PreviewOverrides): RenderOutcome {
+    check(!closed.get()) { "ServeRenderHost is closed" }
+    if (previewId !in previewIds) return RenderOutcome.NotFound
+    // The scroll registry is registered inactive too, and this lane reads no capability of its own.
+    ensureExtensionsEnabled()?.let {
+      return RenderOutcome.Failed(it)
+    }
+
+    val key = ServeOverrides.cacheKey(previewId, overrides)
+    scrollPngCache.get(key)?.let {
+      return RenderOutcome.Ok(it, RenderOutcome.Generation.DAEMON_CACHE)
+    }
+
+    return renderLock.withLock {
+      scrollPngCache.get(key)?.let {
+        return@withLock RenderOutcome.Ok(it, RenderOutcome.Generation.DAEMON_CACHE)
+      }
+
+      val fetchParams = buildJsonObject {
+        put(DataFetchParams.PARAM_FORCE_RERENDER, JsonPrimitive(true))
+        put(
+          DataFetchParams.PARAM_OVERRIDES,
+          Json.encodeToJsonElement(PreviewOverrides.serializer(), overrides),
+        )
+      }
+      val pngPath =
+        try {
+          session.fetchData(previewId, SCROLL_LONG_KIND, params = fetchParams).path?.toPath()
+        } catch (e: Exception) {
+          val reason = "scroll-long fetch failed: ${e.message}"
+          onLog(reason)
+          return@withLock RenderOutcome.Failed(reason)
+        }
+      val bytes =
+        pngPath
+          ?.takeIf { fileSystem.exists(it) }
+          ?.let { p -> fileSystem.read(p) { readByteArray() } }
+      if (bytes == null) {
+        val reason = "render produced no full-page PNG"
+        onLog(reason)
+        return@withLock RenderOutcome.Failed(reason)
+      }
+
+      scrollPngCache.put(key, bytes)
+      RenderOutcome.Ok(bytes)
+    }
+  }
+
+  /**
+   * Inline a hybrid SVG's sibling `figma-raster/<node>.png` crops as `data:` URIs so the served SVG
+   * is self-contained — the Figma importer (and any consumer that can't resolve external hrefs)
+   * needs every layer embedded. A vector-only SVG has no such refs and passes through. Shares the
+   * inlining with the static catalog path via {@link inlineFigmaRasters}.
+   */
+  private fun inlineRasters(svgPath: okio.Path, raw: ByteArray): ByteArray {
+    val dir = svgPath.parent ?: return raw
+    return inlineFigmaRasters(fileSystem, dir, raw.decodeToString()).encodeToByteArray()
+  }
+
+  /**
+   * Render [previewId] at [overrides] and return its declared **preview slots** as
+   * [PreviewSlotsPayload] JSON, serving a cached result when one exists. Thread-safe.
+   *
+   * The slots are the `dp-slot:<name>` markers the preview's author placed (see [PreviewSlots]);
+   * they're captured into the `compose/semantics` tree of the *same* render that produces the PNG,
+   * with their absolute-to-root bounds. Like [renderSvg] this renders (reusing [render] and its
+   * retry/timeout handling) then fetches the just-written product, both under [renderLock] with the
+   * PNG cache entry evicted first — the semantics file is shared per preview and overwritten by
+   * every render, so it must be read in the same critical section as the render that produced it.
+   */
+  override fun renderSlots(previewId: String, overrides: PreviewOverrides): SlotsOutcome {
+    check(!closed.get()) { "ServeRenderHost is closed" }
+    if (previewId !in previewIds) return SlotsOutcome.NotFound
+    // `compose/semantics` is registered inactive like the rest; this lane reads no capability.
+    ensureExtensionsEnabled()?.let {
+      return SlotsOutcome.Failed(it)
+    }
+
+    val key = ServeOverrides.cacheKey(previewId, overrides)
+    slotsCache.get(key)?.let {
+      return SlotsOutcome.Ok(it)
+    }
+
+    return renderLock.withLock {
+      slotsCache.get(key)?.let {
+        return@withLock SlotsOutcome.Ok(it)
+      }
+
+      // Force a fresh render of these overrides so the shared per-preview semantics file on disk is
+      // theirs; the held lock keeps any other render from overwriting it before the fetch below.
+      cache.remove(key)
+      when (val pngOutcome = render(previewId, overrides)) {
+        RenderOutcome.NotFound -> return@withLock SlotsOutcome.NotFound
+        is RenderOutcome.Failed -> return@withLock SlotsOutcome.Failed(pngOutcome.reason)
+        // Unreachable in practice — render() re-enters the lock we already hold — but keep the
+        // match exhaustive and degrade to a clean failure rather than pretending we rendered.
+        RenderOutcome.Busy -> return@withLock SlotsOutcome.Failed("daemon busy")
+        is RenderOutcome.Ok -> {} // rendered; the semantics for these overrides is now on disk
+      }
+
+      val payload =
+        try {
+          fetchSemantics(previewId)
+        } catch (e: Exception) {
+          val reason = "compose/semantics fetch failed: ${e.message}"
+          onLog(reason)
+          return@withLock SlotsOutcome.Failed(reason)
+        } ?: return@withLock SlotsOutcome.Failed("render produced no semantics")
+
+      val slots = PreviewSlots.extractSlots(payload)
+      val json =
+        dataJson
+          .encodeToString(PreviewSlotsPayload.serializer(), PreviewSlotsPayload(previewId, slots))
+          .encodeToByteArray()
+      slotsCache.put(key, json)
+      SlotsOutcome.Ok(json)
+    }
+  }
+
+  /**
+   * Render [previewId] at [overrides] and return its **typography + theme** inspection layers as
+   * `{"previewId":"…","annotations":[…]}`, serving a cached result when one exists. Thread-safe.
+   *
+   * Same shape as [renderSlots] — both read the `compose/semantics` tree of the render that just
+   * produced the pixels, so both force a fresh render under [renderLock] before fetching the
+   * per-preview file it overwrote. The layers themselves are pure projection
+   * ([ServeDesignAnnotations]): resolved type size / face / weight per text node, resolved fill /
+   * border / corner radius per container.
+   *
+   * The response also carries [ServeSemanticsTags]' tag index for that same tree. Both projections
+   * read one payload under one lock, so the index and the annotations always agree with each other.
+   *
+   * **That is not yet the coupling the parity element gates need**, and the difference matters.
+   * `/render/<id>.png` and `/render/<id>.annotations` are separate requests, and this method
+   * deliberately evicts the PNG cache entry and re-renders before reading semantics — so a client
+   * that already displayed the PNG holds pixels from the *previous* render while these bounds
+   * describe the new one. Identical for a deterministic preview; not for one that animates or
+   * composes conditionally, where an element gate could then validate a region the scored frame
+   * never contained. Closing it needs the two responses to share a render generation the client can
+   * match (or the index to travel with the pixels), which the design doc assigns to Phase 2's
+   * transport work — see the "same render" requirement in
+   * [COMPONENT_PARITY_WORKFLOW.md](../../../../../../../../docs/design/COMPONENT_PARITY_WORKFLOW.md).
+   */
+  override fun renderAnnotations(
+    previewId: String,
+    // Accepted and deliberately ignored: all three layers come off ONE semantics + theme + layout
+    // capture, so narrowing the response would save no work and would fragment `annotationsCache`
+    // by layer set. The contract ([ServeHost.renderAnnotations]) permits a superset; what `layers`
+    // decides is whether this host is asked at all, which is settled before the call reaches here.
+    overrides: PreviewOverrides,
+    @Suppress("UNUSED_PARAMETER") layers: Set<String>?,
+  ): AnnotationsOutcome {
+    check(!closed.get()) { "ServeRenderHost is closed" }
+    if (previewId !in previewIds) return AnnotationsOutcome.NotFound
+    // Same precondition as the lanes above: `compose/semantics` (and the theme product below) are
+    // registered inactive, and the capability read further down forces the enable through a lazy
+    // that throws when the daemon can't be opened at all. Doing it here turns that into this
+    // request's failure instead of an exception escaping past the route's 500-with-reason.
+    ensureExtensionsEnabled()?.let {
+      return AnnotationsOutcome.Failed(it)
+    }
+
+    val key = ServeOverrides.cacheKey(previewId, overrides)
+    annotationsCache.get(key)?.let {
+      return AnnotationsOutcome.Ok(it)
+    }
+
+    return renderLock.withLock {
+      annotationsCache.get(key)?.let {
+        return@withLock AnnotationsOutcome.Ok(it)
+      }
+
+      cache.remove(key)
+      // The container layers read the layout tree when the daemon has it: `layout/inspector` walks
+      // every `LayoutNode`, so a `Column` that declares padding and an arrangement gap but no
+      // semantics still reaches the overlay. A daemon too old to know the kind leaves it in
+      // `unknown` and the layers fall back to the semantics tree's mirrored tokens.
+      val captureLayout = LayoutInspectorProduct.KIND !in extensionEnableResult.unknown
+      val captureTheme = THEME_EXTENSION_ID !in extensionEnableResult.unknown
+      if (captureTheme) {
+        runCatching { session.subscribeData(previewId, Material3ThemeProduct.KIND) }
+          .onFailure { onLog("compose/theme subscription failed: ${it.message}") }
+      }
+      try {
+        when (val pngOutcome = render(previewId, overrides)) {
+          RenderOutcome.NotFound -> return@withLock AnnotationsOutcome.NotFound
+          is RenderOutcome.Failed -> return@withLock AnnotationsOutcome.Failed(pngOutcome.reason)
+          RenderOutcome.Busy -> return@withLock AnnotationsOutcome.Failed("daemon busy")
+          is RenderOutcome.Ok -> {} // rendered; the semantics for these overrides is now on disk
+        }
+
+        val payload =
+          try {
+            fetchSemantics(previewId)
+          } catch (e: Exception) {
+            val reason = "compose/semantics fetch failed: ${e.message}"
+            onLog(reason)
+            return@withLock AnnotationsOutcome.Failed(reason)
+          } ?: return@withLock AnnotationsOutcome.Failed("render produced no semantics")
+        val theme = if (captureTheme) fetchTheme(previewId, overrides) else null
+        val layout = if (captureLayout) fetchLayout(previewId) else null
+
+        val json =
+          ServeAnnotationsPayload.encode(
+            previewId,
+            ServeDesignAnnotations.annotations(payload, theme, layout),
+            ServeSemanticsTags.index(payload),
+          )
+        annotationsCache.put(key, json)
+        AnnotationsOutcome.Ok(json)
+      } finally {
+        if (captureTheme) {
+          runCatching { session.unsubscribeData(previewId, Material3ThemeProduct.KIND) }
+            .onFailure { onLog("compose/theme unsubscribe failed: ${it.message}") }
+        }
+      }
+    }
+  }
+
+  /**
+   * Fetch and decode the freshly written `compose/semantics` tree for [previewId] from whichever
+   * transport the session used (inline payload or an on-disk path); null when the fetch yielded
+   * neither. Callers hold [renderLock] so the file read matches the render that produced it.
+   */
+  private fun fetchSemantics(previewId: String): ComposeSemanticsPayload? {
+    val result = session.fetchData(previewId, ComposeSemanticsProduct.KIND)
+    result.payload?.let {
+      return dataJson.decodeFromJsonElement(ComposeSemanticsPayload.serializer(), it)
+    }
+    val path = result.path?.toPath()?.takeIf { fileSystem.exists(it) } ?: return null
+    val text = fileSystem.read(path) { readUtf8() }
+    return dataJson.decodeFromString(ComposeSemanticsPayload.serializer(), text)
+  }
+
+  /**
+   * Fetch and decode the freshly written `layout/inspector` tree for [previewId], the twin of
+   * [fetchSemantics]; null when the product is absent or unreadable, which drops the container
+   * layers back to the semantics tree rather than failing the request. Callers hold [renderLock].
+   */
+  private fun fetchLayout(previewId: String): LayoutInspectorPayload? = runCatching {
+    val result = session.fetchData(previewId, LayoutInspectorProduct.KIND)
+    result.payload?.let {
+      return@runCatching dataJson.decodeFromJsonElement(
+        LayoutInspectorPayload.serializer(),
+        it,
+      )
+    }
+    val path = result.path?.toPath()?.takeIf { fileSystem.exists(it) } ?: return@runCatching null
+    dataJson.decodeFromString(
+      LayoutInspectorPayload.serializer(),
+      fileSystem.read(path) { readUtf8() },
+    )
+  }
+    .onFailure { onLog("layout/inspector fetch failed: ${it.message}") }
+    .getOrNull()
+
+  /** The theme captured by the same subscribed render as [fetchSemantics], when available. */
+  private fun fetchTheme(previewId: String, overrides: PreviewOverrides): ThemePayload? =
+    runCatching {
+      val params = buildJsonObject {
+        put(
+          DataFetchParams.PARAM_OVERRIDES,
+          Json.encodeToJsonElement(PreviewOverrides.serializer(), overrides),
+        )
+      }
+      val result =
+        session.fetchData(previewId, Material3ThemeProduct.KIND, inline = true, params = params)
+      result.payload?.let { dataJson.decodeFromJsonElement(ThemePayload.serializer(), it) }
+        ?: result.path
+          ?.toPath()
+          ?.takeIf { fileSystem.exists(it) }
+          ?.let { path ->
+            dataJson.decodeFromString(
+              ThemePayload.serializer(),
+              fileSystem.read(path) { readUtf8() },
+            )
+          }
+    }
+    .onFailure { onLog("compose/theme fetch failed: ${it.message}") }
+    .getOrNull()
+
+  /**
+   * Fetch [previewId]'s accessibility products at [overrides] and return them merged as one JSON
+   * object the viewer can draw an overlay + legend from:
+   * ```json
+   * {"previewId":"…","nodes":[…],"findings":[…],"touchTargets":[…]}
+   * ```
+   *
+   * `nodes` is `a11y/hierarchy` (what a screen reader sees — label, role, states, merged-ness and
+   * source-bitmap bounds), `findings` is `a11y/atf` (Android-only; empty on the desktop backend)
+   * and `touchTargets` is `a11y/touchTargets` (Android-only, absent elsewhere). Each is fetched
+   * independently and tolerantly: a kind this backend doesn't carry contributes an empty array
+   * rather than failing the request, so the desktop overlay still draws its focus map.
+   *
+   * The products are per-preview files the daemon overwrites on every render, and they're produced
+   * only by a render in `a11y` mode — so the fetch asks for a forced re-render carrying [overrides]
+   * (like [renderScrollPng]) and runs under [renderLock] so nothing else overwrites them in
+   * between. Results are cached per `(previewId, overrides)`; only a miss pays for the re-render.
+   */
+  override fun renderA11y(previewId: String, overrides: PreviewOverrides): A11yOutcome {
+    check(!closed.get()) { "ServeRenderHost is closed" }
+    if (previewId !in previewIds) return A11yOutcome.NotFound
+    // Enable the daemon's inactive a11y extension before fetching from it; a daemon that can't be
+    // opened is this request's failure, not an escaped exception. Past that, a backend that reports
+    // the extension `unknown` can't produce the hierarchy at all, so answer NotFound (a clean 404)
+    // rather than fetching into a `-32020` 500 — the same shape [renderSvg] gives a backend without
+    // figma-svg. [hasA11yOverlay] only reads the result the line above already resolved.
+    ensureExtensionsEnabled()?.let {
+      return A11yOutcome.Failed(it)
+    }
+    if (!hasA11yOverlay) return A11yOutcome.NotFound
+
+    val key = ServeOverrides.cacheKey(previewId, overrides)
+    a11yCache.get(key)?.let {
+      return A11yOutcome.Ok(it)
+    }
+
+    return renderLock.withLock {
+      a11yCache.get(key)?.let {
+        return@withLock A11yOutcome.Ok(it)
+      }
+
+      val fetchParams = buildJsonObject {
+        put(DataFetchParams.PARAM_FORCE_RERENDER, JsonPrimitive(true))
+        put(
+          DataFetchParams.PARAM_OVERRIDES,
+          Json.encodeToJsonElement(PreviewOverrides.serializer(), overrides),
+        )
+      }
+      // The hierarchy is the overlay itself — without it there is nothing to draw, so its failure
+      // is the request's failure. The other two only decorate it.
+      val hierarchy =
+        try {
+          fetchA11yProduct(previewId, A11Y_HIERARCHY_KIND, fetchParams)
+        } catch (e: Exception) {
+          val reason = "a11y/hierarchy fetch failed: ${e.message}"
+          onLog(reason)
+          return@withLock A11yOutcome.Failed(reason)
+        } ?: return@withLock A11yOutcome.Failed("render produced no accessibility hierarchy")
+
+      val json =
+        dataJson
+          .encodeToString(
+            JsonObject.serializer(),
+            buildJsonObject {
+              put("previewId", JsonPrimitive(previewId))
+              put("nodes", arrayField(hierarchy, "nodes"))
+              put("findings", arrayField(optionalA11yProduct(previewId, A11Y_ATF_KIND), "findings"))
+              put(
+                "touchTargets",
+                arrayField(optionalA11yProduct(previewId, A11Y_TOUCH_TARGETS_KIND), "targets"),
+              )
+            },
+          )
+          .encodeToByteArray()
+      a11yCache.put(key, json)
+      A11yOutcome.Ok(json)
+    }
+  }
+
+  /**
+   * Fetch an a11y product for [previewId] from whichever transport the daemon used (an inline
+   * payload, or an on-disk path written by the re-render), or null when it yielded neither. Callers
+   * hold [renderLock] so a path read matches the render that produced it.
+   */
+  private fun fetchA11yProduct(previewId: String, kind: String, params: JsonObject?): JsonObject? {
+    val result = session.fetchData(previewId, kind, inline = true, params = params)
+    result.payload?.let {
+      return it as? JsonObject
+    }
+    val path = result.path?.toPath()?.takeIf { fileSystem.exists(it) } ?: return null
+    val text = fileSystem.read(path) { readUtf8() }
+    return dataJson.parseToJsonElement(text) as? JsonObject
+  }
+
+  /**
+   * [fetchA11yProduct] for a kind that may not exist on this backend (ATF findings and touch
+   * targets are Android-only). Swallows the fetch failure — the overlay is still worth drawing from
+   * the hierarchy alone. No `params`: the forced re-render already ran for the hierarchy, and
+   * asking for another one per optional product would triple the cost of every overlay.
+   */
+  private fun optionalA11yProduct(previewId: String, kind: String): JsonObject? =
+    try {
+      fetchA11yProduct(previewId, kind, params = null)
+    } catch (e: Exception) {
+      onLog("$kind unavailable for '$previewId': ${e.message}")
+      null
+    }
+
+  /** [obj]'s [name] array, or an empty one when the product was absent or shaped differently. */
+  private fun arrayField(obj: JsonObject?, name: String): JsonArray =
+    obj?.get(name) as? JsonArray ?: JsonArray(emptyList())
+
+  /**
+   * Try to open a daemon-backed live stream for [previewId] (tier-2). On success the daemon pushes
+   * `streamFrame` notifications; each is decoded and handed to [onFrame], and the returned
+   * [StreamHandle] forwards input + tears the stream down on close. Returns **null** when streaming
+   * is unsupported (older daemon / backend without held compositions, or a `stream/start` that
+   * couldn't allocate a held session) so the caller falls back to the [render]-per-frame lane.
+   * Independent of the snapshot render lock — a held stream runs concurrently with snapshot
+   * renders.
+   */
+  fun startStream(
+    previewId: String,
+    overrides: PreviewOverrides,
+    codec: StreamCodec? = null,
+    maxFps: Int? = null,
+    onUnavailable: ((String) -> Unit)? = null,
+    onFrame: (StreamFrameParams) -> Unit,
+  ): StreamHandle? {
+    check(!closed.get()) { "ServeRenderHost is closed" }
+    if (previewId !in previewIds) {
+      onUnavailable?.invoke("daemon has no preview '$previewId'")
+      return null
+    }
+
+    // Register the listener BEFORE stream/start: the daemon's frame loop can emit the initial
+    // keyframe before the RPC response returns, and missing it leaves static previews blank (later
+    // frames are payload-less `unchanged` heartbeats). We don't know the frameStreamId yet, so
+    // buffer frames until it's known, then replay the matching ones.
+    val frameStreamIdRef = AtomicReference<String?>(null)
+    val pending = ArrayList<StreamFrameParams>()
+    val listener = session.onNotification { method, params ->
+      if (method != "streamFrame" || params == null) return@onNotification
+      val frame =
+        try {
+          streamJson.decodeFromJsonElement(StreamFrameParams.serializer(), params)
+        } catch (_: Exception) {
+          return@onNotification
+        }
+      val known = frameStreamIdRef.get()
+      if (known != null) {
+        if (frame.frameStreamId == known) onFrame(frame)
+        return@onNotification
+      }
+      // id not yet known — buffer under lock, re-checking in case it was just set.
+      synchronized(pending) {
+        if (frameStreamIdRef.get() == null) {
+          pending.add(frame)
+          return@onNotification
+        }
+      }
+      if (frame.frameStreamId == frameStreamIdRef.get()) onFrame(frame)
+    }
+
+    val result =
+      try {
+        session.streamStart(
+          previewId = previewId,
+          codec = codec,
+          maxFps = maxFps,
+          overrides = overrides,
+        )
+      } catch (e: Exception) {
+        // UnsupportedOperationException (no streaming on this backend) or a daemon error — degrade.
+        // The exception message IS the daemon's original failure (e.g. "interactive session already
+        // held", "previewSpecResolver returned null for previewId=…", a 30s interactive-start
+        // timeout) — carry it to the viewer via [onUnavailable] rather than only logging it, so the
+        // client can show why input isn't live instead of the opaque "input requires a live
+        // stream".
+        val reason = e.message?.takeIf { it.isNotBlank() } ?: e.javaClass.simpleName
+        onLog("stream/start unavailable for $previewId ($reason); falling back to snapshots")
+        onUnavailable?.invoke(reason)
+        runCatching { listener.close() }
+        return null
+      }
+
+    if (!result.heldSession) {
+      // The daemon accepted stream/start but couldn't hold an interactive session, so it won't run
+      // the live frame loop — fall back to the snapshot lane rather than open a frameless stream.
+      // The daemon records the actual acquisition failure in `fallbackReason` (e.g.
+      // `UnsupportedOperationException: interactive session already held`); prefer it so the viewer
+      // shows the real cause, and use the generic text only when the daemon sent none.
+      val reason =
+        result.fallbackReason?.takeIf { it.isNotBlank() }
+          ?: "the daemon could not hold an interactive session for this preview"
+      onLog("stream/start for $previewId has no held session ($reason); falling back to snapshots")
+      onUnavailable?.invoke(reason)
+      runCatching { listener.close() }
+      runCatching { session.streamStop(result.frameStreamId) }
+      return null
+    }
+
+    val frameStreamId = result.frameStreamId
+    // Publish the id and replay any frames that arrived before it was known.
+    val replay: List<StreamFrameParams>
+    synchronized(pending) {
+      frameStreamIdRef.set(frameStreamId)
+      replay = pending.filter { it.frameStreamId == frameStreamId }
+      pending.clear()
+    }
+    replay.forEach(onFrame)
+
+    return object : StreamHandle {
+      private val handleClosed = AtomicBoolean(false)
+
+      override fun input(
+        kind: InteractiveInputKind,
+        pixelX: Int?,
+        pixelY: Int?,
+        pointerId: Int?,
+        scrollDeltaY: Float?,
+        keyCode: String?,
+        text: String?,
+        pointerType: String?,
+      ) {
+        if (handleClosed.get()) return
+        runCatching {
+          session.interactiveInput(
+            frameStreamId,
+            kind,
+            pixelX,
+            pixelY,
+            pointerId,
+            scrollDeltaY,
+            keyCode,
+            text,
+            pointerType,
+          )
+        }
+      }
+
+      override fun visibility(visible: Boolean, fps: Int?) {
+        if (handleClosed.get()) return
+        // Fire-and-forget, and optional: a daemon that predates `stream/visibility` (or a backend
+        // that doesn't implement it at all) throws UnsupportedOperationException here, which must
+        // not take down a lane that is otherwise streaming fine.
+        runCatching { session.streamVisibility(frameStreamId, visible, fps) }
+      }
+
+      override fun close() {
+        if (!handleClosed.compareAndSet(false, true)) return
+        runCatching { listener.close() }
+        runCatching { session.streamStop(frameStreamId) }
+      }
+    }
+  }
+
+  /**
+   * Join the shared live stream for [previewId] (tier-2), opening one upstream daemon stream per
+   * distinct preview + overrides + codec + fps and fanning its frames out to every watcher. This is
+   * the multi-client front door to [startStream]: prefer it over [startStream] for client
+   * connections so N viewers of the same preview ride one held session. Returns `null` when
+   * streaming is unsupported (caller falls back to the snapshot lane).
+   */
+  override fun subscribeStream(
+    previewId: String,
+    overrides: PreviewOverrides,
+    codec: StreamCodec?,
+    maxFps: Int?,
+    onUnavailable: ((String) -> Unit)?,
+    onFrame: (StreamFrameParams) -> Unit,
+  ): StreamHandle? {
+    check(!closed.get()) { "ServeRenderHost is closed" }
+    return broadcast.subscribe(
+      previewId,
+      overrides,
+      codec,
+      maxFps,
+      onUnavailable = onUnavailable,
+      onFrame = onFrame,
+    )
+  }
+
+  /** Live shared upstream streams (one per distinct preview/overrides/codec/fps). Diagnostics. */
+  override fun activeStreamCount(): Int = broadcast.activeStreamCount()
+
+  override fun close() {
+    if (!closed.compareAndSet(false, true)) return
+    // A host that was never used has no subprocess to tear down — and touching `session` here would
+    // spawn one only to kill it, which on an Android backend is tens of seconds of pure waste. This
+    // is the common case now that catalogs register without opening: a republish closes and
+    // replaces every host, most of which nobody visited.
+    synchronized(sessionLock) {
+      // `daemonStarted`, not `isInitialized()`: a host constructed around an already-open session
+      // owns a subprocess from birth, and must close it even if nothing ever touched the lazy.
+      if (!daemonStarted) return
+      try {
+        notificationHandle?.close()
+      } catch (_: Exception) {
+        // best effort
+      }
+      session.close()
+    }
+  }
+
+  companion object {
+    // Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
+    // and the `:server` call sites are in a different module now. Not a widened API by intent.
+    const val SCROLL_LONG_KIND = "render/scroll/long"
+    internal const val SCROLL_EXTENSION_ID = "scroll"
+
+    // The accessibility extension + its three product kinds, spelled here rather than imported
+    // from `:data-a11y-core` — the CLI doesn't depend on that module, and these are wire strings
+    // (`AccessibilityPreviewExtension.ID` / `KIND_HIERARCHY`, `AtfChecksPreviewExtension.KIND_ATF`
+    // / `KIND_TOUCH_TARGETS`), not types. Both daemon backends register all of them under the one
+    // `a11y` extension id; the desktop one advertises no `a11y/touchTargets` (ATF is Android-only)
+    // and answers `a11y/atf` with empty findings, which the overlay handles as "nothing to flag".
+    internal const val A11Y_EXTENSION_ID = "a11y"
+    internal const val A11Y_HIERARCHY_KIND = "a11y/hierarchy"
+    internal const val A11Y_ATF_KIND = "a11y/atf"
+    internal const val A11Y_TOUCH_TARGETS_KIND = "a11y/touchTargets"
+    internal const val THEME_EXTENSION_ID = "data/theme"
+    /** RPC ack budget for the (fast, queue-only) `renderNow` call itself. */
+    private val RENDER_ACK_TIMEOUT = 60.seconds
+
+    /**
+     * Cold-start render budget — the first render pays the daemon's warm-up. 180s covers a
+     * desktop/Skiko daemon, but an **Android/Robolectric** daemon's first render is much slower (it
+     * fetches the `android-all-instrumented` runtime and initialises the Android/Compose stack), so
+     * make it overridable via `-Dcomposeai.serve.renderTimeoutSeconds=<n>` for those backends.
+     */
+    private val RENDER_TIMEOUT_SECONDS: Long =
+      System.getProperty("composeai.serve.renderTimeoutSeconds")?.toLongOrNull()?.coerceAtLeast(1)
+        ?: 180L
+
+    /**
+     * Per-frame render budget once warm; a wedged render can't hold the slot past this. 10s suits a
+     * warm Skiko daemon; a warm Android/Robolectric render is slower, so it's overridable via
+     * `-Dcomposeai.serve.frameRenderTimeoutSeconds=<n>`.
+     */
+    private val FRAME_RENDER_TIMEOUT_SECONDS: Long =
+      System.getProperty("composeai.serve.frameRenderTimeoutSeconds")
+        ?.toLongOrNull()
+        ?.coerceAtLeast(1) ?: 10L
+
+    /**
+     * Bounded retries when the daemon coalesces an override-bearing render already in flight. The
+     * window only needs to outlast the daemon clearing its in-flight flag right after
+     * `renderFinished`, so a handful of short backoffs is ample.
+     */
+    private const val MAX_COALESCED_RETRIES = 50
+    private const val COALESCED_RETRY_BACKOFF_MS = 100L
+
+    /**
+     * How long a render waits for the per-daemon [renderLock] before reporting
+     * [RenderOutcome.Busy]. The lock is held for the whole render, and a cold Android render can
+     * hold it for `renderTimeoutSeconds` (minutes on a public host). Blocking that long pins a
+     * shared HTTP render slot ([ServeHttpServer.renderSemaphore]) and — enough times over —
+     * saturates the whole server. This caps the wait to a couple of seconds (enough to ride out a
+     * fast warm re-emit); past it the caller serves the baked fallback instead of blocking a slot
+     * on a busy daemon.
+     */
+    private const val DAEMON_BUSY_WAIT_MS = 2_000L
+
+    private const val MAX_CACHE_ENTRIES = 256
+
+    /**
+     * Open a long-lived session against a daemon launch descriptor and wrap it. Mirrors
+     * [ee.schimke.composeai.cli.MatrixRenderFetcher] config; the caller supplies the servable
+     * [previews] read from the module manifest.
+     *
+     * Does NOT spawn the daemon — the session opens on first use, so [RenderSessionException] now
+     * surfaces at the first request that needs it rather than here.
+     */
+    fun open(
+      descriptorPath: File,
+      workspaceRoot: File,
+      workspaceName: String,
+      previews: List<ServePreview>,
+      label: String = "",
+      declaredThemes: List<ServeTheme> = emptyList(),
+      systemPropertyOverrides: Map<String, String> = emptyMap(),
+      onLog: (String) -> Unit = {},
+      factory: RenderSessionFactory = SubprocessRenderSessions,
+    ): ServeRenderHost {
+      val config =
+        RenderSessionConfig(
+          descriptorPath = descriptorPath,
+          workspaceRoot = workspaceRoot.absoluteFile,
+          workspaceName = workspaceName.ifBlank { workspaceRoot.name },
+          systemPropertyOverrides = systemPropertyOverrides,
+          logSink = onLog,
+        )
+      return ServeRenderHost(
+        openSession = { factory.open(config) },
+        previews = previews,
+        label = label,
+        declaredThemes = declaredThemes,
+        onLog = onLog,
+        // Four diagnoses, tried in order of how specifically each one explains THIS failure — the
+        // open breaker's reason is the only report anyone outside the box reads, so the most
+        // specific true thing goes in it. A split Skiko pair names the exact versions; a gap record
+        // that can attribute the failing type to a coordinate names that artifact and what is wrong
+        // with it; a Remote Compose family split across bundle and sidecar names the seam. Last,
+        // and only last, the unattributed gap: "n coordinates are missing, one of them is probably
+        // it" fires on any unresolved coordinate, related or not, so ahead of the family split it
+        // would answer a Remote Compose trip on a catalog missing one unrelated optional dependency
+        // by sending the operator to fix repositories.
+        linkageDiagnosis = { reason ->
+          SkikoNativePairing.linkageDiagnosis(reason, descriptorPath)
+            ?: BundleClasspathGaps.attributedDiagnosis(reason, descriptorPath)
+            ?: RemoteComposePairing.linkageDiagnosis(reason, descriptorPath)
+            ?: BundleClasspathGaps.unattributedDiagnosis(reason, descriptorPath)
+        },
+      )
+    }
+  }
+}
+
+/** Minimal thread-safe LRU byte cache (access-order [LinkedHashMap] under a lock). */
+private class LruByteCache(private val maxEntries: Int) {
+  private val map =
+    object : LinkedHashMap<String, ByteArray>(16, 0.75f, true) {
+      override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, ByteArray>): Boolean =
+        size > maxEntries
+    }
+
+  @Synchronized fun get(key: String): ByteArray? = map[key]
+
+  @Synchronized
+  fun put(key: String, value: ByteArray) {
+    map[key] = value
+  }
+
+  @Synchronized
+  fun remove(key: String) {
+    map.remove(key)
+  }
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSemanticsTags.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSemanticsTags.kt
@@ -1,0 +1,125 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsNode
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload
+import ee.schimke.composeai.data.layoutinspector.SlotBounds
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+
+/**
+ * Project a render's `compose/semantics` tree into a **tag index** — `testTag → {count, bounds}`.
+ *
+ * This is the identity a scoped parity acceptance targets an element by
+ * ([docs/design/COMPONENT_PARITY_WORKFLOW.md](../../../../../../../../docs/design/COMPONENT_PARITY_WORKFLOW.md)).
+ * It exists because the obvious alternative does not work:
+ * [ee.schimke.composeai.data.layoutinspector.SemanticsRefs] assigns a `ref` per node, but it
+ * *indexes siblings that share an anchor* — so `r/role:Button[0]` names "the first Button under
+ * this parent", and inserting a Button ahead of it silently retargets the same string at different
+ * pixels. A `testTag` is authored, not positional, so it survives the edit or stops resolving; both
+ * are honest outcomes where a silent retarget is not.
+ *
+ * ## Why `count` is the load-bearing field
+ *
+ * A tag is only a usable identity while exactly one node carries it. Compose does not enforce that
+ * — nothing stops the same `testTag` appearing on every row of a list — so a consumer that resolved
+ * "the node with this tag" would silently pick one of several. [TagEntry.count] is what makes that
+ * checkable without shipping the whole tree to the client, which production never does.
+ *
+ * So **every** node carrying the tag counts, including nodes whose bounds are unusable. Counting
+ * only the drawable ones would let a zero-area duplicate hide behind a usable sibling and report
+ * `count = 1` for a tag that is genuinely ambiguous — the exact failure the field exists to catch.
+ * [TagEntry.bounds] is the first *usable* box in depth-first order, and is null when no node
+ * carrying the tag has one.
+ *
+ * ## Coordinates, and an open contract question
+ *
+ * Bounds are `boundsInRoot` — absolute-to-root **render pixels**, the same space
+ * [ServeDesignAnnotations] reports and the same space the served PNG is in.
+ *
+ * The design doc says the *index* publishes bounds already transformed into an acceptance's
+ * **canonical plane**, and that the server does that transform once so no consumer repeats it. This
+ * projection cannot: the canonical plane is resolved per comparison from the reference raster and
+ * the acceptance's recorded plane, and this is a per-preview endpoint with neither in scope. So one
+ * of the two has to move — either the transform belongs to the comparison (and the doc's placement
+ * is wrong), or the index must be produced by a comparison-scoped projection that has the plane.
+ *
+ * Until that is settled, every entry states its own space on the wire ([TagEntry.space]). A
+ * consumer that reads `render-pixels` cannot silently treat these as canonical, which is the one
+ * failure mode a mismatch here produces — a wrong `element-moved` verdict from bounds nobody
+ * converted.
+ */
+object ServeSemanticsTags {
+
+  /**
+   * The coordinate space [TagEntry.bounds] is in. See the class KDoc for why this is on the wire.
+   */
+  const val RENDER_PIXELS = "render-pixels"
+
+  /**
+   * One tag's occupancy of the tree. [count] is every node carrying the tag; [bounds] is the first
+   * usable box among them, absent when none of them has one (a tag on a zero-area or malformed node
+   * is still worth reporting, because `count` is what a uniqueness check reads).
+   *
+   * [space] names the coordinate space of [bounds] explicitly rather than leaving it to a
+   * consumer's reading of the spec, which currently disagrees with this producer. It is always
+   * [RENDER_PIXELS] today; the field exists so that a consumer cannot assume otherwise, and so a
+   * later canonical-plane producer is distinguishable on the wire instead of by version guessing.
+   *
+   * `@EncodeDefault` because the host serialises with `encodeDefaults = false`, which would drop a
+   * default-valued property from the JSON entirely — a discriminator that never reaches the wire is
+   * worse than none, since it reads as present in Kotlin and is absent to the browser. Same
+   * treatment, for the same reason, as the schema discriminators on `HistoryDataDelta`.
+   */
+  @OptIn(ExperimentalSerializationApi::class)
+  @Serializable
+  data class TagEntry(
+    val count: Int,
+    val bounds: AnnotationBounds? = null,
+    @EncodeDefault val space: String = RENDER_PIXELS,
+  )
+
+  /**
+   * [payload]'s tag index, in depth-first encounter order.
+   *
+   * Blank tags are skipped: `testTag = ""` is not an identity anything can resolve, and admitting
+   * it would give every untagged-but-present node one shared key.
+   */
+  fun index(payload: ComposeSemanticsPayload): Map<String, TagEntry> {
+    val out = LinkedHashMap<String, TagEntry>()
+    fun walk(node: ComposeSemanticsNode) {
+      // A trial-measured copy is not a second use of the tag: it was never placed, so it is not on
+      // the frame and its bounds read as the origin. Counting it publishes `count = 2` for a tag
+      // that identifies exactly one node, which a scoped parity consumer rejects as ambiguous.
+      // See `ComposeSemanticsNode.placed`.
+      if (!node.placed) return
+      // Blank-or-absent decides *omission*; the key is then the tag VERBATIM. Trimming it would be
+      // a second identity rule, and Compose (and `SemanticsTargets.Tag`) match the exact string —
+      // so normalising here collapses `"item"` and `" item "` into one entry reporting `count = 2`
+      // (false ambiguity) while an acceptance recording `" item "` finds no key at all (false
+      // disappearance). Two wrong verdicts for two tags each unique in the tree.
+      val tag = node.testTag?.takeIf { it.isNotBlank() }
+      if (tag != null) {
+        val box = SlotBounds.parse(node.boundsInRoot)?.takeIf { it.hasArea() }
+        val existing = out[tag]
+        out[tag] =
+          if (existing == null) TagEntry(count = 1, bounds = box?.toAnnotationBounds())
+          // Keep the first usable box, not the latest: depth-first order is the one both engines
+          // walk, so "first" is reproducible where "last" depends on where the duplicate landed.
+          else
+            existing.copy(
+              count = existing.count + 1,
+              bounds = existing.bounds ?: box?.toAnnotationBounds(),
+            )
+      }
+      node.children.forEach(::walk)
+    }
+    walk(payload.root)
+    return out
+  }
+
+  private fun SlotBounds.hasArea(): Boolean = right > left && bottom > top
+
+  private fun SlotBounds.toAnnotationBounds(): AnnotationBounds =
+    AnnotationBounds(x = left, y = top, width = right - left, height = bottom - top)
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionState.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionState.kt
@@ -1,0 +1,109 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+
+/**
+ * The cheap, durable "instance state" of a serve session — everything needed to (re)open its
+ * daemon-backed [ServeRenderHost] *without* rebuilding. Produced once by a [ServeSessionFactory]
+ * (the expensive discover/build step) and retained across suspend/resume, so an idle session can
+ * release its daemon subprocess and be brought back from this state alone — like an Activity
+ * restoring from saved instance state rather than being recreated from scratch.
+ *
+ * Most fields already persist on disk (the `daemon-launch.json` descriptor + the discovered preview
+ * list), so holding them costs almost nothing while the daemon is suspended. A trusted catalog may
+ * additionally retain its bounded `previews × declaredThemes` PNG cache here so idle daemon
+ * suspension does not discard completed optimization work.
+ */
+data class ServeSessionState(
+  /** `build/compose-previews/daemon-launch.json` the daemon relaunches from. */
+  val descriptor: File,
+  val workspaceRoot: File,
+  val workspaceName: String,
+  val previews: List<ServePreview>,
+  /** Human label for the tenant (e.g. the module's Gradle path, or `module@rev`). */
+  val label: String,
+  /**
+   * App-declared `@ThemeCatalog` themes (module-global) surfaced in the viewer's Theme selector.
+   */
+  val declaredThemes: List<ServeTheme> = emptyList(),
+  /**
+   * Optional **catalog-id → daemon-preview-id** alias map, set only for a trusted-catalog live
+   * session ([ServeCatalogStore] / [ServeBundleDaemon]). The daemon knows previews by their
+   * function-based descriptor id (`FilledButton_Dark`), but the published catalog links and image
+   * routes use the componentId-slug id (`button-filled__ideal__default__dark`). This maps the
+   * latter to the former so the live host answers the published URLs. Empty for plain project /
+   * revision sessions (whose ids already match). See [bakedFallback].
+   */
+  val previewAliases: Map<String, String> = emptyMap(),
+  /**
+   * Optional factory for a **baked-PNG fallback host** covering catalog ids the daemon can't render
+   * (e.g. the Android-only inset focus-ring variant, absent from the desktop bundle). Set only for
+   * a trusted-catalog live session: [openHost][ServeCommand] wraps the daemon [ServeRenderHost] and
+   * this fallback in a [ServeCatalogLiveHost] so browsing, deep links, and thumbnails resolve to
+   * the baked catalog exactly as before while the mapped ids gain a live lane. Rebuilt on each
+   * resume (the baked dir persists), so suspend/resume is preserved. Null for plain sessions.
+   */
+  val bakedFallback: (() -> ServeHost)? = null,
+  /**
+   * Optional **per-preview live lane** resolver, set only for a trusted-catalog live-bundle session
+   * whose branch ships per-preview FULL bundles ([ServeCatalogStore]). Given a daemon-preview id it
+   * returns a daemon-backed host that re-renders **only that one preview** from its own bundle,
+   * pooled with idle LRU eviction, or null when none is available. [openHost][ServeCommand] hands
+   * it to the [ServeCatalogLiveHost] as the default render lane (tried before the monolithic
+   * daemon), so the small per-preview bundles are exercised routinely; a null result falls back to
+   * the monolithic daemon, so the session never regresses. The pool is owned by the command (closed
+   * at server shutdown) and outlives suspend/resume, so this stays valid across re-opens. Null for
+   * plain sessions and for a branch that ships only the monolithic bundle.
+   */
+  val perPreviewResolve: ((daemonId: String) -> ServeHost?)? = null,
+  /** Probe whether a published, hydrated per-preview bundle is actually available. */
+  val executableBundleAvailable: ((daemonId: String) -> Boolean)? = null,
+  /** Resolve a hydrated, self-contained per-preview bundle for download. */
+  val executableBundleProvider: ((daemonId: String) -> ByteArray?)? = null,
+  /** Live upstream stream count across the pooled per-preview daemons (see [perPreviewResolve]). */
+  val perPreviewStreamCount: () -> Int = { 0 },
+  /**
+   * Render-latency snapshots of the pooled per-preview daemons (see [perPreviewResolve]), folded
+   * into the catalog host's `/status` `renderStats` roll-up — the per-preview lane is the default
+   * render path, so without these the catalog's stats would miss most real renders.
+   */
+  val perPreviewRenderStats: () -> List<RenderPerfSnapshot> = { emptyList() },
+  /** Occupancy snapshots of the pooled per-preview daemons, surfaced on `/status.json`. */
+  val perPreviewPoolStats: () -> List<DaemonPoolSnapshot> = { emptyList() },
+  /**
+   * Closes per-preview daemons idle past the given window, returning how many. Drives the pooled
+   * half of [ServeHost.releaseIdleDaemons] so a pinned catalog sheds processes without being
+   * unregistered.
+   */
+  val perPreviewReapIdle: (idleMillis: Long) -> Int = { 0 },
+  /**
+   * Rendered PNG cache retained for this catalog generation across daemon suspend/resume cycles.
+   */
+  val catalogThemeCache: CatalogThemeCache? = null,
+  /**
+   * Whole-server idle clock used by background catalog optimization; null means traffic is active.
+   * The server wraps the registry clock in [ServeBackgroundWork.idleClock], so a catalog load in
+   * progress reads as active too.
+   */
+  val serverIdleMillis: () -> Long? = { Long.MAX_VALUE },
+  /** Server-wide admission for background catalog work (see [ServeBackgroundWork]). */
+  val backgroundWork: ServeBackgroundWork = ServeBackgroundWork(),
+  /**
+   * Optional reclaim hook invoked when the registry **removes** this session entirely — the
+   * second-level GC of a long-idle *suspended* forked session (issue #2022), NOT ordinary
+   * suspend/resume. Set by the project-mode factory ([ServeRevisionFactory]) to prune the
+   * revision's git worktree from disk once the session is reclaimed; null for sessions with nothing
+   * on-disk to reclaim (the pinned checkout, bundle/catalog hosts). Best-effort and expected to be
+   * idempotent — the registry runs it under `runCatching`.
+   */
+  val reclaim: (() -> Unit)? = null,
+  /**
+   * Cost of this session's live daemon in **live-seat permits** ([LiveSeatLimiter]). Defaults to
+   * `1` (a desktop CMP daemon, and every plain project / revision session). A trusted-catalog live
+   * session sets it higher for a heavier backend — an Android/Robolectric daemon costs
+   * [ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT] — so one heavy catalog can't starve several cheap
+   * ones out of a flat seat count. Only consulted when [ServeHttpServer] enforces a live-seat
+   * budget (`--live-seats`); ignored for static (snapshot/Wasm) sessions, which take no seat.
+   */
+  val liveSeatWeight: Int = 1,
+)

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSpatialAsset.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSpatialAsset.kt
@@ -1,0 +1,4 @@
+package ee.schimke.composeai.cli.serve
+
+/** Bytes and media type for an asset in a preview's portable spatial scene. */
+data class ServeSpatialAsset(val bytes: ByteArray, val contentType: String)

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeTagIndex.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeTagIndex.kt
@@ -1,0 +1,151 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toOkioPath
+import okio.Path.Companion.toPath
+
+/**
+ * A catalog's **published** tag index — `served preview id → testTag → {count, bounds}`.
+ *
+ * The element identity a scoped parity acceptance resolves against
+ * ([docs/design/COMPONENT_PARITY_WORKFLOW.md](../../../../../../../../docs/design/COMPONENT_PARITY_WORKFLOW.md)).
+ *
+ * ## Why this exists alongside [ServeSemanticsTags]
+ *
+ * They are the same projection with different producers, because a published catalog has no daemon.
+ * [ServeSemanticsTags] projects the index live from a render this host just performed; that path
+ * requires a semantics tree, which only a daemon produces. A catalog's renders happened in CI, at
+ * catalog-generation time — so its index is computed *there* (`scripts/design-artifacts/
+ * tag-index.mjs`, the JS twin) and published as `tags/index.json` beside the stickers. This class
+ * is the reader for that file.
+ *
+ * The consequence worth stating: without this, the whole element-gate half of the parity workflow
+ * was unreachable on exactly the surfaces the epic is about, since every published design catalog
+ * is a static bundle.
+ *
+ * ## Fail-soft, like every other carried artifact
+ *
+ * A malformed index, an unknown schema token, or an oversized one drops **wholesale** and the
+ * catalog serves exactly as before — matching [ServeAnnotationStore] and
+ * [ServeDesignReferenceStore].
+ *
+ * **What an acceptance does next is not "degrade to no element gate".** An earlier revision of this
+ * sentence said so and called it the safe direction; it is only safe if the acceptance also stops
+ * *suppressing*. An element-scoped acceptance whose gate cannot run and whose mask still joins the
+ * valid union has silently become a plain ignore rectangle — and a tagged element that has
+ * disappeared or moved goes on being hidden, which is precisely the failure the element gate was
+ * added to catch. So the outcome is defined the other way: **an element-scoped acceptance that
+ * cannot resolve its tag suppresses nothing.** The engine reaches that verdict already — an absent
+ * entry resolves to no node, which is `element-moved`, which invalidates — and
+ * `gate-element-vanished` in the conformance fixtures is what keeps both engines there.
+ */
+@Serializable
+data class TagIndexManifest(
+  val schema: String = SCHEMA,
+  /** Keyed by the **served** preview id (`button-filled__ideal__default__light`). */
+  val previews: Map<String, Map<String, WireTagEntry>> = emptyMap(),
+) {
+  companion object {
+    const val SCHEMA = "compose-preview-tags/v1"
+  }
+}
+
+/**
+ * The on-the-wire shape of one entry, deliberately **not** [ServeSemanticsTags.TagEntry].
+ *
+ * The difference is [space], which is nullable here and defaulted there. Decoding straight into the
+ * producer type would fill a missing `space` in with the Kotlin default, and the host could no
+ * longer tell "the publisher declared render-pixels" from "the publisher declared nothing" — which
+ * is precisely what the discriminator exists to distinguish. A later element gate reading an
+ * undeclared index would then compare or transform bounds in a plane nobody stated.
+ *
+ * So the wire type keeps absence representable, [ServeTagIndexStore] rejects it, and only validated
+ * entries are converted to the producer type.
+ */
+@Serializable
+data class WireTagEntry(
+  val count: Int = 0,
+  val bounds: AnnotationBounds? = null,
+  val space: String? = null,
+)
+
+/** Validated, read-only view of a catalog's `tags/index.json`. */
+class ServeTagIndexStore
+private constructor(private val byPreview: Map<String, Map<String, ServeSemanticsTags.TagEntry>>) {
+
+  /** The tag index for [previewId], empty when the catalog published none for it. */
+  fun forPreview(previewId: String): Map<String, ServeSemanticsTags.TagEntry> =
+    byPreview[previewId].orEmpty()
+
+  val isEmpty: Boolean = byPreview.isEmpty()
+
+  /** Previews the catalog published an index for. */
+  val previewIds: Set<String> = byPreview.keys
+
+  companion object {
+    const val DIRECTORY = "tags"
+    const val INDEX_FILE = "index.json"
+
+    /**
+     * Cap on indexed previews. A catalog is third-party data and this file is read at staging time
+     * on a shared host, so it gets the same treatment as the acceptance budget: a bound that a
+     * hostile or broken publisher cannot raise. Generous against real use — the largest published
+     * catalog is in the hundreds of stickers.
+     */
+    const val MAX_PREVIEWS = 4096
+
+    private val JSON = Json { ignoreUnknownKeys = true }
+
+    /**
+     * Empty store — a catalog that publishes no index at all, which is every catalog until it does.
+     */
+    val EMPTY = ServeTagIndexStore(emptyMap())
+
+    fun load(bundleDir: File, fileSystem: FileSystem = FileSystem.SYSTEM): ServeTagIndexStore =
+      load(bundleDir.toOkioPath(), fileSystem)
+
+    fun load(bundleRoot: Path, fileSystem: FileSystem): ServeTagIndexStore {
+      val index = bundleRoot / DIRECTORY.toPath() / INDEX_FILE.toPath()
+      if (!fileSystem.exists(index)) return EMPTY
+      val manifest =
+        runCatching {
+          JSON.decodeFromString<TagIndexManifest>(fileSystem.read(index) { readUtf8() })
+        }
+          .getOrNull() ?: return EMPTY
+      if (manifest.schema != TagIndexManifest.SCHEMA) return EMPTY
+      if (manifest.previews.size > MAX_PREVIEWS) return EMPTY
+      return ServeTagIndexStore(
+        manifest.previews
+          .mapValues { (_, tags) ->
+            tags.mapNotNull { (tag, e) -> e.validated()?.let { tag to it } }.toMap()
+          }
+          .filterValues { it.isNotEmpty() }
+      )
+    }
+
+    /**
+     * The entry as [ServeSemanticsTags.TagEntry], or null when it is not usable.
+     *
+     * A count below 1 is not a tag anything carried, and a zero-area box is not geometry a gate can
+     * measure against — both indicate a producer bug rather than something to resolve badly. Absent
+     * bounds are *not* a rejection: a tag whose every node had unusable bounds still counts, which
+     * is the point of `count`.
+     *
+     * An **absent or unrecognised `space` is** a rejection. Silently defaulting it would let an
+     * index that declared no coordinate space read as though it had declared render pixels, and a
+     * gate would then compare bounds in a plane nobody stated — the exact confusion the field was
+     * added to prevent. An unknown value is refused for the same reason rather than assumed: a
+     * future canonical-plane producer must not be read as render-pixel by an older host.
+     */
+    private fun WireTagEntry.validated(): ServeSemanticsTags.TagEntry? {
+      if (count < 1) return null
+      if (space != ServeSemanticsTags.RENDER_PIXELS) return null
+      if (bounds != null && (bounds.width <= 0 || bounds.height <= 0)) return null
+      return ServeSemanticsTags.TagEntry(count = count, bounds = bounds, space = space)
+    }
+  }
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/SkikoNativePairing.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/SkikoNativePairing.kt
@@ -1,0 +1,198 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.bundle.BundleReader
+import java.io.File
+
+/**
+ * Keeps a served bundle's Skiko **bindings** and the `libskiko` **native** they call at one
+ * version, by resolving the platform runtime artifact the bundle forgot to record.
+ *
+ * ## The failure this exists to prevent
+ *
+ * A packed bundle records its runtime classpath as Maven *coordinates*, and [ServeBundleDaemon]
+ * promotes the Compose/Skiko ones ahead of the server's own daemon sidecar so the catalog's
+ * framework versions win (see `shouldPrecedeDaemonSidecar`). Skiko splits across two artifacts: the
+ * bindings (`skiko-awt`, carrying `org.jetbrains.skia.*` and its `external` declarations) and one
+ * `skiko-awt-runtime-<os>-<arch>` per platform, carrying the actual `libskiko` for that host. The
+ * bindings depend on all six with a `strictly` constraint, so Gradle resolves the pair together —
+ * but a **constraint is not a classpath entry**, and the platform jar reaches the render classpath
+ * as a transitive artifact the bundle's coordinate capture never wrote down.
+ *
+ * The result is a bundle that lists `org.jetbrains.skiko:skiko-awt:0.148.2` and no native at all.
+ * Promoted first, its bindings win class resolution; the only `libskiko` on the classpath is the
+ * sidecar's own (0.144.6 at the time of writing), so the JVM links 0.148 declarations against a
+ * 0.144 library. Every render then dies with `UnsatisfiedLinkError: 'int
+ * org.jetbrains.skia.paragraph.ParagraphKt._nGetUnresolvedCodepointsCount(long)'` — a symbol
+ * 0.148.2 added and 0.144.6 never exported — which the [RenderCircuitBreaker] correctly classifies
+ * as fatal and latches the whole catalog behind (compose-ai-tools#4220; the same split-Skiko shape
+ * as #3447 and #1844, reached through the serve path rather than through Gradle conflict
+ * resolution).
+ *
+ * ## The rule
+ *
+ * A bundle that promotes Skiko bindings must bring its **own** native. So when the recorded
+ * coordinates name bindings at version V with no `skiko-awt-runtime-<host>` at V, synthesize that
+ * coordinate and let [ee.schimke.composeai.bundle.coordinates.CoordinateResolver] fetch it like any
+ * other — it is a published artifact on the same repository the bindings came from. Bindings and
+ * native then travel together, exactly as they do on a Gradle-resolved render classpath
+ * ([ee.schimke.composeai.plugin.ValidateComposePreviewClasspathTask] enforces the same invariant
+ * there).
+ *
+ * Deliberately narrow: it fires only when the bundle carries bindings *and* no host native for
+ * them. A bundle that already recorded the pair (or that records no Skiko at all, i.e. an Android
+ * backend) is left exactly as it was.
+ */
+internal object SkikoNativePairing {
+
+  const val GROUP: String = "org.jetbrains.skiko"
+
+  /** Artifacts that carry `org.jetbrains.skia.*` bindings but no platform library. */
+  private val BINDINGS_ARTIFACTS = setOf("skiko", "skiko-awt")
+
+  private const val RUNTIME_PREFIX = "skiko-awt-runtime-"
+
+  /**
+   * The `skiko-awt-runtime-<os>-<arch>` artifact for this host, or null on a platform Skiko
+   * publishes no native for (in which case the render was never going to work and there is nothing
+   * useful to add to the classpath).
+   *
+   * The six published targets are `linux-x64`, `linux-arm64`, `macos-x64`, `macos-arm64`,
+   * `windows-x64`, `windows-arm64` — see the `strictly` constraints on `skiko-awt`'s POM.
+   */
+  fun hostRuntimeArtifact(
+    osName: String = System.getProperty("os.name").orEmpty(),
+    osArch: String = System.getProperty("os.arch").orEmpty(),
+  ): String? {
+    val os =
+      osName.lowercase().let {
+        when {
+          it.contains("mac") || it.contains("darwin") -> "macos"
+          it.contains("win") -> "windows"
+          it.contains("linux") -> "linux"
+          else -> return null
+        }
+      }
+    val arch =
+      when (osArch.lowercase()) {
+        "aarch64",
+        "arm64" -> "arm64"
+        "x86_64",
+        "amd64",
+        "x64" -> "x64"
+        else -> return null
+      }
+    return "$RUNTIME_PREFIX$os-$arch"
+  }
+
+  /**
+   * The Skiko native coordinate [coords] is missing for this host, or null when nothing is missing
+   * — the bundle records no Skiko bindings, already records the matching native, or runs on a
+   * platform with no published native.
+   *
+   * The synthesized coordinate carries **no `sha256`**: the bundle never recorded one for an
+   * artifact it never listed, and the resolver treats a null hash as "unverifiable", which is the
+   * honest description. It is still the right bytes — the version is taken from the bindings the
+   * bundle *did* record, and Skiko publishes the pair together.
+   */
+  fun missingHostRuntime(
+    coords: List<BundleReader.ClasspathEntry.Maven>,
+    osName: String = System.getProperty("os.name").orEmpty(),
+    osArch: String = System.getProperty("os.arch").orEmpty(),
+  ): BundleReader.ClasspathEntry.Maven? {
+    val bindings =
+      coords.firstOrNull { it.group == GROUP && it.artifact in BINDINGS_ARTIFACTS } ?: return null
+    val hostArtifact = hostRuntimeArtifact(osName, osArch) ?: return null
+    val carried = coords.any {
+      it.group == GROUP && it.artifact == hostArtifact && it.version == bindings.version
+    }
+    if (carried) return null
+    return BundleReader.ClasspathEntry.Maven(
+      group = GROUP,
+      artifact = hostArtifact,
+      version = bindings.version,
+      type = "jar",
+      sha256 = null,
+    )
+  }
+
+  /**
+   * The Skiko skew the assembled daemon classpath will actually load, or null when it is coherent.
+   *
+   * The repair above closes the one cause this server knows about; this is the backstop that says
+   * so out loud for every other cause — an offline box that could not fetch the native, a host with
+   * no published native, a bundle that recorded a native for the wrong platform. **Classpath order
+   * decides**, because both halves are plain classloader lookups: the bindings are `.class` files
+   * and `libskiko-<target>.so` is a root-level resource in the platform jar
+   * ([ee.schimke.composeai.bundle.coordinates.CoordinateResolver] puts each resolved jar where the
+   * caller asked). So the pair that runs is the FIRST of each on the ordered `-cp`, which is what
+   * this reads — not the set of versions present, which would call a harmless shadowed duplicate a
+   * skew.
+   *
+   * The **first of each**, never a count of distinct versions — the distinction #4234/#4235 drew
+   * for the Gradle-side guard, and it holds here for the same reason. Two independently-resolved
+   * but individually-matched pairs on one classpath are fine: the trailing pair is shadowed whole.
+   * What is not fine is a leading half-pair, which is precisely the serve case — bindings with no
+   * native lead, so they pair with the first native behind them, which belongs to somebody else.
+   *
+   * Read off filenames, matching
+   * [ee.schimke.composeai.plugin.ValidateComposePreviewClasspathTask.skikoVersionsOnClasspath]:
+   * these are resolved files, not a dependency graph, and the version travels with the artifact.
+   */
+  fun classpathSkew(orderedClasspath: List<String>): String? {
+    fun firstVersion(nativeJar: Boolean): String? = orderedClasspath.firstNotNullOfOrNull { path ->
+      val filename = path.replace('\\', '/').substringAfterLast('/')
+      val version =
+        SKIKO_ARTIFACT.matchEntire(filename)?.groupValues?.get(1)
+          ?: return@firstNotNullOfOrNull null
+      val isNative = filename.startsWith(RUNTIME_PREFIX)
+      if (isNative == nativeJar) version else null
+    }
+    val bindings = firstVersion(nativeJar = false) ?: return null
+    val native = firstVersion(nativeJar = true) ?: return null
+    if (bindings == native) return null
+    return "Skiko bindings $bindings will link against libskiko $native — the daemon classpath " +
+      "resolves them from different artifacts, and every render that touches a symbol the two do " +
+      "not share will fail with UnsatisfiedLinkError. Republish the catalog against a Compose " +
+      "Multiplatform version whose Skiko this server ships."
+  }
+
+  /**
+   * [classpathSkew] for the daemon launched from [descriptorPath], to be appended to a **fatal**
+   * linkage failure — or null when this failure is not Skia's, the descriptor is unreadable, or the
+   * classpath is coherent and the link error therefore has some other cause.
+   *
+   * The startup log already carries [classpathSkew], but nobody outside the box reads it. What they
+   * read is the open breaker's reason, which the host returns as the body of every `409` the dead
+   * lane answers with — and in compose-ai-tools#4220 that body was the whole report: it named the
+   * missing symbol and nothing that explains it, so the skew had to be inferred from the outside.
+   * Attaching the skew here means a lane that dies of a split Skiko says so to whoever finds it.
+   *
+   * Read at trip time rather than at host construction: the descriptor is a file the daemon already
+   * launched from, and a diagnosis nobody needs must not cost a read per host.
+   */
+  fun linkageDiagnosis(reason: String, descriptorPath: File): String? {
+    if (SKIA_PACKAGE !in reason) return null
+    val descriptor = ServeBundleDaemon.readLaunchDescriptor(descriptorPath) ?: return null
+    return classpathSkew(descriptor.classpath)
+  }
+
+  /**
+   * Enough of the package name to catch both halves — `org.jetbrains.skia.*` (the bindings whose
+   * `external` declarations fail to link) and `org.jetbrains.skiko.*` (the loader). A linkage error
+   * naming neither belongs to some other library, and the Skiko pair says nothing about it.
+   */
+  private const val SKIA_PACKAGE = "org.jetbrains.ski"
+
+  /** `skiko`, `skiko-awt`, `skiko-awt-runtime-<platform>` — anything but the version suffix. */
+  private val SKIKO_ARTIFACT = Regex("""^skiko(?:-[a-z0-9]+)*-(\d[\w.\-]*)\.jar$""")
+
+  /**
+   * One log line naming what was added and why, so a catalog whose bundle needed the repair says so
+   * in the daemon startup log rather than only in the absence of a later crash.
+   */
+  fun repairLog(coordinate: BundleReader.ClasspathEntry.Maven): String =
+    "bundle carries Skiko bindings ${coordinate.version} with no native runtime for this host — " +
+      "adding ${coordinate.group}:${coordinate.artifact}:${coordinate.version} so the bindings " +
+      "and libskiko match (an unpaired bindings jar links against the server's own older " +
+      "libskiko and fails every render with UnsatisfiedLinkError)"
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/SvgSanitizer.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/SvgSanitizer.kt
@@ -1,0 +1,350 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.ByteArrayInputStream
+import java.io.StringWriter
+import javax.xml.XMLConstants
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.transform.OutputKeys
+import javax.xml.transform.TransformerFactory
+import javax.xml.transform.dom.DOMSource
+import javax.xml.transform.stream.StreamResult
+import org.w3c.dom.Element
+import org.w3c.dom.Node
+import org.xml.sax.InputSource
+
+/**
+ * Reduce a design tool's SVG export to markup that is safe to **inline** into a served page.
+ *
+ * Inlining is not a stylistic choice here: it is the entire point of the `/{system}/pages/`
+ * surface. An `<img src="page.svg">` is a picture — the page's own script cannot reach inside it to
+ * hide the design's drawing of one node and put a render in its place. An inline `<svg>` is a
+ * document, and `data-node-id` makes every node in it addressable. That capability and this file
+ * are the same decision: the moment third-party markup lands in the document tree it can carry
+ * script, and the catalog that produced it is not trusted ([ServeCatalogStore] treats a delivery
+ * branch as third-party throughout).
+ *
+ * ## Allowlist, never a denylist
+ *
+ * Elements and attributes are dropped unless they are named below. A denylist of "dangerous" tags
+ * is a losing game — `<foreignObject>` smuggles arbitrary HTML, `<animate attributeName="href">`
+ * rewrites a link after load, `<set>` does it without an animation, an `<a>` inside the picture is
+ * a navigation the page never offered — and the set of such tricks is not closed. What a specimen
+ * sheet actually needs is shapes, paint and text, which is a short list.
+ *
+ * Three rules carry most of the weight, and each closes a hole the obvious version leaves open:
+ *
+ * - **`on*` attributes go before the allowlist is consulted**, so no future addition to
+ *   [SAFE_ATTRIBUTES] can accidentally admit one.
+ * - **URL-bearing attributes are re-validated by value**, not merely by name. `href` is legitimate
+ *   (`url(#clip0)` internal references are how every Figma export clips), so the *name* cannot be
+ *   the check: `#local` and `data:` rasters are kept, and everything else — `javascript:`, an
+ *   `http:` beacon that would tell a third party who opened the page, a protocol-relative `//host`
+ *   — is dropped. `data:image/svg+xml` is refused with the rest, because an SVG carried inside a
+ *   data URI is an SVG this function never saw.
+ * - **`style` is parsed for `url(` targets**, since a stylesheet reaches the network as readily as
+ *   an attribute does and `mix-blend-mode` is a real thing Figma emits.
+ *
+ * ## Parser hardening
+ *
+ * The document is parsed with secure processing, DOCTYPEs refused outright, and an entity resolver
+ * that answers nothing. Without the first two, an export is a billion-laughs bomb; without the
+ * third, an external entity turns "render this catalog's page" into "read a file off the server".
+ *
+ * Returns null for anything that fails to parse, is not rooted at `<svg>`, or exceeds [MAX_BYTES] —
+ * fail-soft, like every other reader on this surface. A page that cannot be sanitized is a page the
+ * catalog serves without, never a page it serves unsafely.
+ */
+object SvgSanitizer {
+
+  /**
+   * A ceiling on the export this will parse into a DOM.
+   *
+   * A specimen sheet is large — the Material 3 kit's `Buttons` page is ~14 MB with its text
+   * outlined — so the limit must cover a real maximum-node export, but it is not absent: parsing is
+   * O(bytes) in both time and heap, it happens at catalog load, and a delivery branch is not
+   * trusted to be sane about what it publishes.
+   */
+  const val MAX_BYTES: Int = 16 * 1024 * 1024
+
+  /**
+   * What a specimen sheet is made of: shapes, paint, and text.
+   *
+   * Notable absences, all deliberate: `script`, `foreignObject`, `a`, `style`, `animate` / `set` /
+   * `animateTransform` / `animateMotion`, `handler`, `audio`, `video`, `iframe`. Figma emits none
+   * of them for a design page, and each is a way for markup to become behaviour.
+   */
+  private val SAFE_ELEMENTS =
+    setOf(
+      "svg",
+      "g",
+      "defs",
+      "symbol",
+      "use",
+      "title",
+      "desc",
+      "path",
+      "rect",
+      "circle",
+      "ellipse",
+      "line",
+      "polyline",
+      "polygon",
+      "text",
+      "tspan",
+      "image",
+      "clippath",
+      "mask",
+      "pattern",
+      "lineargradient",
+      "radialgradient",
+      "stop",
+      "filter",
+      "fegaussianblur",
+      "fecolormatrix",
+      "feoffset",
+      "feblend",
+      "feflood",
+      "fecomposite",
+      "femerge",
+      "femergenode",
+      "fedropshadow",
+      "femorphology",
+      "fetile",
+      "feturbulence",
+      "fedisplacementmap",
+    )
+
+  /**
+   * Geometry, paint and layout attributes.
+   *
+   * `data-node-id` is on this list for the same reason the whole surface exists — it is the join
+   * between a shape in the picture and a component in the catalog, and stripping it would leave a
+   * document that is safe and useless. `id` is kept because internal `url(#…)` references depend on
+   * it; note that inlining therefore puts the export's id namespace into the host document, which
+   * is why exactly one page is ever inlined at a time.
+   */
+  private val SAFE_ATTRIBUTES =
+    setOf(
+      "data-node-id",
+      "id",
+      "class",
+      "viewbox",
+      "preserveaspectratio",
+      "width",
+      "height",
+      "x",
+      "y",
+      "x1",
+      "y1",
+      "x2",
+      "y2",
+      "cx",
+      "cy",
+      "r",
+      "rx",
+      "ry",
+      "fx",
+      "fy",
+      "d",
+      "points",
+      "transform",
+      "gradienttransform",
+      "patterntransform",
+      "gradientunits",
+      "patternunits",
+      "patterncontentunits",
+      "spreadmethod",
+      "maskunits",
+      "maskcontentunits",
+      "clippathunits",
+      "filterunits",
+      "primitiveunits",
+      "offset",
+      "stop-color",
+      "stop-opacity",
+      "fill",
+      "fill-opacity",
+      "fill-rule",
+      "stroke",
+      "stroke-width",
+      "stroke-opacity",
+      "stroke-linecap",
+      "stroke-linejoin",
+      "stroke-miterlimit",
+      "stroke-dasharray",
+      "stroke-dashoffset",
+      "opacity",
+      "color",
+      "clip-path",
+      "clip-rule",
+      "mask",
+      "filter",
+      "mix-blend-mode",
+      "shape-rendering",
+      "vector-effect",
+      "paint-order",
+      "font-family",
+      "font-size",
+      "font-style",
+      "font-weight",
+      "letter-spacing",
+      "word-spacing",
+      "text-anchor",
+      "dominant-baseline",
+      "alignment-baseline",
+      "white-space",
+      "xml:space",
+      "in",
+      "in2",
+      "result",
+      "mode",
+      "operator",
+      "type",
+      "values",
+      "stddeviation",
+      "dx",
+      "dy",
+      "flood-color",
+      "flood-opacity",
+      "radius",
+      "k1",
+      "k2",
+      "k3",
+      "k4",
+      "basefrequency",
+      "numoctaves",
+      "seed",
+      "scale",
+      "xchannelselector",
+      "ychannelselector",
+    )
+
+  /** Attributes whose value is a URL and must therefore be judged by value, not by name. */
+  private val URL_ATTRIBUTES = setOf("href", "xlink:href")
+
+  /**
+   * Raster payloads a `data:` URI may carry.
+   *
+   * `image/svg+xml` is absent on purpose: an SVG inside a data URI is markup this sanitizer never
+   * walked, and `<image>` renders it. Keeping the raster formats means a design page with a photo
+   * on it still works; admitting nested SVG would mean the allowlist stops at the first hop.
+   */
+  private val DATA_IMAGE_PREFIX =
+    Regex("^data:image/(png|jpeg|jpg|gif|webp|bmp);base64,[A-Za-z0-9+/=\\s]+$")
+
+  /** Anything in a `style` value that would reach off-document, plus the classic CSS escapes. */
+  private val UNSAFE_STYLE =
+    Regex("""(?i)@import|expression\s*\(|javascript:|url\s*\(\s*(?!#|'#|"#)""")
+
+  fun sanitize(svg: String): String? {
+    val bytes = svg.toByteArray()
+    if (bytes.isEmpty() || bytes.size > MAX_BYTES) return null
+    val document =
+      runCatching {
+        val factory = DocumentBuilderFactory.newInstance()
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
+        // The two that actually stop entity attacks. Set individually rather than in one
+        // runCatching so a parser missing one still gets the others.
+        runCatching { factory.setFeature(DISALLOW_DOCTYPE, true) }
+        runCatching { factory.setFeature(EXTERNAL_GENERAL_ENTITIES, false) }
+        runCatching { factory.setFeature(EXTERNAL_PARAMETER_ENTITIES, false) }
+        runCatching { factory.setFeature(LOAD_EXTERNAL_DTD, false) }
+        factory.isXIncludeAware = false
+        factory.isExpandEntityReferences = false
+        factory.isNamespaceAware = true
+        val builder = factory.newDocumentBuilder()
+        // Belt and braces: if a parser silently ignored `disallow-doctype-decl`, this makes every
+        // external reference resolve to nothing instead of to a file on this host.
+        builder.setEntityResolver { _, _ -> InputSource(ByteArrayInputStream(ByteArray(0))) }
+        builder.parse(InputSource(ByteArrayInputStream(bytes)))
+      }
+        .getOrNull() ?: return null
+
+    val root = document.documentElement ?: return null
+    if (localName(root) != "svg") return null
+    scrub(root)
+
+    return runCatching {
+      val factory = TransformerFactory.newInstance()
+      runCatching { factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true) }
+      val transformer = factory.newTransformer()
+      // No `<?xml …?>` prologue: the output is spliced into an HTML document, where a prologue is
+      // a parse error rather than a declaration.
+      transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes")
+      transformer.setOutputProperty(OutputKeys.METHOD, "xml")
+      val writer = StringWriter()
+      transformer.transform(DOMSource(root), StreamResult(writer))
+      writer.toString()
+    }
+      .getOrNull()
+  }
+
+  /**
+   * Depth-first prune. Children are walked over a snapshot, since removal mutates the live list.
+   */
+  private fun scrub(element: Element) {
+    scrubAttributes(element)
+    val children = (0 until element.childNodes.length).map { element.childNodes.item(it) }
+    for (child in children) {
+      when (child.nodeType) {
+        Node.ELEMENT_NODE -> {
+          val childElement = child as Element
+          if (localName(childElement) in SAFE_ELEMENTS) scrub(childElement)
+          // Removed with its subtree. A disallowed element's children are not promoted into its
+          // place: `<foreignObject>`'s children are HTML, and re-parenting them would keep exactly
+          // the payload the removal was for.
+          else element.removeChild(child)
+        }
+        // Comments and processing instructions carry nothing a page needs and PIs are executable in
+        // some contexts. Text and CDATA stay — that is the label on a specimen.
+        Node.COMMENT_NODE,
+        Node.PROCESSING_INSTRUCTION_NODE -> element.removeChild(child)
+        else -> Unit
+      }
+    }
+  }
+
+  private fun scrubAttributes(element: Element) {
+    val attributes = element.attributes
+    val doomed = mutableListOf<String>()
+    for (i in 0 until attributes.length) {
+      val attribute = attributes.item(i)
+      val name = attribute.nodeName.lowercase()
+      val value = attribute.nodeValue.orEmpty()
+      val keep =
+        when {
+          // First, and before the allowlist: an event handler is never geometry, and checking it
+          // here means no later addition to SAFE_ATTRIBUTES can admit one by accident.
+          name.startsWith("on") -> false
+          name == "xmlns" || name.startsWith("xmlns:") -> true
+          name in URL_ATTRIBUTES -> isSafeUrl(value)
+          name == "style" -> !UNSAFE_STYLE.containsMatchIn(value)
+          else -> name in SAFE_ATTRIBUTES
+        }
+      if (!keep) doomed += attribute.nodeName
+    }
+    for (name in doomed) element.removeAttribute(name)
+  }
+
+  /**
+   * An internal reference or an inline raster. Everything else — including `//host` — is refused.
+   */
+  private fun isSafeUrl(value: String): Boolean {
+    val trimmed = value.trim()
+    return trimmed.startsWith("#") || DATA_IMAGE_PREFIX.matches(trimmed.replace("\n", ""))
+  }
+
+  /**
+   * The tag name without its namespace prefix, lowercased. `clipPath` and `clippath` are one tag.
+   */
+  private fun localName(element: Element): String =
+    (element.localName ?: element.tagName).lowercase()
+
+  private const val DISALLOW_DOCTYPE = "http://apache.org/xml/features/disallow-doctype-decl"
+  private const val EXTERNAL_GENERAL_ENTITIES =
+    "http://xml.org/sax/features/external-general-entities"
+  private const val EXTERNAL_PARAMETER_ENTITIES =
+    "http://xml.org/sax/features/external-parameter-entities"
+  private const val LOAD_EXTERNAL_DTD =
+    "http://apache.org/xml/features/nonvalidating/load-external-dtd"
+}

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
@@ -1,0 +1,1172 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import java.io.IOException
+import java.io.RandomAccessFile
+import java.nio.channels.OverlappingFileLockException
+import java.security.MessageDigest
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * On-disk home for rendered theme PNGs, so warming survives the thing that produced it.
+ *
+ * ### What this exists to stop
+ *
+ * [CatalogThemeCache] is process memory. It is dropped by a server restart and, separately, by a
+ * catalog reload — every load builds a fresh `ServeSessionState` and therefore a fresh cache. For
+ * `m3-catalog` on the public box those two together fired 7-10 times a day (3 delivery-branch
+ * regenerations and 4 releases on 2026-08-17 alone) against a catalog needing roughly 28 hours of
+ * lane time to warm its 10,120 targets. It had never once had a window long enough to finish, on
+ * any day. Rotation ([ServeBackgroundWork]) got it warming; only persistence lets the work
+ * accumulate.
+ *
+ * ### Layout
+ *
+ * ```
+ * <root>/<system>/<fingerprint>/manifest.json
+ * <root>/<system>/<fingerprint>/<sha256(cacheKey)>.png
+ * ```
+ *
+ * A **generation** is one `(system, fingerprint)` pair — see [ThemeCacheFingerprint] for what the
+ * fingerprint covers. Generations are never mutated in place: a new catalog revision or a new
+ * server version simply writes under a new directory and the old one is swept. That is what makes
+ * invalidation structural rather than something a reader has to remember to check.
+ *
+ * The manifest is not consulted to decide validity — the directory name already is the decision. It
+ * records the inputs so a drop is *explainable* ("renderer 1.13.0 to 1.14.0 invalidated 8,412
+ * entries") instead of being another unexplained return to zero.
+ */
+class ThemeCacheStore(
+  private val root: File,
+  /**
+   * Ceiling for the whole store across every catalog and generation.
+   *
+   * Enforced by [sweep] rather than at write time. Writes must not block on a byte census — the
+   * optimizer is calling [Generation.put] once per render — and a cache that refused to grow
+   * between sweeps would silently stop persisting exactly when it was working hardest.
+   */
+  private val maxBytes: Long = DEFAULT_MAX_BYTES,
+  /**
+   * How recently a generation must have been created to be spared by [sweep] even when this process
+   * has no use for it.
+   *
+   * This exists for the zero-downtime rollout the image deployment performs: a new replica boots
+   * alongside the running one, sharing the `/config` volume this store defaults into, and knows
+   * nothing of the old replica's fingerprints. Without a grace window it would reclaim the cache of
+   * the replica still serving production — and if the new replica then failed readiness, the old
+   * one would carry on with its warming deleted out from under it.
+   */
+  private val graceMillis: Long = DEFAULT_SWEEP_GRACE_MILLIS,
+  private val clock: () -> Long = System::currentTimeMillis,
+) {
+  private val json = Json {
+    ignoreUnknownKeys = true
+    prettyPrint = true
+  }
+  private val writes = AtomicLong()
+  private val writeFailures = AtomicLong()
+  private val hits = AtomicLong()
+  private val misses = AtomicLong()
+  // Census published by [sweep] and advanced by each write — see [snapshot] for why it is not read
+  // from the filesystem on the request path.
+  private val knownBytes = AtomicLong()
+  private val knownGenerations = java.util.concurrent.atomic.AtomicInteger()
+  /**
+   * Generation directories per system, as of the last [sweep].
+   *
+   * The single number that says whether the *key* is working. A system whose fingerprint is stable
+   * has one generation on disk; one whose fingerprint churns — because some input the digest reads
+   * changes on every load, a staging path that slipped into the render config, a jar rebuilt each
+   * boot — accumulates a directory per restart, each adopted by nobody. Both look identical in
+   * [writes] and in [hits], which is exactly the confusion this exists to remove: writes climbing
+   * while a system's generation count climbs beside them means the cache is buying disk I/O and
+   * nothing else.
+   */
+  private val knownGenerationsBySystem = AtomicReference<Map<String, Int>>(emptyMap())
+  private val lastFailure = ConcurrentHashMap<String, String>()
+  private val tempSequence = AtomicLong()
+  /** Cache for [evictedAtEpochMillis]; -1 until the marker has been looked for. */
+  private val evictedAt = AtomicLong(-1)
+  /** Distinguishes this process's in-flight writes from a concurrently deployed replica's. */
+  private val writerId: String =
+    ProcessHandle.current().pid().toString(36) + "-" + System.identityHashCode(this).toString(36)
+
+  /**
+   * Open (creating if needed) the generation for [system] at [fingerprint], or null when the store
+   * is unusable.
+   *
+   * Null rather than an exception: persistence is an optimisation, and a box with a read-only or
+   * full disk must serve catalogs exactly as it did before this existed.
+   */
+  fun open(system: String, fingerprint: String, inputs: GenerationInputs): Generation? {
+    val safeSystem = system.safeName() ?: return null
+    val safeFingerprint = fingerprint.safeName() ?: return null
+    val dir = File(File(root, safeSystem), safeFingerprint)
+    if (!runCatching { dir.mkdirs() }.getOrDefault(false) && !dir.isDirectory) {
+      recordFailure(system, "could not create $dir")
+      return null
+    }
+    val marked = writeManifest(dir, inputs)
+    knownGenerations.incrementAndGet()
+    knownGenerationsBySystem.getAndUpdate { it + (system to (it[system] ?: 0) + 1) }
+    knownBytes.addAndGet(dir.sizeOnDisk())
+    return Generation(dir, system, markAllDirtyOnOpen = marked == MarkOutcome.UNRECORDED)
+  }
+
+  /**
+   * Write the generation's manifest, or refresh it when a **different build** has opened the same
+   * generation.
+   *
+   * The early return used to be unconditional, on the reasoning that the directory name is the
+   * decision and the manifest is only commentary. That held while the fingerprint keyed on the tool
+   * version, because a new build could never reach an existing generation. It no longer does — a
+   * release now adopts its predecessor's renders (see [ThemeCacheFingerprint]) — so leaving the
+   * manifest alone would have it name a build that has not been near this directory since.
+   *
+   * What the refreshed manifest then records is the build that last **opened** the generation, and
+   * [GenerationInputs.toolVersion] says so. It is deliberately not the build that last *wrote* a
+   * PNG here, and the difference is load-bearing during a rollout: this rewrite happens at open,
+   * before this process has rendered anything, and the incoming replica can fail readiness
+   * immediately afterwards while the outgoing one carries on as the volume's only real writer. An
+   * investigator reading `toolVersion` as "who made these pixels" would be pointed at a build that
+   * made none of them. Deferring the rewrite to the first successful [Generation.put] would fix
+   * that half and break the other: [dirtyBeforeEpochMillis] has to be on disk *before* a single
+   * render is served from this directory, or the adopted set is trusted for however long the first
+   * write takes. The boundary is the correctness half, so it wins, and the version is documented as
+   * what it actually is.
+   *
+   * [GenerationInputs.createdAtEpochMillis] is preserved across the rewrite: it is what the sweep's
+   * grace window reads to spare a generation belonging to a replica that is still serving, and
+   * restamping it on every open would make a long-lived generation permanently young.
+   */
+  private fun writeManifest(dir: File, inputs: GenerationInputs): MarkOutcome {
+    val file = File(dir, MANIFEST_NAME)
+    val existing =
+      if (file.isFile) {
+        runCatching { json.decodeFromString(GenerationInputs.serializer(), file.readText()) }
+          .getOrNull()
+      } else {
+        null
+      }
+    // Everything on this volume older than the last eviction plus the rollout grace window is
+    // untrusted, whoever wrote it and whatever build they were — see [evictAll]. `+ graceMillis`
+    // for the same reason the cross-build boundary uses it: the writes that have to be caught are
+    // the OUTGOING replica's, and those land after the eviction instant, not before it.
+    val evictionBoundary = evictedAtEpochMillis().takeIf { it > 0 }?.plus(graceMillis) ?: 0L
+    // An unreadable manifest beside a live generation is rewritten rather than left: the sweep
+    // falls back to the directory's own timestamp for it, and a readable one is strictly better.
+    //
+    // The eviction clause is what stops the same-build case slipping through. An operator can evict
+    // and restart WITHOUT a release — that is the ordinary shape of "I know the pixels moved" — and
+    // then the outgoing replica carries this build's own version string, the early return fires on
+    // it, and the boundary it repopulated the generation under is whatever the previous manifest
+    // said. Which is usually zero.
+    if (
+      existing != null &&
+        existing.toolVersion == inputs.toolVersion &&
+        existing.dirtyBeforeEpochMillis >= evictionBoundary
+    )
+      return MarkOutcome.NOT_NEEDED
+    val createdAt = existing?.createdAtEpochMillis?.takeIf { it > 0 } ?: clock()
+    // Renders are here that this build did not write. Usually the manifest says so; when it is
+    // MISSING OR CORRUPT it says nothing, and "says nothing" was being read as "this build created
+    // the generation". A manifest write interrupted mid-flight leaves exactly that state beside a
+    // full set of another build's PNGs, which would then open with a zero boundary, verify on a
+    // five-entry sample, and never be regenerated. Files of unknown ownership are not ours.
+    val inherited =
+      existing != null || dir.listFiles()?.any { it.name.endsWith(PNG_SUFFIX) } == true
+    // A DIFFERENT build is opening renders another one wrote, so everything already here is dirty.
+    // On a generation this build created there is nothing older to mark, and the boundary stays at
+    // zero.
+    //
+    // `+ graceMillis`, not `clock()`, because the rollout this deployment performs is
+    // ZERO-DOWNTIME: the outgoing replica keeps serving — and keeps rendering into this same
+    // directory — while the incoming one boots. Renders it writes after this instant would carry a
+    // timestamp past a bare `clock()` boundary and be filed as this build's work, which is exactly
+    // the stale-pixel case the boundary exists to catch, and the sample cannot catch them either
+    // because it only examines what was present at open. The grace window is the same one the sweep
+    // uses to decide another replica may still be live, which is the same question.
+    //
+    // The cost is that some of this build's OWN early renders fall under the boundary and are
+    // re-rendered once. That is the right direction to be wrong in.
+    //
+    // `maxOf` with the eviction boundary rather than either one alone: the two answer different
+    // questions ("did another BUILD write here" and "was this volume evicted under a writer that
+    // is still going"), a generation can be in both states at once, and the later line is the only
+    // one that makes both answers safe. The eviction half applies even to a directory this process
+    // created — a generation deleted by the eviction and recreated under the same fingerprint by
+    // the outgoing replica reaches here as brand new, which is precisely the case.
+    val boundary = maxOf(if (inherited) clock() + graceMillis else 0L, evictionBoundary)
+    val wrote = runCatching {
+      file.writeText(
+        json.encodeToString(
+          inputs.copy(createdAtEpochMillis = createdAt, dirtyBeforeEpochMillis = boundary)
+        )
+      )
+    }
+      .onFailure { recordFailure(dir.name, "manifest: ${it.message}") }
+      .isSuccess
+    // A cross-build open whose boundary did NOT reach the disk is the dangerous case, and it used
+    // to be swallowed: the failure was recorded, `open` still handed back a usable generation, and
+    // that generation re-read the PREVIOUS manifest's boundary — commonly zero — so every file
+    // another build wrote was filed as this build's own work. A five-entry sample then verifies the
+    // generation and a renderer change outside the sample serves stale pixels for the life of the
+    // process. On a full or read-only volume the honest answer is that nothing here is known to be
+    // ours, so the generation opens with everything present marked dirty in memory. That costs a
+    // re-render of a catalog the volume could not record anything about, which is the right
+    // direction to be wrong in.
+    return when {
+      // Nothing on disk to be on the wrong side of either boundary.
+      !inherited -> MarkOutcome.NOT_NEEDED
+      wrote -> MarkOutcome.RECORDED
+      else -> MarkOutcome.UNRECORDED
+    }
+  }
+
+  /** Whether a cross-build open managed to record its dirty boundary. */
+  private enum class MarkOutcome {
+    /** This build created the generation, or already owns the manifest: nothing to mark. */
+    NOT_NEEDED,
+    /** A different build's renders were here and the boundary is on disk. */
+    RECORDED,
+    /** A different build's renders were here and the boundary could NOT be written. */
+    UNRECORDED,
+  }
+
+  /**
+   * The dirty boundary recorded in [dir]'s manifest, or 0 when there is none.
+   *
+   * Read back off disk rather than carried from [writeManifest]'s caller, because the boundary
+   * belongs to the generation rather than to this process's idea of it: on a rolling update the
+   * replica that opened the directory first is the one that set it, and re-deriving it here would
+   * move a line the other replica is already regenerating against.
+   */
+  private fun dirtyBoundary(dir: File): Long = runCatching {
+    json
+      .decodeFromString(GenerationInputs.serializer(), File(dir, MANIFEST_NAME).readText())
+      .dirtyBeforeEpochMillis
+  }
+    .getOrDefault(0L)
+
+  /**
+   * Delete every generation in the store, unconditionally, and report how many went.
+   *
+   * The escape hatch for "the pixels on this volume are wrong and I already know it" — a change to
+   * the render environment that [ThemeCacheFingerprint.rendererIdentity] does not read, say, which
+   * no fingerprint sees and which a five-entry verification sample can miss. [sweep] cannot serve
+   * this purpose: it deliberately spares any generation inside its grace window, which is exactly
+   * the freshly-written one an operator wants gone.
+   *
+   * ### Deleting is not enough on a shared volume
+   *
+   * This is called before this process opens a generation, so it cannot race **this** process's
+   * writes — and that used to be the whole of the reasoning, which was a single-process argument
+   * about a volume that is not single-process. The deployment this store was built for performs a
+   * **zero-downtime rollout**: the outgoing replica keeps serving, and keeps writing PNGs, against
+   * the same mounted `/config` volume while the incoming one boots and evicts. Every render it
+   * publishes in that window repopulates a generation with precisely the pixels the eviction was
+   * meant to destroy, and they land *after* the deletion, so they carry fresh timestamps and read
+   * as this build's own work.
+   *
+   * So the deletion also leaves a mark. [EVICTED_NAME] records when it happened, and every
+   * generation opened from here on treats anything written before that instant plus the rollout
+   * grace window as dirty — the same boundary mechanism, and the same grace window, that
+   * [writeManifest] already uses for the cross-build case, because it is the same question about
+   * the same other replica. An operator gets the eviction they asked for without having to prove
+   * that every other writer has stopped first.
+   *
+   * The mark is not a lock and does not claim to be one. It cannot stop the old replica writing; it
+   * makes what the old replica writes untrusted, which is the outcome that was wanted.
+   */
+  fun evictAll(): Int {
+    var deleted = 0
+    for (systemDir in root.listFiles()?.filter { it.isDirectory }.orEmpty()) {
+      for (generationDir in systemDir.listFiles()?.filter { it.isDirectory }.orEmpty()) {
+        if (generationDir.deleteRecursively()) deleted++
+        else recordFailure(systemDir.name, "could not evict ${generationDir.name}")
+      }
+      if (systemDir.listFiles()?.isEmpty() == true) systemDir.delete()
+    }
+    // Stamped AFTER the deletion, so a crash midway leaves the volume looking un-evicted rather
+    // than leaving surviving generations under a boundary nothing has been deleted against. The
+    // operator re-runs the flag; the alternative silently reports a completed eviction that only
+    // half happened.
+    val at = clock()
+    val stamped = runCatching { File(root, EVICTED_NAME).writeText(at.toString()) }.isSuccess
+    if (stamped) evictedAt.set(at)
+    // A volume that cannot record the eviction cannot make the old replica's repopulated renders
+    // dirty either, and that is worth saying out loud rather than reporting a clean eviction.
+    else recordFailure("store", "evicted but could not record the boundary in $EVICTED_NAME")
+    knownGenerations.set(0)
+    knownGenerationsBySystem.set(emptyMap())
+    knownBytes.set(0)
+    return deleted
+  }
+
+  /**
+   * When this store was last evicted, or 0 when it never was.
+   *
+   * Read off disk once and remembered: it is consulted on every [open] and it can only be changed
+   * by an [evictAll] in this same process, which updates the cached value itself. A concurrently
+   * deployed replica evicting under us is not a case worth polling for — that replica is the one
+   * booting, and the boundary it writes is read by the *next* open on either side.
+   */
+  private fun evictedAtEpochMillis(): Long = evictedAt.updateAndGet { cached ->
+    if (cached >= 0) cached
+    else
+      runCatching { File(root, EVICTED_NAME).readText().trim().toLong() }
+        .getOrDefault(0L)
+        .coerceAtLeast(0L)
+  }
+
+  /**
+   * Delete every generation not in [live], and report whether what remains fits [maxBytes].
+   *
+   * Reclaiming the dead set is the whole of the sweep, and on a box regenerating several times a
+   * day it is also nearly the whole of the garbage: every superseded catalog revision and every
+   * previous server version leaves one behind.
+   *
+   * **A live generation is never deleted, not even to fit the cap.** Evicting what is currently
+   * being warmed to make room for what is not would turn the cap into a treadmill — the optimizer
+   * would re-render exactly what the sweep just discarded, forever, and the box would look busy
+   * while making no progress. So an over-cap *live* set is reported ([SweepResult.overCap]) rather
+   * than acted on: it means the cap is too small for the catalog set, which is a configuration
+   * answer and not something this can quietly fix.
+   */
+  fun sweep(live: Set<GenerationId>, onlySystems: Set<String>? = null): SweepResult {
+    val youngerThan = clock() - graceMillis
+    val beforeScan = knownBytes.get()
+    val liveDirs = live.mapNotNull { it.dir() }.toSet()
+    var deleted = 0
+    var reclaimed = 0L
+    var survivingBytes = 0L
+    var survivingGenerations = 0
+    val survivingBySystem = mutableMapOf<String, Int>()
+
+    for (systemDir in root.listFiles()?.filter { it.isDirectory }.orEmpty()) {
+      val generationDirs = systemDir.listFiles()?.filter { it.isDirectory }.orEmpty()
+      // A system the caller has no current generation for is left entirely alone. Absence from the
+      // live set means "we did not load this catalog", which is not the same as "this catalog's
+      // warmed renders are garbage" — a load can fail transiently, and its cache must outlive that.
+      if (onlySystems != null && systemDir.name !in onlySystems) {
+        survivingBytes += systemDir.sizeOnDisk()
+        survivingGenerations += generationDirs.size
+        if (generationDirs.isNotEmpty()) survivingBySystem[systemDir.name] = generationDirs.size
+        continue
+      }
+      for (generationDir in generationDirs) {
+        val size = generationDir.sizeOnDisk()
+        // Three kinds of survivor, each for its own reason:
+        //  - ours: obviously;
+        //  - young: the image deployment rolls out zero-downtime, so a new replica boots beside the
+        //    running one on the same volume and sees its generations as unreferenced. Reclaiming
+        //    them deletes a possibly 28-hour cache from the replica still serving production — and
+        //    still serving it if the new replica fails readiness;
+        //  - undeletable: the bytes remain on the volume whatever the filesystem reported, and a
+        //    census that omits them can report the store under a cap it is actually over.
+        if (generationDir in liveDirs || createdAt(generationDir) > youngerThan) {
+          survivingBytes += size
+          survivingGenerations++
+          survivingBySystem.merge(systemDir.name, 1, Int::plus)
+          continue
+        }
+        if (generationDir.deleteRecursively()) {
+          deleted++
+          reclaimed += size
+        } else {
+          survivingBytes += size
+          survivingGenerations++
+          survivingBySystem.merge(systemDir.name, 1, Int::plus)
+          recordFailure(systemDir.name, "could not reclaim ${generationDir.name}")
+        }
+      }
+      // A system directory left empty by the sweep is itself garbage.
+      if (systemDir.listFiles()?.isEmpty() == true) systemDir.delete()
+    }
+
+    val total = survivingBytes
+    // Merged, not assigned. A sweep runs concurrently with other catalogs' optimizers writing into
+    // this store — startup releases the background-work gate immediately before sweeping — so a
+    // bare
+    // `set` can discard a write that landed during the scan, or publish a total that never saw a
+    // file created after its directory was walked. Either way `/status` under-reports occupancy
+    // until the next sweep, which is exactly when an over-cap volume most needs to be visible.
+    knownBytes.getAndUpdate { current -> total + (current - beforeScan).coerceAtLeast(0) }
+    knownGenerations.set(survivingGenerations)
+    knownGenerationsBySystem.set(survivingBySystem.toMap())
+    return SweepResult(
+      deletedGenerations = deleted,
+      reclaimedBytes = reclaimed,
+      bytes = total,
+      overCap = total > maxBytes,
+    )
+  }
+
+  /** Every system with a directory in the store, whether or not this server still serves it. */
+  fun systems(): Set<String> =
+    root.listFiles()?.filter { it.isDirectory }?.map { it.name }?.toSet().orEmpty()
+
+  /**
+   * Disk occupancy as of the last sweep, plus everything written since.
+   *
+   * **Deliberately not a live census.** `/status.json` is a monitoring endpoint that gets polled,
+   * and one warmed catalog is 10,120 files — recursively walking the tree per request would put
+   * tens of thousands of filesystem metadata operations on the request path, growing with every
+   * catalog served. The sweep already walks the tree for its own reasons, so it publishes the total
+   * on the way past and writes add to it from there. Slightly stale between sweeps, which is the
+   * right trade for a number nobody acts on within a second.
+   */
+  fun snapshot(): ThemeCacheStoreSnapshot =
+    ThemeCacheStoreSnapshot(
+      root = root.path,
+      generations = knownGenerations.get(),
+      generationsBySystem = knownGenerationsBySystem.get(),
+      bytes = knownBytes.get(),
+      maxBytes = maxBytes,
+      writes = writes.get(),
+      writeFailures = writeFailures.get(),
+      hits = hits.get(),
+      misses = misses.get(),
+      lastFailureReason = lastFailure["reason"],
+    )
+
+  /**
+   * When this generation was first created, from its manifest, falling back to the directory's own
+   * timestamp and finally to "now" — an unreadable age must read as *young*, so an unparseable
+   * manifest errs toward keeping bytes rather than deleting another replica's cache.
+   */
+  private fun createdAt(dir: File): Long =
+    runCatching {
+      json
+        .decodeFromString(GenerationInputs.serializer(), File(dir, MANIFEST_NAME).readText())
+        .createdAtEpochMillis
+        .takeIf { it > 0 }
+    }
+      .getOrNull() ?: dir.lastModified().takeIf { it > 0 } ?: clock()
+
+  private fun recordFailure(system: String, reason: String) {
+    writeFailures.incrementAndGet()
+    lastFailure["reason"] = "$system: ${reason.take(MAX_REASON_CHARS)}"
+  }
+
+  /** One `(system, fingerprint)` generation's directory of PNGs. */
+  inner class Generation
+  internal constructor(
+    private val dir: File,
+    private val system: String,
+    /**
+     * Treat everything already on disk as dirty regardless of what the manifest says.
+     *
+     * Set when a cross-build open could not record its boundary — see [writeManifest]. The volume
+     * could not be told that another build's renders are here, so this process must not conclude
+     * from that same volume that they are its own.
+     */
+    private val markAllDirtyOnOpen: Boolean = false,
+  ) {
+
+    /**
+     * Cache keys already on disk, read once at open.
+     *
+     * Held as a set rather than re-listed per lookup because the question "is this target already
+     * warm" is asked for every target on every optimizer pass — 10,120 times for one catalog — and
+     * a directory listing per question would make the cache slower than the renders it replaces.
+     */
+    private val present: MutableSet<String> =
+      java.util.Collections.newSetFromMap(ConcurrentHashMap<String, Boolean>()).apply {
+        dir
+          .listFiles()
+          ?.filter { it.isFile && it.name.endsWith(PNG_SUFFIX) }
+          ?.forEach { add(it.name.removeSuffix(PNG_SUFFIX)) }
+      }
+
+    /** How many renders were already on disk when this generation was opened. */
+    val loadedEntries: Int = present.size
+
+    /** This generation's directory name — the fingerprint it was opened under. */
+    val fingerprint: String = dir.name
+
+    /**
+     * Renders written before this instant came from a build that is not the one running, and are
+     * **dirty**: still servable once the load-time sample has vouched for them, but queued for
+     * re-render so the store converges on pixels this renderer actually produced.
+     *
+     * Volatile because [markAllDirty] moves it while the optimizer is reading it.
+     */
+    @Volatile private var dirtyBefore: Long = dirtyBoundary(dir)
+
+    /**
+     * The dirty file names, resolved **once** and then maintained in memory.
+     *
+     * The boundary and each file's timestamp decide who is dirty, but only when this set is built:
+     * asking the filesystem per query turned `/status` into tens of thousands of synchronous `stat`
+     * calls, because the snapshot walks every target of every catalog and m3-catalog alone declares
+     * 10,440. A render leaves the set when this process rewrites it, which is the only way an entry
+     * becomes clean.
+     */
+    private val dirtyNames: MutableSet<String> =
+      java.util.Collections.newSetFromMap(ConcurrentHashMap<String, Boolean>()).apply {
+        val boundary = dirtyBefore
+        if (markAllDirtyOnOpen) {
+          addAll(present)
+        } else if (boundary > 0L) {
+          addAll(
+            present.filter { name ->
+              val modified = File(dir, "$name$PNG_SUFFIX").lastModified()
+              // A timestamp that cannot be read is treated as dirty: "I cannot tell how old this
+              // is" and "this is current" are not the same answer, and only one is safe to guess.
+              modified == 0L || modified < boundary
+            }
+          )
+        }
+      }
+
+    /**
+     * Renders this process published while the outgoing replica of a rolling update could still
+     * have been publishing too, against the modification time each had immediately after our write.
+     *
+     * The boundary alone does not close the overlap. It files a co-replica's LATER write as dirty
+     * only if that write is the one classification sees, and classification happens once, at open —
+     * so a key we render first and the outgoing replica then renames over is removed from
+     * [dirtyNames] by our own write and never looked at again. Our memory tier keeps serving the
+     * right pixels until it evicts, at which point the read falls through to another build's bytes
+     * under a generation that reports itself converged.
+     *
+     * Recording our own write time makes that detectable without a second classification pass: a
+     * file whose timestamp no longer matches what we left is one somebody else has since replaced.
+     * Populated only while [dirtyBefore] is still in the future, which is exactly the window in
+     * which a second writer can exist, so on the ordinary path this map stays empty.
+     */
+    private val atRiskWrites = ConcurrentHashMap<String, Long>()
+
+    /**
+     * Re-check the renders published during a rollout overlap, once that overlap is over.
+     *
+     * Costs one `stat` per at-risk write, once: the map is emptied on the way out and never
+     * refilled, because past [dirtyBefore] no other replica is still writing here. Anything that
+     * moved under us goes back on the dirty queue to be rendered again.
+     *
+     * An **empty** at-risk map is not an early return, even though it has nothing to stat. The
+     * convergence clear below can be refused — it is try-lock, and a foreground render publishing
+     * at that instant holds the lock — and the map is drained by the loop whether or not the clear
+     * that follows it succeeds. Returning early on an empty map would therefore strand a
+     * future-dated boundary in the manifest permanently, on the one interleaving where the clear
+     * had to be deferred: every later call would see nothing to reconcile and never reach the
+     * retry. The cost of not returning is three field reads in
+     * [clearBoundaryIfConvergedUnderLock]'s own pre-check, which is what keeps the status path off
+     * the file lock.
+     */
+    private fun reconcileAtRiskWrites() {
+      if (clock() < dirtyBefore) return
+      for ((name, writtenAt) in atRiskWrites.toList()) {
+        atRiskWrites.remove(name)
+        if (name !in present) continue
+        val modified = runCatching { File(dir, "$name$PNG_SUFFIX").lastModified() }.getOrDefault(0L)
+        // A timestamp we cannot read is treated the same way classification treats one: unknown is
+        // not the same answer as ours.
+        if (modified != writtenAt) dirtyNames += name
+      }
+      // The reconcile is itself a way of REACHING convergence, and in the ordinary case — no
+      // co-replica overwrote anything — it is the last thing that happens: the dirty set emptied
+      // some time ago and the at-risk set empties here, with no further write to notice. Leaving
+      // the clear to `put` alone stranded the future-dated boundary in the manifest for exactly the
+      // rollout this bookkeeping exists to serve.
+      clearBoundaryIfConvergedUnderLock()
+    }
+
+    /**
+     * Drop the durable boundary once every render on this volume is one this process made, and
+     * nothing it wrote during a rollout overlap is still unverified.
+     *
+     * Called from both places convergence can be reached — the write that clears the last dirty
+     * name, and the reconcile that clears the last at-risk one — because either can be the last.
+     *
+     * **The caller must hold the generation write lock.** The condition read here is exactly the
+     * one [markAllDirty] inverts, so a reader that decides outside the lock is deciding about a
+     * state that can have been replaced by the time it acts. See
+     * [clearBoundaryIfConvergedUnderLock].
+     */
+    private fun clearBoundaryIfConverged() {
+      if (dirtyBefore > 0L && dirtyNames.isEmpty() && atRiskWrites.isEmpty()) clearDirtyBoundary()
+    }
+
+    /**
+     * [clearBoundaryIfConverged] for a caller that does **not** already hold the generation write
+     * lock — the rollout reconcile, which reaches convergence from `dirtyCount()` on the status
+     * path rather than from inside a write.
+     *
+     * The interleaving this closes loses an operator's regenerate outright. The reconcile observes
+     * both sets empty; [markAllDirty] then takes the lock, persists a fresh boundary, repopulates
+     * `dirtyNames` and answers the admin route `{"queued": true, "entries": N}`; and the reconcile,
+     * still acting on what it saw before any of that, writes a zero boundary over the new mark and
+     * clears the queue it never looked at. The endpoint has promised a request that survives the
+     * next roll and there is nothing left of it, in memory or on disk.
+     *
+     * So the decision is re-taken under the lock, and `markAllDirty` — which is already try-lock
+     * and already answers `-1` when it cannot have the lock — reports an honest failure instead of
+     * a mark that is about to be erased. Whichever of the two gets the lock first, the other sees
+     * its result rather than a stale copy of the state it replaced.
+     *
+     * The pre-check outside the lock is not the decision, only an early exit: `dirtyCount()` is on
+     * the status path and the ordinary answer is "there is no boundary to clear", which should not
+     * cost a file lock per call.
+     */
+    private fun clearBoundaryIfConvergedUnderLock() {
+      if (dirtyBefore == 0L || dirtyNames.isNotEmpty() || atRiskWrites.isNotEmpty()) return
+      val generationWriteLock = tryGenerationWriteLock() ?: return
+      try {
+        clearBoundaryIfConverged()
+      } finally {
+        generationWriteLock.close()
+      }
+    }
+
+    /** Whether [cacheKey] is on disk from an older build and has not been re-rendered since. */
+    fun isDirty(cacheKey: String): Boolean = isDirtyName(fileName(cacheKey))
+
+    /**
+     * The same question asked of a **file name** rather than a cache key.
+     *
+     * [present] holds hashed names, not the keys they were derived from — the store never needs to
+     * map back, and could not: the hash is one-way. So every internal walk over what is on disk
+     * goes through this, and only the caller-facing [isDirty] hashes. Routing an internal walk
+     * through that one instead hashes an already-hashed name, lands on a file that does not exist,
+     * and — since a missing file reads as dirty — quietly reports the entire generation dirty.
+     */
+    private fun isDirtyName(name: String): Boolean = name in dirtyNames
+
+    /**
+     * How many renders on disk are still an older build's work.
+     *
+     * The one call every dirty-queue read already goes through, so it is where the rollout
+     * reconcile hangs — see [reconcileAtRiskWrites] for why that costs nothing on the ordinary
+     * path.
+     */
+    fun dirtyCount(): Int {
+      reconcileAtRiskWrites()
+      return dirtyNames.size
+    }
+
+    /**
+     * Mark every render currently on disk dirty, by moving the boundary to now.
+     *
+     * The operator's "regenerate this catalog" — for pixels suspected wrong by something no
+     * fingerprint sees, a base image that changed the installed fonts being the case that motivated
+     * it. Deliberately not a delete: the entries keep serving while the background pass replaces
+     * them, so asking for a refresh does not cost every preview a cold render.
+     */
+    fun markAllDirty(): Int {
+      // Under the generation write lock, because the transition races the one thing that undoes it.
+      // A render publishing the last dirty entry calls `clearDirtyBoundary` from inside `put`,
+      // which holds this lock — so an unlocked mark could write its boundary, be overwritten by
+      // that older in-flight convergence, then repopulate `dirtyNames` and report a durable mark
+      // that is not on disk. Regeneration would proceed in this process and a restart before it
+      // finished would silently forget the rest of the operator's request.
+      val generationWriteLock = tryGenerationWriteLock() ?: return -1
+      try {
+        val now = clock()
+        // Persist FIRST, and refuse to claim the mark if it did not land. The contract this action
+        // sells is that a request survives the next roll; a full or read-only volume would
+        // otherwise leave the boundary in memory only, answer the operator 200 with a queued count,
+        // and forget the whole thing at the next restart — the one failure a durable-sounding API
+        // must not have.
+        val persisted = runCatching {
+          val file = File(dir, MANIFEST_NAME)
+          val existing = json.decodeFromString(GenerationInputs.serializer(), file.readText())
+          file.writeText(json.encodeToString(existing.copy(dirtyBeforeEpochMillis = now)))
+        }
+          .onFailure { recordFailure(system, "manifest: ${it.message}") }
+          .isSuccess
+        if (!persisted) return -1
+        dirtyBefore = now
+        // Everything on disk predates a boundary set to now, so the whole of `present` is dirty.
+        dirtyNames.addAll(present)
+        // A mark supersedes the overlap bookkeeping: every one of those entries is dirty now, so
+        // there is nothing left for the reconcile to decide, and leaving it populated would block
+        // the convergence clear for a window that has already been overtaken.
+        atRiskWrites.clear()
+        return dirtyNames.size
+      } finally {
+        generationWriteLock.close()
+      }
+    }
+
+    // Per-generation counters. The store-wide ones next to them answer "is the volume being used";
+    // these answer "is THIS catalog's cache working", which is the question an operator actually
+    // has — a box serving fifteen catalogs where one has an unstable fingerprint reports healthy
+    // store-wide totals while that one catalog re-renders from scratch every restart.
+    private val generationHits = AtomicLong()
+    private val generationMisses = AtomicLong()
+    private val generationWrites = AtomicLong()
+
+    /**
+     * Exactly the renders that were on disk when this generation was opened — the ones written by
+     * some *other* process, and therefore the only ones whose trustworthiness is in question.
+     *
+     * Snapshotted because [present] grows as this process writes, and a render this process just
+     * produced needs no verification: it came from this renderer.
+     */
+    private val adopted: MutableSet<String> =
+      java.util.Collections.newSetFromMap(ConcurrentHashMap<String, Boolean>()).apply {
+        addAll(present)
+      }
+
+    /** Whether [cacheKey] came from a previous process rather than from this one. */
+    fun wasAdopted(cacheKey: String): Boolean = fileName(cacheKey) in adopted
+
+    fun contains(cacheKey: String): Boolean = fileName(cacheKey) in present
+
+    fun get(cacheKey: String): ByteArray? {
+      val name = fileName(cacheKey)
+      if (name !in present) {
+        misses.incrementAndGet()
+        generationMisses.incrementAndGet()
+        return null
+      }
+      val bytes = runCatching { File(dir, "$name$PNG_SUFFIX").readBytes() }.getOrNull()
+      if (bytes == null) {
+        // On disk a moment ago and unreadable now — a sweep, an external delete, a truncated write.
+        // Forget it so the optimizer treats it as work still to do rather than as permanently
+        // cached-but-broken.
+        present.remove(name)
+        misses.incrementAndGet()
+        generationMisses.incrementAndGet()
+        return null
+      }
+      hits.incrementAndGet()
+      generationHits.incrementAndGet()
+      return bytes
+    }
+
+    /**
+     * Persist one render. Best-effort and never throws: a failed write costs a re-render later,
+     * which is strictly better than failing the render that just succeeded.
+     *
+     * Written to a temp file and renamed, so a crash or a full disk leaves no half-PNG that a later
+     * process would read as a valid cached render.
+     */
+    fun put(cacheKey: String, png: ByteArray, replaceExisting: Boolean = false) {
+      val name = fileName(cacheKey)
+      // Presence alone is not proof that no write is needed. While a generation is quarantined a
+      // foreground request deliberately misses the adopted copy and renders fresh bytes; returning
+      // here would leave the suspect PNG on disk, and once verification passed on OTHER sampled
+      // keys
+      // the read path would serve it again the moment the fresh copy fell out of memory.
+      // `|| isDirty` is what lets the regeneration pass actually land. A dirty entry an operator
+      // marked was written by THIS process, so it is not in `adopted`, and the adopted-only test
+      // would drop its replacement on the floor — the pass would re-render the catalog every slice
+      // and never clear a single flag.
+      if (name in present && !(replaceExisting && (name in adopted || name in dirtyNames))) return
+      // Optimizer admission prevents duplicate warming, but foreground renders can still complete
+      // on two zero-downtime replicas at once. Serialize writes for the whole generation across
+      // processes. This is try-lock rather than lock: persistence is best-effort and a visitor must
+      // never wait for another replica's disk write.
+      val generationWriteLock = tryGenerationWriteLock() ?: return
+      val target = File(dir, "$name$PNG_SUFFIX")
+      // Writer-unique, because the zero-downtime rollout puts two processes on this volume at once.
+      // A temp path shared by cache key lets one replica rename the inode while the other is still
+      // writing it, publishing a half-PNG under a name that claims to be complete — and a reader
+      // then promotes those bytes as a valid render.
+      val temp = File(dir, "$name.${writerId}-${tempSequence.incrementAndGet()}$TEMP_SUFFIX")
+      val existingSize = target.length()
+      try {
+        temp.writeBytes(png)
+        if (!temp.renameTo(target)) {
+          temp.delete()
+          recordFailure(system, "rename failed for $name")
+          return
+        }
+        // The size DELTA, not the payload size: two hosts for the same fingerprint can race to
+        // publish the same key during a catalog replacement and both rename over the target, but
+        // only one file ends up occupying the volume.
+        val previousSize = if (name in present) existingSize else 0L
+        present += name
+        // Replaced by this process, so it is no longer a candidate for verifying the previous one.
+        adopted -= name
+        // ...and no longer another build's work. This is the ONLY way an entry becomes clean, which
+        // is what keeps the dirty set honest without re-reading the volume: it shrinks exactly when
+        // a render is rewritten, and nothing else touches it.
+        dirtyNames -= name
+        // Inside the overlap window, remember what we left behind so a co-replica renaming over it
+        // can be caught later; outside it there is no second writer and nothing to remember.
+        // Strictly BEFORE the boundary: the boundary is when the overlap window closes, so a write
+        // at or past it has no second writer to be at risk from. It also keeps a store configured
+        // with no grace window — every test that is not about the rollout, and any deployment that
+        // is not zero-downtime — out of this bookkeeping entirely.
+        if (clock() < dirtyBefore) atRiskWrites[name] = target.lastModified()
+        // Converged: every render on this volume is now one this process made. Clearing the durable
+        // boundary is what makes that survive a restart — a cross-build open dates the boundary a
+        // grace window into the FUTURE, so leaving it behind would have the next start reclassify
+        // this build's own early renders as another build's work and regenerate them again, once
+        // per restart, forever.
+        clearBoundaryIfConverged()
+        writes.incrementAndGet()
+        generationWrites.incrementAndGet()
+        knownBytes.addAndGet(png.size.toLong() - previousSize)
+      } catch (e: IOException) {
+        runCatching { temp.delete() }
+        recordFailure(system, e.message ?: e::class.simpleName ?: "write failed")
+      } finally {
+        generationWriteLock.close()
+      }
+    }
+
+    /**
+     * Drop this whole generation — used when load-time verification finds a cached render that no
+     * longer matches what the renderer produces.
+     *
+     * The whole generation, not the offending entry: a mismatch means the fingerprint failed to
+     * capture some input, so every entry sharing it is suspect. Keeping the rest would be trusting
+     * the same broken identity that just proved untrustworthy.
+     */
+    /**
+     * Delete only the **dirty** renders, keeping everything this build wrote, and report how many
+     * went.
+     *
+     * What a failed sample verification should do now that a generation can hold renders from two
+     * builds at once. [discard] takes the lot, which was right while every entry present at open
+     * came from the same suspect build — it is wrong once this process has spent an hour rendering
+     * fresh entries into the same directory, because those are the one thing the sample just
+     * *confirmed* and throwing them away is a straight hour of rendering lost.
+     *
+     * Returns -1 when the generation write lock could not be taken, matching [discard]'s "could
+     * not" so the caller can keep the entries quarantined rather than assume they are gone.
+     */
+    fun discardDirty(): Int {
+      if (dirtyBefore <= 0L) return 0
+      return discardNames(dirtyNames.toList(), "dirty")
+    }
+
+    /**
+     * Delete every render this process **adopted** — everything that was on disk when the
+     * generation opened — keeping only what this process has rendered since, and report how many
+     * went.
+     *
+     * The correct answer to a failed sample, and a strict superset of [discardDirty]. Dirtiness
+     * asks "did a different BUILD write this", which is not the same question as "did a different
+     * PROCESS write this", and the sample only ever examines the second kind. A same-version
+     * restart of a partly converged generation inherits the earlier process's renders as *clean* —
+     * its own build wrote them — so a mismatch caused by an untracked input such as the base image
+     * or the installed fonts would delete the older build's leftovers, report a positive count that
+     * suppresses the fallback [discard], lift the quarantine, and go on serving the very renders
+     * the sample was drawn from. Adoption is the boundary the sample actually tests, so it is the
+     * boundary the discard has to use.
+     */
+    fun discardAdopted(): Int = discardNames(adopted.toList(), "adopted")
+
+    /**
+     * Delete [names] under the generation write lock, all-or-nothing, reporting how many went or -1
+     * if any delete or the lock itself failed.
+     */
+    private fun discardNames(names: List<String>, label: String): Int {
+      var generationWriteLock = tryGenerationWriteLock()
+      var attempt = 0
+      while (generationWriteLock == null && attempt < DISCARD_LOCK_ATTEMPTS) {
+        attempt++
+        runCatching { Thread.sleep(DISCARD_LOCK_BACKOFF_MILLIS) }
+        generationWriteLock = tryGenerationWriteLock()
+      }
+      if (generationWriteLock == null) return -1
+      try {
+        var removed = 0
+        var failed = 0
+        for (name in names) {
+          val file = File(dir, "$name$PNG_SUFFIX")
+          val size = file.length()
+          if (runCatching { !file.exists() || file.delete() }.getOrDefault(false)) {
+            present.remove(name)
+            adopted.remove(name)
+            dirtyNames.remove(name)
+            knownBytes.addAndGet(-size)
+            removed++
+          } else {
+            failed++
+            recordFailure(system, "could not discard $label ${file.name}")
+          }
+        }
+        // ALL or nothing. The caller is `verifySample`, which reads any success as licence to trust
+        // this generation and lift the read quarantine — so one PNG left behind by a failed delete
+        // would go from "proved stale" to "served", which is the single outcome this whole path
+        // exists to prevent. Reporting the failure keeps the quarantine and lets the next pass try
+        // again.
+        if (failed > 0) return -1
+        // Nothing older than the boundary survives, so the boundary has nothing left to mark. Left
+        // in place it would make every entry this build writes from here look dirty the moment a
+        // filesystem timestamp rounded the wrong way.
+        clearDirtyBoundary()
+        return removed
+      } finally {
+        generationWriteLock.close()
+      }
+    }
+
+    private fun clearDirtyBoundary() {
+      dirtyBefore = 0L
+      dirtyNames.clear()
+      runCatching {
+        val file = File(dir, MANIFEST_NAME)
+        val existing = json.decodeFromString(GenerationInputs.serializer(), file.readText())
+        file.writeText(json.encodeToString(existing.copy(dirtyBeforeEpochMillis = 0L)))
+      }
+        .onFailure { recordFailure(system, "manifest: ${it.message}") }
+    }
+
+    fun discard(): Boolean {
+      // Retried, because the contended case is transient and the consequence of giving up is not.
+      // The lock is held only for the length of one PNG write, so a foreground render that happens
+      // to be publishing right now clears in milliseconds; the caller, on the other hand, has just
+      // proved this generation's bytes wrong, and a `false` it does not act on leaves those bytes
+      // on disk to be served. See `CatalogThemeCache.verifySample`, which now keeps the generation
+      // quarantined when this still fails.
+      var generationWriteLock = tryGenerationWriteLock()
+      var attempt = 0
+      while (generationWriteLock == null && attempt < DISCARD_LOCK_ATTEMPTS) {
+        attempt++
+        runCatching { Thread.sleep(DISCARD_LOCK_BACKOFF_MILLIS) }
+        generationWriteLock = tryGenerationWriteLock()
+      }
+      if (generationWriteLock == null) return false
+      try {
+        present.clear()
+        adopted.clear()
+        // The manifest goes with everything else below, so the in-memory boundary must go too or
+        // this object would keep marking a directory it just emptied.
+        dirtyBefore = 0L
+        dirtyNames.clear()
+        // Measured before the delete and subtracted, or the census would carry the discarded
+        // generation's bytes plus its rebuilt replacement until the next sweep — making the one
+        // number an operator uses to judge occupancy roughly twice the truth.
+        knownBytes.addAndGet(-dir.sizeOnDisk())
+        return runCatching {
+            // The PNGs go; the DIRECTORY stays. This generation object remains attached to a live
+            // CatalogThemeCache, and deleting the directory under it would make every later `put`
+            // fail its temp write, catch the IOException and persist nothing — so the optimizer
+            // would
+            // re-render the whole catalog into memory alone and lose it all again at restart. The
+            // point of discarding is to stop trusting these bytes, not to stop writing new ones.
+            // EVERY child must go. A partial discard leaves stale PNGs under a fingerprint this
+            // process has already decided it cannot trust, and the next restart adopts them again —
+            // reproducing the exact mismatch that triggered the discard, indefinitely.
+            val cleared =
+              dir
+                .listFiles()
+                ?.filterNot { it.name == GENERATION_WRITE_LOCK }
+                ?.all { it.deleteRecursively() } ?: true
+            if (!cleared) recordFailure(system, "could not fully discard ${dir.name}")
+            cleared && (dir.isDirectory || dir.mkdirs())
+          }
+          .getOrDefault(false)
+      } finally {
+        generationWriteLock.close()
+      }
+    }
+
+    private fun tryGenerationWriteLock(): AutoCloseable? {
+      val randomAccess =
+        runCatching { RandomAccessFile(File(dir, GENERATION_WRITE_LOCK), "rw") }.getOrNull()
+          ?: return null
+      val channel = randomAccess.channel
+      val lock =
+        try {
+          channel.tryLock()
+        } catch (_: OverlappingFileLockException) {
+          null
+        } catch (_: IOException) {
+          null
+        }
+      if (lock == null) {
+        runCatching { channel.close() }
+        runCatching { randomAccess.close() }
+        return null
+      }
+      return AutoCloseable {
+        runCatching { lock.release() }
+        runCatching { channel.close() }
+        runCatching { randomAccess.close() }
+      }
+    }
+
+    /**
+     * What this generation has actually done, for `/status`.
+     *
+     * [ThemeCacheGenerationSnapshot.adopted] is the load-bearing number: it is the only evidence
+     * that persistence carried anything across a process boundary at all.
+     */
+    fun stats(): ThemeCacheGenerationSnapshot =
+      ThemeCacheGenerationSnapshot(
+        fingerprint = fingerprint,
+        adopted = loadedEntries,
+        entries = present.size,
+        hits = generationHits.get(),
+        misses = generationMisses.get(),
+        writes = generationWrites.get(),
+      )
+
+    private fun fileName(cacheKey: String): String =
+      MessageDigest.getInstance("SHA-256").digest(cacheKey.toByteArray()).joinToString("") {
+        "%02x".format(it)
+      }
+  }
+
+  /** A generation's coordinates, for [sweep]'s live set. */
+  data class GenerationId(val system: String, val fingerprint: String)
+
+  private fun GenerationId.dir(): File? {
+    val safeSystem = system.safeName() ?: return null
+    val safeFingerprint = fingerprint.safeName() ?: return null
+    return File(File(root, safeSystem), safeFingerprint)
+  }
+
+  companion object {
+    const val DEFAULT_MAX_BYTES: Long = 8L * 1024 * 1024 * 1024
+
+    /** Long enough to cover a rollout's readiness window, short enough to reclaim the same day. */
+    const val DEFAULT_SWEEP_GRACE_MILLIS: Long = 60L * 60 * 1000
+    const val MANIFEST_NAME: String = "manifest.json"
+
+    /**
+     * Store-root marker recording the epoch millis of the last [evictAll].
+     *
+     * At the ROOT rather than inside a generation, because the generations it applies to are the
+     * ones that do not exist yet: an eviction deletes what is on the volume, and what it has to
+     * survive is what gets written next. A plain integer in a plain file so that an operator
+     * looking at a mounted volume can read and clear it without tooling.
+     */
+    const val EVICTED_NAME: String = "evicted-at"
+    const val MAX_REASON_CHARS: Int = 200
+    private const val PNG_SUFFIX = ".png"
+    private const val TEMP_SUFFIX = ".png.tmp"
+    private const val GENERATION_WRITE_LOCK = ".write.lock"
+    /**
+     * Bounded retry for [Generation.discard]'s write lock.
+     *
+     * The lock is held for one PNG write, so ~1s of retries covers a foreground render that happens
+     * to be mid-publish many times over. Bounded rather than blocking because the caller is the
+     * idle verification task, not a request: it must not wedge behind a pathologically stuck
+     * writer, and a genuine failure has a correct handling (keep the generation quarantined).
+     */
+    private const val DISCARD_LOCK_ATTEMPTS = 20
+    private const val DISCARD_LOCK_BACKOFF_MILLIS = 50L
+
+    /**
+     * Names that may become a directory under the store root.
+     *
+     * A system id reaches here from deployment config and a fingerprint from a digest, so neither
+     * is attacker-controlled today — but both name a path, and a component that can contain `..` or
+     * a separator is a directory traversal waiting for the day one of them is. Rejected rather than
+     * sanitised: a silently rewritten name would let two catalogs share a generation.
+     */
+    private val SAFE_NAME = Regex("[A-Za-z0-9._-]{1,128}")
+
+    private fun String.safeName(): String? = takeIf {
+      it.isNotEmpty() && it != "." && it != ".." && SAFE_NAME.matches(it)
+    }
+
+    private fun File.sizeOnDisk(): Long = runCatching {
+      walkTopDown().filter { it.isFile }.sumOf { it.length() }
+    }
+      .getOrDefault(0L)
+  }
+}
+
+/**
+ * What a generation was fingerprinted from, recorded beside its PNGs.
+ *
+ * Never read to decide validity — the directory name is that decision. This exists so an operator
+ * can answer "why did the cache reset" from the box itself.
+ */
+@Serializable
+data class GenerationInputs(
+  val system: String,
+  val fingerprint: String,
+  /**
+   * The build that last **opened** this generation — not necessarily one that wrote a PNG into it.
+   *
+   * Rewritten by [ThemeCacheStore.writeManifest] at open time, before this process has rendered
+   * anything, so a replica that fails readiness still leaves its version here. Read it as "the last
+   * build that thought this generation was its own", which is the question the dirty boundary
+   * beside it was set to answer; do not read it as authorship of the pixels. See that function's
+   * doc for why it is stamped at open rather than on the first write.
+   */
+  val toolVersion: String,
+  val variant: String,
+  val renderConfig: String,
+  val createdAtEpochMillis: Long = 0,
+  /**
+   * When a build other than the one that wrote them last opened this generation — the line
+   * separating **dirty** renders from fresh ones.
+   *
+   * Dirtiness is derived from this and each file's own timestamp rather than tracked per entry: a
+   * render written before the boundary came from an older build, one written after came from this
+   * one, and re-rendering an entry moves its timestamp past the boundary for free. That is the
+   * whole of the bookkeeping — no parallel index to keep consistent with 18,604 files, and no write
+   * amplification on the regeneration path it exists to drive.
+   *
+   * Zero means nothing is dirty: every render here was written by a build that agrees with this
+   * one.
+   */
+  val dirtyBeforeEpochMillis: Long = 0,
+)
+
+/** What one [ThemeCacheStore.sweep] reclaimed. */
+data class SweepResult(
+  val deletedGenerations: Int,
+  val reclaimedBytes: Long,
+  val bytes: Long,
+  val overCap: Boolean,
+)
+
+/**
+ * What one catalog generation's disk tier has done this process, for `/status.json`.
+ *
+ * The point of publishing this per catalog rather than only store-wide: a disk cache that is
+ * working and one that is pure write amplification produce the same store-wide `writes`, and the
+ * difference between them is visible only here. Read it in this order:
+ * - [adopted] `0` after a restart that should have found a warm generation ⇒ the **key** moved.
+ *   Compare [fingerprint] with the previous process's; if it changed while nothing about the
+ *   catalog or the server did, some input the digest reads is unstable, and every write this
+ *   process makes is being left for a sweep to reclaim.
+ * - [adopted] high but [hits] `0` ⇒ the entries are there and nothing is reading them: either
+ *   nothing asked for those keys, or the generation is still quarantined pending verification.
+ * - [writes] climbing with [adopted] `0` on every restart is the "disk I/O for nothing" case,
+ *   stated in two numbers.
+ */
+@Serializable
+data class ThemeCacheGenerationSnapshot(
+  /** The generation directory this catalog is reading and writing — its cache key. */
+  val fingerprint: String,
+  /** Renders already on disk when this process opened the generation. */
+  val adopted: Int,
+  /** Renders on disk now, adopted plus written since. */
+  val entries: Int,
+  /** Reads this process served from disk. */
+  val hits: Long,
+  /** Reads that went to disk and found nothing. */
+  val misses: Long,
+  /** Renders this process wrote to disk. */
+  val writes: Long,
+)
+
+/** Disk-tier counters for `/status.json` (`themeCache`). */
+@Serializable
+data class ThemeCacheStoreSnapshot(
+  val root: String,
+  val generations: Int,
+  /**
+   * Generation directories per system, as of the last sweep.
+   *
+   * More than one for a system that has only ever been served one way is fingerprint churn, and
+   * churn is the failure mode that reports itself as success everywhere else.
+   */
+  val generationsBySystem: Map<String, Int> = emptyMap(),
+  val bytes: Long,
+  val maxBytes: Long,
+  val writes: Long,
+  val writeFailures: Long,
+  val hits: Long,
+  val misses: Long,
+  val lastFailureReason: String? = null,
+)

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/BundleClasspathGapsTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/BundleClasspathGapsTest.kt
@@ -1,0 +1,247 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.bundle.BundleReader
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Coverage for [BundleClasspathGaps] — the record that lets a fatal linkage trip name the
+ * coordinates this server could not resolve, instead of only the class the JVM couldn't find
+ * (issues #4259 / #4265).
+ */
+class BundleClasspathGapsTest {
+
+  private val destDir = Files.createTempDirectory("classpath-gaps-test-").toFile()
+  private val descriptor = File(destDir, "daemon-launch.json")
+  private val logs = mutableListOf<String>()
+
+  @AfterTest fun cleanup() = destDir.deleteRecursively().let {}
+
+  private fun maven(group: String, artifact: String, version: String = "1.0.0-SNAPSHOT") =
+    BundleReader.ClasspathEntry.Maven(
+      group = group,
+      artifact = artifact,
+      version = version,
+      type = "aar",
+      sha256 = null,
+    )
+
+  /** The real shape from the reports: the whole Remote Compose runtime unresolved. */
+  private fun recordRemoteComposeGap() =
+    BundleClasspathGaps.record(
+      destDir = destDir,
+      unresolved =
+        listOf(
+          maven("androidx.compose.remote", "remote-core"),
+          maven("androidx.compose.remote", "remote-player-view"),
+          maven("androidx.wear.compose.remote", "remote-material3"),
+        ),
+      total = 84,
+      system = "remote-m3",
+      onLog = { logs += it },
+    )
+
+  @Test
+  fun `a complete classpath records nothing and diagnoses nothing`() {
+    BundleClasspathGaps.record(
+      destDir = destDir,
+      unresolved = emptyList(),
+      total = 84,
+      system = "remote-m3",
+      onLog = { logs += it },
+    )
+
+    assertTrue(logs.isEmpty(), "a healthy catalog must not log a gap")
+    assertEquals(emptyList(), destDir.listFiles()?.toList() ?: emptyList())
+    assertNull(
+      BundleClasspathGaps.linkageDiagnosis("render failed: NoClassDefFoundError: a/B", descriptor)
+    )
+  }
+
+  @Test
+  fun `an unresolved coordinate whose group owns the missing type is named`() {
+    recordRemoteComposeGap()
+
+    val diagnosis =
+      BundleClasspathGaps.linkageDiagnosis(
+        "render failed: NoClassDefFoundError: " +
+          "androidx/compose/remote/player/view/RemoteComposePlayer",
+        descriptor,
+      )
+
+    val text = requireNotNull(diagnosis) { "a linkage failure with a recorded gap must diagnose" }
+    // The artifact whose id tokens (`player`, `view`) also appear in the package wins over its
+    // siblings in the same group — otherwise the sentence would blame `remote-core`.
+    assertContains(text, "androidx.compose.remote:remote-player-view:1.0.0-SNAPSHOT, which is")
+    assertContains(text, "3 of them")
+    assertContains(text, "84 Maven coordinate(s)")
+  }
+
+  @Test
+  fun `a linkage failure the gap cannot attribute still reports the gap`() {
+    recordRemoteComposeGap()
+
+    val text =
+      requireNotNull(
+        BundleClasspathGaps.linkageDiagnosis(
+          "render failed: NoClassDefFoundError: com/example/other/Thing",
+          descriptor,
+        )
+      )
+
+    assertContains(text, "one of them is likely")
+    assertContains(text, "androidx.compose.remote:remote-core:1.0.0-SNAPSHOT")
+  }
+
+  @Test
+  fun `failures an absent artifact does not explain are left alone`() {
+    recordRemoteComposeGap()
+
+    // Skiko's split-native fault has its own diagnosis; a VerifyError is bad bytecode, not a
+    // missing jar. Neither is made clearer by listing unresolved coordinates.
+    assertNull(
+      BundleClasspathGaps.linkageDiagnosis(
+        "render failed: UnsatisfiedLinkError: 'long org.jetbrains.skia.Foo._nMake()'",
+        descriptor,
+      )
+    )
+    assertNull(BundleClasspathGaps.linkageDiagnosis("render failed: VerifyError: bad", descriptor))
+  }
+
+  @Test
+  fun `the aggregate is logged once with every unresolved coordinate`() {
+    recordRemoteComposeGap()
+
+    assertEquals(1, logs.size)
+    assertContains(logs.single(), "3 of 84 classpath coordinate(s) did not resolve")
+    assertContains(logs.single(), "androidx.wear.compose.remote:remote-material3:1.0.0-SNAPSHOT")
+  }
+
+  /**
+   * meshcore-mobile's shape (#187): nothing unresolved, but part of the Remote Compose family
+   * resolved to another androidx.dev build's bytes under the same `1.0.0-SNAPSHOT` version string.
+   */
+  private fun recordRemoteComposeMismatch() =
+    BundleClasspathGaps.record(
+      destDir = destDir,
+      unresolved = emptyList(),
+      total = 119,
+      system = "meshcore-mobile",
+      onLog = { logs += it },
+      mismatched =
+        listOf(
+          maven("androidx.compose.remote", "remote-player-core"),
+          maven("androidx.compose.remote", "remote-player-view"),
+        ),
+    )
+
+  @Test
+  fun `a mismatched coordinate that owns the missing member is named as the cause`() {
+    recordRemoteComposeMismatch()
+
+    val text =
+      requireNotNull(
+        BundleClasspathGaps.linkageDiagnosis(
+          "render failed: NoSuchFieldError: Class androidx.compose.remote.core.RemoteClock does " +
+            "not have member field 'androidx.compose.remote.core.RemoteClock SYSTEM'",
+          descriptor,
+        )
+      ) {
+        "a hash mismatch is the whole cause here — nothing was unresolved to fall back on"
+      }
+
+    assertContains(text, "resolved to different bytes")
+    assertContains(text, "androidx.compose.remote:remote-player-core:1.0.0-SNAPSHOT")
+    assertContains(text, "two builds of one library")
+    assertContains(text, "-SNAPSHOT")
+  }
+
+  @Test
+  fun `a mismatch nothing in the failure points at is not claimed as the cause`() {
+    recordRemoteComposeMismatch()
+
+    // The wrong bytes are real, but they are not what this `NoSuchMethodError` is about — blaming
+    // them would send the reader to the wrong artifact. Better to say nothing.
+    assertNull(
+      BundleClasspathGaps.linkageDiagnosis(
+        "render failed: NoSuchMethodError: 'void com.example.other.Thing.go()'",
+        descriptor,
+      )
+    )
+  }
+
+  @Test
+  fun `an attributable mismatch outranks the unresolved list`() {
+    // Both shapes at once. The mismatch names the artifact AND what is wrong with it, so it wins.
+    BundleClasspathGaps.record(
+      destDir = destDir,
+      unresolved = listOf(maven("com.example.other", "widgets")),
+      total = 119,
+      system = "meshcore-mobile",
+      onLog = { logs += it },
+      mismatched = listOf(maven("androidx.compose.remote", "remote-player-core")),
+    )
+
+    val text =
+      requireNotNull(
+        BundleClasspathGaps.linkageDiagnosis(
+          "render failed: NoSuchFieldError: Class androidx.compose.remote.core.RemoteClock does " +
+            "not have member field 'androidx.compose.remote.core.RemoteClock SYSTEM'",
+          descriptor,
+        )
+      )
+
+    assertContains(text, "resolved to different bytes")
+    assertTrue(
+      "could not resolve" !in text,
+      "the unresolved sentence must not be appended to the mismatch one: $text",
+    )
+  }
+
+  @Test
+  fun `mismatches are logged separately from unresolved coordinates`() {
+    recordRemoteComposeMismatch()
+
+    assertEquals(1, logs.size, "nothing was unresolved, so only the mismatch line: $logs")
+    assertContains(logs.single(), "2 of 119 classpath coordinate(s) resolved to bytes")
+    assertContains(logs.single(), "androidx.compose.remote:remote-player-view:1.0.0-SNAPSHOT")
+  }
+
+  /**
+   * The generic half fires on any unresolved coordinate, related or not. Split out so a caller with
+   * a more specific diagnosis — a Remote Compose family split, say — can sit between attribution
+   * and "something is missing", instead of having its answer swallowed by one unrelated optional
+   * dependency the server could not fetch (Codex review on compose-preview-server#219).
+   */
+  @Test
+  fun `an unattributed gap answers last, not first`() {
+    BundleClasspathGaps.record(
+      destDir = destDir,
+      unresolved = listOf(maven("com.squareup.okhttp3", "okhttp", "5.5.0")),
+      total = 84,
+      system = "meshcore-mobile",
+      onLog = { logs += it },
+    )
+    val reason = "java.lang.NoSuchFieldError: androidx.compose.remote.core.RemoteClock"
+
+    assertNull(
+      BundleClasspathGaps.attributedDiagnosis(reason, descriptor),
+      "an unresolved okhttp explains nothing about a Remote Compose field",
+    )
+    val unattributed = BundleClasspathGaps.unattributedDiagnosis(reason, descriptor)
+    assertNotNull(unattributed, "it is still worth saying once nothing better has been found")
+    assertContains(unattributed, "one of them is likely where the missing type lives")
+    assertEquals(
+      unattributed,
+      BundleClasspathGaps.linkageDiagnosis(reason, descriptor),
+      "the combined entry point keeps its old answer",
+    )
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCacheTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCacheTest.kt
@@ -1,0 +1,292 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class CatalogThemeCacheTest {
+  @Test
+  fun `render cache evicts least recently used entries at its byte cap`() {
+    val cache = CatalogThemeCache(maxBytes = 6)
+    cache.put("a", byteArrayOf(1, 1, 1))
+    cache.put("b", byteArrayOf(2, 2, 2))
+    assertContentEquals(byteArrayOf(1, 1, 1), cache.get("a")) // a is now newest
+
+    cache.put("c", byteArrayOf(3, 3, 3))
+
+    assertNull(cache.get("b"))
+    assertContentEquals(byteArrayOf(1, 1, 1), cache.get("a"))
+    assertContentEquals(byteArrayOf(3, 3, 3), cache.get("c"))
+    // Occupancy only. The same snapshot also carries read counters, and asserting the whole object
+    // would make this eviction test fail whenever a read is added to it.
+    val snapshot = cache.renderCacheSnapshot()
+    assertEquals(2, snapshot.entries)
+    assertEquals(6, snapshot.bytes)
+    assertEquals(6, snapshot.maxBytes)
+    assertEquals(1, snapshot.evictions)
+  }
+
+  @Test
+  fun `a render larger than the byte cap is not retained`() {
+    val cache = CatalogThemeCache(maxBytes = 2)
+    cache.put("large", byteArrayOf(1, 2, 3))
+
+    assertNull(cache.get("large"))
+    assertEquals(0, cache.renderCacheSnapshot().entries)
+    assertEquals(0, cache.renderCacheSnapshot().bytes)
+  }
+
+  /**
+   * A preview the daemon can never render (a `painterResource` whose drawable was pruned out of the
+   * bundle) must stop being re-attempted, or every request pays a render-lock wait that pushes the
+   * rest of the grid into a Busy back-off.
+   */
+  @Test
+  fun `a run of render failures latches, and the reason is readable`() {
+    val cache = CatalogThemeCache()
+
+    assertEquals(false, cache.recordRenderFailure("k", "boom"))
+    assertNull(cache.failureReason("k"), "one failure may still be a cold-start blip")
+    assertEquals(false, cache.recordRenderFailure("k", "boom"))
+    assertNull(cache.failureReason("k"))
+
+    assertEquals(true, cache.recordRenderFailure("k", "NotFoundException: ic_play.xml"))
+    assertEquals("NotFoundException: ic_play.xml", cache.failureReason("k"))
+  }
+
+  @Test
+  fun `a successful render clears the latch and its failure count`() {
+    val cache = CatalogThemeCache()
+    repeat(CatalogThemeCache.FAILURE_LATCH) { cache.recordRenderFailure("k", "boom") }
+    assertEquals("boom", cache.failureReason("k"))
+
+    cache.put("k", byteArrayOf(1, 2, 3))
+
+    assertNull(cache.failureReason("k"), "a render that worked un-latches the key")
+    // ...and the count restarts, so it takes a fresh run of failures to latch again.
+    assertEquals(false, cache.recordRenderFailure("k", "boom"))
+  }
+
+  /**
+   * The optimizer gives up after a bounded number of attempts, and it gives up on a key the daemon
+   * was merely too busy to reach just as it does on one that threw. Only the latter may be reported
+   * to a visitor as terminal — otherwise a preview that happened to be contended during the
+   * optimization pass 409s forever.
+   */
+  @Test
+  fun `an optimizer miss with no captured failure stays retryable`() {
+    val cache = CatalogThemeCache()
+
+    cache.markFailed("busy-only")
+    assertNull(cache.failureReason("busy-only"), "running out of attempts is not a render failure")
+    // It still counts toward the /status `failed` metric, which is what markFailed is for.
+    cache.configureTargets(listOf("busy-only"))
+    assertEquals(1, cache.snapshot().failed)
+
+    cache.markFailed("really-broken", "NotFoundException: ic_play.xml")
+    assertEquals("NotFoundException: ic_play.xml", cache.failureReason("really-broken"))
+    assertNull(cache.failureReason("never-seen"))
+  }
+
+  /**
+   * `Busy` means "ask again", and for a warming daemon that is right — but with no ceiling it is
+   * indistinguishable from "never". meshcore-mobile sat at `paused 288/372, failed: 0` across two
+   * server lifetimes on exactly that: 84 targets that answered `Busy`, were left unmarked, and so
+   * were never counted, never reported, and never given up on.
+   */
+  @Test
+  fun `a long run of background Busy latches with a readable reason`() {
+    val cache = CatalogThemeCache()
+
+    repeat(CatalogThemeCache.BUSY_LATCH - 1) {
+      assertEquals(false, cache.recordBackgroundBusy("k"), "a contended key must survive a run")
+      assertNull(cache.failureReason("k"))
+    }
+
+    assertEquals(true, cache.recordBackgroundBusy("k"))
+    val reason = cache.failureReason("k")
+    assertNotNull(reason, "a latched key must answer the request lane terminally")
+    assertTrue(reason.contains("busy or absent"), "the reason names the condition: $reason")
+  }
+
+  @Test
+  fun `Busy tolerance is far looser than the render-failure latch`() {
+    // Otherwise a daemon that is merely slow to warm would be reported as permanently broken.
+    assertTrue(CatalogThemeCache.BUSY_LATCH > CatalogThemeCache.FAILURE_LATCH)
+    val cache = CatalogThemeCache()
+    repeat(CatalogThemeCache.FAILURE_LATCH) { cache.recordBackgroundBusy("k") }
+    assertNull(cache.failureReason("k"), "a Busy run as long as FAILURE_LATCH is not yet terminal")
+  }
+
+  @Test
+  fun `a successful render clears the Busy run`() {
+    val cache = CatalogThemeCache()
+    repeat(CatalogThemeCache.BUSY_LATCH) { cache.recordBackgroundBusy("k") }
+    assertNotNull(cache.failureReason("k"))
+
+    cache.put("k", byteArrayOf(1, 2, 3))
+
+    assertNull(cache.failureReason("k"), "a key that eventually rendered is never penalised")
+    assertEquals(false, cache.recordBackgroundBusy("k"), "and the run restarts from zero")
+  }
+
+  @Test
+  fun `a latched Busy key is reported in the failed count and ends the pass degraded`() {
+    // The point of latching: /status names the stuck previews instead of showing `failed: 0`
+    // beside a `remaining` that never moves, and the state stops reading like ordinary throttling.
+    val cache = CatalogThemeCache()
+    cache.configureTargets(listOf("stuck", "fine"))
+    cache.put("fine", byteArrayOf(1))
+    repeat(CatalogThemeCache.BUSY_LATCH) { cache.recordBackgroundBusy("stuck") }
+
+    cache.markPassFinished(1_000)
+
+    val snapshot = cache.snapshot()
+    assertEquals(1, snapshot.failed)
+    assertEquals(1, snapshot.remaining)
+    assertEquals("degraded", snapshot.state)
+  }
+
+  /** A reason recorded before the latch closes must not make the key terminal on its own. */
+  @Test
+  fun `a reason without the full run of failures is not yet terminal`() {
+    val cache = CatalogThemeCache()
+    cache.recordRenderFailure("k", "boom")
+    assertNull(cache.failureReason("k"))
+  }
+
+  /**
+   * The instrumentation exists because `cached`/`remaining` alone cannot answer the question that
+   * actually matters — is the pass keeping up, and if not, is it render-bound or gate-bound. Two
+   * throughput readings against the live server were wrong before this existed: one measured a
+   * different lane entirely, one divided by lifetime instead of active time.
+   */
+  @Test
+  fun `optimizer stats report rate, ETA, time split and observed batch width`() {
+    val cache = CatalogThemeCache()
+    cache.configureTargets((1..10).map { "k$it" })
+
+    cache.recordTurnGranted()
+    cache.recordGateWait(20_000) // the gate withheld the turn
+    cache.recordPermitWait(10_000) // then it queued behind other catalogs for a permit
+    cache.recordBatch(width = 5, millis = 24_000)
+    cache.recordWarm(6_000) // a cold daemon, paid once and producing nothing
+    cache.recordProduced(5)
+    cache.recordTurnYielded()
+    repeat(5) { cache.put("k${it + 1}", byteArrayOf(1)) }
+
+    val s = cache.snapshot()
+    assertEquals(5, s.cached)
+    // 5 entries over 60s of ACTIVE time = 5/min; 5 remaining at that rate = 60s.
+    assertEquals(5.0, s.entriesPerMinute)
+    assertEquals(60L, s.etaSeconds)
+    // The split is the diagnostic: half the time rendering, half waiting — and BOTH halves split
+    // again, because within each pair the two causes have opposite fixes and the sum cannot tell
+    // them apart. Cold-start cost vs per-entry render cost; gate withholding vs permit contention.
+    assertEquals(30_000L, s.renderMillis)
+    assertEquals(24_000L, s.batchMillis)
+    assertEquals(6_000L, s.warmMillis)
+    assertEquals(30_000L, s.waitingMillis)
+    assertEquals(20_000L, s.gateWaitMillis)
+    assertEquals(10_000L, s.permitWaitMillis)
+    assertEquals(1, s.turnsGranted)
+    assertEquals(1, s.turnsYielded)
+    // Width is daemons that ran concurrently, so a batch collapsing onto one host is visible.
+    assertEquals(5, s.lastBatchWidth)
+    assertEquals(5, s.maxBatchWidth)
+  }
+
+  /**
+   * Measured on the deployed box: 14 catalogs all optimizing at once, every one reporting waiting
+   * at 3–6× its render time. The total said "not render-bound" and stopped there — it could not say
+   * whether the gate was withholding turns (loosen the quiet window) or the catalogs were starving
+   * each other for render permits (prefetch fewer at once). Those two shapes must read differently.
+   */
+  @Test
+  fun `a permit-starved pass and a gate-starved pass are distinguishable`() {
+    fun snapshotOf(gate: Long, permit: Long) =
+      CatalogThemeCache()
+        .apply {
+          configureTargets(listOf("a"))
+          recordGateWait(gate)
+          recordPermitWait(permit)
+          recordBatch(width = 1, millis = 10_000)
+        }
+        .snapshot()
+
+    val gateStarved = snapshotOf(gate = 90_000, permit = 0)
+    val permitStarved = snapshotOf(gate = 0, permit = 90_000)
+
+    // Identical on the old instrumentation …
+    assertEquals(gateStarved.waitingMillis, permitStarved.waitingMillis)
+    assertEquals(gateStarved.renderMillis, permitStarved.renderMillis)
+    // … and opposite on the new.
+    assertEquals(90_000L, gateStarved.gateWaitMillis)
+    assertEquals(0L, gateStarved.permitWaitMillis)
+    assertEquals(0L, permitStarved.gateWaitMillis)
+    assertEquals(90_000L, permitStarved.permitWaitMillis)
+  }
+
+  /**
+   * The companion to the wait split. Measured on the deployed box, catalogs reported 88–201s of
+   * `renderMillis` against a known warm p50 of 238–1111ms — which reads as a slow renderer until
+   * you notice a cold Android warm is 34–68s and each pass had only 3–4 turns. Back the warm out
+   * and the per-entry cost is sub-second. "Buy a faster renderer" and "stop paying for cold starts"
+   * are not the same project, and the total cannot tell you which one you have.
+   */
+  @Test
+  fun `a cold-start-dominated pass and a render-dominated pass are distinguishable`() {
+    fun snapshotOf(batch: Long, warm: Long) =
+      CatalogThemeCache()
+        .apply {
+          configureTargets(listOf("a"))
+          recordBatch(width = 5, millis = batch)
+          recordWarm(warm)
+        }
+        .snapshot()
+
+    val coldStarts = snapshotOf(batch = 10_000, warm = 110_000)
+    val slowRenders = snapshotOf(batch = 110_000, warm = 10_000)
+
+    // Identical on the old instrumentation …
+    assertEquals(coldStarts.renderMillis, slowRenders.renderMillis)
+    // … and opposite on the new.
+    assertEquals(110_000L, coldStarts.warmMillis)
+    assertEquals(10_000L, coldStarts.batchMillis)
+    assertEquals(10_000L, slowRenders.warmMillis)
+    assertEquals(110_000L, slowRenders.batchMillis)
+  }
+
+  @Test
+  fun `rate and ETA stay null before the pass has done anything to divide by`() {
+    val cache = CatalogThemeCache()
+    cache.configureTargets(listOf("a", "b"))
+    val s = cache.snapshot()
+    assertNull(s.entriesPerMinute)
+    assertNull(s.etaSeconds)
+    assertEquals(0, s.maxBatchWidth)
+  }
+
+  /**
+   * Codex review on #3373. Foreground renders land in this same cache via `cacheCatalogRender`, so
+   * counting them toward the rate reports a prefetch throughput the prefetcher never achieved —
+   * against a denominator made only of optimizer time. The numerator has to be optimizer output.
+   */
+  @Test
+  fun `foreground-filled entries do not inflate the prefetch rate`() {
+    val cache = CatalogThemeCache()
+    cache.configureTargets((1..10).map { "k$it" })
+    cache.recordGateWait(60_000)
+
+    // Five entries arrive from foreground requests; the optimizer produced none of them.
+    repeat(5) { cache.put("k${it + 1}", byteArrayOf(1)) }
+
+    val s = cache.snapshot()
+    assertEquals(5, s.cached, "they are cached, and `cached` should say so")
+    assertNull(s.entriesPerMinute, "but the prefetcher produced nothing, so it has no rate")
+    assertNull(s.etaSeconds)
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/GitWorktreesTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/GitWorktreesTest.kt
@@ -1,0 +1,265 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class GitWorktreesTest {
+
+  private fun tempDir(prefix: String): File =
+    java.nio.file.Files.createTempDirectory(prefix).toFile().also { it.deleteOnExit() }
+
+  /**
+   * Records git invocations and simulates the three calls [GitWorktrees] makes:
+   * - `rev-parse <rev>^{commit}` resolves a requested revision to [resolveSha];
+   * - `rev-parse <refs/…>^{commit}` (ref qualification) succeeds only for refs in [existingRefs];
+   * - `merge-base --is-ancestor <sha> <ref>^{commit}` succeeds only for refs in [ancestorRefs].
+   *
+   * Refs are modelled fully-qualified so the qualification gate (short name → `refs/heads`/
+   * `refs/remotes`, never `refs/tags`) can be exercised without a real repo.
+   */
+  private class FakeGit(
+    var resolveSha: String? = "abc123def",
+    val existingRefs: Set<String> = setOf("refs/heads/main", "refs/heads/release"),
+    val ancestorRefs: Set<String> = emptySet(),
+  ) : GitRunner {
+    val calls = CopyOnWriteArrayList<List<String>>()
+
+    fun count(prefix: List<String>): Int = calls.count { it.take(prefix.size) == prefix }
+
+    override fun run(workdir: File, args: List<String>): GitResult {
+      calls.add(args)
+      return when {
+        args.take(1) == listOf("rev-parse") -> {
+          val token = args.last().removeSuffix("^{commit}")
+          if (token.startsWith("refs/")) {
+            if (token in existingRefs) GitResult(0, "$token\n") else GitResult(1, "")
+          } else {
+            resolveSha?.let { GitResult(0, "$it\n") } ?: GitResult(1, "")
+          }
+        }
+        args.take(2) == listOf("merge-base", "--is-ancestor") -> {
+          val ref = args[3].removeSuffix("^{commit}")
+          if (ref in ancestorRefs) GitResult(0, "") else GitResult(1, "")
+        }
+        args.take(2) == listOf("worktree", "add") -> {
+          val dir = File(args[args.size - 2])
+          dir.mkdirs()
+          File(dir, ".git").writeText("gitdir: elsewhere")
+          GitResult(0, "")
+        }
+        else -> GitResult(0, "")
+      }
+    }
+  }
+
+  @Test
+  fun `prepare resolves the commit and adds a worktree once, reusing it after`() {
+    val git = FakeGit(ancestorRefs = setOf("refs/heads/main"))
+    val cache = tempDir("wt-cache")
+    GitWorktrees(
+        repoRoot = tempDir("repo"),
+        cacheRoot = cache,
+        allowedRefs = listOf("main"),
+        git = git,
+      )
+      .use { wt ->
+        val dir = assertNotNull(wt.prepare("HEAD"))
+        assertEquals(File(cache, "abc123def"), dir)
+        assertTrue(File(dir, ".git").exists())
+        assertEquals(1, git.count(listOf("worktree", "add")))
+
+        // Second request for the same revision reuses the existing worktree — no second add.
+        val again = assertNotNull(wt.prepare("HEAD"))
+        assertEquals(dir, again)
+        assertEquals(1, git.count(listOf("worktree", "add")), "an existing worktree is reused")
+      }
+  }
+
+  @Test
+  fun `prepare returns null when the revision cannot be resolved`() {
+    val git = FakeGit(resolveSha = null, ancestorRefs = setOf("refs/heads/main"))
+    GitWorktrees(
+        repoRoot = tempDir("repo"),
+        cacheRoot = tempDir("wt-cache"),
+        allowedRefs = listOf("main"),
+        git = git,
+      )
+      .use { wt ->
+        assertNull(wt.prepare("does-not-exist"))
+        assertEquals(
+          0,
+          git.count(listOf("worktree", "add")),
+          "no worktree added for a bad revision",
+        )
+      }
+  }
+
+  @Test
+  fun `prepare refuses a revision not reachable from any allowed ref`() {
+    // Resolves fine, but the sha is reachable only from 'feature', which is not in the allowlist.
+    val git = FakeGit(ancestorRefs = setOf("refs/heads/feature"))
+    GitWorktrees(
+        repoRoot = tempDir("repo"),
+        cacheRoot = tempDir("wt-cache"),
+        allowedRefs = listOf("main", "release"),
+        git = git,
+      )
+      .use { wt ->
+        assertNull(wt.prepare("deadbeef"))
+        assertEquals(0, git.count(listOf("worktree", "add")), "no checkout for a disallowed rev")
+      }
+  }
+
+  @Test
+  fun `prepare fails closed when no refs are allowed`() {
+    // Even a resolvable sha that is reachable from refs is refused when the allowlist is empty.
+    val git = FakeGit(ancestorRefs = setOf("refs/heads/main"))
+    GitWorktrees(
+        repoRoot = tempDir("repo"),
+        cacheRoot = tempDir("wt-cache"),
+        allowedRefs = emptyList(),
+        git = git,
+      )
+      .use { wt ->
+        assertNull(wt.prepare("HEAD"))
+        assertEquals(0, git.count(listOf("worktree", "add")))
+      }
+  }
+
+  @Test
+  fun `prepare allows a revision reachable from any one of several allowed refs`() {
+    val git = FakeGit(ancestorRefs = setOf("refs/heads/release"))
+    GitWorktrees(
+        repoRoot = tempDir("repo"),
+        cacheRoot = tempDir("wt-cache"),
+        allowedRefs = listOf("main", "release"),
+        git = git,
+      )
+      .use { wt -> assertNotNull(wt.prepare("HEAD")) }
+  }
+
+  @Test
+  fun `prepare does not let a same-named tag satisfy a short branch allowlist`() {
+    // Only a TAG 'main' exists (no refs/heads/main), and the sha is reachable from it. A short
+    // allowlist entry 'main' must qualify to a branch/remote only, so this is refused — closing the
+    // tag-shadowing hole where gitrevisions resolves refs/tags/<name> before the branch.
+    val git =
+      FakeGit(existingRefs = setOf("refs/tags/main"), ancestorRefs = setOf("refs/tags/main"))
+    GitWorktrees(
+        repoRoot = tempDir("repo"),
+        cacheRoot = tempDir("wt-cache"),
+        allowedRefs = listOf("main"),
+        git = git,
+      )
+      .use { wt ->
+        assertNull(wt.prepare("deadbeef"))
+        assertEquals(0, git.count(listOf("worktree", "add")))
+      }
+  }
+
+  @Test
+  fun `prepare honours an explicitly fully-qualified tag ref`() {
+    // An operator can still opt a tag in deliberately by qualifying it as refs/tags/<name>.
+    val git = FakeGit(existingRefs = setOf("refs/tags/v1"), ancestorRefs = setOf("refs/tags/v1"))
+    GitWorktrees(
+        repoRoot = tempDir("repo"),
+        cacheRoot = tempDir("wt-cache"),
+        allowedRefs = listOf("refs/tags/v1"),
+        git = git,
+      )
+      .use { wt -> assertNotNull(wt.prepare("deadbeef")) }
+  }
+
+  @Test
+  fun `close removes the worktrees it created`() {
+    val git = FakeGit(ancestorRefs = setOf("refs/heads/main"))
+    GitWorktrees(
+        repoRoot = tempDir("repo"),
+        cacheRoot = tempDir("wt-cache"),
+        allowedRefs = listOf("main"),
+        git = git,
+      )
+      .use { wt -> wt.prepare("HEAD") }
+    assertEquals(1, git.count(listOf("worktree", "remove")))
+    assertEquals(1, git.count(listOf("worktree", "prune")))
+  }
+
+  @Test
+  fun `remove prunes a single prepared worktree and close does not remove it again`() {
+    val git = FakeGit(ancestorRefs = setOf("refs/heads/main"))
+    GitWorktrees(
+        repoRoot = tempDir("repo"),
+        cacheRoot = tempDir("wt-cache"),
+        allowedRefs = listOf("main"),
+        git = git,
+      )
+      .use { wt ->
+        val dir = assertNotNull(wt.prepare("HEAD"))
+        wt.remove(dir)
+        assertEquals(1, git.count(listOf("worktree", "remove")), "remove pruned the worktree")
+      }
+    // close() must not remove the already-reclaimed worktree a second time (it was dropped from
+    // `prepared`); only the terminal `git worktree prune` runs.
+    assertEquals(1, git.count(listOf("worktree", "remove")), "no double remove on close")
+    assertEquals(1, git.count(listOf("worktree", "prune")))
+  }
+
+  @Test
+  fun `a worktree shared by two revisions is pruned only after both reclaim`() {
+    // Both revisions resolve to the same commit (FakeGit's single resolveSha), so prepare() hands
+    // back the same <cacheRoot>/<sha> dir. GC of the first alias must NOT delete the worktree the
+    // second alias is still using (issue #2022 review) — only the last reclaim prunes it.
+    val git = FakeGit(ancestorRefs = setOf("refs/heads/main"))
+    GitWorktrees(
+        repoRoot = tempDir("repo"),
+        cacheRoot = tempDir("wt-cache"),
+        allowedRefs = listOf("main"),
+        git = git,
+      )
+      .use { wt ->
+        val a = assertNotNull(wt.prepare("HEAD"))
+        val b = assertNotNull(wt.prepare("main"))
+        assertEquals(a, b, "both revisions share one worktree")
+        assertEquals(1, git.count(listOf("worktree", "add")), "shared worktree added once")
+
+        wt.remove(a)
+        assertEquals(
+          0,
+          git.count(listOf("worktree", "remove")),
+          "the first reclaim only drops a reference — the worktree is still in use",
+        )
+        wt.remove(b)
+        assertEquals(
+          1,
+          git.count(listOf("worktree", "remove")),
+          "the last reclaim prunes the now-unused worktree",
+        )
+      }
+    // close() must not remove the already-pruned worktree again.
+    assertEquals(1, git.count(listOf("worktree", "remove")))
+  }
+
+  @Test
+  fun `remove is a no-op for a worktree this instance did not prepare`() {
+    val git = FakeGit(ancestorRefs = setOf("refs/heads/main"))
+    GitWorktrees(
+        repoRoot = tempDir("repo"),
+        cacheRoot = tempDir("wt-cache"),
+        allowedRefs = listOf("main"),
+        git = git,
+      )
+      .use { wt ->
+        wt.remove(File("/some/unrelated/worktree"))
+        assertEquals(
+          0,
+          git.count(listOf("worktree", "remove")),
+          "an unprepared path is never git-removed",
+        )
+      }
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmissionTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmissionTest.kt
@@ -1,0 +1,887 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class HostOptimizerAdmissionTest {
+  @Test
+  fun `file coordinator caps the whole host and excludes duplicate systems`() {
+    val directory = Files.createTempDirectory("optimizer-host-locks").toFile()
+    try {
+      val firstReplica = FileOptimizerHostCoordinator(directory, lanes = 2)
+      val secondReplica = FileOptimizerHostCoordinator(directory, lanes = 2)
+      val first = assertNotNull(firstReplica.tryAcquire("catalog-a"))
+      assertNull(
+        secondReplica.tryAcquire("catalog-a"),
+        "the same catalog must not warm in two replicas",
+      )
+      assertNull(
+        secondReplica.tryAcquire("catalog-b"),
+        "only the elected replica may warm, so its cache index stays coherent",
+      )
+      val second = assertNotNull(firstReplica.tryAcquire("catalog-b"))
+      assertNull(firstReplica.tryAcquire("catalog-c"), "the two lanes belong to the whole host")
+
+      first.close()
+      assertNotNull(firstReplica.tryAcquire("catalog-c")).close()
+      second.close()
+      firstReplica.close()
+      assertNotNull(secondReplica.tryAcquire("catalog-a"), "leadership fails over on exit").close()
+      secondReplica.close()
+    } finally {
+      directory.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `pressure stops immediately and resumes only after a quiet recovery window`() {
+    var now = 0L
+    var sample =
+      HostResourceSample(loadPerCpu = 0.2, cpuUtilization = 0.2, memoryAvailableFraction = 0.8)
+    val gate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds =
+          OptimizerPressureThresholds(resumeQuietMillis = 1_000, sampleIntervalMillis = 0),
+        clock = { now },
+      )
+    assertFalse(gate.snapshot().constrained)
+
+    sample = sample.copy(cpuUtilization = 0.9)
+    assertTrue(gate.snapshot().constrained)
+    assertTrue(gate.snapshot().reason.orEmpty().contains("CPU"))
+
+    now = 100
+    sample = sample.copy(cpuUtilization = 0.2)
+    assertTrue(gate.snapshot().constrained, "one safe sample must not flap the optimizer back on")
+    assertTrue(gate.snapshot().reason.orEmpty().contains("recovering"))
+    now = 1_099
+    assertTrue(gate.snapshot().constrained)
+    now = 1_100
+    assertFalse(gate.snapshot().constrained)
+  }
+
+  @Test
+  fun `a reading parked in the dead band cannot hold the gate forever`() {
+    // The production stall: memory settles at 18% available, which is neither at-or-below the 15%
+    // stop side (so nothing re-trips) nor at-or-above the 25% resume side (so the quiet window
+    // never starts). Before maxRecoveryMillis this held admission for eight hours.
+    var now = 0L
+    var sample =
+      HostResourceSample(loadPerCpu = 0.02, cpuUtilization = 0.02, memoryAvailableFraction = 0.8)
+    val gate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds =
+          OptimizerPressureThresholds(
+            resumeQuietMillis = 1_000,
+            sampleIntervalMillis = 0,
+            maxRecoveryMillis = 10_000,
+          ),
+        clock = { now },
+      )
+    assertFalse(gate.snapshot().constrained)
+
+    sample = sample.copy(memoryAvailableFraction = 0.10)
+    assertTrue(gate.snapshot().constrained)
+
+    sample = sample.copy(memoryAvailableFraction = 0.18)
+    now = 1_000
+    assertTrue(gate.snapshot().constrained, "the dead band must still hold the gate at first")
+    val reason = gate.snapshot().reason.orEmpty()
+    assertTrue(reason.contains("18%"), "reason should name the reading: $reason")
+    assertTrue(reason.contains("25%"), "reason should name the bar it must clear: $reason")
+
+    now = 10_999
+    assertTrue(gate.snapshot().constrained)
+    now = 11_000
+    assertFalse(gate.snapshot().constrained, "the hold must expire once no stop threshold is met")
+  }
+
+  @Test
+  fun `a dead band hold does not expire while a stop threshold is still met`() {
+    var now = 0L
+    var sample =
+      HostResourceSample(loadPerCpu = 0.02, cpuUtilization = 0.02, memoryAvailableFraction = 0.10)
+    val gate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds =
+          OptimizerPressureThresholds(
+            resumeQuietMillis = 1_000,
+            sampleIntervalMillis = 0,
+            maxRecoveryMillis = 10_000,
+          ),
+        clock = { now },
+      )
+    assertTrue(gate.snapshot().constrained)
+
+    // Still under the stop threshold well past maxRecoveryMillis: the cap must not admit into a
+    // host that is genuinely out of memory.
+    now = 60_000
+    assertTrue(gate.snapshot().constrained)
+    assertTrue(gate.snapshot().reason.orEmpty().contains("memory available 10%"))
+
+    sample = sample.copy(memoryAvailableFraction = 0.30)
+    now = 60_001
+    assertTrue(gate.snapshot().constrained, "recovery is still gated on the quiet window")
+    now = 61_001
+    assertFalse(gate.snapshot().constrained)
+  }
+
+  @Test
+  fun `a hold whose stop threshold keeps re-tripping duty-cycles instead of latching forever`() {
+    var now = 0L
+    // The preview.coo.ee steady state: an idle box whose 17 resident daemons keep MemAvailable a
+    // hair under the stop side, so every sample re-trips and nothing ever "recovers".
+    val sample =
+      HostResourceSample(loadPerCpu = 0.17, cpuUtilization = 0.03, memoryAvailableFraction = 0.14)
+    val thresholds =
+      OptimizerPressureThresholds(
+        sampleIntervalMillis = 0,
+        starvationCapMillis = 10_000,
+        dutyCycleMillis = 1_000,
+      )
+    val gate = OptimizerPressureGate(sample = { sample }, thresholds = thresholds, clock = { now })
+    assertTrue(gate.snapshot().constrained)
+
+    now = 9_999
+    assertTrue(gate.snapshot().constrained, "the cap must not open early")
+    assertEquals(9_999, gate.snapshot().heldMillis)
+
+    now = 10_000
+    val open = gate.snapshot()
+    assertFalse(open.constrained, "a bounded duty cycle beats never optimizing at all")
+    assertEquals(1, open.dutyCycles)
+    assertEquals(11_000, open.dutyCycleUntilEpochMillis)
+    assertTrue(
+      open.reason.orEmpty().contains("memory available 14%"),
+      "the reading is still what is holding, so keep naming it: $open",
+    )
+
+    now = 11_000
+    assertTrue(gate.snapshot().constrained, "the window is bounded too")
+    now = 20_999
+    assertTrue(gate.snapshot().constrained)
+    now = 21_000
+    assertFalse(gate.snapshot().constrained, "the cap re-arms from the end of the window")
+    assertEquals(2, gate.snapshot().dutyCycles)
+  }
+
+  @Test
+  fun `the default duty cycle outlives a cold daemon warm`() {
+    var now = 0L
+    val gate =
+      OptimizerPressureGate(
+        sample = {
+          HostResourceSample(
+            loadPerCpu = 0.17,
+            cpuUtilization = 0.03,
+            memoryAvailableFraction = 0.14,
+          )
+        },
+        thresholds = OptimizerPressureThresholds(sampleIntervalMillis = 0),
+        clock = { now },
+      )
+    assertTrue(gate.snapshot().constrained)
+
+    now = 30 * 60_000L
+    assertFalse(gate.snapshot().constrained, "the starvation cap opens a bounded work window")
+
+    // The deployed Android lanes take up to about 68 seconds merely to warm. The old 60-second
+    // default had already closed here, so a pass reached its first render gate with no work done.
+    now += 70_000L
+    val afterWarm = gate.snapshot()
+    assertFalse(afterWarm.constrained, "the concession must leave time to render after warming")
+    assertNotNull(afterWarm.dutyCycleUntilEpochMillis)
+
+    now = 35 * 60_000L
+    assertTrue(gate.snapshot().constrained, "the longer concession remains bounded")
+  }
+
+  @Test
+  fun `an expired duty cycle closes even when sampling has stopped working`() {
+    var now = 0L
+    var readable = true
+    val gate =
+      OptimizerPressureGate(
+        sample = {
+          if (readable) {
+            HostResourceSample(
+              loadPerCpu = 0.17,
+              cpuUtilization = 0.03,
+              memoryAvailableFraction = 0.14,
+            )
+          } else {
+            null
+          }
+        },
+        thresholds =
+          OptimizerPressureThresholds(
+            sampleIntervalMillis = 0,
+            starvationCapMillis = 10_000,
+            dutyCycleMillis = 1_000,
+          ),
+        clock = { now },
+      )
+    assertTrue(gate.snapshot().constrained)
+
+    now = 10_000
+    assertFalse(gate.snapshot().constrained)
+
+    // `/proc` stops answering mid-window. The cached snapshot says "open"; without expiring it on
+    // the clock the concession becomes permanent, under pressure nothing can observe any more.
+    readable = false
+    now = 10_500
+    assertFalse(gate.snapshot().constrained, "the window itself is still running")
+    now = 11_000
+    val closed = gate.snapshot()
+    assertTrue(closed.constrained, "an elapsed window must close without a fresh reading")
+    assertNull(closed.dutyCycleUntilEpochMillis)
+    now = 60_000
+    assertTrue(gate.snapshot().constrained)
+  }
+
+  @Test
+  fun `the duty cycle never opens on a host that is genuinely out of memory`() {
+    var now = 0L
+    val sample =
+      HostResourceSample(loadPerCpu = 0.1, cpuUtilization = 0.1, memoryAvailableFraction = 0.02)
+    val gate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds =
+          OptimizerPressureThresholds(
+            sampleIntervalMillis = 0,
+            starvationCapMillis = 10_000,
+            dutyCycleMillis = 1_000,
+          ),
+        clock = { now },
+      )
+    assertTrue(gate.snapshot().constrained)
+    now = 100_000
+    val held = gate.snapshot()
+    assertTrue(held.constrained, "below the floor the latch is the correct failure mode")
+    assertEquals(0, held.dutyCycles)
+  }
+
+  @Test
+  fun `a newly tripped signal closes an open duty cycle`() {
+    var now = 0L
+    var sample =
+      HostResourceSample(loadPerCpu = 0.17, cpuUtilization = 0.03, memoryAvailableFraction = 0.14)
+    val gate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds =
+          OptimizerPressureThresholds(
+            sampleIntervalMillis = 0,
+            starvationCapMillis = 10_000,
+            dutyCycleMillis = 1_000,
+          ),
+        clock = { now },
+      )
+    assertTrue(gate.snapshot().constrained)
+    now = 10_000
+    assertFalse(gate.snapshot().constrained)
+
+    // The memory reading that earned the concession may stay over its threshold — that is the
+    // point — but CPU crossing its own stop side is new pressure the window never answered for,
+    // and "a high reading stops admission immediately" outranks it.
+    sample = sample.copy(cpuUtilization = 0.95)
+    now = 10_500
+    val stopped = gate.snapshot()
+    assertTrue(stopped.constrained, "a new signal must cut the window short")
+    assertNull(stopped.dutyCycleUntilEpochMillis)
+    assertTrue(stopped.reason.orEmpty().contains("CPU 95%"), "and name itself: $stopped")
+  }
+
+  @Test
+  fun `a signal that tripped earlier in the hold still closes a later window`() {
+    var now = 0L
+    var sample =
+      HostResourceSample(loadPerCpu = 0.17, cpuUtilization = 0.95, memoryAvailableFraction = 0.14)
+    val gate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds =
+          OptimizerPressureThresholds(
+            sampleIntervalMillis = 0,
+            starvationCapMillis = 10_000,
+            dutyCycleMillis = 1_000,
+          ),
+        clock = { now },
+      )
+    // CPU trips at the start of the hold and then goes quiet; memory keeps the hold alive, so
+    // `trippedBy` still remembers CPU for the rest of it. A second CPU spike is new pressure all
+    // the same, and must not be filtered out as "already tripped".
+    assertTrue(gate.snapshot().constrained)
+    now = 1_000
+    sample = sample.copy(cpuUtilization = 0.03)
+    assertTrue(gate.snapshot().constrained)
+
+    now = 11_000
+    assertFalse(gate.snapshot().constrained, "the cap opens a window")
+    now = 11_500
+    sample = sample.copy(cpuUtilization = 0.95)
+    val stopped = gate.snapshot()
+    assertTrue(stopped.constrained, "the CPU spike is new pressure, whenever it last happened")
+    assertNull(stopped.dutyCycleUntilEpochMillis)
+  }
+
+  @Test
+  fun `pressure after a window has elapsed does not re-arm the cap again`() {
+    var now = 0L
+    var sample =
+      HostResourceSample(loadPerCpu = 0.17, cpuUtilization = 0.03, memoryAvailableFraction = 0.14)
+    val gate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds =
+          OptimizerPressureThresholds(
+            sampleIntervalMillis = 0,
+            starvationCapMillis = 10_000,
+            dutyCycleMillis = 1_000,
+          ),
+        clock = { now },
+      )
+    assertTrue(gate.snapshot().constrained)
+    now = 10_000
+    assertFalse(gate.snapshot().constrained, "window open, scheduled to end at 11s")
+    now = 11_000
+    assertTrue(gate.snapshot().constrained, "and elapsed, having been served in full")
+
+    // A CPU trip four seconds later is cutting nothing short — the window is long over — so it must
+    // not push the next concession out from 21s to 25s.
+    now = 15_000
+    sample = sample.copy(cpuUtilization = 0.95)
+    assertTrue(gate.snapshot().constrained)
+    sample = sample.copy(cpuUtilization = 0.03)
+
+    now = 20_999
+    assertTrue(gate.snapshot().constrained)
+    now = 21_000
+    assertFalse(gate.snapshot().constrained, "still due 10s after the window that was served")
+  }
+
+  @Test
+  fun `an expiry noticed late still re-arms from the scheduled window end`() {
+    var now = 0L
+    var readable = true
+    val gate =
+      OptimizerPressureGate(
+        sample = {
+          if (readable) {
+            HostResourceSample(
+              loadPerCpu = 0.17,
+              cpuUtilization = 0.03,
+              memoryAvailableFraction = 0.14,
+            )
+          } else {
+            null
+          }
+        },
+        thresholds =
+          OptimizerPressureThresholds(
+            sampleIntervalMillis = 0,
+            starvationCapMillis = 10_000,
+            dutyCycleMillis = 1_000,
+          ),
+        clock = { now },
+      )
+    assertTrue(gate.snapshot().constrained)
+    now = 10_000
+    assertFalse(gate.snapshot().constrained, "the window opens, scheduled to end at 11s")
+
+    // The sampler goes blind across the expiry and stays blind until 20s. The concession was
+    // served in full, so the next one is due 10s after the scheduled end — charging a fresh cap
+    // from the moment someone happened to look would make blindness cost the host admission.
+    readable = false
+    now = 20_000
+    assertTrue(gate.snapshot().constrained)
+    readable = true
+    now = 20_999
+    assertTrue(gate.snapshot().constrained)
+    now = 21_000
+    assertFalse(gate.snapshot().constrained, "due at 21s, not 30s")
+  }
+
+  @Test
+  fun `a window cut short re-arms the cap from when it actually closed`() {
+    var now = 0L
+    var sample =
+      HostResourceSample(loadPerCpu = 0.17, cpuUtilization = 0.03, memoryAvailableFraction = 0.14)
+    val gate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds =
+          OptimizerPressureThresholds(
+            sampleIntervalMillis = 0,
+            starvationCapMillis = 10_000,
+            dutyCycleMillis = 1_000,
+          ),
+        clock = { now },
+      )
+    assertTrue(gate.snapshot().constrained)
+    now = 10_000
+    assertFalse(gate.snapshot().constrained)
+
+    // Cut short 100ms in. The next concession is owed 10s from *here*, not 10s from the end the
+    // window never reached — otherwise the cap silently becomes cap + window.
+    now = 10_100
+    sample = sample.copy(cpuUtilization = 0.95)
+    assertTrue(gate.snapshot().constrained)
+    sample = sample.copy(cpuUtilization = 0.03)
+
+    now = 20_099
+    assertTrue(gate.snapshot().constrained)
+    now = 20_100
+    assertFalse(gate.snapshot().constrained, "the cap runs from the early close")
+  }
+
+  @Test
+  fun `a hold closed while sampling is broken keeps reporting how long it has held`() {
+    var now = 0L
+    var readable = true
+    val gate =
+      OptimizerPressureGate(
+        sample = {
+          if (readable) {
+            HostResourceSample(
+              loadPerCpu = 0.17,
+              cpuUtilization = 0.03,
+              memoryAvailableFraction = 0.14,
+            )
+          } else {
+            null
+          }
+        },
+        thresholds =
+          OptimizerPressureThresholds(
+            sampleIntervalMillis = 0,
+            starvationCapMillis = 10_000,
+            dutyCycleMillis = 1_000,
+          ),
+        clock = { now },
+      )
+    assertTrue(gate.snapshot().constrained)
+    assertEquals(0, gate.snapshot().heldMillis)
+    now = 10_000
+    assertFalse(gate.snapshot().constrained)
+    // The hold is still on during the window, and it started at t=0 — the cap bookkeeping moving
+    // its own anchor to the window end must not make the reported duration collapse to zero.
+    assertEquals(10_000, gate.snapshot().heldMillis)
+
+    readable = false
+    now = 3_600_000
+    val stale = gate.snapshot()
+    assertTrue(stale.constrained)
+    assertEquals(3_600_000, stale.heldMillis, "an hour held must not report as zero: $stale")
+  }
+
+  @Test
+  fun `a zero-length window is not counted as a duty cycle`() {
+    var now = 0L
+    val sample =
+      HostResourceSample(loadPerCpu = 0.17, cpuUtilization = 0.03, memoryAvailableFraction = 0.14)
+    val gate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds =
+          OptimizerPressureThresholds(
+            sampleIntervalMillis = 0,
+            starvationCapMillis = 10_000,
+            dutyCycleMillis = 0,
+          ),
+        clock = { now },
+      )
+    assertTrue(gate.snapshot().constrained)
+    now = 10_000
+    assertTrue(gate.snapshot().constrained, "a window that admits nothing is not a concession")
+    now = 100_000
+    val held = gate.snapshot()
+    assertTrue(held.constrained)
+    assertEquals(0, held.dutyCycles, "and must not be reported as one: $held")
+  }
+
+  @Test
+  fun `the duty cycle stays shut while memory cannot be read at all`() {
+    var now = 0L
+    // `/proc/meminfo` unreadable while load and CPU are fine: the sampler reports a partial sample
+    // rather than none, and an unverified OOM floor must not buy a concession.
+    val sample =
+      HostResourceSample(loadPerCpu = 0.90, cpuUtilization = 0.10, memoryAvailableFraction = null)
+    val gate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds =
+          OptimizerPressureThresholds(
+            sampleIntervalMillis = 0,
+            starvationCapMillis = 10_000,
+            dutyCycleMillis = 1_000,
+          ),
+        clock = { now },
+      )
+    assertTrue(gate.snapshot().constrained)
+    now = 100_000
+    val held = gate.snapshot()
+    assertTrue(held.constrained, "an unknown memory reading is not a safe one")
+    assertEquals(0, held.dutyCycles)
+  }
+
+  @Test
+  fun `a zero starvation cap keeps the hold permanent`() {
+    var now = 0L
+    val sample =
+      HostResourceSample(loadPerCpu = 0.1, cpuUtilization = 0.1, memoryAvailableFraction = 0.14)
+    val gate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds = OptimizerPressureThresholds(sampleIntervalMillis = 0, starvationCapMillis = 0),
+        clock = { now },
+      )
+    assertTrue(gate.snapshot().constrained)
+    now = 10 * 60_000
+    assertTrue(gate.snapshot().constrained)
+    assertEquals(0, gate.snapshot().dutyCycles)
+  }
+
+  @Test
+  fun `recovery clears the starvation clock`() {
+    var now = 0L
+    var sample =
+      HostResourceSample(loadPerCpu = 0.1, cpuUtilization = 0.1, memoryAvailableFraction = 0.14)
+    val gate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds =
+          OptimizerPressureThresholds(
+            resumeQuietMillis = 0,
+            sampleIntervalMillis = 0,
+            starvationCapMillis = 10_000,
+          ),
+        clock = { now },
+      )
+    assertTrue(gate.snapshot().constrained)
+
+    now = 5_000
+    sample = sample.copy(memoryAvailableFraction = 0.80)
+    val recovered = gate.snapshot()
+    assertFalse(recovered.constrained)
+    assertNull(recovered.heldMillis)
+
+    // A new hold starts its own cap rather than inheriting the previous one's 5s of credit.
+    now = 6_000
+    sample = sample.copy(memoryAvailableFraction = 0.14)
+    assertTrue(gate.snapshot().constrained)
+    now = 15_999
+    assertTrue(gate.snapshot().constrained)
+    now = 16_000
+    assertFalse(gate.snapshot().constrained)
+  }
+
+  @Test
+  fun `only the signal that tripped the hold has to recover`() {
+    var now = 0L
+    var sample =
+      HostResourceSample(loadPerCpu = 0.2, cpuUtilization = 0.2, memoryAvailableFraction = 0.8)
+    val gate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds =
+          OptimizerPressureThresholds(resumeQuietMillis = 1_000, sampleIntervalMillis = 0),
+        clock = { now },
+      )
+    assertFalse(gate.snapshot().constrained)
+
+    sample = sample.copy(memoryAvailableFraction = 0.10)
+    assertTrue(gate.snapshot().constrained)
+
+    // Memory is back above its resume side. CPU sits between its resume (0.70) and stop (0.85)
+    // thresholds — uncomfortable, but it never stopped anything, so it must not block resumption.
+    sample = sample.copy(memoryAvailableFraction = 0.40, cpuUtilization = 0.75)
+    now = 1
+    assertTrue(gate.snapshot().constrained, "one safe sample must not flap the optimizer back on")
+    now = 1_001
+    assertFalse(gate.snapshot().constrained)
+  }
+
+  /**
+   * Load average per CPU is a queue depth, not a percentage.
+   *
+   * Both load thresholds were parsed as fractions and silently discarded every value over 1.0 —
+   * which is every value that matters on a host rendering flat out. Measured on preview.coo.ee
+   * while the optimizer worked: 1.03, 1.12 and 1.74 per CPU. The stop side therefore could not be
+   * lifted off its 0.85 default, so the gate tripped on the optimizer's own load and the operator's
+   * override vanished without a word.
+   */
+  @Test
+  fun `a load threshold above one is a setting, not a typo`() {
+    val stop = "composeai.serve.optimizerStopLoadPerCpu"
+    val resume = "composeai.serve.optimizerResumeLoadPerCpu"
+    val previousStop = System.getProperty(stop)
+    val previousResume = System.getProperty(resume)
+    try {
+      // The case the box actually needs: hold only once load passes two runnable tasks per core,
+      // and resume at one and a half. Neither is expressible as a fraction.
+      System.setProperty(stop, "2.5")
+      System.setProperty(resume, "1.5")
+      val tuned = OptimizerPressureThresholds.fromSystemProperties()
+      assertEquals(2.5, tuned.stopLoadPerCpu)
+      assertEquals(1.5, tuned.resumeLoadPerCpu)
+
+      // Still bounded — a typo is still a typo, just not at a ceiling every busy box exceeds.
+      System.setProperty(stop, "1000")
+      assertEquals(
+        OptimizerPressureThresholds().stopLoadPerCpu,
+        OptimizerPressureThresholds.fromSystemProperties().stopLoadPerCpu,
+      )
+
+      // Negative load is meaningless, so it falls back too.
+      System.setProperty(stop, "-1")
+      assertEquals(
+        OptimizerPressureThresholds().stopLoadPerCpu,
+        OptimizerPressureThresholds.fromSystemProperties().stopLoadPerCpu,
+      )
+    } finally {
+      if (previousStop == null) System.clearProperty(stop)
+      else System.setProperty(stop, previousStop)
+      if (previousResume == null) System.clearProperty(resume)
+      else System.setProperty(resume, previousResume)
+    }
+  }
+
+  /**
+   * The limbs that ARE fractions must stay fractions — the fix above must not widen CPU or memory,
+   * where a value over 1.0 really is a percentage someone forgot to divide.
+   */
+  @Test
+  fun `a cpu or memory threshold above one is still refused`() {
+    val cpu = "composeai.serve.optimizerStopCpuUtilization"
+    val previous = System.getProperty(cpu)
+    try {
+      System.setProperty(cpu, "96")
+      assertEquals(
+        OptimizerPressureThresholds().stopCpuUtilization,
+        OptimizerPressureThresholds.fromSystemProperties().stopCpuUtilization,
+        "96 means 96%, and obeying it as a ratio would disable the CPU limb entirely",
+      )
+      System.setProperty(cpu, "0.96")
+      assertEquals(0.96, OptimizerPressureThresholds.fromSystemProperties().stopCpuUtilization)
+    } finally {
+      if (previous == null) System.clearProperty(cpu) else System.setProperty(cpu, previous)
+    }
+  }
+
+  @Test
+  fun `thresholds fall back to defaults when system properties are absent or unparseable`() {
+    val key = "composeai.serve.optimizerStopMemoryAvailableFraction"
+    val quiet = "composeai.serve.optimizerResumeQuietMillis"
+    val previous = System.getProperty(key)
+    val previousQuiet = System.getProperty(quiet)
+    try {
+      System.clearProperty(key)
+      System.clearProperty(quiet)
+      assertEquals(
+        OptimizerPressureThresholds(),
+        OptimizerPressureThresholds.fromSystemProperties(),
+      )
+
+      System.setProperty(key, "0.35")
+      System.setProperty(quiet, "5000")
+      val tuned = OptimizerPressureThresholds.fromSystemProperties()
+      assertEquals(0.35, tuned.stopMemoryAvailableFraction)
+      assertEquals(5_000L, tuned.resumeQuietMillis)
+
+      // A ratio outside 0..1 and a negative duration are typos, not instructions.
+      System.setProperty(key, "35")
+      System.setProperty(quiet, "-1")
+      val rejected = OptimizerPressureThresholds.fromSystemProperties()
+      assertEquals(
+        OptimizerPressureThresholds().stopMemoryAvailableFraction,
+        rejected.stopMemoryAvailableFraction,
+      )
+      assertEquals(OptimizerPressureThresholds().resumeQuietMillis, rejected.resumeQuietMillis)
+    } finally {
+      if (previous == null) System.clearProperty(key) else System.setProperty(key, previous)
+      if (previousQuiet == null) System.clearProperty(quiet)
+      else System.setProperty(quiet, previousQuiet)
+    }
+  }
+
+  @Test
+  fun `load and memory independently constrain optimization`() {
+    var sample =
+      HostResourceSample(loadPerCpu = 0.9, cpuUtilization = 0.1, memoryAvailableFraction = 0.8)
+    val loadGate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds = OptimizerPressureThresholds(sampleIntervalMillis = 0),
+      )
+    assertTrue(loadGate.snapshot().constrained)
+    assertTrue(loadGate.snapshot().reason.orEmpty().contains("load"))
+
+    sample =
+      HostResourceSample(loadPerCpu = 0.1, cpuUtilization = 0.1, memoryAvailableFraction = 0.1)
+    val memoryGate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds = OptimizerPressureThresholds(sampleIntervalMillis = 0),
+      )
+    assertTrue(memoryGate.snapshot().constrained)
+    assertTrue(memoryGate.snapshot().reason.orEmpty().contains("memory"))
+  }
+
+  @Test
+  fun `background work reports automatic pressure as a pause`() {
+    val gate =
+      OptimizerPressureGate(
+        sample = {
+          HostResourceSample(
+            loadPerCpu = 1.2,
+            cpuUtilization = 0.95,
+            memoryAvailableFraction = 0.05,
+          )
+        },
+        thresholds = OptimizerPressureThresholds(sampleIntervalMillis = 0),
+      )
+    val work = ServeBackgroundWork(pressureGate = gate)
+
+    assertNull(work.withOptimizerSlot("catalog", waitMillis = 0) { true })
+    val snapshot = work.optimizerAdmissionSnapshot()
+    assertTrue(snapshot.paused)
+    assertTrue(snapshot.pressure?.constrained == true)
+    assertTrue(snapshot.pauseReason.orEmpty().contains("load"))
+  }
+
+  @Test
+  fun `background work admits a slice once the starvation cap opens the gate`() {
+    var now = 0L
+    val gate =
+      OptimizerPressureGate(
+        sample = {
+          HostResourceSample(
+            loadPerCpu = 0.17,
+            cpuUtilization = 0.03,
+            memoryAvailableFraction = 0.14,
+          )
+        },
+        thresholds =
+          OptimizerPressureThresholds(
+            sampleIntervalMillis = 0,
+            starvationCapMillis = 10_000,
+            dutyCycleMillis = 1_000,
+          ),
+        clock = { now },
+      )
+    val work = ServeBackgroundWork(clock = { now }, pressureGate = gate)
+
+    assertNull(work.withOptimizerSlot("catalog", waitMillis = 0) { true })
+    assertTrue(work.optimizersPaused())
+
+    now = 10_000
+    assertEquals(true, work.withOptimizerSlot("catalog", waitMillis = 0) { true })
+    val snapshot = work.optimizerAdmissionSnapshot()
+    assertFalse(snapshot.paused, "the duty cycle has to reach the admission path, not just /status")
+    assertEquals(1, snapshot.pressure?.dutyCycles)
+  }
+
+  /**
+   * `/proc/meminfo` inside a container reports the HOST's memory. The deployed profiles cap preview
+   * at 3 GiB and 6 GiB on far larger hosts, so a replica already near its own OOM limit read as
+   * having plenty of headroom and the gate kept admitting optimizer work.
+   */
+  @Test
+  fun `memory headroom is the smaller of the host and the cgroup`() {
+    val root = Files.createTempDirectory("host-sampler").toFile()
+    val proc = File(root, "proc").apply { mkdirs() }
+    // 32 GiB host, 24 GiB of it available: 75%, comfortably unconstrained on its own.
+    File(proc, "meminfo").writeText("MemTotal:       33554432 kB\nMemAvailable:   25165824 kB\n")
+
+    val hostOnly = LinuxHostResourceSampler(proc, File(root, "absent")).sample()
+    assertEquals(0.75, assertNotNull(hostOnly?.memoryAvailableFraction), 0.001)
+
+    // Same host, but this process is in a 3 GiB cgroup with 2.9 GiB charged to it.
+    val cgroupV2 = File(root, "cgroup2").apply { mkdirs() }
+    File(cgroupV2, "memory.max").writeText("${3L * 1024 * 1024 * 1024}\n")
+    File(cgroupV2, "memory.current").writeText("${(2.9 * 1024 * 1024 * 1024).toLong()}\n")
+
+    val constrained = LinuxHostResourceSampler(proc, cgroupV2).sample()
+    assertTrue(
+      assertNotNull(constrained?.memoryAvailableFraction) < 0.05,
+      "the container's own ceiling has to win over the host's spare memory",
+    )
+  }
+
+  @Test
+  fun `page cache charged to the cgroup is not counted as used`() {
+    val root = Files.createTempDirectory("host-sampler-cache").toFile()
+    val proc = File(root, "proc").apply { mkdirs() }
+    File(proc, "meminfo").writeText("MemTotal:       33554432 kB\nMemAvailable:   25165824 kB\n")
+    val cgroup = File(root, "cgroup2").apply { mkdirs() }
+    val limit = 4L * 1024 * 1024 * 1024
+    File(cgroup, "memory.max").writeText("$limit\n")
+    File(cgroup, "memory.current").writeText("${limit / 2}\n")
+    // Half of what is charged is reclaimable page cache, so the real headroom is 75%, not 50%.
+    File(cgroup, "memory.stat").writeText("anon 1\ninactive_file ${limit / 4}\nslab 2\n")
+
+    val sample = LinuxHostResourceSampler(proc, cgroup).sample()
+
+    assertEquals(0.75, assertNotNull(sample?.memoryAvailableFraction), 0.001)
+  }
+
+  @Test
+  fun `an unlimited cgroup leaves the host reading untouched`() {
+    val root = Files.createTempDirectory("host-sampler-unlimited").toFile()
+    val proc = File(root, "proc").apply { mkdirs() }
+    File(proc, "meminfo").writeText("MemTotal:       33554432 kB\nMemAvailable:   25165824 kB\n")
+
+    // cgroup v2 spells it as a word...
+    val v2 = File(root, "cgroup2").apply { mkdirs() }
+    File(v2, "memory.max").writeText("max\n")
+    File(v2, "memory.current").writeText("1024\n")
+    assertEquals(
+      0.75,
+      assertNotNull(LinuxHostResourceSampler(proc, v2).sample()?.memoryAvailableFraction),
+      0.001,
+    )
+
+    // ...cgroup v1 as a sentinel near Long.MAX_VALUE, which must not be read as a real ceiling.
+    val v1 = File(root, "cgroup1").apply { mkdirs() }
+    File(v1, "memory").apply {
+      mkdirs()
+      File(this, "memory.limit_in_bytes").writeText("9223372036854771712\n")
+      File(this, "memory.usage_in_bytes").writeText("1024\n")
+    }
+    assertEquals(
+      0.75,
+      assertNotNull(LinuxHostResourceSampler(proc, v1).sample()?.memoryAvailableFraction),
+      0.001,
+    )
+  }
+
+  @Test
+  fun `a cgroup v1 limit is honoured`() {
+    val root = Files.createTempDirectory("host-sampler-v1").toFile()
+    val proc = File(root, "proc").apply { mkdirs() }
+    File(proc, "meminfo").writeText("MemTotal:       33554432 kB\nMemAvailable:   25165824 kB\n")
+    val cgroup = File(root, "cgroup1").apply { mkdirs() }
+    File(cgroup, "memory").apply {
+      mkdirs()
+      val limit = 6L * 1024 * 1024 * 1024
+      File(this, "memory.limit_in_bytes").writeText("$limit\n")
+      File(this, "memory.usage_in_bytes").writeText("${limit - limit / 10}\n")
+      File(this, "memory.stat").writeText("total_inactive_file 0\n")
+    }
+
+    val sample = LinuxHostResourceSampler(proc, cgroup).sample()
+
+    assertEquals(0.1, assertNotNull(sample?.memoryAvailableFraction), 0.001)
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiterPerPreviewReserveTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiterPerPreviewReserveTest.kt
@@ -1,0 +1,143 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The per-preview lane's guaranteed slice of the seat budget.
+ *
+ * Observed on preview.coo.ee before it existed: eight resident catalog daemons held all 8 permits
+ * with `activeStreams: 0`, so every `acquireBackground` was refused,
+ * [ServePerPreviewDaemonPool.get] returned null, and `ServeCatalogLiveHost.renderInternal` turned
+ * that `NotFound` into `Busy`. All 21 of meshcore-mobile's supplement-module previews answered `503
+ * render busy; retry shortly` on 39 of 39 attempts, and the catalog's theme prefetch pinned at
+ * 288/372 for the life of the server. `liveSeatsAvailable: 0` and `liveSeatRefusals: 0` were the
+ * only symptoms visible from outside.
+ *
+ * A burst replica can narrow onto the primary when it is refused; a preview whose only live lane is
+ * its own per-preview bundle has no such fallback, which is why this lane — and only this lane —
+ * gets a floor.
+ */
+class LiveSeatLimiterPerPreviewReserveTest {
+
+  @Test
+  fun `a saturated general lane cannot starve the per-preview slice`() {
+    val limiter = LiveSeatLimiter(totalPermits = 8, perPreviewReserve = 1)
+    // Drain the general lane exactly as the resident catalog daemons did.
+    val held = (1..7).mapNotNull { limiter.acquire(1) }
+    assertEquals(7, held.size, "the general lane is the budget minus the slice")
+    assertNull(limiter.acquire(1), "and is now full")
+
+    assertNotNull(
+      limiter.acquireBackground(1),
+      "the per-preview lane still opens — this is the whole point",
+    )
+  }
+
+  @Test
+  fun `the slice is not available to the general lane`() {
+    val limiter = LiveSeatLimiter(totalPermits = 4, perPreviewReserve = 1)
+    val held = (1..3).mapNotNull { limiter.acquire(1) }
+    assertEquals(3, held.size)
+    assertNull(limiter.acquire(1), "the reserved permit is never handed to a stream or replica")
+  }
+
+  @Test
+  fun `a reserved permit returns to the reserve, not the general pool`() {
+    // Otherwise the slice leaks into the general lane on the first eviction and the starvation
+    // reappears — silently, and only after the box has been up a while.
+    val limiter = LiveSeatLimiter(totalPermits = 4, perPreviewReserve = 1)
+    (1..3).mapNotNull { limiter.acquire(1) }
+    val background = assertNotNull(limiter.acquireBackground(1))
+
+    background.close()
+
+    assertNull(limiter.acquire(1), "the returned permit did not become general capacity")
+    assertNotNull(limiter.acquireBackground(1), "it went back to the lane it came from")
+  }
+
+  @Test
+  fun `background falls back to the general lane while it has stream headroom`() {
+    // The slice is a floor, not a ceiling: a second concurrent per-preview daemon competes for the
+    // general pool exactly as before, and still leaves room for an interactive stream.
+    val limiter = LiveSeatLimiter(totalPermits = 8, perPreviewReserve = 1)
+    val first = assertNotNull(limiter.acquireBackground(1))
+    val second = assertNotNull(limiter.acquireBackground(1), "general lane has plenty free")
+    assertTrue(first.permits == 1 && second.permits == 1)
+  }
+
+  @Test
+  fun `a heavy backend is coerced to the general lane, not the whole budget`() {
+    // Coercing to totalPermits would ask for more than the general semaphore can ever hold and
+    // refuse the backend forever — the exact deadlock the coercion exists to prevent.
+    val limiter = LiveSeatLimiter(totalPermits = 4, perPreviewReserve = 1)
+    assertNotNull(limiter.acquire(99), "a backend heavier than the budget still runs alone")
+  }
+
+  @Test
+  fun `availablePermits sums both lanes so status stays comparable to the total`() {
+    val limiter = LiveSeatLimiter(totalPermits = 4, perPreviewReserve = 1)
+    assertEquals(4, limiter.availablePermits())
+    assertEquals(1, limiter.perPreviewPermitsAvailable())
+
+    (1..3).mapNotNull { limiter.acquire(1) }
+
+    assertEquals(1, limiter.availablePermits(), "the free slice is not reported as capacity gone")
+    assertEquals(1, limiter.perPreviewPermitsAvailable())
+  }
+
+  @Test
+  fun `a budget too small to afford the slice gets none, and cannot over-admit`() {
+    // The `--live-seats 2` case. A general lane of 1 would coerce an Android stream (weight 2) down
+    // to a single permit, and a per-preview daemon could then take the reserved one — three
+    // permits' worth of processes on a box budgeted for two, defeating the OOM protection that is
+    // the entire reason the budget is weighted. So a box this small keeps its old behaviour.
+    val limiter = LiveSeatLimiter(totalPermits = 2, perPreviewReserve = 1)
+    assertEquals(0, limiter.perPreviewPermits, "no slice is carved out of a budget this small")
+
+    val android = assertNotNull(limiter.acquire(ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT))
+    assertEquals(2, android.permits, "the heavy backend is charged its true weight, not clamped")
+    assertEquals(0, limiter.availablePermits(), "and it holds the whole box")
+    assertNull(limiter.acquireBackground(1), "nothing else may run alongside it")
+  }
+
+  @Test
+  fun `the slice never eats the headroom a heaviest-backend stream needs`() {
+    // The invariant that makes the clamp above safe: whenever a slice exists, the general lane can
+    // still hold ANDROID_LIVE_SEAT_WEIGHT at full weight, so `acquire` never under-charges.
+    for (total in 1..12) {
+      val limiter = LiveSeatLimiter(totalPermits = total, perPreviewReserve = 4)
+      val general = total - limiter.perPreviewPermits
+      if (limiter.perPreviewPermits > 0) {
+        assertTrue(
+          general >= ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT,
+          "budget $total left a general lane of $general, too small for the heaviest backend",
+        )
+      }
+      assertTrue(limiter.perPreviewPermits >= 0 && general >= 0)
+    }
+  }
+
+  @Test
+  fun `an oversized reserve is clamped, and status reports what is actually held`() {
+    // `/status` must publish the EFFECTIVE slice. Reporting the requested value would state a
+    // reserve the limiter does not hold — and a diagnostic added to make starvation visible must
+    // not itself be able to lie.
+    val limiter = LiveSeatLimiter(totalPermits = 8, perPreviewReserve = 99)
+    assertEquals(6, limiter.perPreviewPermits, "clamped to the budget minus the stream reserve")
+    assertEquals(99, limiter.perPreviewReserve, "the requested value is kept, but is not the truth")
+    assertEquals(6, limiter.perPreviewPermitsAvailable())
+    assertEquals(8, limiter.availablePermits())
+  }
+
+  @Test
+  fun `an unbounded limiter is unaffected`() {
+    val limiter = LiveSeatLimiter(totalPermits = 0, perPreviewReserve = 1)
+    assertTrue(limiter.unbounded)
+    assertNotNull(limiter.acquireBackground(1))
+    assertNotNull(limiter.acquire(99))
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiterTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiterTest.kt
@@ -1,0 +1,152 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the live-seat permit budget ([LiveSeatLimiter]) — the gate that lets a heavy
+ * Android daemon cost more of the box than a cheap desktop CMP one, replacing the flat seat count
+ * that let one heavy catalog starve the rest.
+ */
+class LiveSeatLimiterTest {
+  // Several cases below pass `perPreviewReserve = 0` deliberately. They pin the GENERAL lane's
+  // arithmetic against the whole budget, which is what they were written to describe; the slice
+  // carved out of that budget by default is covered by LiveSeatLimiterPerPreviewReserveTest.
+
+  @Test
+  fun `refusals are counted so seat pressure is visible after the fact`() {
+    val limiter = LiveSeatLimiter(totalPermits = 2)
+    assertEquals(0L, limiter.refusalCount())
+
+    val held = assertNotNull(limiter.acquire(2))
+    // Two refusals while the budget is fully held…
+    assertNull(limiter.acquire(1))
+    assertNull(limiter.acquire(1))
+    assertEquals(2L, limiter.refusalCount())
+
+    // …and the count is monotonic: releasing does not rewind history, which is the point of a
+    // counter over the availablePermits gauge beside it.
+    held.close()
+    assertNotNull(limiter.acquire(1)).close()
+    assertEquals(2L, limiter.refusalCount())
+  }
+
+  @Test
+  fun `an attempt for an unknown session is refused without counting`() {
+    val limiter = LiveSeatLimiter(totalPermits = 1)
+    val held = assertNotNull(limiter.acquire(1))
+
+    // Seats are reserved before the session is leased, so a request naming a session this box does
+    // not have still reaches the budget. It is refused like any other — but it must not move the
+    // counter, or anyone could manufacture the evidence a capacity decision rests on.
+    assertNull(limiter.acquire(1, verified = false))
+    assertEquals(0L, limiter.refusalCount())
+    // Not dropped, though: a `--revisions` session is legitimately unknown until its first lease
+    // builds it, so the number is kept in its own bucket rather than lost.
+    assertEquals(1L, limiter.unverifiedRefusalCount())
+
+    // A real one still counts as demand.
+    assertNull(limiter.acquire(1))
+    assertEquals(1L, limiter.refusalCount())
+    assertEquals(1L, limiter.unverifiedRefusalCount())
+    held.close()
+  }
+
+  @Test
+  fun `an unbounded limiter never refuses and so never counts`() {
+    val limiter = LiveSeatLimiter(totalPermits = 0)
+    repeat(5) { assertNotNull(limiter.acquire(2)) }
+    assertEquals(0L, limiter.refusalCount())
+  }
+
+  @Test
+  fun `zero budget is unbounded — every acquire is a free ticket`() {
+    val limiter = LiveSeatLimiter(0)
+    assertTrue(limiter.unbounded)
+    // Even an absurd weight succeeds and holds no permits.
+    val ticket = limiter.acquire(999)
+    assertNotNull(ticket)
+    assertEquals(0, ticket.permits)
+    assertEquals(Int.MAX_VALUE, limiter.availablePermits())
+    ticket.close()
+  }
+
+  @Test
+  fun `a static (zero-weight) session takes no permit`() {
+    val limiter = LiveSeatLimiter(2)
+    val ticket = limiter.acquire(0)
+    assertNotNull(ticket)
+    assertEquals(0, ticket.permits)
+    // Budget untouched — two daemon-backed sessions can still run alongside it.
+    assertEquals(2, limiter.availablePermits())
+  }
+
+  @Test
+  fun `desktop-weight sessions fill the budget then the next is refused`() {
+    val limiter = LiveSeatLimiter(2, perPreviewReserve = 0)
+    val a = assertNotNull(limiter.acquire(1))
+    assertNotNull(limiter.acquire(1))
+    assertEquals(0, limiter.availablePermits())
+    // Third desktop session over budget → refused (caller closes WS 1013).
+    assertNull(limiter.acquire(1))
+    // Freeing one reopens a seat.
+    a.close()
+    assertEquals(1, limiter.availablePermits())
+    val c = limiter.acquire(1)
+    assertNotNull(c)
+  }
+
+  @Test
+  fun `an Android session costs its heavier weight and blocks a concurrent desktop one`() {
+    val limiter = LiveSeatLimiter(2, perPreviewReserve = 0)
+    // Weight 2 (Android) consumes the whole budget of 2.
+    val android = assertNotNull(limiter.acquire(ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT))
+    assertEquals(2, android.permits)
+    assertEquals(0, limiter.availablePermits())
+    // A cheap desktop session can't squeeze in while the heavy one holds both permits.
+    assertNull(limiter.acquire(1))
+    // Once the Android daemon releases, the desktop session gets a seat.
+    android.close()
+    assertEquals(2, limiter.availablePermits())
+    assertNotNull(limiter.acquire(1))
+  }
+
+  @Test
+  fun `a weight heavier than the whole budget is coerced so it can still run alone`() {
+    // Budget 1, Android weight 2: without coercion the Android catalog would be permanently refused
+    // (its weight exceeds the ceiling). Coerce to the budget so it runs solo instead of
+    // deadlocking.
+    val limiter = LiveSeatLimiter(1)
+    val android = assertNotNull(limiter.acquire(ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT))
+    assertEquals(1, android.permits)
+    assertEquals(0, limiter.availablePermits())
+    // …but it does hold the whole box: nothing else runs concurrently.
+    assertNull(limiter.acquire(1))
+    android.close()
+    assertEquals(1, limiter.availablePermits())
+  }
+
+  @Test
+  fun `releasing a ticket is idempotent — a double close returns permits only once`() {
+    val limiter = LiveSeatLimiter(2, perPreviewReserve = 0)
+    val a = assertNotNull(limiter.acquire(1))
+    a.close()
+    a.close() // second close is a no-op
+    assertEquals(2, limiter.availablePermits())
+    // Sanity: the budget didn't inflate past its total.
+    assertNotNull(limiter.acquire(1))
+    assertNotNull(limiter.acquire(1))
+    assertNull(limiter.acquire(1))
+  }
+
+  @Test
+  fun `a bounded limiter reports itself bounded`() {
+    assertFalse(LiveSeatLimiter(2).unbounded)
+    assertTrue(LiveSeatLimiter(0).unbounded)
+    assertTrue(LiveSeatLimiter(-3).unbounded)
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundPreviewsTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundPreviewsTest.kt
@@ -1,0 +1,85 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.previewdata.PreviewManifest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.serialization.json.Json
+import okio.Path.Companion.toPath
+
+/**
+ * The synthesized `previews.json` a bundle-less playground daemon renders against. What matters
+ * here is coverage: the daemon can only stream a preview the manifest names, so a snippet that
+ * compiled several must see all of them listed — otherwise the extras are compiled and then
+ * unreachable, which is exactly the single-preview limit this manifest used to impose.
+ */
+class PlaygroundPreviewsTest {
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  private fun snippet(previewIds: List<String>) =
+    PlaygroundTokenStore.PlaygroundSnippet(
+      mode = PlaygroundMode.CMP,
+      workDir = "/w/snippet".toPath(),
+      classesDir = "/w/snippet/classes".toPath(),
+      classpath = listOf("/w/snippet/classes".toPath()),
+      moduleName = "playground-cmp",
+      previewId = previewIds.first(),
+      previewIds = previewIds,
+    )
+
+  private fun decode(previewIds: List<String>): PreviewManifest =
+    json.decodeFromString(
+      PreviewManifest.serializer(),
+      PlaygroundPreviews.previewManifestJson(snippet(previewIds)),
+    )
+
+  @Test
+  fun `every declared preview is listed, in declaration order`() {
+    val manifest =
+      decode(
+        listOf(
+          "com.example.SnippetKt.Alpha",
+          "com.example.OtherKt.Beta",
+          "com.example.OtherKt.Gamma",
+        )
+      )
+    assertEquals(
+      listOf(
+        "com.example.SnippetKt.Alpha",
+        "com.example.OtherKt.Beta",
+        "com.example.OtherKt.Gamma",
+      ),
+      manifest.previews.map { it.id },
+      "the live session can only navigate to previews the manifest names",
+    )
+    assertEquals("playground-cmp", manifest.module)
+  }
+
+  @Test
+  fun `an id is split back into its class and function`() {
+    val entry = decode(listOf("com.example.SnippetKt.Alpha")).previews.single()
+    assertEquals("com.example.SnippetKt", entry.className)
+    assertEquals("Alpha", entry.functionName)
+  }
+
+  @Test
+  fun `a snippet that names only one preview still yields exactly one entry`() {
+    // The default `previewIds = listOf(previewId)` keeps every pre-existing single-preview caller
+    // producing the manifest it always did.
+    val manifest =
+      json.decodeFromString(
+        PreviewManifest.serializer(),
+        PlaygroundPreviews.previewManifestJson(
+          PlaygroundTokenStore.PlaygroundSnippet(
+            mode = PlaygroundMode.CMP,
+            workDir = "/w/snippet".toPath(),
+            classesDir = "/w/snippet/classes".toPath(),
+            classpath = listOf("/w/snippet/classes".toPath()),
+            moduleName = "playground-cmp",
+            previewId = "com.example.SnippetKt.Only",
+          )
+        ),
+      )
+    assertEquals(listOf("com.example.SnippetKt.Only"), manifest.previews.map { it.id })
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSandboxProbeTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSandboxProbeTest.kt
@@ -1,0 +1,238 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import java.util.concurrent.TimeUnit
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The sandbox preflight (issue #3016): the throwaway JVM that runs *inside* the configured jail and
+ * reports what it can still reach. Everything here is about fail-closed reading of that report — a
+ * jail that never launched, or one that printed nothing, must never read as "contained".
+ */
+class PlaygroundSandboxProbeTest {
+
+  private val tempDir: File =
+    java.nio.file.Files.createTempDirectory("playground-sandbox-probe-test").toFile()
+
+  @AfterTest
+  fun cleanUp() {
+    tempDir.deleteRecursively()
+  }
+
+  @Test
+  fun `a clean report is parsed and marked as having run`() {
+    val launch =
+      PlaygroundSandboxProbe.Launch(
+        exitCode = 0,
+        stdout =
+          "Picked up JAVA_TOOL_OPTIONS: -Dfoo\n" +
+            PlaygroundSandboxProbe.REPORT_PREFIX +
+            """{"egressBlocked":true,"filesystemContained":true,"processIsolated":true,""" +
+            """"workDirWritable":true,"detail":"probed from pid 7"}""",
+        stderr = "",
+      )
+
+    val report = PlaygroundSandboxProbe.parse(launch)
+
+    assertTrue(report.ran)
+    assertEquals(emptyList(), report.failedChecks())
+  }
+
+  @Test
+  fun `a missing tool reads as did-not-run, not as contained`() {
+    val launch =
+      PlaygroundSandboxProbe.Launch(
+        exitCode = 127,
+        stdout = "",
+        stderr = "bwrap: command not found\n",
+      )
+
+    val report = PlaygroundSandboxProbe.parse(launch)
+
+    assertFalse(report.ran)
+    assertEquals("bwrap: command not found", report.detail)
+    assertTrue("the probe JVM never reported" in report.failedChecks())
+    // The individual properties stay false: nothing was measured, so nothing is proven.
+    assertFalse(report.egressBlocked)
+    assertFalse(report.filesystemContained)
+  }
+
+  @Test
+  fun `garbled output is a refusal rather than a parse crash`() {
+    val launch =
+      PlaygroundSandboxProbe.Launch(
+        exitCode = 0,
+        stdout = PlaygroundSandboxProbe.REPORT_PREFIX + "{not json",
+        stderr = "",
+      )
+
+    val report = PlaygroundSandboxProbe.parse(launch)
+
+    assertFalse(report.ran)
+    assertTrue("unreadable probe report" in report.detail, report.detail)
+  }
+
+  @Test
+  fun `an inactive sandbox is never probed`() {
+    var launched = false
+
+    val report =
+      PlaygroundSandboxProbe.run(
+        sandbox = PlaygroundSandbox.NONE,
+        javaHome = File(System.getProperty("java.home")),
+        classpath = listOf("/cli.jar"),
+        workRoot = tempDir,
+      ) { _, _ ->
+        launched = true
+        PlaygroundSandboxProbe.Launch(0, "", "")
+      }
+
+    assertFalse(launched, "there is no jail to probe")
+    assertFalse(report.ran)
+  }
+
+  @Test
+  fun `the probe launches the jail argv, the real java binary, and the probe main`() {
+    var argv: List<String> = emptyList()
+
+    PlaygroundSandboxProbe.run(
+      sandbox = PlaygroundSandbox(profile = PlaygroundSandbox.Profile.BWRAP),
+      javaHome = File("/opt/jdk17"),
+      classpath = listOf("/cli.jar", "/dep.jar"),
+      workRoot = tempDir,
+    ) { command, _ ->
+      argv = command
+      PlaygroundSandboxProbe.Launch(0, "", "")
+    }
+
+    assertEquals("bwrap", argv.first())
+    assertTrue("/opt/jdk17/bin/java" in argv, argv.toString())
+    assertTrue(PlaygroundSandboxProbe.PROBE_MAIN_CLASS in argv)
+    // The canary the child must NOT be able to read lives outside every bound path.
+    val canaryArg = argv.last { it.endsWith("canary.txt") }
+    assertFalse(
+      argv.windowed(3).any { it[0] == "--ro-bind-try" && it[1] == canaryArg },
+      "the canary must not be bound into the jail",
+    )
+  }
+
+  @Test
+  fun `the in-jail probe measures the properties it claims to`() {
+    val workDir = File(tempDir, "work").apply { mkdirs() }
+    val canary = File(tempDir, "canary.txt").apply { writeText("secret") }
+
+    // Unjailed, in this very JVM: the canary is readable and this process's pid is visible, so the
+    // probe must report NOT contained — the same reading that keeps a broken jail out of --public.
+    val unjailed =
+      PlaygroundSandboxProbeMain.probe(
+        workDir = workDir,
+        canary = canary,
+        hostPid = ProcessHandle.current().pid(),
+      )
+
+    assertTrue(unjailed.ran)
+    assertTrue(unjailed.workDirWritable)
+    assertFalse(unjailed.filesystemContained, "the canary is readable from an unjailed JVM")
+    if (File("/proc/${ProcessHandle.current().pid()}").exists()) {
+      assertFalse(unjailed.processIsolated, "this JVM can see its own pid in /proc")
+    }
+
+    // A canary that isn't there at all — what a real jail's child sees — reads as contained.
+    val contained =
+      PlaygroundSandboxProbeMain.probe(
+        workDir = workDir,
+        canary = File(tempDir, "absent-canary.txt"),
+        hostPid = 999_999_999L,
+      )
+    assertTrue(contained.filesystemContained)
+    assertTrue(contained.processIsolated)
+  }
+
+  /**
+   * End-to-end: spawn the probe JVM behind a real `unshare(1)` jail and assert it comes back with
+   * egress blocked. Skipped where unprivileged user namespaces are unavailable (some hardened
+   * kernels, most macOS/Windows dev boxes) — the point is to exercise the real launch path wherever
+   * the kernel allows it, not to make the suite kernel-dependent.
+   */
+  @Test
+  fun `a real unshare jail reports egress blocked`() {
+    if (!unshareAvailable()) return
+
+    val report =
+      PlaygroundSandboxProbe.run(
+        sandbox = PlaygroundSandbox(profile = PlaygroundSandbox.Profile.UNSHARE),
+        javaHome = File(System.getProperty("java.home")),
+        classpath =
+          System.getProperty("java.class.path").split(File.pathSeparator).filter {
+            it.isNotBlank()
+          },
+        workRoot = tempDir,
+      )
+
+    assertTrue(report.ran, "probe did not run: ${report.detail}")
+    assertTrue(report.egressBlocked, "an empty network namespace must have no route out")
+    assertTrue(report.workDirWritable)
+    assertTrue(report.processIsolated, "a fresh pid namespace hides the serve host's pid")
+    // …and `unshare` alone still leaves the host filesystem visible, which is exactly why it does
+    // not pass the --public gate: PlaygroundPublicGate refuses on filesystemContained = false.
+    assertFalse(report.filesystemContained)
+  }
+
+  /**
+   * `bwrap` is the containment half of the `--public`-grade `strict` profile, so it must satisfy
+   * **all four** probe checks — the whole of what the probe can measure. (Admission additionally
+   * requires cgroup caps, which is why `strict` and not bare `bwrap` is what a public host runs;
+   * that half is `systemd-run`'s and is not probe-measurable.) Skipped where bubblewrap isn't
+   * installed or the kernel refuses its namespaces.
+   */
+  @Test
+  fun `a real bwrap jail passes every check the probe can measure`() {
+    if (!toolAvailable(listOf("bwrap", "--version"))) return
+
+    val sandbox = PlaygroundSandbox(profile = PlaygroundSandbox.Profile.BWRAP)
+    val report =
+      PlaygroundSandboxProbe.run(
+        sandbox = sandbox,
+        javaHome = File(System.getProperty("java.home")),
+        classpath =
+          System.getProperty("java.class.path").split(File.pathSeparator).filter {
+            it.isNotBlank()
+          },
+        workRoot = tempDir,
+      )
+
+    assertTrue(report.ran, "probe did not run: ${report.detail}")
+    assertEquals(emptyList(), report.failedChecks(), report.summary())
+    // The same report under `strict` — bwrap's containment plus systemd's cgroup caps — is what the
+    // gate admits.
+    assertTrue(
+      PlaygroundPublicGate.decide(
+        isPublic = true,
+        // On containment alone — no GitHub auth in the picture.
+        repoAccessGated = false,
+        sandbox = PlaygroundSandbox(profile = PlaygroundSandbox.Profile.STRICT),
+        probe = report,
+      ) is PlaygroundPublicGate.Decision.Allow
+    )
+  }
+
+  private fun unshareAvailable(): Boolean =
+    toolAvailable(listOf("unshare", "--user", "--map-root-user", "--net", "true"))
+
+  /**
+   * True when [argv] runs and exits 0 — the tool exists and the kernel permits what it asks for.
+   */
+  private fun toolAvailable(argv: List<String>): Boolean = runCatching {
+    val process =
+      ProcessBuilder(argv)
+        .redirectErrorStream(true)
+        .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+        .start()
+    process.waitFor(20, TimeUnit.SECONDS) && process.exitValue() == 0
+  }
+    .getOrDefault(false)
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSandboxTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSandboxTest.kt
@@ -1,0 +1,529 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The playground's per-session sandbox policy (PLAYGROUND.md §6, issue #3016): the argv each
+ * profile jails a snippet JVM behind, the JVM-level caps that apply regardless of profile, and the
+ * knob validation that turns a typo into a startup failure rather than a silently unconfined
+ * playground.
+ */
+class PlaygroundSandboxTest {
+
+  private val paths =
+    PlaygroundSandbox.Paths(
+      workDir = File("/tmp/pg/snippet-1"),
+      readOnly = listOf(File("/cache/m3.jar"), File("/tmp/pg/snippet-1/classes")),
+      javaHome = File("/opt/jdk17"),
+    )
+
+  @Test
+  fun `none is inert`() {
+    val sandbox = PlaygroundSandbox.NONE
+    assertFalse(sandbox.isActive)
+    assertEquals(emptyList(), sandbox.command(paths))
+    assertEquals(emptyList(), sandbox.jvmArgs(paths.workDir))
+  }
+
+  @Test
+  fun `bwrap unshares the network, clears the env, and leaves exactly one writable path`() {
+    val argv = PlaygroundSandbox(profile = PlaygroundSandbox.Profile.BWRAP).command(paths)
+
+    assertEquals("bwrap", argv.first())
+    assertTrue("--unshare-net" in argv, "egress must be unshared: $argv")
+    assertTrue("--die-with-parent" in argv)
+    // The serve JVM's env carries operator secrets (--admin-token); a snippet must not read them.
+    assertTrue("--clearenv" in argv)
+    // The JDK and every classpath entry are read-only…
+    assertTrue(argv.windowed(3).any { it == listOf("--ro-bind-try", "/opt/jdk17", "/opt/jdk17") })
+    assertTrue(
+      argv.windowed(3).any { it == listOf("--ro-bind-try", "/cache/m3.jar", "/cache/m3.jar") }
+    )
+    // …and the work dir is the ONLY --bind (read-write) in the whole argv.
+    val writableBinds = argv.windowed(3).filter { it[0] == "--bind" }
+    assertEquals(
+      listOf(listOf("--bind", "/tmp/pg/snippet-1", "/tmp/pg/snippet-1")),
+      writableBinds,
+      "exactly one writable path, the session work dir",
+    )
+    assertEquals("--", argv.last(), "the jail argv must terminate before the JVM command")
+  }
+
+  @Test
+  fun `unshare blocks egress and pids without needing bubblewrap`() {
+    val argv = PlaygroundSandbox(profile = PlaygroundSandbox.Profile.UNSHARE).command(paths)
+
+    assertEquals("unshare", argv.first())
+    assertTrue("--net" in argv)
+    assertTrue("--pid" in argv)
+    assertTrue("--kill-child" in argv, "the jailed JVM must die with the serve host")
+    // It sees the host filesystem, which is exactly why it does not claim containment — and so
+    // cannot pass the --public gate on its declared properties alone.
+    assertFalse(PlaygroundSandbox.Profile.UNSHARE.declaresFilesystemContained)
+  }
+
+  @Test
+  fun `systemd carries the cgroup caps and its own runtime deadline`() {
+    val argv =
+      PlaygroundSandbox(
+          profile = PlaygroundSandbox.Profile.SYSTEMD,
+          memoryMb = 2048,
+          cpus = 1.5,
+          pids = 64,
+          ttlSeconds = 300,
+        )
+        .command(paths)
+
+    assertTrue("MemoryMax=2048M" in argv)
+    assertTrue("CPUQuota=150%" in argv)
+    assertTrue("TasksMax=64" in argv)
+    // A transient *scope* takes cgroup properties only. Service exec-context settings would fail
+    // unit creation outright, so a scope must never be handed one — and the profile must not claim
+    // the isolation those settings would have provided.
+    assertTrue(argv.none { it.startsWith("PrivateNetwork") }, argv.toString())
+    assertTrue(argv.none { it.startsWith("ProtectSystem") }, argv.toString())
+    assertTrue(argv.none { it.startsWith("NoNewPrivileges") }, argv.toString())
+    assertFalse(PlaygroundSandbox.Profile.SYSTEMD.declaresEgressBlocked)
+    assertFalse(PlaygroundSandbox.Profile.SYSTEMD.declaresFilesystemContained)
+    assertTrue(PlaygroundSandbox.Profile.SYSTEMD.declaresResourceCaps)
+  }
+
+  @Test
+  fun `strict is systemd caps wrapping the bwrap jail`() {
+    val argv = PlaygroundSandbox(profile = PlaygroundSandbox.Profile.STRICT).command(paths)
+
+    assertEquals("systemd-run", argv.first())
+    assertTrue(argv.indexOf("systemd-run") < argv.indexOf("bwrap"))
+    assertTrue("--unshare-net" in argv)
+    // The only built-in that provides every property the --public gate asks for.
+    assertTrue(
+      PlaygroundSandbox.Profile.entries.filter {
+        it.declaresEgressBlocked && it.declaresFilesystemContained && it.declaresResourceCaps
+      } == listOf(PlaygroundSandbox.Profile.STRICT)
+    )
+  }
+
+  @Test
+  fun `jvm caps bound heap and cpu on every active profile`() {
+    val sandbox =
+      PlaygroundSandbox(profile = PlaygroundSandbox.Profile.BWRAP, memoryMb = 2048, cpus = 1.2)
+
+    val jvmArgs = sandbox.jvmArgs(paths.workDir)
+
+    // Three quarters of the budget: the rest is metaspace / code cache / Skiko native, which a
+    // cgroup counts too — a heap sized at the full budget gets OOM-killed before -Xmx ever bites.
+    assertEquals(1536, sandbox.heapMb())
+    assertTrue("-Xmx1536m" in jvmArgs)
+    assertTrue("-XX:ActiveProcessorCount=2" in jvmArgs)
+    assertTrue("-XX:+ExitOnOutOfMemoryError" in jvmArgs)
+    assertTrue(jvmArgs.any { it.startsWith("-Djava.io.tmpdir=") && it.endsWith("snippet-1") })
+  }
+
+  @Test
+  fun `jailed robolectric launch resolves dependencies from the host maven repository`() {
+    val sandbox = PlaygroundSandbox(profile = PlaygroundSandbox.Profile.BWRAP)
+    val base = linkedMapOf("robolectric.graphicsMode" to "NATIVE")
+
+    val fromHome =
+      sandbox.robolectricSystemProperties(base = base, mavenRepoLocal = null, userHome = "/root")
+    assertEquals("NATIVE", fromHome["robolectric.graphicsMode"])
+    assertEquals("/root/.m2/repository", fromHome["maven.repo.local"])
+
+    val overridden =
+      sandbox.robolectricSystemProperties(
+        base = base,
+        mavenRepoLocal = "/cache/maven",
+        userHome = "/ignored",
+      )
+    assertEquals("/cache/maven", overridden["maven.repo.local"])
+  }
+
+  @Test
+  fun `unsandboxed robolectric launch stays unchanged`() {
+    val base = linkedMapOf("robolectric.graphicsMode" to "NATIVE")
+
+    assertTrue(
+      PlaygroundSandbox.NONE.robolectricSystemProperties(
+        base = base,
+        mavenRepoLocal = "/cache/maven",
+        userHome = "/root",
+      ) === base
+    )
+  }
+
+  @Test
+  fun `custom carries the operator argv verbatim and claims nothing`() {
+    val sandbox = PlaygroundSandbox.parseProfile("custom:firejail --net=none").getOrThrow()
+
+    assertEquals(PlaygroundSandbox.Profile.CUSTOM, sandbox.profile)
+    assertEquals(listOf("firejail", "--net=none"), sandbox.command(paths))
+    assertFalse(PlaygroundSandbox.Profile.CUSTOM.declaresEgressBlocked)
+  }
+
+  @Test
+  fun `profile parsing is fail-closed on nonsense`() {
+    assertEquals(PlaygroundSandbox.NONE, PlaygroundSandbox.parseProfile(null).getOrThrow())
+    assertEquals(PlaygroundSandbox.NONE, PlaygroundSandbox.parseProfile("  ").getOrThrow())
+    assertTrue(PlaygroundSandbox.parseProfile("docker").isFailure)
+    assertTrue(PlaygroundSandbox.parseProfile("custom:").isFailure)
+    // `custom` without an argv is not a profile name.
+    assertTrue(PlaygroundSandbox.parseProfile("custom").isFailure)
+  }
+
+  @Test
+  fun `resource knobs are validated so a typo fails at startup`() {
+    val base = PlaygroundSandbox(profile = PlaygroundSandbox.Profile.BWRAP)
+
+    assertTrue(PlaygroundSandbox.validate(base).isSuccess)
+    assertTrue(PlaygroundSandbox.validate(base.copy(memoryMb = 15)).isFailure)
+    assertTrue(PlaygroundSandbox.validate(base.copy(cpus = 0.0)).isFailure)
+    assertTrue(PlaygroundSandbox.validate(base.copy(pids = 1)).isFailure)
+    assertTrue(PlaygroundSandbox.validate(base.copy(ttlSeconds = 5)).isFailure)
+    // …but an inert sandbox is never rejected: `none` has no caps to get wrong.
+    assertTrue(PlaygroundSandbox.validate(PlaygroundSandbox.NONE.copy(memoryMb = 15)).isSuccess)
+  }
+
+  @Test
+  fun `the default ttl outlives a preview token so sessions end by expiry, not by the axe`() {
+    assertTrue(PlaygroundSandbox.DEFAULT_TTL_SECONDS > PlaygroundTokenStore.DEFAULT_TTL_SECONDS)
+  }
+
+  @Test
+  fun `dropping the jail removes the argv and keeps every cap`() {
+    // The recovery for a jail that cannot launch on this host. The argv is what fails to spawn, so
+    // it is the only thing that goes; the caps are the half that actually protects the box.
+    val dropped = PlaygroundSandbox(profile = PlaygroundSandbox.Profile.UNSHARE).droppingJail()
+
+    assertEquals(emptyList(), dropped.command(paths), "no jail argv survives the drop")
+    assertTrue(dropped.isActive, "still active — otherwise the caps would go too")
+    assertTrue("-Xmx1152m" in dropped.jvmArgs(paths.workDir))
+    assertTrue(dropped.jvmArgs(paths.workDir).any { it.startsWith("-XX:ActiveProcessorCount=") })
+    assertTrue("-XX:+ExitOnOutOfMemoryError" in dropped.jvmArgs(paths.workDir))
+    assertEquals(
+      PlaygroundSandbox.DEFAULT_TTL_SECONDS,
+      dropped.ttlSeconds,
+      "the hard kill still arms",
+    )
+  }
+
+  @Test
+  fun `a dropped jail says so, so a log or status is never mistaken for containment`() {
+    val dropped = PlaygroundSandbox(profile = PlaygroundSandbox.Profile.BWRAP).droppingJail()
+
+    assertTrue("jail dropped" in dropped.describe(), dropped.describe())
+    // The profile id is retained: what the operator ASKED for stays visible next to what happened.
+    assertTrue("bwrap" in dropped.describe(), dropped.describe())
+  }
+
+  @Test
+  fun `the profiles excluded from the drop are exactly those whose caps live in the argv`() {
+    // The discriminator ServeCommand refuses on. `systemd`/`strict` enforce MemoryMax, CPUQuota
+    // and TasksMax through the systemd-run prefix that command() emits, so dropping that argv
+    // drops the enforcement — heap and pool sizing are all that would remain. Pinning the set here
+    // means adding a future cgroup-backed profile can't silently inherit the caps-only fallback.
+    val capBacked =
+      PlaygroundSandbox.Profile.entries.filter { it.declaresResourceCaps }.map { it.id }.toSet()
+
+    assertEquals(setOf("systemd", "strict"), capBacked)
+
+    val strict = PlaygroundSandbox(profile = PlaygroundSandbox.Profile.STRICT)
+    assertTrue(
+      strict.command(paths).any { it.startsWith("MemoryMax=") },
+      "the enforceable cap is in the argv, which is what makes dropping it unsafe",
+    )
+    assertTrue(
+      strict.jvmArgs(paths.workDir).none { it.startsWith("MemoryMax") },
+      "and jvmArgs cannot replace it",
+    )
+  }
+
+  @Test
+  fun `dropping is inert for every profile that had no argv anyway`() {
+    val none = PlaygroundSandbox.NONE.droppingJail()
+    assertEquals(emptyList(), none.command(paths))
+    assertFalse(none.isActive, "none stays none — there was nothing to drop")
+  }
+}
+
+/**
+ * The `--public` admission decision (issues #3016, #3210). Two independent postures admit the lane:
+ * **contained** — a sandbox that has *proved* it contains a snippet, where every uncertain state
+ * (no profile, no probe, a probe that failed to launch, a probe with any failing check) stays a
+ * refusal — and **repo-access-gated**, where GitHub auth limits the callers to repo collaborators
+ * and the containment evidence is no longer the thing being asked for. Only anonymous *and*
+ * uncontained is refused outright.
+ */
+class PlaygroundPublicGateTest {
+
+  private val bwrap = PlaygroundSandbox(profile = PlaygroundSandbox.Profile.BWRAP)
+
+  private val cleanProbe =
+    PlaygroundSandboxProbe.Report(
+      ran = true,
+      egressBlocked = true,
+      filesystemContained = true,
+      processIsolated = true,
+      workDirWritable = true,
+    )
+
+  @Test
+  fun `a token-gated host serves with or without a sandbox`() {
+    assertTrue(
+      PlaygroundPublicGate.decide(
+        isPublic = false,
+        repoAccessGated = false,
+        sandbox = PlaygroundSandbox.NONE,
+        probe = null,
+      ) is PlaygroundPublicGate.Decision.Allow
+    )
+    assertTrue(
+      PlaygroundPublicGate.decide(
+        isPublic = false,
+        repoAccessGated = false,
+        sandbox = bwrap,
+        probe = null,
+      ) is PlaygroundPublicGate.Decision.Allow
+    )
+  }
+
+  @Test
+  fun `public with no sandbox is refused, as before Phase 4`() {
+    val decision =
+      PlaygroundPublicGate.decide(
+        isPublic = true,
+        repoAccessGated = false,
+        sandbox = PlaygroundSandbox.NONE,
+        probe = null,
+      )
+
+    val refusal = assertRefused(decision)
+    assertTrue("--playground-sandbox" in refusal, refusal)
+  }
+
+  @Test
+  fun `public with a sandbox but no probe result is refused`() {
+    assertRefused(
+      PlaygroundPublicGate.decide(
+        isPublic = true,
+        repoAccessGated = false,
+        sandbox = bwrap,
+        probe = null,
+      )
+    )
+  }
+
+  @Test
+  fun `public is refused when the jail could not even launch`() {
+    val refusal =
+      assertRefused(
+        PlaygroundPublicGate.decide(
+          isPublic = true,
+          repoAccessGated = false,
+          sandbox = bwrap,
+          probe = PlaygroundSandboxProbe.Report(ran = false, detail = "bwrap: command not found"),
+        )
+      )
+    assertTrue("bwrap: command not found" in refusal, refusal)
+  }
+
+  @Test
+  fun `public is refused when any single check fails`() {
+    val leaks = cleanProbe.copy(egressBlocked = false)
+    val refusal = assertRefused(PlaygroundPublicGate.decide(true, false, bwrap, leaks))
+    assertTrue("outbound network reachable" in refusal, refusal)
+
+    assertRefused(
+      PlaygroundPublicGate.decide(true, false, bwrap, cleanProbe.copy(filesystemContained = false))
+    )
+    assertRefused(
+      PlaygroundPublicGate.decide(true, false, bwrap, cleanProbe.copy(processIsolated = false))
+    )
+    // A jail so tight the render can't write its PNG is also a refusal — it would fail every run.
+    assertRefused(
+      PlaygroundPublicGate.decide(true, false, bwrap, cleanProbe.copy(workDirWritable = false))
+    )
+  }
+
+  @Test
+  fun `public is allowed on a verified, resource-capped sandbox`() {
+    val strict = PlaygroundSandbox(profile = PlaygroundSandbox.Profile.STRICT)
+
+    val decision =
+      PlaygroundPublicGate.decide(
+        isPublic = true,
+        repoAccessGated = false,
+        sandbox = strict,
+        probe = cleanProbe,
+      )
+
+    val allow = decision as? PlaygroundPublicGate.Decision.Allow
+    requireNotNull(allow) { "expected Allow, got $decision" }
+    assertTrue("verified" in allow.detail, allow.detail)
+  }
+
+  @Test
+  fun `a sealed jail with no cpu or pid cap is still refused under public`() {
+    // bwrap contains a snippet perfectly and caps nothing: -Xmx bounds heap, ActiveProcessorCount
+    // only sizes JVM pools, and the probe cannot measure either. A snippet could spin CPU-bound
+    // threads until the box starves, so containment alone is not admission.
+    val refusal = assertRefused(PlaygroundPublicGate.decide(true, false, bwrap, cleanProbe))
+
+    assertTrue("no CPU or process-count cap" in refusal, refusal)
+    assertTrue("strict" in refusal, refusal)
+
+    val unshare = PlaygroundSandbox(profile = PlaygroundSandbox.Profile.UNSHARE)
+    assertRefused(PlaygroundPublicGate.decide(true, false, unshare, cleanProbe))
+  }
+
+  @Test
+  fun `a custom profile that proves itself is admitted, one that does not is not`() {
+    val custom = PlaygroundSandbox.parseProfile("custom:my-jail --net=none").getOrThrow()
+
+    assertTrue(
+      PlaygroundPublicGate.decide(true, false, custom, cleanProbe)
+        is PlaygroundPublicGate.Decision.Allow,
+      "a custom jail is admitted on evidence, not on its name",
+    )
+    assertRefused(
+      PlaygroundPublicGate.decide(true, false, custom, cleanProbe.copy(egressBlocked = false))
+    )
+  }
+
+  @Test
+  fun `a repo-access-gated public host is admitted with no sandbox at all`() {
+    // Issue #3210: the routes already reject anyone without access to --github-auth-repo, so the
+    // snippet is a collaborator's, not a stranger's — the same trust level as the token-gated
+    // posture, which `decide` admits with no sandbox.
+    val allow =
+      assertAllowed(
+        PlaygroundPublicGate.decide(
+          isPublic = true,
+          repoAccessGated = true,
+          sandbox = PlaygroundSandbox.NONE,
+          probe = null,
+        )
+      )
+
+    assertTrue("repo-access-gated" in allow, allow)
+    assertTrue("no sandbox" in allow, allow)
+  }
+
+  @Test
+  fun `a repo-access-gated public host keeps a configured sandbox, as defence in depth`() {
+    // bwrap is refused as an *admission basis* (no cpu/pid cap) but must still be applied when the
+    // lane is admitted on repo access — and the log must not read as if containment let it in.
+    val allow =
+      assertAllowed(
+        PlaygroundPublicGate.decide(
+          isPublic = true,
+          repoAccessGated = true,
+          sandbox = bwrap,
+          probe = cleanProbe,
+        )
+      )
+
+    assertTrue("repo-access-gated" in allow, allow)
+    assertTrue("defence in depth" in allow, allow)
+  }
+
+  @Test
+  fun `repo-access gating does not rescue a jail that failed its probe from being reported`() {
+    // The lane still serves — admission never rested on the jail here — so this is an Allow. The
+    // ServeCommand caller is what warns; the gate's job is only not to refuse.
+    assertAllowed(
+      PlaygroundPublicGate.decide(
+        isPublic = true,
+        repoAccessGated = true,
+        sandbox = bwrap,
+        probe = cleanProbe.copy(egressBlocked = false),
+      )
+    )
+  }
+
+  @Test
+  fun `anonymous and uncontained names both remedies`() {
+    // Issue #3214: the refusal an operator hits on a container that cannot jail a snippet used to
+    // point only at --playground-sandbox, which that box cannot satisfy. GitHub auth is the way
+    // out, so the message has to say so.
+    val refusal =
+      assertRefused(
+        PlaygroundPublicGate.decide(
+          isPublic = true,
+          repoAccessGated = false,
+          sandbox = PlaygroundSandbox.NONE,
+          probe = null,
+        )
+      )
+
+    assertTrue("--github-auth-repo" in refusal, refusal)
+    assertTrue("--playground-sandbox" in refusal, refusal)
+  }
+
+  @Test
+  fun `the anonymous contained posture says it is anonymous`() {
+    // Still admitted (PLAYGROUND.md §6's designed posture), but an operator must not read
+    // "admitted" and assume sign-in is enforced.
+    val strict = PlaygroundSandbox(profile = PlaygroundSandbox.Profile.STRICT)
+
+    val allow =
+      assertAllowed(
+        PlaygroundPublicGate.decide(
+          isPublic = true,
+          repoAccessGated = false,
+          sandbox = strict,
+          probe = cleanProbe,
+        )
+      )
+
+    assertTrue("ANONYMOUS" in allow, allow)
+  }
+
+  @Test
+  fun `a jail that cannot launch is still refused when containment is the admission basis`() {
+    // The safety property the auto-fallback rests on. ServeCommand only drops a jail AFTER the
+    // gate has admitted the lane, so this refusal is what keeps the fallback from ever handing an
+    // anonymous --public host an uncontained playground: it never gets past `decide`.
+    val refusal =
+      assertRefused(
+        PlaygroundPublicGate.decide(
+          isPublic = true,
+          repoAccessGated = false,
+          sandbox = bwrap,
+          probe = PlaygroundSandboxProbe.Report(ran = false, detail = "bwrap: not found"),
+        )
+      )
+
+    assertTrue("bwrap: not found" in refusal, refusal)
+  }
+
+  @Test
+  fun `a repo-access-gated host with an unlaunchable jail is admitted, so it can fall back`() {
+    // The mirror of the case above: here the lane is admitted on WHO can reach it, so the dead
+    // jail is a degradation to report rather than a reason to refuse — which is exactly the state
+    // ServeCommand converts into a caps-only sandbox.
+    assertAllowed(
+      PlaygroundPublicGate.decide(
+        isPublic = true,
+        repoAccessGated = true,
+        sandbox = bwrap,
+        probe = PlaygroundSandboxProbe.Report(ran = false, detail = "bwrap: not found"),
+      )
+    )
+  }
+
+  private fun assertAllowed(decision: PlaygroundPublicGate.Decision): String {
+    val allow = decision as? PlaygroundPublicGate.Decision.Allow
+    requireNotNull(allow) { "expected Allow, got $decision" }
+    return allow.detail
+  }
+
+  private fun assertRefused(decision: PlaygroundPublicGate.Decision): String {
+    val refuse = decision as? PlaygroundPublicGate.Decision.Refuse
+    requireNotNull(refuse) { "expected Refuse, got $decision" }
+    return refuse.reason
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundTokenStoreTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundTokenStoreTest.kt
@@ -1,0 +1,123 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+
+/**
+ * The expiring preview-token store behind `/pg/<token>`: mint, redeem, TTL, caps, and work-dir
+ * cleanup.
+ */
+class PlaygroundTokenStoreTest {
+
+  private var now = 1_000_000L
+  private var ids = 0
+  private val fs = FakeFileSystem()
+
+  private fun store(ttlSeconds: Long = 600, maxTokens: Int = 8) =
+    PlaygroundTokenStore(
+      ttlSeconds = ttlSeconds,
+      maxTokens = maxTokens,
+      fileSystem = fs,
+      clock = { now },
+      mintId = { "pg_${(++ids).toString().padStart(16, '0')}" },
+    )
+
+  /** A snippet whose work dir actually exists on the fake FS, so cleanup is observable. */
+  private fun snippet(
+    name: String,
+    mode: PlaygroundMode = PlaygroundMode.CMP,
+  ): PlaygroundTokenStore.PlaygroundSnippet {
+    val work = "/work/$name".toPath()
+    val classes = work / "classes"
+    fs.createDirectories(classes)
+    fs.write(classes / "Snippet.class") { writeUtf8("cafebabe") }
+    return PlaygroundTokenStore.PlaygroundSnippet(
+      mode = mode,
+      workDir = work,
+      classesDir = classes,
+      classpath = listOf(classes),
+      moduleName = "playground-$name",
+      previewId = "com.example.$name.Preview",
+    )
+  }
+
+  @Test
+  fun `a minted token redeems until it expires, then is gone`() {
+    val store = store(ttlSeconds = 600)
+
+    val token = store.add(snippet("a"), isSecurityChecked = true)
+    assertEquals("/pg/${token.id}", token.path)
+    assertTrue(PlaygroundTokenStore.isWellFormedId(token.id), token.id)
+    assertEquals(600, token.secondsUntilExpiry(now))
+    assertEquals(token.id, store.get(token.id)?.id)
+
+    now += 599_000
+    assertEquals(token.id, store.get(token.id)?.id, "still redeemable one second before expiry")
+
+    now += 2_000
+    assertNull(store.get(token.id), "the link stops resolving once the TTL is up")
+    assertTrue(store.snapshot().isEmpty())
+    assertFalse(fs.exists("/work/a".toPath()), "and the work dir is deleted, not merely hidden")
+  }
+
+  @Test
+  fun `the snippet's mode and preview id survive the round trip`() {
+    val store = store()
+    val token = store.add(snippet("wear", mode = PlaygroundMode.ANDROID), isSecurityChecked = true)
+    val got = store.get(token.id)!!.snippet
+    assertEquals(PlaygroundMode.ANDROID, got.mode)
+    assertEquals("com.example.wear.Preview", got.previewId)
+  }
+
+  @Test
+  fun `overflow evicts the nearest-expiry token and deletes its work dir`() {
+    val store = store(maxTokens = 2)
+
+    val first = store.add(snippet("first"), isSecurityChecked = true)
+    now += 1_000
+    store.add(snippet("second"), isSecurityChecked = true)
+    now += 1_000
+    store.add(snippet("third"), isSecurityChecked = true) // pushes over the cap of 2
+
+    assertNull(store.get(first.id), "the oldest token is evicted on overflow")
+    assertFalse(fs.exists("/work/first".toPath()), "and its work dir is cleaned up")
+    assertEquals(2, store.snapshot().size)
+  }
+
+  @Test
+  fun `explicit remove drops the token and its work dir`() {
+    val store = store()
+    val token = store.add(snippet("gone"), isSecurityChecked = true)
+
+    assertTrue(store.remove(token.id))
+    assertNull(store.get(token.id))
+    assertFalse(fs.exists("/work/gone".toPath()))
+    assertFalse(store.remove(token.id), "removing an unknown id is a no-op")
+  }
+
+  @Test
+  fun `clear drops every token and work dir`() {
+    val store = store()
+    store.add(snippet("x"), isSecurityChecked = true)
+    store.add(snippet("y"), isSecurityChecked = true)
+
+    store.clear()
+    assertTrue(store.snapshot().isEmpty())
+    assertFalse(fs.exists("/work/x".toPath()))
+    assertFalse(fs.exists("/work/y".toPath()))
+  }
+
+  @Test
+  fun `confType maps to the right mode`() {
+    assertEquals(PlaygroundMode.CMP, PlaygroundMode.fromConfType("compose-cmp"))
+    assertEquals(PlaygroundMode.ANDROID, PlaygroundMode.fromConfType("compose-android"))
+    assertEquals(PlaygroundMode.REMOTE_COMPOSE, PlaygroundMode.fromConfType("remote-compose"))
+    assertEquals(PlaygroundMode.CMP, PlaygroundMode.fromConfType("canvas"), "stock frontend target")
+    assertEquals(PlaygroundMode.CMP, PlaygroundMode.fromConfType(null), "absent confType")
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/PreviewHistoryManifestTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/PreviewHistoryManifestTest.kt
@@ -1,0 +1,304 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PreviewHistoryManifestTest {
+
+  private val a = "a".repeat(40)
+  private val b = "b".repeat(40)
+
+  private fun gitLog(vararg entries: Pair<String, List<Pair<String, String>>>): String =
+    buildString {
+      entries.forEach { (subject, files) ->
+        val sha = subject.hashCode().toUInt().toString(16).padStart(40, '0')
+        append("\u0001").append(sha).append("\u001F").append("2026-08-06T10:00:00+00:00")
+        append("\u001F").append(subject).append("\n\n")
+        files.forEach { (path, blob) ->
+          append(":100644 100644 ").append(b).append(' ').append(blob).append(" M\t").append(path)
+          append('\n')
+        }
+      }
+    }
+
+  private fun timelines(log: String) = PreviewHistory.collapse(PreviewHistory.parseGitLog(log))
+
+  private val baselines =
+    """
+    {
+      "samples:wear/com.example.PreviewsKt.Foo_Large Round": {
+        "module": "samples:wear",
+        "renderBasename": "Foo_Large_Round.png",
+        "sha256": "irrelevant"
+      }
+    }
+    """
+      .trimIndent()
+
+  @Test
+  fun `baselines entries reverse into a render-path lookup`() {
+    val lookup = PreviewHistoryManifest.renderPathsToPreviewIds(baselines)
+
+    assertEquals(
+      mapOf(
+        "renders/samples:wear/Foo_Large_Round.png" to
+          "samples:wear/com.example.PreviewsKt.Foo_Large Round"
+      ),
+      lookup,
+    )
+  }
+
+  @Test
+  fun `entries missing module or basename are skipped rather than guessed`() {
+    val partial =
+      """
+      {
+        "no-module": { "renderBasename": "Foo.png" },
+        "no-basename": { "module": "samples:wear" },
+        "empty-module": { "module": "", "renderBasename": "Foo.png" },
+        "not-an-object": 7,
+        "good": { "module": "m", "renderBasename": "Foo.png" }
+      }
+      """
+        .trimIndent()
+
+    val lookup = PreviewHistoryManifest.renderPathsToPreviewIds(partial)
+
+    assertEquals(mapOf("renders/m/Foo.png" to "good"), lookup)
+  }
+
+  @Test
+  fun `malformed baselines yield an empty lookup instead of throwing`() {
+    assertEquals(emptyMap(), PreviewHistoryManifest.renderPathsToPreviewIds("{not json"))
+  }
+
+  @Test
+  fun `the manifest is keyed by preview id and carries the render path`() {
+    val log =
+      gitLog(
+        "Update preview baselines from 27ea28c1" to
+          listOf("renders/samples:wear/Foo_Large_Round.png" to a)
+      )
+
+    val manifest =
+      PreviewHistoryManifest.build(
+        timelines(log),
+        PreviewHistoryManifest.renderPathsToPreviewIds(baselines),
+        generatedFrom = "tip",
+      )
+
+    val entry = manifest.previews.getValue("samples:wear/com.example.PreviewsKt.Foo_Large Round")
+    assertEquals("renders/samples:wear/Foo_Large_Round.png", entry.path)
+    assertEquals("27ea28c1", entry.versions.single().sourceSha, "source commit survives the join")
+    assertEquals(PreviewHistoryManifest.FORMAT_VERSION, manifest.formatVersion)
+    assertEquals("tip", manifest.generatedFrom)
+  }
+
+  @Test
+  fun `a render with no preview id is dropped`() {
+    // The normal fate of a deleted or renamed preview: still has branch commits, but nothing in
+    // baselines.json addresses it, so no viewer could ask for it.
+    val log = gitLog("publish" to listOf("renders/samples:wear/Orphaned.png" to a))
+
+    val manifest =
+      PreviewHistoryManifest.build(
+        timelines(log),
+        PreviewHistoryManifest.renderPathsToPreviewIds(baselines),
+        generatedFrom = "tip",
+      )
+
+    assertTrue(manifest.previews.isEmpty())
+  }
+
+  @Test
+  fun `an unstable preview is marked and carries its trimmed versions`() {
+    val path = "renders/samples:wear/Foo_Large_Round.png"
+    val log = gitLog(*Array(8) { i -> "publish $i" to listOf(path to if (i % 2 == 0) a else b) })
+
+    val entry =
+      PreviewHistoryManifest.build(
+          timelines(log),
+          PreviewHistoryManifest.renderPathsToPreviewIds(baselines),
+          generatedFrom = "tip",
+        )
+        .previews
+        .values
+        .single()
+
+    assertTrue(entry.unstable)
+    assertEquals(6, entry.flapCount)
+    assertEquals(8, entry.observations, "the raw count stays, so the trim is visible not hidden")
+    assertEquals(2, entry.versions.size, "trimmed to the states it flips between")
+    assertEquals(4, entry.versions.first().occurrences)
+  }
+
+  @Test
+  fun `occurrences is omitted for the ordinary single-run version`() {
+    val log = gitLog("publish" to listOf("renders/samples:wear/Foo_Large_Round.png" to a))
+
+    val manifest =
+      PreviewHistoryManifest.build(
+        timelines(log),
+        PreviewHistoryManifest.renderPathsToPreviewIds(baselines),
+        generatedFrom = "tip",
+      )
+    val encoded = PreviewHistoryManifest.encode(manifest)
+
+    assertNull(manifest.previews.values.single().versions.single().occurrences)
+    assertFalse(encoded.contains("occurrences"), "no redundant field on every stable entry")
+  }
+
+  @Test
+  fun `sinceCommit is omitted when it would repeat commit`() {
+    val log = gitLog("publish" to listOf("renders/samples:wear/Foo_Large_Round.png" to a))
+
+    val manifest =
+      PreviewHistoryManifest.build(
+        timelines(log),
+        PreviewHistoryManifest.renderPathsToPreviewIds(baselines),
+        generatedFrom = "tip",
+      )
+    val version = manifest.previews.values.single().versions.single()
+
+    assertNull(version.sinceCommit, "single-publish version introduces itself")
+    assertEquals(version.commit, version.introducedBy, "readers still get a commit")
+    assertFalse(PreviewHistoryManifest.encode(manifest).contains("sinceCommit"))
+  }
+
+  @Test
+  fun `sinceCommit is kept when a version spans several publishes`() {
+    val path = "renders/samples:wear/Foo_Large_Round.png"
+    val log = gitLog("newest" to listOf(path to a), "oldest" to listOf(path to a))
+
+    val version =
+      PreviewHistoryManifest.build(
+          timelines(log),
+          PreviewHistoryManifest.renderPathsToPreviewIds(baselines),
+          generatedFrom = "tip",
+        )
+        .previews
+        .values
+        .single()
+        .versions
+        .single()
+
+    assertNotNull(version.sinceCommit)
+    assertEquals(version.sinceCommit, version.introducedBy)
+    assertTrue(version.sinceCommit != version.commit, "spans two distinct commits")
+  }
+
+  @Test
+  fun `regenerating an unchanged branch produces a byte-identical file`() {
+    // Otherwise every publish would show a spurious history.json diff on the delivery branch.
+    val log =
+      gitLog(
+        "publish" to listOf("renders/m/B.png" to a, "renders/m/A.png" to b, "renders/m/C.png" to a)
+      )
+    val lookup =
+      mapOf("renders/m/A.png" to "m/A", "renders/m/B.png" to "m/B", "renders/m/C.png" to "m/C")
+
+    val first =
+      PreviewHistoryManifest.encode(PreviewHistoryManifest.build(timelines(log), lookup, "tip"))
+    val again =
+      PreviewHistoryManifest.encode(PreviewHistoryManifest.build(timelines(log), lookup, "tip"))
+
+    assertEquals(first, again)
+    val order = Regex("\"(m/[ABC])\"").findAll(first).map { it.groupValues[1] }.toList()
+    assertEquals(listOf("m/A", "m/B", "m/C"), order, "sorted, not git's discovery order")
+  }
+
+  @Test
+  fun `the format version is always written to the wire`() {
+    // Regression: formatVersion is a defaulted field and the encoder sets encodeDefaults = false
+    // to keep redundant fields off the wire, which silently dropped the one discriminator a viewer
+    // needs to reject an incompatible manifest. A round-trip assertion cannot catch this — decode
+    // restores the default — so this asserts on the encoded text.
+    val log = gitLog("publish" to listOf("renders/samples:wear/Foo_Large_Round.png" to a))
+
+    val encoded =
+      PreviewHistoryManifest.encode(
+        PreviewHistoryManifest.build(
+          timelines(log),
+          PreviewHistoryManifest.renderPathsToPreviewIds(baselines),
+          generatedFrom = "tip",
+        )
+      )
+
+    assertTrue(
+      encoded.contains("\"formatVersion\": \"${PreviewHistoryManifest.FORMAT_VERSION}\""),
+      "published manifests must carry the discriminator; got:\n${encoded.take(200)}",
+    )
+  }
+
+  @Test
+  fun `a manifest missing the format version still decodes`() {
+    // It is always written now, but keeping it a defaulted field means an older or hand-edited
+    // file is still readable rather than a hard parse failure.
+    val text =
+      """
+      {
+        "generatedFrom": "tip",
+        "previews": {}
+      }
+      """
+        .trimIndent()
+
+    val decoded = assertNotNull(PreviewHistoryManifest.decode(text))
+
+    assertEquals(PreviewHistoryManifest.FORMAT_VERSION, decoded.formatVersion)
+  }
+
+  @Test
+  fun `the encoded manifest round-trips`() {
+    val log =
+      gitLog("publish from 1a2b3c4d" to listOf("renders/samples:wear/Foo_Large_Round.png" to a))
+    val manifest =
+      PreviewHistoryManifest.build(
+        timelines(log),
+        PreviewHistoryManifest.renderPathsToPreviewIds(baselines),
+        generatedFrom = "tip",
+      )
+
+    val decoded = PreviewHistoryManifest.decode(PreviewHistoryManifest.encode(manifest))
+
+    assertEquals(manifest, assertNotNull(decoded))
+  }
+
+  @Test
+  fun `a manifest with unknown fields still decodes`() {
+    // Forward-compat: a branch written by a newer CLI must not break an older viewer.
+    val text =
+      """
+      {
+        "formatVersion": "${PreviewHistoryManifest.FORMAT_VERSION}",
+        "generatedFrom": "tip",
+        "somethingNew": {"nested": true},
+        "previews": {
+          "m/A": {
+            "path": "renders/m/A.png",
+            "versions": [
+              {"blob": "$a", "commit": "c1", "date": "d", "commits": 1, "extra": 9}
+            ],
+            "observations": 1,
+            "unstable": false,
+            "flapCount": 0
+          }
+        }
+      }
+      """
+        .trimIndent()
+
+    val decoded = assertNotNull(PreviewHistoryManifest.decode(text))
+
+    assertEquals("renders/m/A.png", decoded.previews.getValue("m/A").path)
+  }
+
+  @Test
+  fun `undecodable text yields null rather than throwing`() {
+    assertNull(PreviewHistoryManifest.decode("{not json"))
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/PreviewHistoryTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/PreviewHistoryTest.kt
@@ -1,0 +1,283 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PreviewHistoryTest {
+
+  private val a = "a".repeat(40)
+  private val b = "b".repeat(40)
+  private val c = "c".repeat(40)
+  private val nullSha = "0".repeat(40)
+
+  /**
+   * Builds the exact bytes `git log --format=%x01%H%x1f%aI%x1f%s --raw --no-abbrev` emits, so the
+   * parser is tested against the real wire shape rather than a convenient approximation. [entries]
+   * is newest-first: each is a commit plus the paths it touched, as `path to newBlob`.
+   */
+  private fun gitLog(vararg entries: Pair<String, List<Pair<String, String>>>): String =
+    buildString {
+      entries.forEach { (subject, files) ->
+        val sha = subject.hashCode().toUInt().toString(16).padStart(40, '0')
+        append("\u0001").append(sha).append("\u001F").append("2026-08-06T10:00:00+00:00")
+        append("\u001F").append(subject).append("\n\n")
+        files.forEach { (path, blob) ->
+          // Real git prints the pre-image too; the parser only reads column 4 (post-image).
+          append(":100644 100644 ").append(c).append(' ').append(blob).append(" M\t").append(path)
+          append('\n')
+        }
+      }
+    }
+
+  private fun timeline(log: String, path: String): PreviewHistory.Timeline =
+    PreviewHistory.collapse(PreviewHistory.parseGitLog(log)).getValue(path)
+
+  @Test
+  fun `adjacent identical renders collapse into one version`() {
+    val log =
+      gitLog(
+        "publish 4" to listOf("renders/m/Foo.png" to a),
+        "publish 3" to listOf("renders/m/Foo.png" to a),
+        "publish 2" to listOf("renders/m/Foo.png" to a),
+        "publish 1" to listOf("renders/m/Foo.png" to b),
+      )
+    val t = timeline(log, "renders/m/Foo.png")
+
+    assertEquals(4, t.observations, "raw commit count is preserved")
+    assertEquals(2, t.versions.size, "three identical publishes are one version")
+    assertEquals(3, t.versions.first().commits)
+    assertEquals(0, t.flapCount)
+    assertFalse(t.unstable)
+  }
+
+  @Test
+  fun `a version spans from the commit that introduced it to the newest carrying it`() {
+    val log =
+      gitLog(
+        "newest" to listOf("renders/m/Foo.png" to a),
+        "middle" to listOf("renders/m/Foo.png" to a),
+        "oldest" to listOf("renders/m/Foo.png" to a),
+      )
+    val v = timeline(log, "renders/m/Foo.png").versions.single()
+
+    assertEquals("oldest", v.since.subject, "since is the run's oldest commit")
+    assertEquals("newest", v.until.subject, "until is the run's newest commit")
+  }
+
+  @Test
+  fun `a clean sequence of distinct renders never reads as unstable`() {
+    val log =
+      gitLog(
+        "third" to listOf("renders/m/Foo.png" to c),
+        "second" to listOf("renders/m/Foo.png" to b),
+        "first" to listOf("renders/m/Foo.png" to a),
+      )
+    val t = timeline(log, "renders/m/Foo.png")
+
+    assertEquals(3, t.versions.size)
+    assertEquals(0, t.flapCount, "changing a lot is not flapping")
+    assertFalse(t.unstable)
+    assertEquals(t.versions, t.displayVersions, "a stable timeline is shown untrimmed")
+  }
+
+  @Test
+  fun `a single revert is not enough to call a preview unstable`() {
+    val log =
+      gitLog(
+        "reverted back to a" to listOf("renders/m/Foo.png" to a),
+        "changed to b" to listOf("renders/m/Foo.png" to b),
+        "first" to listOf("renders/m/Foo.png" to a),
+      )
+    val t = timeline(log, "renders/m/Foo.png")
+
+    assertEquals(1, t.flapCount, "one return to earlier bytes")
+    assertFalse(t.unstable, "a legitimate revert must not be flagged")
+  }
+
+  /** The real shape found on `compose-preview/main`: two renders alternating on every publish. */
+  @Test
+  fun `alternating renders flag as unstable and trim to their distinct states`() {
+    val log =
+      gitLog(
+        *Array(8) { i -> "publish $i" to listOf("renders/m/Flaky.png" to if (i % 2 == 0) a else b) }
+      )
+    val t = timeline(log, "renders/m/Flaky.png")
+
+    assertEquals(8, t.observations)
+    assertEquals(8, t.versions.size, "every publish changed the bytes, so every run is length 1")
+    assertEquals(2, t.distinctBlobs)
+    assertEquals(6, t.flapCount)
+    assertTrue(t.unstable)
+    assertEquals(setOf(a, b), t.recurringBlobs)
+
+    val trimmed = t.displayVersions
+    assertEquals(2, trimmed.size, "225-run reality collapses to the states it flips between")
+    assertEquals(listOf(a, b), trimmed.map { it.blob }, "newest state leads")
+    assertTrue(trimmed.all { it.recurring })
+    assertEquals(4, trimmed.first().occurrences, "four separate runs had these bytes")
+    assertEquals(8, trimmed.sumOf { it.commits }, "trimming loses no commits")
+  }
+
+  @Test
+  fun `a trimmed state spans its whole period in play`() {
+    val log =
+      gitLog(
+        *Array(4) { i -> "publish $i" to listOf("renders/m/Flaky.png" to if (i % 2 == 0) a else b) }
+      )
+    val newest = timeline(log, "renders/m/Flaky.png").displayVersions.first()
+
+    assertEquals("publish 0", newest.until.subject, "until is the most recent appearance")
+    assertEquals("publish 2", newest.since.subject, "since reaches back to the oldest run")
+  }
+
+  @Test
+  fun `history stops at the most recent deletion`() {
+    val log =
+      gitLog(
+        "re-added" to listOf("renders/m/Foo.png" to c),
+        "deleted" to listOf("renders/m/Foo.png" to nullSha),
+        "older a" to listOf("renders/m/Foo.png" to a),
+        "older b" to listOf("renders/m/Foo.png" to b),
+      )
+    val t = timeline(log, "renders/m/Foo.png")
+
+    assertEquals(1, t.observations, "history covers only the current incarnation")
+    assertEquals(listOf(c), t.versions.map { it.blob })
+  }
+
+  @Test
+  fun `delete and re-add churn does not read as flapping`() {
+    // Without deletion truncation the null sha alternates with content and scores flaps, which
+    // would mark every renamed or removed-and-restored preview as non-deterministic.
+    val log =
+      gitLog(
+        "re-added" to listOf("renders/m/Foo.png" to a),
+        "deleted" to listOf("renders/m/Foo.png" to nullSha),
+        "added" to listOf("renders/m/Foo.png" to a),
+        "deleted again" to listOf("renders/m/Foo.png" to nullSha),
+        "first" to listOf("renders/m/Foo.png" to a),
+      )
+    val t = timeline(log, "renders/m/Foo.png")
+
+    assertEquals(0, t.flapCount)
+    assertFalse(t.unstable)
+  }
+
+  @Test
+  fun `one commit touching many renders splits per path`() {
+    val log =
+      gitLog(
+        "publish 2" to listOf("renders/m/A.png" to a, "renders/m/B.png" to b),
+        "publish 1" to listOf("renders/m/A.png" to a, "renders/m/B.png" to c),
+      )
+    val all = PreviewHistory.collapse(PreviewHistory.parseGitLog(log))
+
+    assertEquals(setOf("renders/m/A.png", "renders/m/B.png"), all.keys)
+    assertEquals(1, all.getValue("renders/m/A.png").versions.size, "unchanged across both commits")
+    assertEquals(2, all.getValue("renders/m/B.png").versions.size)
+  }
+
+  @Test
+  fun `source sha is recovered from either publisher's subject`() {
+    val log =
+      gitLog(
+        "Update preview baselines from 27ea28c1" to listOf("renders/m/Foo.png" to a),
+        "chore(design-artifacts): regenerate compose-m3 catalog (2026-08-06, 1a2b3c4d)" to
+          listOf("renders/m/Foo.png" to b),
+        "a subject with no sha at all" to listOf("renders/m/Foo.png" to c),
+      )
+    val versions = timeline(log, "renders/m/Foo.png").versions
+
+    assertEquals("27ea28c1", versions[0].until.sourceSha, "compose-preview wording")
+    assertEquals("1a2b3c4d", versions[1].until.sourceSha, "design-artifacts wording")
+    assertEquals(null, versions[2].until.sourceSha, "absent rather than guessed")
+  }
+
+  @Test
+  fun `paths containing spaces and colons survive the parse`() {
+    // Module segments are Gradle paths (`samples:wear`) and preview names can carry spaces.
+    val path = "renders/samples:wear/PreviewsKt.Foo_Devices_-_Large Round.png"
+    val log = gitLog("publish" to listOf(path to a))
+
+    assertEquals(setOf(path), PreviewHistory.parseGitLog(log).keys)
+  }
+
+  @Test
+  fun `git log is asked not to quote non-ASCII paths`() {
+    val args = PreviewHistory.logArgs("compose-preview/main", "renders")
+
+    assertEquals(listOf("-c", "core.quotePath=false"), args.take(2), "must precede the subcommand")
+  }
+
+  /**
+   * The escaped form is exactly what `git log --raw` emitted for `renders/café/Foo—dash.png` with
+   * git's default `core.quotePath`, captured from a real repo — not hand-written.
+   */
+  @Test
+  fun `octal-escaped non-ASCII paths decode back to UTF-8`() {
+    val quoted = """"renders/caf\303\251/Foo\342\200\224dash.png""""
+
+    assertEquals("renders/café/Foo—dash.png", PreviewHistory.unquotePath(quoted))
+  }
+
+  @Test
+  fun `a quoted path still keys history under its real name`() {
+    // core.quotePath=false does not cover a path containing a quote or backslash, so the parser
+    // must decode rather than rely on the config alone.
+    val log = gitLog("publish" to listOf(""""renders/m/Say \"hi\".png"""" to a))
+
+    assertEquals(setOf("""renders/m/Say "hi".png"""), PreviewHistory.parseGitLog(log).keys)
+  }
+
+  @Test
+  fun `control-character and backslash escapes decode`() {
+    assertEquals("renders/m/a\tb.png", PreviewHistory.unquotePath(""""renders/m/a\tb.png""""))
+    assertEquals("""renders/m/a\b.png""", PreviewHistory.unquotePath(""""renders/m/a\\b.png""""))
+  }
+
+  @Test
+  fun `an unquoted path is passed through untouched`() {
+    val plain = "renders/samples:wear/Foo_Devices_-_Large Round.png"
+
+    assertEquals(
+      plain,
+      PreviewHistory.unquotePath(plain),
+      "no round-trip damage in the common case",
+    )
+  }
+
+  @Test
+  fun `malformed lines are skipped rather than failing the whole history`() {
+    val good = gitLog("publish" to listOf("renders/m/Foo.png" to a))
+    val log = good + ":not-a-real-raw-line\n" + "\u0001truncated-header\n" + "stray text\n"
+
+    assertEquals(setOf("renders/m/Foo.png"), PreviewHistory.parseGitLog(log).keys)
+  }
+
+  @Test
+  fun `an unreadable ref yields no history instead of throwing`() {
+    val failing = GitRunner { _, _ -> GitResult(exitCode = 128, stdout = "fatal: bad revision") }
+
+    val history = PreviewHistory.read(File("."), "compose-preview/main", git = failing)
+
+    assertTrue(history.isEmpty(), "a clone without the delivery branch degrades to no timeline")
+  }
+
+  @Test
+  fun `read passes the ref and pathspec through to git`() {
+    var seen: List<String> = emptyList()
+    val recording = GitRunner { _, args ->
+      seen = args
+      GitResult(0, gitLog("publish" to listOf("renders/m/Foo.png" to a)))
+    }
+
+    val history = PreviewHistory.read(File("."), "compose-preview/main", "renders", recording)
+
+    assertEquals(PreviewHistory.logArgs("compose-preview/main", "renders"), seen)
+    assertTrue(seen.contains("--no-abbrev"), "blob shas must not be abbreviated")
+    assertEquals(1, history.size)
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/RemoteComposePairingTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/RemoteComposePairingTest.kt
@@ -1,0 +1,413 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.bundle.BundleReader
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Coverage for [RemoteComposePairing] — the diagnosis for a daemon classpath that carries two
+ * Remote Compose lines because the bundle recorded part of the family and the sidecar supplied the
+ * rest (compose-preview-server#187: `NoSuchFieldError … RemoteClock … SYSTEM` on every IR replay,
+ * with a breaker reason that named no cause).
+ */
+class RemoteComposePairingTest {
+
+  private val destDir = Files.createTempDirectory("remote-compose-line-test-").toFile()
+  private val descriptor = File(destDir, "daemon-launch.json")
+  private val logs = mutableListOf<String>()
+
+  @AfterTest fun cleanup() = destDir.deleteRecursively().let {}
+
+  private fun maven(artifact: String, version: String, group: String = "androidx.compose.remote") =
+    BundleReader.ClasspathEntry.Maven(
+      group = group,
+      artifact = artifact,
+      version = version,
+      type = "aar",
+      sha256 = null,
+    )
+
+  private fun sidecar(vararg jars: String) = jars.map { "/opt/compose-preview/lib/$it" }
+
+  /** The `meshcore-mobile` shape: a snapshot bundle half-covering a sidecar on released alphas. */
+  private fun recordMeshcoreShape() =
+    RemoteComposePairing.record(
+      destDir = destDir,
+      bundle =
+        RemoteComposePairing.bundleMembers(
+          listOf(
+            maven("remote-player-core", "1.0.0-SNAPSHOT"),
+            maven("remote-creation", "1.0.0-SNAPSHOT"),
+          )
+        ),
+      sidecar =
+        RemoteComposePairing.sidecarMembers(
+          sidecar(
+            "remote-core-1.0.0-alpha18.jar",
+            "remote-player-core-1.0.0-alpha18.jar",
+            "kotlin-stdlib-2.4.10.jar",
+          )
+        ),
+      system = "meshcore-mobile",
+      onLog = { logs += it },
+    )
+
+  @Test
+  fun `a bundle carrying part of the family at another version is a skew`() {
+    recordMeshcoreShape()
+
+    val logged = logs.singleOrNull()
+    assertNotNull(logged, "a mixed family must be logged at materialization: $logs")
+    assertContains(logged, "remote-core")
+    assertContains(logged, "1.0.0-SNAPSHOT")
+    assertContains(logged, "1.0.0-alpha18")
+  }
+
+  @Test
+  fun `the skew is the diagnosis a Remote Compose linkage trip carries`() {
+    recordMeshcoreShape()
+
+    val diagnosis =
+      RemoteComposePairing.linkageDiagnosis(
+        "java.lang.NoSuchFieldError: Class androidx.compose.remote.core.RemoteClock does not " +
+          "have member field 'androidx.compose.remote.core.RemoteClock SYSTEM'",
+        descriptor,
+      )
+
+    assertNotNull(diagnosis, "the trip that this record exists for must be diagnosed")
+    assertContains(diagnosis, "remote-core")
+  }
+
+  @Test
+  fun `the internal class-name form is diagnosed too`() {
+    recordMeshcoreShape()
+
+    assertNotNull(
+      RemoteComposePairing.linkageDiagnosis(
+        "java.lang.NoClassDefFoundError: androidx/compose/remote/player/core/RemoteDocument",
+        descriptor,
+      )
+    )
+  }
+
+  @Test
+  fun `a bundle carrying the whole family shadows the sidecar and is coherent`() {
+    RemoteComposePairing.record(
+      destDir = destDir,
+      bundle =
+        RemoteComposePairing.bundleMembers(
+          listOf(
+            maven("remote-core", "1.0.0-SNAPSHOT"),
+            maven("remote-player-core", "1.0.0-SNAPSHOT"),
+          )
+        ),
+      sidecar =
+        RemoteComposePairing.sidecarMembers(
+          sidecar("remote-core-1.0.0-alpha18.jar", "remote-player-core-1.0.0-alpha18.jar")
+        ),
+      system = "meshcore-mobile",
+      onLog = { logs += it },
+    )
+
+    assertTrue(logs.isEmpty(), "a fully-carried family is coherent whatever its version: $logs")
+    assertNull(
+      RemoteComposePairing.linkageDiagnosis(
+        "java.lang.NoSuchFieldError: androidx.compose.remote.core.RemoteClock",
+        descriptor,
+      )
+    )
+  }
+
+  @Test
+  fun `a bundle on the sidecar's own version is coherent`() {
+    RemoteComposePairing.record(
+      destDir = destDir,
+      bundle = RemoteComposePairing.bundleMembers(listOf(maven("remote-core", "1.0.0-alpha18"))),
+      sidecar =
+        RemoteComposePairing.sidecarMembers(
+          sidecar("remote-core-1.0.0-alpha18.jar", "remote-player-core-1.0.0-alpha18.jar")
+        ),
+      system = "meshcore-mobile",
+      onLog = { logs += it },
+    )
+
+    assertTrue(logs.isEmpty(), "one version across both sides is one line: $logs")
+  }
+
+  @Test
+  fun `a bundle that names no Remote Compose artifact records nothing`() {
+    RemoteComposePairing.record(
+      destDir = destDir,
+      bundle = RemoteComposePairing.bundleMembers(listOf(maven("material3", "1.10.0", "androidx"))),
+      sidecar = RemoteComposePairing.sidecarMembers(sidecar("remote-core-1.0.0-alpha18.jar")),
+      system = "desktop-catalog",
+      onLog = { logs += it },
+    )
+
+    assertTrue(logs.isEmpty(), "a catalog with no Remote Compose previews says nothing: $logs")
+    assertTrue(
+      File(destDir, "remote-compose-line.json").exists().not(),
+      "no record is written for a catalog the family cannot explain",
+    )
+  }
+
+  @Test
+  fun `a failure outside the Remote Compose packages is not this record's to claim`() {
+    recordMeshcoreShape()
+
+    assertNull(
+      RemoteComposePairing.linkageDiagnosis(
+        "java.lang.NoSuchMethodError: androidx.compose.material3.AppBarKt.TopAppBar-gNPyAyM",
+        descriptor,
+      ),
+      "a Material3 linkage error says nothing about the Remote Compose family",
+    )
+  }
+
+  @Test
+  fun `a non-linkage failure is not diagnosed`() {
+    recordMeshcoreShape()
+
+    assertNull(
+      RemoteComposePairing.linkageDiagnosis(
+        "java.lang.IllegalStateException: androidx.compose.remote.core.RemoteClock is not ready",
+        descriptor,
+      )
+    )
+  }
+
+  @Test
+  fun `an unrelated remote- jar on the sidecar is not read as a family member`() {
+    assertTrue(
+      RemoteComposePairing.sidecarMembers(sidecar("remote-config-21.6.0.jar")).isEmpty(),
+      "only the published Remote Compose artifacts count",
+    )
+  }
+
+  @Test
+  fun `the wear family travels with the rest`() {
+    assertContains(
+      RemoteComposePairing.bundleMembers(
+          listOf(maven("remote-material3", "1.0.0-alpha10", "androidx.wear.compose.remote"))
+        )
+        .map { it.artifact },
+      "remote-material3",
+    )
+  }
+
+  @Test
+  fun `a demoted line says the sidecar won, and the record remembers it`() {
+    RemoteComposePairing.record(
+      destDir = destDir,
+      bundle =
+        RemoteComposePairing.bundleMembers(listOf(maven("remote-creation", "1.0.0-SNAPSHOT"))),
+      sidecar =
+        RemoteComposePairing.sidecarMembers(
+          sidecar("remote-core-1.0.0-alpha18.jar", "remote-player-core-1.0.0-alpha18.jar")
+        ),
+      system = "meshcore-mobile",
+      onLog = { logs += it },
+      demoted = true,
+    )
+
+    val logged = logs.single()
+    assertContains(logged, "sidecar's line win")
+    val diagnosis =
+      RemoteComposePairing.linkageDiagnosis(
+        "java.lang.NoSuchFieldError: androidx.compose.remote.core.RemoteClock",
+        descriptor,
+      )
+    assertNotNull(diagnosis)
+    assertContains(diagnosis, "sidecar's line win")
+  }
+
+  @Test
+  fun `family membership is what the demotion keys on`() {
+    assertTrue(RemoteComposePairing.isFamilyMember(maven("remote-core", "1.0.0-alpha18")))
+    assertTrue(
+      RemoteComposePairing.isFamilyMember(
+        maven("remote-material3", "1.0.0-alpha10", "androidx.wear.compose.remote")
+      )
+    )
+    assertTrue(
+      RemoteComposePairing.isFamilyMember(
+          maven("material3", "1.10.0", "androidx.compose.material3")
+        )
+        .not()
+    )
+  }
+
+  @Test
+  fun `a skewed family is demoted out of the parent overlay, and nothing else is`() {
+    val remoteCore = maven("remote-core", "1.0.0-SNAPSHOT")
+    val material3 = maven("material3", "1.10.0", "androidx.compose.material3")
+
+    val base = setOf(RemoteComposePairing.BASE_GROUP)
+    assertTrue(
+      ServeBundleDaemon.overlaysDaemonSidecar(remoteCore, demotedRemoteComposeGroups = emptySet()),
+      "a coherent family keeps the catalog's own versions, as every other androidx artifact does",
+    )
+    assertTrue(
+      ServeBundleDaemon.overlaysDaemonSidecar(remoteCore, demotedRemoteComposeGroups = base).not(),
+      "a half-carried family must fall behind the sidecar so one line answers the IR replay",
+    )
+    assertTrue(
+      ServeBundleDaemon.overlaysDaemonSidecar(material3, demotedRemoteComposeGroups = base),
+      "the demotion is the Remote Compose family's alone — Material3 still wins for the catalog",
+    )
+    assertTrue(
+      ServeBundleDaemon.overlaysDaemonSidecar(
+        maven("remote-material3", "1.0.0-alpha10", "androidx.wear.compose.remote"),
+        demotedRemoteComposeGroups = base,
+      ),
+      "a split base line must not drag the independently-versioned Wear line down with it",
+    )
+  }
+
+  /**
+   * The demotion's justification is that the sidecar's IR replay links against the family. A bundle
+   * with no IR has consumer bytecode compiled against the versions it records, so the catalog keeps
+   * them — the split is reported without being rearranged (Codex review on #219).
+   */
+  @Test
+  fun `only an IR bundle demotes, a class-backed one keeps its own versions`() {
+    val skewed =
+      RemoteComposePairing.Line(
+        bundle = listOf(RemoteComposePairing.Member("remote-creation", "1.0.0-SNAPSHOT")),
+        sidecar = listOf(RemoteComposePairing.Member("remote-core", "1.0.0-alpha18")),
+      )
+    assertNotNull(RemoteComposePairing.skew(skewed), "the split itself is reported either way")
+
+    for (hasIr in listOf(true, false)) {
+      val demoted = if (hasIr) RemoteComposePairing.skewedGroups(skewed) else emptySet()
+      assertEquals(
+        hasIr,
+        ServeBundleDaemon.overlaysDaemonSidecar(maven("remote-core", "1.0.0-SNAPSHOT"), demoted)
+          .not(),
+        "hasIr=$hasIr must decide whether the family falls behind the sidecar",
+      )
+    }
+  }
+
+  /**
+   * Two sides reading one `-SNAPSHOT` are not two sides reading one build. Not enough to demote on,
+   * but enough to say once a linkage error has actually happened (Codex review on #219).
+   */
+  @Test
+  fun `a mutable version on both sides is not proof of coherence once something breaks`() {
+    val line =
+      RemoteComposePairing.Line(
+        bundle = listOf(RemoteComposePairing.Member("remote-creation", "1.0.0-SNAPSHOT")),
+        sidecar = listOf(RemoteComposePairing.Member("remote-player-core", "1.0.0-SNAPSHOT")),
+      )
+    RemoteComposePairing.record(
+      destDir = destDir,
+      bundle = line.bundle,
+      sidecar = line.sidecar,
+      system = "meshcore-mobile",
+      onLog = { logs += it },
+    )
+
+    assertTrue(logs.isEmpty(), "a matching version must not demote or shout at materialization")
+    val diagnosis =
+      RemoteComposePairing.linkageDiagnosis(
+        "java.lang.NoSuchFieldError: androidx.compose.remote.core.RemoteClock",
+        descriptor,
+      )
+    assertNotNull(diagnosis, "a Remote Compose trip is the evidence the version string withheld")
+    assertContains(diagnosis, "names no single build")
+    assertContains(diagnosis, "remote-player-core")
+  }
+
+  @Test
+  fun `released versions that agree stay coherent even after a trip`() {
+    RemoteComposePairing.record(
+      destDir = destDir,
+      bundle =
+        RemoteComposePairing.bundleMembers(listOf(maven("remote-creation", "1.0.0-alpha18"))),
+      sidecar = RemoteComposePairing.sidecarMembers(sidecar("remote-core-1.0.0-alpha18.jar")),
+      system = "meshcore-mobile",
+      onLog = { logs += it },
+    )
+
+    assertNull(
+      RemoteComposePairing.linkageDiagnosis(
+        "java.lang.NoSuchFieldError: androidx.compose.remote.core.RemoteClock",
+        descriptor,
+      ),
+      "one released version on both sides names one build — this failure is someone else's",
+    )
+  }
+
+  /**
+   * `androidx.compose.remote` and `androidx.wear.compose.remote` version independently — this
+   * server's own sidecar ships `remote-core` alpha18 beside `remote-material3` alpha10 — so one
+   * "single version across the whole family" rule would call every such bundle skewed and demote a
+   * base family it carries coherently (Codex review on #219).
+   */
+  @Test
+  fun `the base and Wear lines are compared apart, not against each other`() {
+    val line =
+      RemoteComposePairing.Line(
+        bundle =
+          RemoteComposePairing.bundleMembers(
+            listOf(
+              maven("remote-core", "1.0.0-alpha18"),
+              maven("remote-player-core", "1.0.0-alpha18"),
+              maven("remote-material3", "1.0.0-alpha10", "androidx.wear.compose.remote"),
+            )
+          ),
+        sidecar =
+          RemoteComposePairing.sidecarMembers(
+            sidecar("remote-core-1.0.0-alpha18.jar", "remote-material3-1.0.0-alpha10.jar")
+          ),
+      )
+
+    assertTrue(
+      RemoteComposePairing.skewedGroups(line).isEmpty(),
+      "two lines at their own versions are two coherent lines, not one skewed family",
+    )
+    assertNull(RemoteComposePairing.skew(line))
+  }
+
+  @Test
+  fun `only a group whose own supply is split is demoted`() {
+    val line =
+      RemoteComposePairing.Line(
+        bundle =
+          RemoteComposePairing.bundleMembers(
+            listOf(
+              maven("remote-creation", "1.0.0-SNAPSHOT"),
+              maven("remote-material3", "1.0.0-alpha10", "androidx.wear.compose.remote"),
+            )
+          ),
+        sidecar =
+          RemoteComposePairing.sidecarMembers(
+            sidecar("remote-core-1.0.0-alpha18.jar", "remote-material3-1.0.0-alpha10.jar")
+          ),
+      )
+
+    assertEquals(
+      setOf(RemoteComposePairing.BASE_GROUP),
+      RemoteComposePairing.skewedGroups(line),
+      "the base line is split snapshot-against-alpha18; the Wear line the bundle covers is intact",
+    )
+  }
+
+  @Test
+  fun `a missing record diagnoses nothing`() {
+    assertNull(
+      RemoteComposePairing.linkageDiagnosis(
+        "java.lang.NoSuchFieldError: androidx.compose.remote.core.RemoteClock",
+        descriptor,
+      )
+    )
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/RenderCircuitBreakerTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/RenderCircuitBreakerTest.kt
@@ -1,0 +1,140 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/** Unit coverage for the fatal-vs-transient classifier and the two breaker trips (issue #3448). */
+class RenderCircuitBreakerTest {
+
+  private val linkage =
+    "render failed: UnsatisfiedLinkError: 'long " +
+      "org.jetbrains.skia.PathBuilderKt.PathBuilder_nMakeFromPath(long)'"
+
+  @Test
+  fun `linkage faults classify as fatal, ordinary render errors do not`() {
+    assertEquals("UnsatisfiedLinkError", RenderFailureClassifier.fatalMarker(linkage))
+    assertTrue(RenderFailureClassifier.isFatal("render failed: NoClassDefFoundError: androidx/Foo"))
+    assertTrue(RenderFailureClassifier.isFatal("render failed: NoSuchMethodError: Bar.baz()"))
+    assertFalse(RenderFailureClassifier.isFatal("render failed: java.lang.NullPointerException"))
+    assertFalse(RenderFailureClassifier.isFatal("timed out after 10s waiting for render"))
+  }
+
+  @Test
+  fun `a fatal trip carries the diagnosis the caller supplies`() {
+    // The open breaker's reason IS the body of every refused render, so it is the only diagnosis
+    // anyone outside the box sees — #4220 was reported from exactly that text, naming the missing
+    // symbol and nothing that explains it.
+    val breaker =
+      RenderCircuitBreaker(
+        linkageDiagnosis = { reason ->
+          "Skiko bindings 0.148.2 will link against libskiko 0.144.6"
+            .takeIf { "org.jetbrains.ski" in reason }
+        }
+      )
+
+    breaker.recordFailure(linkage)
+
+    val reason = assertNotNull(breaker.peekReason())
+    assertTrue(reason.endsWith("Skiko bindings 0.148.2 will link against libskiko 0.144.6"), reason)
+    assertTrue(reason.contains("UnsatisfiedLinkError"), "the raw failure is still there: $reason")
+  }
+
+  @Test
+  fun `a diagnosis that throws or declines costs the trip nothing`() {
+    val thrower = RenderCircuitBreaker(linkageDiagnosis = { error("boom") })
+    thrower.recordFailure(linkage)
+    assertTrue(assertNotNull(thrower.peekReason()).contains("UnsatisfiedLinkError"))
+
+    // A coherent classpath has nothing to add, and must not leave a dangling space behind.
+    val quiet = RenderCircuitBreaker(linkageDiagnosis = { null })
+    quiet.recordFailure(linkage)
+    assertTrue(assertNotNull(quiet.peekReason()).endsWith(linkage))
+  }
+
+  @Test
+  fun `one fatal failure opens the breaker terminally`() {
+    // The #3448 behaviour: 3794 retries of an UnsatisfiedLinkError in ~14 minutes. One is enough.
+    var now = 0L
+    val breaker = RenderCircuitBreaker(clock = { now })
+    assertNull(breaker.blockedReason())
+
+    breaker.recordFailure(linkage)
+
+    val reason = assertNotNull(breaker.blockedReason())
+    assertTrue(reason.contains("UnsatisfiedLinkError"), "reason should name the fault: $reason")
+    val snapshot = assertNotNull(breaker.snapshot())
+    assertTrue(snapshot.open)
+    assertTrue(snapshot.fatal)
+
+    // No cooldown, no probe: a linkage fault cannot succeed later, so time buys nothing.
+    now += 10 * RenderCircuitBreaker.PROBE_COOLDOWN_MILLIS
+    assertNotNull(breaker.blockedReason())
+    // And a stray success cannot re-open the lane — the classpath is still broken.
+    breaker.recordOk()
+    assertNotNull(breaker.blockedReason())
+  }
+
+  @Test
+  fun `a sustained failure rate trips the breaker even for unclassified errors`() {
+    var now = 0L
+    val breaker = RenderCircuitBreaker(clock = { now })
+    // Below the sample floor nothing trips, however bad the rate looks.
+    repeat(RenderCircuitBreaker.MIN_SAMPLES - 1) { breaker.recordFailure("render produced no PNG") }
+    assertNull(breaker.peekReason())
+
+    breaker.recordFailure("render produced no PNG")
+
+    val snapshot = assertNotNull(breaker.snapshot())
+    assertTrue(snapshot.open)
+    assertFalse(snapshot.fatal, "an unclassified error is a rate trip, not a fatal one")
+    assertNotNull(breaker.peekReason())
+  }
+
+  @Test
+  fun `a healthy run keeps the rate breaker closed`() {
+    val breaker = RenderCircuitBreaker(clock = { 0L })
+    repeat(100) {
+      breaker.recordOk()
+      breaker.recordFailure("render produced no PNG")
+    }
+    assertNull(breaker.peekReason(), "a 50% failure rate is not the sustained failure this catches")
+  }
+
+  @Test
+  fun `a rate-tripped breaker probes after the cooldown and closes on success`() {
+    var now = 0L
+    val breaker = RenderCircuitBreaker(clock = { now })
+    repeat(RenderCircuitBreaker.MIN_SAMPLES) { breaker.recordFailure("render produced no PNG") }
+    assertNotNull(breaker.blockedReason())
+
+    // Still shut inside the cooldown: this is what turns a retry storm into one render a minute.
+    now += RenderCircuitBreaker.PROBE_COOLDOWN_MILLIS - 1
+    assertNotNull(breaker.blockedReason())
+
+    // Past it, exactly one render is admitted — the next is shut out until the cooldown re-elapses.
+    now += 1
+    assertNull(breaker.blockedReason())
+    assertNotNull(breaker.blockedReason())
+
+    // The probe succeeded: the lane is healthy again and reports itself so.
+    breaker.recordOk()
+    assertNull(breaker.blockedReason())
+    assertNull(breaker.snapshot())
+  }
+
+  @Test
+  fun `short-circuited renders are counted for status`() {
+    val breaker = RenderCircuitBreaker(clock = { 0L })
+    breaker.recordFailure(linkage)
+    repeat(5) { breaker.blockedReason() }
+    // The first blockedReason above the repeat is the trip check itself; count what we refused.
+    assertEquals(5, assertNotNull(breaker.snapshot()).shortCircuitedRenders)
+    // A status poll must never spend a probe or inflate the count.
+    breaker.peekReason()
+    assertEquals(5, assertNotNull(breaker.snapshot()).shortCircuitedRenders)
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/RenderPerfStatsTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/RenderPerfStatsTest.kt
@@ -1,0 +1,116 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class RenderPerfStatsTest {
+
+  @Test
+  fun emptyStatsSnapshotHasNoSamples() {
+    val snap = RenderPerfStats().snapshot()
+    assertEquals(0, snap.renders)
+    assertNull(snap.firstRenderMs)
+    assertNull(snap.minMs)
+    assertNull(snap.p50Ms)
+    assertEquals(0, snap.windowSize)
+  }
+
+  @Test
+  fun coldAndWarmRendersAreSeparated() {
+    val stats = RenderPerfStats()
+    stats.recordOk(30_000, cold = true)
+    stats.recordOk(2_000, cold = false)
+    stats.recordOk(1_000, cold = false)
+    stats.recordCacheHit()
+    stats.recordBusy()
+    stats.recordFailed(120_000, timeout = true, reason = "timed out after 120s waiting for render")
+
+    val snap = stats.snapshot()
+    assertEquals(4, snap.renders)
+    assertEquals(3, snap.ok)
+    assertEquals(1, snap.failed)
+    assertEquals(1, snap.timedOut)
+    assertEquals(1, snap.busy)
+    assertEquals(1, snap.cacheHits)
+    assertEquals(1, snap.coldRenders)
+    assertEquals(30_000, snap.firstRenderMs)
+    assertEquals(30_000, snap.coldMaxMs)
+    assertEquals(1_000, snap.minMs)
+    assertEquals(30_000, snap.maxMs)
+    assertEquals(11_000, snap.avgMs)
+    // Failed durations don't enter the percentile window; lastMs still reflects the failure.
+    assertEquals(120_000, snap.lastMs)
+    assertEquals(3, snap.windowSize)
+    assertEquals(2_000, snap.p50Ms)
+    // The failure's "why" is carried so /status can explain a climbing failed counter.
+    assertEquals("timed out after 120s waiting for render", snap.lastFailureReason)
+    assertNotNull(snap.lastFailureAtEpochMillis)
+  }
+
+  @Test
+  fun percentileWindowIsBoundedToMostRecentSamples() {
+    val stats = RenderPerfStats()
+    // Overfill the ring: the first (slow) samples must age out of the percentile window while the
+    // all-time max keeps them.
+    repeat(RenderPerfStats.WINDOW_SIZE) { stats.recordOk(60_000, cold = false) }
+    repeat(RenderPerfStats.WINDOW_SIZE) { stats.recordOk(1_000, cold = false) }
+    val snap = stats.snapshot()
+    assertEquals(RenderPerfStats.WINDOW_SIZE, snap.windowSize)
+    assertEquals(1_000, snap.p50Ms)
+    assertEquals(1_000, snap.p95Ms)
+    assertEquals(60_000, snap.maxMs)
+  }
+
+  @Test
+  fun recentFailuresAreBoundedAndNewestFirst() {
+    val stats = RenderPerfStats()
+    repeat(RenderPerfStats.FAILURE_WINDOW_SIZE + 2) { index ->
+      stats.recordFailed(index.toLong(), timeout = index % 2 == 0, reason = "failure $index")
+    }
+
+    val failures = stats.snapshot().recentFailures
+    assertEquals(RenderPerfStats.FAILURE_WINDOW_SIZE, failures.size)
+    assertEquals("failure 11", failures.first().reason)
+    assertEquals("failure 2", failures.last().reason)
+  }
+
+  @Test
+  fun successfulRenderClearsCurrentFailureButPreservesDiagnostics() {
+    val stats = RenderPerfStats()
+    stats.recordFailed(500, timeout = false, reason = "transient failure")
+
+    assertTrue(stats.snapshot().lastRenderFailed)
+
+    stats.recordOk(100, cold = false)
+    val recovered = stats.snapshot()
+    assertFalse(recovered.lastRenderFailed)
+    assertEquals("transient failure", recovered.lastFailureReason)
+    assertEquals("transient failure", recovered.recentFailures.single().reason)
+  }
+
+  @Test
+  fun aggregateSumsCountsAndReportsWorstFirstRender() {
+    val a = RenderPerfStats().apply { recordOk(10_000, cold = true) }.snapshot()
+    val b =
+      RenderPerfStats()
+        .apply {
+          recordOk(40_000, cold = true)
+          recordOk(2_000, cold = false)
+        }
+        .snapshot()
+    val agg = RenderPerfSnapshot.aggregate(listOf(a, b))!!
+    assertEquals(3, agg.ok)
+    assertEquals(2, agg.coldRenders)
+    // Worst first render across daemons — the cold-start headline number.
+    assertEquals(40_000, agg.firstRenderMs)
+    assertEquals(2_000, agg.minMs)
+    assertEquals(40_000, agg.maxMs)
+    // Percentiles don't merge across windows.
+    assertNull(agg.p50Ms)
+    assertNull(RenderPerfSnapshot.aggregate(emptyList()))
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWorkOptimizerTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWorkOptimizerTest.kt
@@ -1,0 +1,358 @@
+package ee.schimke.composeai.cli.serve
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Cross-catalog admission for the theme optimizer.
+ *
+ * The measurement this exists to make impossible again: on the deployed box every loaded catalog
+ * entered its pass within half a second of the idle gate opening, 15 of them then contended for 8
+ * render permits, and the result was 64% of optimizer time spent waiting and 43.5% of the rest
+ * spent re-warming daemons that were yielded before they rendered. Bounding the *renders* never
+ * addressed it, because a pass holding no render permit is still holding a turn, a warm daemon and
+ * a seat.
+ */
+class ServeBackgroundWorkOptimizerTest {
+
+  private fun work(lanes: Int, now: () -> Long = { 0L }) =
+    ServeBackgroundWork(maxConcurrentRenders = 8, clock = now, maxConcurrentOptimizers = lanes)
+
+  @Test
+  fun `only as many passes as there are lanes run at once`() {
+    val bg = work(lanes = 2)
+    val inside = AtomicInteger()
+    val peak = AtomicInteger()
+    val release = CountDownLatch(1)
+    val entered = CountDownLatch(2)
+
+    // Two holders occupy both lanes and stay there. Deterministic on purpose: letting the extra
+    // threads race the holders' release tests the scheduler, not the cap.
+    val holders =
+      (1..2).map { n ->
+        Thread {
+            bg.withOptimizerSlot("holder-$n", waitMillis = 1_000) {
+              val now = inside.incrementAndGet()
+              peak.getAndUpdate { max -> maxOf(max, now) }
+              entered.countDown()
+              release.await(5, TimeUnit.SECONDS)
+              inside.decrementAndGet()
+              true
+            }
+          }
+          .also(Thread::start)
+      }
+    assertTrue(entered.await(5, TimeUnit.SECONDS), "both lanes should be admitted immediately")
+    assertEquals(2, bg.optimizerAdmissionSnapshot().running)
+
+    // A third catalog, while both lanes are genuinely occupied.
+    var thirdRan = false
+    val third =
+      bg.withOptimizerSlot("third", waitMillis = 20) {
+        thirdRan = true
+        true
+      }
+    assertNull(third, "a third pass must not be admitted")
+    assertFalse(thirdRan)
+    assertEquals(2, peak.get(), "a third pass must never be inside the door")
+    assertTrue(bg.optimizerAdmissionSnapshot().refusals >= 1)
+
+    release.countDown()
+    holders.forEach { it.join(10_000) }
+    assertEquals(0, bg.optimizerAdmissionSnapshot().running)
+  }
+
+  @Test
+  fun `a refused pass does not run its block`() {
+    val bg = work(lanes = 1)
+    val held = CountDownLatch(1)
+    val release = CountDownLatch(1)
+    val holder = Thread {
+      bg.withOptimizerSlot("holder", waitMillis = 100) {
+        held.countDown()
+        release.await(5, TimeUnit.SECONDS)
+        true
+      }
+    }
+      .also(Thread::start)
+    assertTrue(held.await(5, TimeUnit.SECONDS))
+
+    var ran = false
+    val result =
+      bg.withOptimizerSlot("refused", waitMillis = 10) {
+        ran = true
+        true
+      }
+
+    assertNull(result, "a refused pass reports null")
+    assertFalse(ran, "a refused pass must not do the work anyway")
+    release.countDown()
+    holder.join(10_000)
+  }
+
+  @Test
+  fun `the running systems are named, so a stuck pass can be identified`() {
+    val bg = work(lanes = 2)
+    val held = CountDownLatch(1)
+    val release = CountDownLatch(1)
+    val t = Thread {
+      bg.withOptimizerSlot("m3-catalog", waitMillis = 100) {
+        held.countDown()
+        release.await(5, TimeUnit.SECONDS)
+        true
+      }
+    }
+      .also(Thread::start)
+    assertTrue(held.await(5, TimeUnit.SECONDS))
+
+    assertEquals(listOf("m3-catalog"), bg.optimizerAdmissionSnapshot().runningSystems)
+    release.countDown()
+    t.join(10_000)
+    assertEquals(emptyList(), bg.optimizerAdmissionSnapshot().runningSystems)
+  }
+
+  @Test
+  fun `a slot is released even when the pass throws`() {
+    val bg = work(lanes = 1)
+    runCatching { bg.withOptimizerSlot("boom", waitMillis = 100) { error("pass blew up") } }
+    assertEquals(0, bg.optimizerAdmissionSnapshot().running)
+    assertNotNull(
+      bg.withOptimizerSlot("next", waitMillis = 100) { true },
+      "a thrown pass must not leak its lane",
+    )
+  }
+
+  @Test
+  fun `a pause refuses admission until it lifts`() {
+    var now = 1_000L
+    val bg = work(lanes = 2, now = { now })
+
+    val until = bg.pauseOptimizers(millis = 60_000, reason = "traffic spike")
+    assertEquals(61_000L, until)
+    assertTrue(bg.optimizersPaused())
+    assertNull(
+      bg.withOptimizerSlot("cat", waitMillis = 100) { true },
+      "no pass is admitted while paused",
+    )
+
+    val snap = bg.optimizerAdmissionSnapshot()
+    assertTrue(snap.paused)
+    assertEquals(61_000L, snap.pausedUntilEpochMillis)
+    assertEquals("traffic spike", snap.pauseReason, "a quiet server should explain itself")
+
+    // It lifts on its own — a pause is a deferral, not a disable.
+    now = 61_001L
+    assertFalse(bg.optimizersPaused())
+    assertNotNull(bg.withOptimizerSlot("cat", waitMillis = 100) { true })
+    assertNull(bg.optimizerAdmissionSnapshot().pausedUntilEpochMillis)
+  }
+
+  @Test
+  fun `resume lifts a pause early`() {
+    var now = 0L
+    val bg = work(lanes = 1, now = { now })
+    bg.pauseOptimizers(millis = 10 * 60_000, reason = "deploy")
+    assertTrue(bg.optimizersPaused())
+
+    bg.resumeOptimizers()
+
+    assertFalse(bg.optimizersPaused())
+    now = 1L
+    assertNotNull(bg.withOptimizerSlot("cat", waitMillis = 100) { true })
+    val snap = bg.optimizerAdmissionSnapshot()
+    assertFalse(snap.paused)
+    assertNull(snap.pauseReason)
+  }
+
+  /**
+   * Park [system] at the admission door and return once it is genuinely queued.
+   *
+   * The polling matters: starting the thread proves nothing about whether it has reached the lock,
+   * and asserting on priority order before both waiters are registered would test the scheduler
+   * rather than the priority rule.
+   */
+  private fun queueWaiter(
+    bg: ServeBackgroundWork,
+    system: String,
+    expectWaiting: Int,
+    ran: MutableList<String>,
+    release: CountDownLatch,
+  ): Thread {
+    val t = Thread {
+      bg.withOptimizerSlot(system, waitMillis = 10_000) {
+        synchronized(ran) { ran += system }
+        release.await(5, TimeUnit.SECONDS)
+        true
+      }
+    }
+      .also(Thread::start)
+    // Polled on the queue itself, not the `waiting` counter: the two are updated together under the
+    // same lock, but only the queue is what the priority assertions below actually read.
+    val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+    while (bg.optimizerAdmissionSnapshot().waitingSystems.size < expectWaiting) {
+      check(System.nanoTime() < deadline) { "$system never reached the door" }
+      Thread.sleep(5)
+    }
+    return t
+  }
+
+  @Test
+  fun `the lane goes to whoever has gone longest without one, not whoever asked first`() {
+    // The starvation this exists to prevent: a fair semaphore only orders the callers blocked on it
+    // right now, so a catalog refused twenty times arrived at attempt twenty-one with no advantage
+    // over one that had just run. On the deployed box that read as `admissions 5, refusals 20` with
+    // m3-catalog — the largest queue on the box — never admitted once.
+    var now = 0L
+    val bg = work(lanes = 1, now = { now })
+    val ran = mutableListOf<String>()
+
+    // `recent` runs first and therefore most recently; `stale` ran long ago.
+    now = 100
+    bg.withOptimizerSlot("stale", waitMillis = 1_000) { true }
+    now = 200
+    bg.withOptimizerSlot("recent", waitMillis = 1_000) { true }
+
+    now = 300
+    val holderRelease = CountDownLatch(1)
+    val holding = CountDownLatch(1)
+    val holder = Thread {
+      bg.withOptimizerSlot("holder", waitMillis = 1_000) {
+        holding.countDown()
+        holderRelease.await(5, TimeUnit.SECONDS)
+        true
+      }
+    }
+      .also(Thread::start)
+    assertTrue(holding.await(5, TimeUnit.SECONDS))
+
+    // `recent` queues FIRST, `stale` second — so arrival order and priority order disagree.
+    val release = CountDownLatch(1)
+    val tRecent = queueWaiter(bg, "recent", expectWaiting = 1, ran = ran, release = release)
+    val tStale = queueWaiter(bg, "stale", expectWaiting = 2, ran = ran, release = release)
+
+    assertEquals(
+      listOf("stale", "recent"),
+      bg.optimizerAdmissionSnapshot().waitingSystems,
+      "the door should report who is next, in the order they will be let in",
+    )
+
+    holderRelease.countDown()
+    holder.join(10_000)
+    // One lane, so the first entrant is decided before the second can start.
+    val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+    while (synchronized(ran) { ran.isEmpty() }) {
+      check(System.nanoTime() < deadline) { "nobody was admitted" }
+      Thread.sleep(5)
+    }
+    assertEquals(
+      "stale",
+      synchronized(ran) { ran.first() },
+      "the longest-waiting system goes first",
+    )
+
+    release.countDown()
+    tRecent.join(10_000)
+    tStale.join(10_000)
+    // `waiting` is a gauge, not a tally. It read as a tally once — the decrement was dropped when
+    // admission moved off the semaphore — and a door that reports a permanent queue is worse than
+    // one that reports none, because it looks exactly like the starvation this change fixes.
+    assertEquals(0, bg.optimizerAdmissionSnapshot().waiting)
+    assertEquals(emptyList(), bg.optimizerAdmissionSnapshot().waitingSystems)
+  }
+
+  @Test
+  fun `a system that has never run outranks every system that has`() {
+    // The anti-starvation guarantee stated positively: every catalog gets a lane before any catalog
+    // gets a second one. That holds without knowing how much work each has left, which is why there
+    // is no size heuristic here.
+    var now = 0L
+    val bg = work(lanes = 1, now = { now })
+    val ran = mutableListOf<String>()
+
+    now = 100
+    bg.withOptimizerSlot("veteran", waitMillis = 1_000) { true }
+
+    now = 200
+    val holderRelease = CountDownLatch(1)
+    val holding = CountDownLatch(1)
+    val holder = Thread {
+      bg.withOptimizerSlot("holder", waitMillis = 1_000) {
+        holding.countDown()
+        holderRelease.await(5, TimeUnit.SECONDS)
+        true
+      }
+    }
+      .also(Thread::start)
+    assertTrue(holding.await(5, TimeUnit.SECONDS))
+
+    val release = CountDownLatch(1)
+    val tVeteran = queueWaiter(bg, "veteran", expectWaiting = 1, ran = ran, release = release)
+    val tNewcomer = queueWaiter(bg, "newcomer", expectWaiting = 2, ran = ran, release = release)
+
+    assertEquals(listOf("newcomer", "veteran"), bg.optimizerAdmissionSnapshot().waitingSystems)
+
+    holderRelease.countDown()
+    holder.join(10_000)
+    val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+    while (synchronized(ran) { ran.isEmpty() }) {
+      check(System.nanoTime() < deadline) { "nobody was admitted" }
+      Thread.sleep(5)
+    }
+    assertEquals("newcomer", synchronized(ran) { ran.first() })
+
+    release.countDown()
+    tVeteran.join(10_000)
+    tNewcomer.join(10_000)
+  }
+
+  @Test
+  fun `priority admission still never exceeds the lane count`() {
+    // Rotation must not be bought by widening the door — the cap is the reason the box stopped
+    // thrashing, and a priority queue that admits an extra pass would undo it.
+    val bg = work(lanes = 2)
+    val inside = AtomicInteger()
+    val peak = AtomicInteger()
+    val done = CountDownLatch(6)
+    val threads =
+      (1..6).map { n ->
+        Thread {
+            bg.withOptimizerSlot("cat-$n", waitMillis = 5_000) {
+              val now = inside.incrementAndGet()
+              peak.getAndUpdate { max -> maxOf(max, now) }
+              Thread.sleep(20)
+              inside.decrementAndGet()
+              true
+            }
+            done.countDown()
+          }
+          .also(Thread::start)
+      }
+    assertTrue(done.await(20, TimeUnit.SECONDS))
+    threads.forEach { it.join(10_000) }
+    assertTrue(peak.get() <= 2, "never more than ${2} inside the door, saw ${peak.get()}")
+    assertEquals(0, bg.optimizerAdmissionSnapshot().running)
+  }
+
+  @Test
+  fun `admission counters distinguish work done from work refused`() {
+    // The pair that tells an operator the cap is working rather than wedged: refusals climbing
+    // while admissions also climb is throughput; refusals climbing alone is starvation.
+    val bg = work(lanes = 1)
+    assertNotNull(bg.withOptimizerSlot("a", waitMillis = 100) { true })
+    assertNotNull(bg.withOptimizerSlot("b", waitMillis = 100) { true })
+    bg.pauseOptimizers(millis = 60_000, reason = "x")
+    assertNull(bg.withOptimizerSlot("c", waitMillis = 10) { true })
+
+    val snap = bg.optimizerAdmissionSnapshot()
+    assertEquals(2, snap.admissions)
+    assertEquals(1, snap.refusals)
+    assertEquals(1, snap.lanes)
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBranchFetchTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBranchFetchTest.kt
@@ -1,0 +1,131 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The branch-read outcome and its retry policy ([BranchFetch]).
+ *
+ * The property every one of these guards is the same: **a throttle must never be mistaken for a
+ * missing file.** That confusion is what made a rate-limited read indistinguishable from an
+ * unpublished asset, and it is what let a permanent negative cache remember a transient blip.
+ */
+class ServeBranchFetchTest {
+
+  @Test
+  fun `only a real absence is permanent`() {
+    assertEquals(BranchFetch.NotFound, BranchFetch.ofStatus(404))
+    assertEquals(BranchFetch.NotFound, BranchFetch.ofStatus(410))
+    assertFalse(BranchFetch.NotFound.isTransient, "404 is a fact, not a moment")
+
+    // Everything else is a statement about now, and must stay retryable + uncacheable.
+    for (status in listOf(429, 403, 500, 502, 503, 504)) {
+      assertTrue(
+        BranchFetch.ofStatus(status).isTransient,
+        "$status must not be treated as a missing asset",
+      )
+    }
+  }
+
+  @Test
+  fun `403 is read as a throttle, not an absence`() {
+    // GitHub answers 403 for some rate-limit conditions. Guessing wrong in this direction costs one
+    // wasted retry; guessing wrong the other way caches a throttle as a permanently missing file.
+    assertTrue(BranchFetch.ofStatus(403) is BranchFetch.Throttled)
+  }
+
+  @Test
+  fun `a served response carries its bytes and nothing to retry`() {
+    val ok = BranchFetch.Ok(byteArrayOf(1, 2, 3))
+    assertFalse(ok.isTransient)
+    assertNull(BranchFetch.retryDelayMillis(ok, attempt = 1))
+    assertEquals(3, ok.bytesOrNull?.size)
+    assertNull(BranchFetch.NotFound.bytesOrNull)
+  }
+
+  @Test
+  fun `a missing file is never retried`() {
+    assertNull(
+      BranchFetch.retryDelayMillis(BranchFetch.NotFound, attempt = 1),
+      "retrying a 404 is how a catalog of absent assets becomes a thundering herd",
+    )
+  }
+
+  @Test
+  fun `backoff grows and then gives up`() {
+    val outcome = BranchFetch.Unavailable(503)
+    assertEquals(BranchFetch.BASE_BACKOFF_MILLIS, BranchFetch.retryDelayMillis(outcome, 1))
+    assertEquals(BranchFetch.BASE_BACKOFF_MILLIS * 2, BranchFetch.retryDelayMillis(outcome, 2))
+    assertNull(
+      BranchFetch.retryDelayMillis(outcome, BranchFetch.MAX_RETRIES + 1),
+      "the attempts are bounded — a request is waiting behind this",
+    )
+  }
+
+  @Test
+  fun `the server's own Retry-After wins when it is longer`() {
+    // It is the only party that knows when it will serve again.
+    val throttled = BranchFetch.Throttled(retryAfterSeconds = 5)
+    assertEquals(5_000L, BranchFetch.retryDelayMillis(throttled, 1))
+
+    // …but not when the exponential step is already longer, and never past the cap: a hostile or
+    // confused header must not park a request thread for minutes.
+    assertEquals(
+      BranchFetch.BASE_BACKOFF_MILLIS,
+      BranchFetch.retryDelayMillis(BranchFetch.Throttled(0), 1),
+    )
+    assertEquals(
+      BranchFetch.MAX_RETRY_AFTER_SECONDS * 1000L,
+      BranchFetch.retryDelayMillis(BranchFetch.Throttled(9_999), 1),
+    )
+  }
+
+  @Test
+  fun `a 503 that says when to come back is believed too`() {
+    // `Retry-After` is defined on 503 as much as on 429 (RFC 9110 10.2.3). Dropping it there meant
+    // a host asking for ten seconds got 250ms and 500ms instead — both retries spent inside the
+    // outage, and the asset then reported as missing, which is the confusion this type exists
+    // to end.
+    val outage = BranchFetch.ofStatus(503, retryAfterSeconds = 10)
+    assertEquals(BranchFetch.Unavailable(503, 10), outage)
+    assertEquals(10_000L, BranchFetch.retryDelayMillis(outage, 1))
+
+    // Same cap as a throttle: a header is advice, not a licence to hold a request thread.
+    assertEquals(
+      BranchFetch.MAX_RETRY_AFTER_SECONDS * 1000L,
+      BranchFetch.retryDelayMillis(BranchFetch.ofStatus(503, 9_999), 1),
+    )
+    // And with no header it is still the plain exponential schedule.
+    assertEquals(
+      BranchFetch.BASE_BACKOFF_MILLIS,
+      BranchFetch.retryDelayMillis(BranchFetch.ofStatus(503), 1),
+    )
+  }
+
+  @Test
+  fun `Retry-After parses only what it can trust`() {
+    assertEquals(7L, BranchFetch.parseRetryAfter("7"))
+    assertEquals(7L, BranchFetch.parseRetryAfter("  7 "))
+    assertNull(BranchFetch.parseRetryAfter(null))
+    assertNull(BranchFetch.parseRetryAfter(""))
+    assertNull(BranchFetch.parseRetryAfter("-1"), "a negative delay is not a delay")
+    // The HTTP-date form is legal but no branch host we read sends it; unparseable falls back to
+    // the exponential schedule rather than guessing.
+    assertNull(BranchFetch.parseRetryAfter("Wed, 21 Oct 2026 07:28:00 GMT"))
+  }
+
+  @Test
+  fun `every outcome says why in one line`() {
+    assertEquals("not found", BranchFetch.NotFound.summary)
+    assertEquals("throttled (retry after 3s)", BranchFetch.Throttled(3).summary)
+    assertEquals("throttled", BranchFetch.Throttled(null).summary)
+    assertEquals("unavailable (503)", BranchFetch.Unavailable(503).summary)
+    assertEquals(
+      "transport: SocketTimeoutException",
+      BranchFetch.Transport("SocketTimeoutException").summary,
+    )
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBroadcastHubTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBroadcastHubTest.kt
@@ -1,0 +1,250 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.StreamCodec
+import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+import ee.schimke.composeai.daemon.protocol.UiMode
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ServeBroadcastHubTest {
+
+  /** The `visibility` calls a throttle / un-throttle should produce, typed for `assertEquals`. */
+  private fun hidden(fps: Int?): List<Pair<Boolean, Int?>> = listOf(false to fps)
+
+  private fun shown(): List<Pair<Boolean, Int?>> = listOf(true to null)
+
+  private fun frame(seq: Long, payload: String?): StreamFrameParams =
+    StreamFrameParams(
+      frameStreamId = "fs",
+      seq = seq,
+      ptsMillis = 0,
+      widthPx = 2,
+      heightPx = 2,
+      codec = StreamCodec.PNG,
+      payloadBase64 = payload,
+    )
+
+  /** A single upstream stream: the hub feeds [emit] back as frames; records input + close. */
+  private class FakeUpstream {
+    lateinit var emit: (StreamFrameParams) -> Unit
+    val inputs = CopyOnWriteArrayList<InteractiveInputKind>()
+    val visibilities = CopyOnWriteArrayList<Pair<Boolean, Int?>>()
+    val closed = AtomicBoolean(false)
+    val handle =
+      object : StreamHandle {
+        override fun input(
+          kind: InteractiveInputKind,
+          pixelX: Int?,
+          pixelY: Int?,
+          pointerId: Int?,
+          scrollDeltaY: Float?,
+          keyCode: String?,
+          text: String?,
+          pointerType: String?,
+        ) {
+          inputs.add(kind)
+        }
+
+        override fun visibility(visible: Boolean, fps: Int?) {
+          visibilities.add(visible to fps)
+        }
+
+        override fun close() {
+          closed.set(true)
+        }
+      }
+  }
+
+  /**
+   * A [StreamOpener] that hands out a fresh [FakeUpstream] per open (or `null` if not streamable).
+   */
+  private class FakeOpener(private val streamable: Boolean = true) : StreamOpener {
+    val opens = CopyOnWriteArrayList<FakeUpstream>()
+
+    override fun open(
+      previewId: String,
+      overrides: PreviewOverrides,
+      codec: StreamCodec?,
+      maxFps: Int?,
+      onUnavailable: ((String) -> Unit)?,
+      onFrame: (StreamFrameParams) -> Unit,
+    ): StreamHandle? {
+      if (!streamable) {
+        onUnavailable?.invoke("fake opener: not streamable")
+        return null
+      }
+      val up = FakeUpstream()
+      up.emit = onFrame
+      opens.add(up)
+      return up.handle
+    }
+  }
+
+  @Test
+  fun `watchers of the same key share one upstream and both receive frames`() {
+    val opener = FakeOpener()
+    val hub = ServeBroadcastHub(opener)
+    val a = CopyOnWriteArrayList<Long>()
+    val b = CopyOnWriteArrayList<Long>()
+
+    assertNotNull(hub.subscribe("p", PreviewOverrides()) { a.add(it.seq) })
+    assertNotNull(hub.subscribe("p", PreviewOverrides()) { b.add(it.seq) })
+
+    assertEquals(1, opener.opens.size, "two watchers of one key open a single upstream")
+    assertEquals(1, hub.activeStreamCount())
+
+    opener.opens[0].emit(frame(7, "AA"))
+    assertEquals(listOf(7L), a)
+    assertEquals(listOf(7L), b)
+  }
+
+  @Test
+  fun `a late joiner is replayed the last painted frame`() {
+    val opener = FakeOpener()
+    val hub = ServeBroadcastHub(opener)
+    assertNotNull(hub.subscribe("p", PreviewOverrides()) {})
+    opener.opens[0].emit(frame(3, "AA"))
+
+    val late = CopyOnWriteArrayList<Long>()
+    assertNotNull(hub.subscribe("p", PreviewOverrides()) { late.add(it.seq) })
+    assertEquals(listOf(3L), late, "the newcomer should see the current picture immediately")
+  }
+
+  @Test
+  fun `payload-less heartbeats are not replayed to late joiners`() {
+    val opener = FakeOpener()
+    val hub = ServeBroadcastHub(opener)
+    assertNotNull(hub.subscribe("p", PreviewOverrides()) {})
+    opener.opens[0].emit(frame(1, null)) // unchanged heartbeat — nothing to paint
+
+    val late = CopyOnWriteArrayList<Long>()
+    assertNotNull(hub.subscribe("p", PreviewOverrides()) { late.add(it.seq) })
+    assertTrue(late.isEmpty())
+  }
+
+  @Test
+  fun `closing one of two watchers keeps the upstream, closing the last tears it down`() {
+    val opener = FakeOpener()
+    val hub = ServeBroadcastHub(opener)
+    val h1 = assertNotNull(hub.subscribe("p", PreviewOverrides()) {})
+    val h2 = assertNotNull(hub.subscribe("p", PreviewOverrides()) {})
+    val up = opener.opens[0]
+
+    h1.close()
+    assertFalse(up.closed.get(), "the shared upstream must stay open while a watcher remains")
+    assertEquals(1, hub.activeStreamCount())
+
+    h2.close()
+    assertTrue(up.closed.get(), "the last watcher out tears the upstream down")
+    assertEquals(0, hub.activeStreamCount())
+  }
+
+  @Test
+  fun `distinct overrides open distinct shared streams`() {
+    val opener = FakeOpener()
+    val hub = ServeBroadcastHub(opener)
+    assertNotNull(hub.subscribe("p", PreviewOverrides()) {})
+    assertNotNull(hub.subscribe("p", PreviewOverrides(uiMode = UiMode.DARK)) {})
+
+    assertEquals(2, opener.opens.size)
+    assertEquals(2, hub.activeStreamCount())
+  }
+
+  @Test
+  fun `input from a watcher reaches the shared upstream`() {
+    val opener = FakeOpener()
+    val hub = ServeBroadcastHub(opener)
+    val h = assertNotNull(hub.subscribe("p", PreviewOverrides()) {})
+
+    h.input(InteractiveInputKind.CLICK, pixelX = 1, pixelY = 2)
+    assertEquals(listOf(InteractiveInputKind.CLICK), opener.opens[0].inputs)
+  }
+
+  @Test
+  fun `the shared stream is only throttled once every watcher has hidden it`() {
+    val opener = FakeOpener()
+    val hub = ServeBroadcastHub(opener)
+    val h1 = assertNotNull(hub.subscribe("p", PreviewOverrides()) {})
+    val h2 = assertNotNull(hub.subscribe("p", PreviewOverrides()) {})
+    val up = opener.opens[0]
+
+    h1.visibility(false, null)
+    assertTrue(
+      up.visibilities.isEmpty(),
+      "one watcher hiding must not throttle the tab still watching beside it",
+    )
+
+    h2.visibility(false, 2)
+    assertEquals(hidden(null), up.visibilities.toList(), "the slowest requested rate wins")
+
+    h1.visibility(true, null)
+    assertEquals(hidden(null) + shown(), up.visibilities.toList())
+  }
+
+  @Test
+  fun `the last visible watcher leaving throttles the shared stream`() {
+    val opener = FakeOpener()
+    val hub = ServeBroadcastHub(opener)
+    val leaver = assertNotNull(hub.subscribe("p", PreviewOverrides()) {})
+    val stayer = assertNotNull(hub.subscribe("p", PreviewOverrides()) {})
+    val up = opener.opens[0]
+
+    stayer.visibility(false, 3)
+    // Closing the only watcher that was still looking leaves a stream nobody sees; the upstream
+    // survives (the hidden watcher holds it) and must pick the throttle up.
+    leaver.close()
+
+    assertEquals(hidden(3), up.visibilities.toList())
+    assertFalse(up.closed.get())
+  }
+
+  @Test
+  fun `a new watcher un-throttles a stream every existing watcher had hidden`() {
+    val opener = FakeOpener()
+    val hub = ServeBroadcastHub(opener)
+    assertNotNull(hub.subscribe("p", PreviewOverrides()) {}).visibility(false, null)
+    val up = opener.opens[0]
+    assertEquals(hidden(null), up.visibilities.toList())
+
+    assertNotNull(hub.subscribe("p", PreviewOverrides()) {})
+    assertEquals(
+      hidden(null) + shown(),
+      up.visibilities.toList(),
+      "someone just joined, so the shared stream is being looked at again",
+    )
+  }
+
+  @Test
+  fun `subscribe returns null and opens nothing when the backend cannot stream`() {
+    val hub = ServeBroadcastHub(FakeOpener(streamable = false))
+    assertNull(hub.subscribe("p", PreviewOverrides()) {})
+    assertEquals(0, hub.activeStreamCount())
+  }
+
+  @Test
+  fun `subscribe forwards the opener's unavailable reason`() {
+    val hub = ServeBroadcastHub(FakeOpener(streamable = false))
+    var reason: String? = null
+    assertNull(hub.subscribe("p", PreviewOverrides(), onUnavailable = { reason = it }) {})
+    assertEquals("fake opener: not streamable", reason)
+  }
+
+  @Test
+  fun `after the last watcher leaves a new subscribe opens a fresh upstream`() {
+    val opener = FakeOpener()
+    val hub = ServeBroadcastHub(opener)
+    assertNotNull(hub.subscribe("p", PreviewOverrides()) {}).close()
+    assertNotNull(hub.subscribe("p", PreviewOverrides()) {})
+
+    assertEquals(2, opener.opens.size, "a new watcher after teardown opens a fresh upstream")
+    assertEquals(1, hub.activeStreamCount())
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonKnobSidecarTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonKnobSidecarTest.kt
@@ -1,0 +1,134 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
+import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
+import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
+import ee.schimke.composeai.data.overrides.PreviewOverridesPayload
+import ee.schimke.composeai.data.remotecompose.RemoteComposeDeclarationsPayload
+import ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration
+import ee.schimke.composeai.io.SystemFileSystem
+import ee.schimke.composeai.previewdata.PreviewInfo
+import ee.schimke.composeai.previewdata.PreviewManifest
+import java.io.ByteArrayOutputStream
+import java.nio.file.Files
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+
+/**
+ * Hermetic coverage for [ServeBundleDaemon]'s knob-sidecar plumbing — the serve-advertise half of
+ * the "auto-render Remote Compose knobs" chain. Builds a fake bundle (a `previews.json` + a zip of
+ * `previews/<id>.*.json` sidecars) entirely in a temp dir, then drives [ServeBundleDaemon
+ * .extractKnobSidecars] + [ServeBundleDaemon.readPreviews] directly — no daemon, no Gradle, no
+ * packed bundle — and asserts each [ServePreview] carries both channels: the Remote Compose
+ * `remoteComposeKnobs` (from `previews/<id>.remotecompose.json`) and the plain-Compose `overrides`
+ * (from `previews/<id>.overrides.json`), while a preview with no sidecar carries neither.
+ */
+class ServeBundleDaemonKnobSidecarTest {
+
+  private val json = Json { encodeDefaults = true }
+
+  @Test
+  fun `readPreviews folds both the remotecompose and overrides sidecars onto each preview`() {
+    val dir = Files.createTempDirectory("serve-knob-sidecar").toFile()
+    val previewsDir = java.io.File(dir, "previews").apply { mkdirs() }
+
+    // Three previews: one with an RC knob, one with a plain-Compose override, one bare.
+    val rcId = "pkg.CatalogPreviewsKt.ShaderGradientSticker"
+    val overrideId = "pkg.CatalogPreviewsKt.FilledButton_Light"
+    val bareId = "pkg.CatalogPreviewsKt.PlainSticker"
+    val manifest =
+      PreviewManifest(
+        module = ":catalog",
+        variant = "debug",
+        previews =
+          listOf(
+            PreviewInfo(id = rcId, functionName = "ShaderGradientSticker", className = "pkg.X"),
+            PreviewInfo(id = overrideId, functionName = "FilledButton", className = "pkg.X"),
+            PreviewInfo(id = bareId, functionName = "PlainSticker", className = "pkg.X"),
+          ),
+      )
+    val previewsJson = java.io.File(dir, "previews.json")
+    previewsJson.writeText(json.encodeToString(PreviewManifest.serializer(), manifest))
+
+    // A bundle zip carrying the two knob sidecars (and an unrelated PNG entry the extractor must
+    // ignore, plus a zip-slip attempt the extractor must refuse to write outside previewsDir).
+    val rcPayload =
+      RemoteComposeDeclarationsPayload(
+        listOf(
+          RemoteComposeKnobDeclaration("shaderColor", RemoteNamedValue.ColorValue("#FF7DE2FF"))
+        )
+      )
+    val overridesPayload =
+      PreviewOverridesPayload(
+        listOf(
+          PreviewOverrideDeclaration(
+            key = "label",
+            type = "string",
+            default = PreviewOverrideValue.StringValue("Filled"),
+          )
+        )
+      )
+    val zipBytes =
+      zipOf(
+        "previews/$rcId.remotecompose.json" to
+          json.encodeToString(RemoteComposeDeclarationsPayload.serializer(), rcPayload),
+        "previews/$overrideId.overrides.json" to
+          json.encodeToString(PreviewOverridesPayload.serializer(), overridesPayload),
+        "previews/$rcId.png" to "not-json",
+        "previews/../escape.remotecompose.json" to "{}",
+      )
+
+    ServeBundleDaemon.extractKnobSidecars(zipBytes, previewsDir, SystemFileSystem)
+    val previews = ServeBundleDaemon.readPreviews(previewsJson, previewsDir, SystemFileSystem)
+
+    assertEquals(3, previews.size, "all three manifest previews should surface")
+
+    val rc = previews.first { it.id == rcId }
+    assertEquals(
+      listOf("shaderColor"),
+      rc.remoteComposeKnobs.map { it.name },
+      "the RC sticker should advertise its declared color knob",
+    )
+    assertTrue(
+      rc.remoteComposeKnobs.single().default is RemoteNamedValue.ColorValue,
+      "the knob default should decode as a ColorValue, got ${rc.remoteComposeKnobs.single().default}",
+    )
+    assertTrue(rc.overrides.isEmpty(), "the RC sticker declared no plain-Compose override")
+
+    val ov = previews.first { it.id == overrideId }
+    assertEquals(
+      listOf("label"),
+      ov.overrides.map { it.key },
+      "the button should advertise its declared plain-Compose label knob",
+    )
+    assertTrue(ov.remoteComposeKnobs.isEmpty(), "the button declared no RC knob")
+
+    val bare = previews.first { it.id == bareId }
+    assertTrue(
+      bare.remoteComposeKnobs.isEmpty() && bare.overrides.isEmpty(),
+      "bare preview: no knobs",
+    )
+
+    // The zip-slip entry must not have escaped previewsDir.
+    assertTrue(
+      !java.io.File(dir, "escape.remotecompose.json").exists(),
+      "extractKnobSidecars must refuse a `..` path traversal",
+    )
+  }
+
+  private fun zipOf(vararg entries: Pair<String, String>): ByteArray {
+    val bos = ByteArrayOutputStream()
+    ZipOutputStream(bos).use { zos ->
+      for ((name, body) in entries) {
+        zos.putNextEntry(ZipEntry(name))
+        zos.write(body.toByteArray())
+        zos.closeEntry()
+      }
+    }
+    return bos.toByteArray()
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
@@ -1,0 +1,781 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.daemon.protocol.DaemonLaunchDescriptor
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.RenderTier
+import ee.schimke.composeai.render.session.RenderSessionConfig
+import ee.schimke.composeai.render.session.subprocess.SubprocessRenderSessions
+import java.io.File
+import java.nio.file.Files
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Exercises [ServeBundleDaemon.materialize] against a real **packed desktop bundle** — the same
+ * shape `serve --catalogs --allow-render-trusted` fetches for a catalog's `liveBundle`. Needs a
+ * bundle on disk (produced by `compose-preview bundle pack --module :samples:design-catalog-m3 -o
+ * <path>`, e.g. via `NonGradleContractTest`'s pattern) plus the CLI's own `:cli:installDist`
+ * sidecars (`lib-daemon-desktop` / `lib-renderer`) to resolve a real daemon classpath — neither is
+ * produced by a normal `:cli:test` run, so this self-skips (same convention as
+ * `NonGradleContractTest` in `:render-session-subprocess`) rather than failing when they're
+ * missing.
+ *
+ * Point `-Dcomposeai.test.bundlePath=<file>` at a pre-packed bundle (defaults to
+ * `/tmp/m3-bundle.png`, the path this feature's own verification pass packs to). The
+ * `lib-daemon-desktop`/`lib-renderer` sidecars are auto-discovered from this checkout's
+ * `cli/build/install/compose-preview/` when present (i.e. after `./gradlew :cli:installDist`);
+ * override via `-Dcomposeai.cli.appHome=<install-root>` to point elsewhere.
+ */
+class ServeBundleDaemonTest {
+
+  @Test
+  fun `bundle dependencies precede daemon sidecars on the shared parent classpath`() {
+    val root = Files.createTempDirectory("serve-bundle-classpaths").toFile()
+    val classes = File(root, "classes").apply { mkdirs() }
+    val resources = File(root, "resources").apply { mkdirs() }
+    val embedded = File(root, "app-project.jar")
+    val catalogMaterial = File(root, "material3-catalog.jar")
+    val catalogCoroutines = File(root, "coroutines-catalog.jar")
+    val catalogSerialization = File(root, "serialization-catalog.jar")
+    val sidecarMaterial = File(root, "material3-sidecar.jar")
+    val daemon = File(root, "daemon.jar")
+    val androidResources = File(root, "android-resources")
+
+    val result =
+      ServeBundleDaemon.bundleDaemonClasspaths(
+        classesDir = classes,
+        extraClasspathDirs = listOf(resources, File(root, "missing-resources")),
+        embeddedLibJars = listOf(embedded),
+        parentOverlayJars = listOf(catalogMaterial, catalogCoroutines, catalogMaterial),
+        childDependencyJars = listOf(catalogSerialization),
+        daemonSidecarClasspath = listOf(sidecarMaterial.absolutePath, daemon.absolutePath),
+        androidResourceClasspath = listOf(androidResources.absolutePath),
+        hasIr = false,
+      )
+
+    assertEquals(
+      listOf(
+        catalogMaterial.absolutePath,
+        catalogCoroutines.absolutePath,
+        androidResources.absolutePath,
+        sidecarMaterial.absolutePath,
+        daemon.absolutePath,
+      ),
+      result.daemonClasspath,
+      "catalog dependencies must win parent-classpath lookup ahead of host sidecars",
+    )
+    assertEquals(
+      listOf(classes, resources, embedded, catalogSerialization).joinToString(File.pathSeparator) {
+        it.absolutePath
+      },
+      result.userClassPath,
+    )
+    assertTrue(
+      catalogMaterial.absolutePath !in result.userClassPath,
+      "parent-loaded framework dependencies must not be duplicated in the user child loader",
+    )
+  }
+
+  @Test
+  fun `IR replay dependencies are visible to the daemon parent after its sidecars`() {
+    val root = Files.createTempDirectory("serve-bundle-ir-classpaths").toFile()
+    val classes = File(root, "classes").apply { mkdirs() }
+    val embeddedPlayer = File(root, "embedded-player.jar")
+    val childRuntime = File(root, "child-runtime.jar")
+    val sharedOverlay = File(root, "shared-overlay.jar")
+    val daemon = File(root, "daemon.jar")
+
+    val result =
+      ServeBundleDaemon.bundleDaemonClasspaths(
+        classesDir = classes,
+        extraClasspathDirs = emptyList(),
+        embeddedLibJars = listOf(embeddedPlayer),
+        parentOverlayJars = listOf(sharedOverlay),
+        childDependencyJars = listOf(childRuntime),
+        daemonSidecarClasspath = listOf(daemon.absolutePath),
+        androidResourceClasspath = emptyList(),
+        hasIr = true,
+      )
+
+    assertEquals(
+      listOf(
+        sharedOverlay.absolutePath,
+        daemon.absolutePath,
+        embeddedPlayer.absolutePath,
+        childRuntime.absolutePath,
+      ),
+      result.daemonClasspath,
+      "IR replay connectors are parent-loaded and must see every carried player dependency",
+    )
+    assertTrue(embeddedPlayer.absolutePath in result.userClassPath)
+    assertTrue(childRuntime.absolutePath in result.userClassPath)
+  }
+
+  @Test
+  fun `materialize wires carried IR into the daemon descriptor`() {
+    val root = Files.createTempDirectory("serve-bundle-ir-descriptor").toFile()
+    val daemonDir = File(root, "daemon").apply { mkdirs() }
+    val rendererDir = File(root, "renderer").apply { mkdirs() }
+    File(daemonDir, "daemon.jar").writeBytes(byteArrayOf())
+    File(rendererDir, "renderer.jar").writeBytes(byteArrayOf())
+    val previewId = "com.example.CatalogKt.RemotePreview"
+    val document = byteArrayOf(0x52, 0x43, 0x01)
+    val manifest =
+      """
+      {"schemaVersion":8,"backend":"desktop","previewIds":["$previewId"],
+       "coverPreviewId":"$previewId","classpath":[],"modulePath":":remote",
+       "producedBy":"test","intermediateRepresentations":[
+         {"previewId":"$previewId","format":"remotecompose","path":"ir/$previewId.rc"}]}
+      """
+        .trimIndent()
+        .toByteArray()
+    val previews =
+      """
+      {"module":":remote","variant":"debug","previews":[
+        {"id":"$previewId","functionName":"RemotePreview","className":"com.example.CatalogKt",
+         "params":{"uiMode":32}}]}
+      """
+        .trimIndent()
+        .toByteArray()
+    val bundle = File(root, "remote-bundle.zip")
+    java.util.zip.ZipOutputStream(bundle.outputStream()).use { zip ->
+      for ((name, bytes) in
+        listOf(
+          "bundle.json" to manifest,
+          "previews.json" to previews,
+          "ir/$previewId.rc" to document,
+        )) {
+        zip.putNextEntry(java.util.zip.ZipEntry(name))
+        zip.write(bytes)
+        zip.closeEntry()
+      }
+    }
+
+    System.setProperty("composeai.cli.libDaemonDesktopDir", daemonDir.absolutePath)
+    System.setProperty("composeai.cli.libRendererDir", rendererDir.absolutePath)
+    try {
+      val state =
+        assertNotNull(
+          ServeBundleDaemon.materialize(bundle, File(root, "session"), "remote"),
+          "a fully IR-backed bundle should materialize without classes/app.jar",
+        )
+      val descriptor =
+        descriptorJson.decodeFromString(
+          DaemonLaunchDescriptor.serializer(),
+          state.descriptor.readText(),
+        )
+      val irDir = assertNotNull(descriptor.systemProperties["composeai.daemon.irDir"])
+      val bundleManifest =
+        assertNotNull(descriptor.systemProperties["composeai.daemon.bundleManifestPath"])
+
+      assertTrue(File(irDir, "$previewId.rc").readBytes().contentEquals(document))
+      assertTrue(File(bundleManifest).readBytes().contentEquals(manifest))
+      assertEquals(listOf(previewId), state.previews.map { it.id })
+      assertEquals(0x20, state.previews.single().uiMode)
+    } finally {
+      System.clearProperty("composeai.cli.libDaemonDesktopDir")
+      System.clearProperty("composeai.cli.libRendererDir")
+    }
+  }
+
+  @Test
+  fun `only consumer shared ABI dependencies overlay daemon internals`() {
+    fun coordinate(group: String, artifact: String) =
+      BundleReader.ClasspathEntry.Maven(group, artifact, "1", "jar")
+
+    assertTrue(
+      ServeBundleDaemon.shouldPrecedeDaemonSidecar(
+        coordinate("androidx.compose.material3", "material3")
+      )
+    )
+    assertTrue(
+      ServeBundleDaemon.shouldPrecedeDaemonSidecar(
+        coordinate("org.jetbrains.kotlinx", "kotlinx-coroutines-core-jvm")
+      )
+    )
+    assertTrue(
+      ServeBundleDaemon.shouldPrecedeDaemonSidecar(
+        coordinate("org.jetbrains.kotlinx", "kotlinx-io-bytestring-jvm")
+      ),
+      "bundle kotlinx-io must win because the child delegates its packages to the daemon parent",
+    )
+    assertTrue(
+      ServeBundleDaemon.shouldPrecedeDaemonSidecar(
+        coordinate("org.jetbrains.compose.components", "components-resources")
+      ),
+      "bundle resource APIs must share the parent-loaded LocalResourceReader with the daemon",
+    )
+    // Compose Multiplatform is `org.jetbrains.compose.*` by group but ships `androidx.compose.*`
+    // packages, which `mustDelegateToParent` force-delegates. Keyed on the group alone, these fell
+    // into the isolated child, were never consulted, and the sidecar's own Compose answered — a
+    // consumer pinning a different version got NoSuchMethodError mid-render (meshcore-mobile on
+    // material3 1.10.0-alpha05: `AppBarKt.TopAppBar-gNPyAyM`).
+    for (group in
+      listOf(
+        "org.jetbrains.compose.material3",
+        "org.jetbrains.compose.ui",
+        "org.jetbrains.compose.foundation",
+        "org.jetbrains.compose.animation",
+        "org.jetbrains.compose.runtime",
+        "org.jetbrains.compose.material",
+      )) {
+      assertTrue(
+        ServeBundleDaemon.shouldPrecedeDaemonSidecar(coordinate(group, "whatever-desktop")),
+        "$group ships androidx.compose.* packages, so the consumer ABI must win over the sidecar",
+      )
+    }
+    // Skiko must travel WITH Compose. `skiko-awt` carries the `org.jetbrains.skia.*` bindings that
+    // mustDelegateToParent force-delegates as well as `org.jetbrains.skiko.*`; promoting Compose
+    // without it pairs the consumer's newer bindings with the sidecar's older native library —
+    // the UnsatisfiedLinkError on skia.paragraph.TextStyleKt._nSetFontEdging that
+    // DesktopRendererGraphAlignmentFunctionalTest documents (#1844).
+    assertTrue(
+      ServeBundleDaemon.shouldPrecedeDaemonSidecar(coordinate("org.jetbrains.skiko", "skiko-awt")),
+      "Skiko bindings and native must stay version-coherent with the promoted Compose graph",
+    )
+    assertTrue(
+      !ServeBundleDaemon.shouldPrecedeDaemonSidecar(
+        coordinate("org.jetbrains.kotlinx", "kotlinx-serialization-json-jvm")
+      ),
+      "daemon protocol serializers must remain version-aligned with the sidecar runtime",
+    )
+    assertTrue(
+      !ServeBundleDaemon.shouldPrecedeDaemonSidecar(coordinate("com.squareup.okhttp3", "okhttp"))
+    )
+  }
+
+  @Test
+  fun `playground shared runtimes overlay daemon sidecar by artifact path`() {
+    assertTrue(
+      ServeBundleDaemon.jarPrecedesDaemonSidecar(
+        File("/cache/org.jetbrains.compose.components/components-resources-desktop/library.jar")
+      )
+    )
+    assertTrue(
+      ServeBundleDaemon.jarPrecedesDaemonSidecar(
+        File("/cache/org.jetbrains.kotlinx/kotlinx-io-bytestring-jvm/0.9.1/library.jar")
+      )
+    )
+    assertTrue(
+      ServeBundleDaemon.jarPrecedesDaemonSidecar(
+        File("/m2/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.9.1/library.jar")
+      )
+    )
+    // The whole Compose Multiplatform graph, in both cache layouts — not just components-resources.
+    assertTrue(
+      ServeBundleDaemon.jarPrecedesDaemonSidecar(
+        File("/cache/org.jetbrains.compose.material3/material3-desktop/1.10.0-alpha05/lib.jar")
+      ),
+      "material3-desktop ships androidx.compose.material3, which the child delegates to the parent",
+    )
+    assertTrue(
+      ServeBundleDaemon.jarPrecedesDaemonSidecar(
+        File("/m2/org/jetbrains/compose/ui/ui-desktop/1.11.1/ui-desktop-1.11.1.jar")
+      )
+    )
+    assertTrue(
+      ServeBundleDaemon.jarPrecedesDaemonSidecar(
+        File("/cache/org.jetbrains.skiko/skiko-awt/0.9.4.2/skiko-awt-0.9.4.2.jar")
+      ),
+      "Skiko carries the parent-delegated org.jetbrains.skia bindings, so it moves with Compose",
+    )
+    assertTrue(
+      ServeBundleDaemon.jarPrecedesDaemonSidecar(
+        File("/m2/org/jetbrains/skiko/skiko-awt-runtime-linux-x64/0.9.4.2/native.jar")
+      ),
+      "the native runtime artifact must not be split from its bindings",
+    )
+    assertTrue(
+      !ServeBundleDaemon.jarPrecedesDaemonSidecar(
+        File("/work/catalog-kotlinx-io-demo/cache/com.example/unrelated/library.jar")
+      ),
+      "a system or work-root name must not promote unrelated jars to the daemon parent",
+    )
+    assertTrue(
+      !ServeBundleDaemon.jarPrecedesDaemonSidecar(
+        File("/work/org.jetbrains.composure/thing/library.jar")
+      ),
+      "a group merely prefixed by org.jetbrains.compose must not be promoted",
+    )
+  }
+
+  @Test
+  fun `materialize produces a valid descriptor plus previews from a packed desktop bundle`() {
+    val state = materializeOrSkip("descriptor-shape") ?: return
+
+    val descriptorFile = state.descriptor
+    assertTrue(descriptorFile.isFile, "daemon-launch.json should exist at ${descriptorFile.path}")
+    val parsed =
+      descriptorJson.decodeFromString(
+        DaemonLaunchDescriptor.serializer(),
+        descriptorFile.readText(),
+      )
+
+    assertEquals("ee.schimke.composeai.daemon.DaemonMain", parsed.mainClass)
+    assertEquals("desktop", parsed.variant)
+    assertEquals(":catalog", parsed.modulePath)
+    assertTrue(parsed.enabled)
+    assertTrue(parsed.classpath.isNotEmpty(), "daemon classpath should not be empty")
+    assertTrue(
+      parsed.classpath.all { File(it).isFile },
+      "every daemon classpath entry should exist on disk: ${parsed.classpath}",
+    )
+    assertEquals(listOf("--enable-native-access=ALL-UNNAMED"), parsed.jvmArgs)
+
+    val userClassDirs = parsed.systemProperties["composeai.daemon.userClassDirs"]
+    assertTrue(!userClassDirs.isNullOrBlank(), "userClassDirs sysprop should be set")
+    assertTrue(
+      userClassDirs.split(File.pathSeparator).all { File(it).exists() },
+      "every userClassDirs entry should exist on disk: $userClassDirs",
+    )
+    val previewsJsonPath = parsed.systemProperties["composeai.daemon.previewsJsonPath"]
+    assertTrue(!previewsJsonPath.isNullOrBlank())
+    assertTrue(File(previewsJsonPath).isFile)
+    assertEquals(previewsJsonPath, parsed.manifestPath)
+    assertEquals(state.workspaceRoot.absolutePath, parsed.workingDirectory)
+
+    // The render-output dir must be set so DaemonMain.dataRoot is non-null and the file-based data
+    // products register — notably compose/figma-svg, without which an override-bearing .svg render
+    // fails "-32020 kind not advertised". It must sit under the working dir so its sibling `data/`
+    // (where both DaemonMain's registry and RenderEngine's producer resolve) is inside this
+    // session's temp tree.
+    val outputDir = parsed.systemProperties["composeai.render.outputDir"]
+    assertTrue(
+      !outputDir.isNullOrBlank(),
+      "composeai.render.outputDir must be set so figma-svg registers",
+    )
+    assertEquals(
+      File(state.workspaceRoot, "renders").absolutePath,
+      outputDir,
+      "output dir lives under the session dir, so its sibling data/ dir does too",
+    )
+
+    assertTrue(state.previews.isNotEmpty(), "materialize should discover at least one preview")
+    assertEquals("compose-m3", state.label)
+
+    // The author-declared knob sidecars (`previews/<id>.overrides.json`) must be folded into the
+    // ServePreview set so the daemon-backed session (and, via ServeCatalogLiveHost, the baked
+    // browse
+    // surface) can advertise the editable knobs. The M3 catalog's FilledButton declares a `label`
+    // string knob; assert it round-trips from the packed bundle.
+    val filled = state.previews.firstOrNull { it.id.endsWith("FilledButton_Light") }
+    if (filled != null) {
+      assertTrue(
+        filled.overrides.any { it.key == "label" },
+        "FilledButton should carry its declared `label` knob, got ${filled.overrides}",
+      )
+    }
+  }
+
+  @Test
+  fun `materialized bundle renders one preview through a real daemon`() {
+    val state = materializeOrSkip("live-render") ?: return
+    val targetId = state.previews.first().id
+
+    val session =
+      try {
+        SubprocessRenderSessions.open(
+          RenderSessionConfig(
+            descriptorPath = state.descriptor,
+            workspaceRoot = state.workspaceRoot,
+            workspaceName = state.workspaceName,
+            logSink = { line -> System.err.println("[daemon] $line") },
+          )
+        )
+      } catch (e: Exception) {
+        System.err.println(
+          "[ServeBundleDaemonTest] skipping live render — daemon failed to open (${e.message}). " +
+            "Needs a display (run under xvfb-run + LIBGL_ALWAYS_SOFTWARE=1) and the CLI's " +
+            "installDist sidecars."
+        )
+        return
+      }
+
+    session.use {
+      val finished = AtomicReference<String?>(null)
+      val latch = CountDownLatch(1)
+      session
+        .onNotification { method, params ->
+          if (method == "renderFinished" && params != null) {
+            val id = params["id"]?.jsonPrimitive?.contentOrNull
+            if (id == targetId) {
+              finished.set(params["pngPath"]?.jsonPrimitive?.contentOrNull)
+              latch.countDown()
+            }
+          }
+        }
+        .use {
+          val ack = session.renderNow(previewIds = listOf(targetId), tier = RenderTier.FULL)
+          assertTrue(
+            ack.rejected.none { it.id == targetId },
+            "renderNow should queue $targetId, got rejected=${ack.rejected}",
+          )
+          assertTrue(
+            latch.await(90, TimeUnit.SECONDS),
+            "daemon should emit renderFinished for $targetId within 90s",
+          )
+        }
+
+      val pngPath = finished.get()
+      assertTrue(!pngPath.isNullOrBlank(), "renderFinished should carry a pngPath")
+      val png = File(pngPath)
+      assertTrue(png.isFile, "rendered PNG must exist on disk: $pngPath")
+      assertTrue(png.length() > 0L)
+    }
+  }
+
+  @Test
+  fun `materialized m3 button surfaces its Material typography in preview inspection`() {
+    val state = materializeOrSkip("typography-inspection") ?: return
+    val target =
+      assertNotNull(
+        state.previews.firstOrNull { it.id.endsWith("CatalogButtonsKt.FilledButton_Light") },
+        "packed m3 catalog should contain the typical FilledButton_Light preview",
+      )
+
+    val host =
+      ServeRenderHost.open(
+        descriptorPath = state.descriptor,
+        workspaceRoot = state.workspaceRoot,
+        workspaceName = state.workspaceName,
+        previews = state.previews,
+        label = state.label,
+        declaredThemes = state.declaredThemes,
+        onLog = { line -> System.err.println("[daemon] $line") },
+      )
+
+    host.use {
+      val outcome = host.renderAnnotations(target.id, PreviewOverrides())
+      assertTrue(
+        outcome is AnnotationsOutcome.Ok,
+        "typography inspection for ${target.id} should succeed, got $outcome",
+      )
+      val payload = Json.parseToJsonElement(outcome.json.decodeToString()).jsonObject
+      val annotations =
+        Json.decodeFromJsonElement(
+          ListSerializer(DesignAnnotation.serializer()),
+          payload.getValue("annotations"),
+        )
+      val label =
+        assertNotNull(
+          annotations.firstOrNull { it.kind == AnnotationKind.TYPOGRAPHY && it.role == "Filled" },
+          "the Filled button label should be available in the Typography inspection layer",
+        )
+
+      assertTrue(
+        label.detail["token"]?.split(',')?.contains("labelLarge") == true,
+        "the stock Button label should resolve to the Material labelLarge token: $label",
+      )
+      assertTrue(!label.detail["fontSize"].isNullOrBlank(), "fontSize should be resolved: $label")
+      assertTrue(
+        !label.detail["fontFamily"].isNullOrBlank(),
+        "fontFamily should be resolved: $label",
+      )
+      assertTrue(
+        !label.detail["fontWeight"].isNullOrBlank(),
+        "fontWeight should be resolved: $label",
+      )
+    }
+  }
+
+  /**
+   * Production compatibility proof for a published Android catalog whose Compose/AndroidX/Kotlin
+   * dependencies differ from the daemon sidecar's. This caught Jetcaster's
+   * `MotionScheme.expressive()` / mangled `TopAppBar` failures: materialization used to leave the
+   * catalog dependency graph in the child loader even though those packages delegate to the parent,
+   * so the older sidecar APIs won.
+   *
+   * Self-skips unless `-Dcomposeai.test.androidCompatibilityBundlePath=<bundle.png>` is supplied.
+   * Optionally select a known compatibility-sensitive preview with
+   * `-Dcomposeai.test.androidCompatibilityPreviewContains=<substring>`; otherwise the first preview
+   * is rendered.
+   */
+  @Test
+  fun `android bundle renders against its carried dependency versions`() {
+    val bundlePath = System.getProperty(ANDROID_COMPATIBILITY_BUNDLE_PATH_PROPERTY)
+    if (bundlePath.isNullOrBlank()) {
+      System.err.println(
+        "[ServeBundleDaemonTest] skipping android dependency compatibility — set " +
+          "-D$ANDROID_COMPATIBILITY_BUNDLE_PATH_PROPERTY=<published android bundle .png>."
+      )
+      return
+    }
+    val bundleFile = File(bundlePath)
+    assertTrue(bundleFile.isFile, "no compatibility bundle at $bundlePath")
+    ensureAppHomeConfigured()
+
+    val state =
+      assertNotNull(
+        ServeBundleDaemon.materialize(
+          bundleFile,
+          Files.createTempDirectory("serve-bundle-daemon-android-compat").toFile(),
+          "android-compatibility",
+        ),
+        "published Android compatibility bundle should materialize",
+      )
+    val parsed =
+      descriptorJson.decodeFromString(
+        DaemonLaunchDescriptor.serializer(),
+        state.descriptor.readText(),
+      )
+    val firstSidecar =
+      parsed.classpath.indexOfFirst {
+        it.contains("staged-daemon-android-libs") || it.contains("lib-daemon-android")
+      }
+    assertTrue(firstSidecar > 0, "descriptor should contain bundle dependencies before the sidecar")
+    assertTrue(
+      parsed.classpath.take(firstSidecar).any { it.contains("bundle-deps") },
+      "at least one bundle-resolved dependency should precede the Android daemon sidecar",
+    )
+
+    val selector = System.getProperty(ANDROID_COMPATIBILITY_PREVIEW_CONTAINS_PROPERTY)
+    val target =
+      selector?.let { needle -> state.previews.firstOrNull { needle in it.id } }
+        ?: state.previews.firstOrNull()
+    assertNotNull(target, "compatibility bundle should contain a selectable preview")
+
+    ServeRenderHost.open(
+        descriptorPath = state.descriptor,
+        workspaceRoot = state.workspaceRoot,
+        workspaceName = state.workspaceName,
+        previews = state.previews,
+        label = state.label,
+        declaredThemes = state.declaredThemes,
+        onLog = { line -> System.err.println("[android compatibility daemon] $line") },
+      )
+      .use { host ->
+        var outcome: RenderOutcome? = null
+        repeat(3) {
+          outcome = host.render(target.id, PreviewOverrides())
+          if (outcome is RenderOutcome.Ok) return@use
+        }
+        assertTrue(
+          outcome is RenderOutcome.Ok,
+          "catalog preview ${target.id} should render with its carried dependency APIs; got $outcome",
+        )
+      }
+  }
+
+  /**
+   * The load-bearing proof for the **android** backend: an Android/Wear catalog's `liveBundle`
+   * materialises to a Robolectric daemon whose `compose/figma-svg` lane is **per-variant** — the
+   * fix for the baked `figma/<slug>.svg` collapsing every state/selection variant of a component
+   * onto one vector (`FilledButton` == `ButtonDisabled` == … in the served SVG). Renders the SVG
+   * for pairs that share a slug but differ in state and asserts the bytes differ.
+   *
+   * Self-skips unless pointed at a packed **android** bundle via
+   * `-Dcomposeai.test.androidBundlePath` (pack one with
+   * `:samples:design-catalog-wear-m3:composePreviewBundle`) with the Android daemon sidecar
+   * reachable (`-Dcomposeai.cli.libDaemonAndroidDir=<…>/staged-daemon-android-libs`) and a local
+   * Android SDK (`ANDROID_HOME`/`ANDROID_SDK_ROOT`). The first render cold-starts Robolectric
+   * (fetches `android-all-instrumented`), so the budget is generous.
+   */
+  @Test
+  fun `android bundle serves per-variant SVG through a real Robolectric daemon`() {
+    val bundlePath = System.getProperty(ANDROID_BUNDLE_PATH_PROPERTY)
+    if (bundlePath.isNullOrBlank()) {
+      System.err.println(
+        "[ServeBundleDaemonTest] skipping android per-variant SVG — set " +
+          "-D$ANDROID_BUNDLE_PATH_PROPERTY=<wear bundle .png> (from " +
+          "`:samples:design-catalog-wear-m3:composePreviewBundle`)."
+      )
+      return
+    }
+    val bundleFile = File(bundlePath)
+    if (!bundleFile.isFile) {
+      System.err.println("[ServeBundleDaemonTest] skipping android — no bundle at $bundlePath")
+      return
+    }
+    ensureAppHomeConfigured()
+
+    val destDir = Files.createTempDirectory("serve-bundle-daemon-android").toFile()
+    val state = ServeBundleDaemon.materialize(bundleFile, destDir, "wear-m3")
+    if (state == null) {
+      System.err.println(
+        "[ServeBundleDaemonTest] skipping android — materialize returned null (see log). Needs the " +
+          "lib-daemon-android sidecar (-Dcomposeai.cli.libDaemonAndroidDir=…) + android.jar " +
+          "(ANDROID_HOME/ANDROID_SDK_ROOT)."
+      )
+      return
+    }
+    // Sanity: the descriptor really is the android launch (Robolectric flags present).
+    val parsed =
+      descriptorJson.decodeFromString(
+        DaemonLaunchDescriptor.serializer(),
+        state.descriptor.readText(),
+      )
+    assertEquals("android", parsed.variant, "wear-m3 bundle should materialize an android daemon")
+    assertTrue(
+      parsed.systemProperties["robolectric.graphicsMode"] == "NATIVE",
+      "android descriptor should carry the robolectric.* render flags",
+    )
+    assertTrue(
+      parsed.systemProperties["composeai.daemon.backgroundSandboxBoot"] == "true",
+      "serve-spawned android daemons should default to background pool boot (fast cold start)",
+    )
+
+    val host =
+      try {
+        ServeRenderHost.open(
+          descriptorPath = state.descriptor,
+          workspaceRoot = state.workspaceRoot,
+          workspaceName = state.workspaceName,
+          previews = state.previews,
+          label = state.label,
+          declaredThemes = state.declaredThemes,
+          onLog = { line -> System.err.println("[android daemon] $line") },
+        )
+      } catch (e: Exception) {
+        System.err.println(
+          "[ServeBundleDaemonTest] skipping android live render — daemon failed to open " +
+            "(${e.message})."
+        )
+        return
+      }
+
+    host.use {
+      val ids = state.previews.map { it.id }
+      // Warm the Robolectric daemon: its FIRST render cold-starts (android-all instrumentation +
+      // Compose init) and can blow the host's internal 180s render budget. The daemon stays alive
+      // across a timed-out render, so retry a throwaway PNG render until one lands before timing
+      // the
+      // real per-variant SVG lane. Skip (not fail) if it never warms — that's an
+      // environment-too-slow
+      // signal, not a regression.
+      val warmId = ids.firstOrNull { it.endsWith("CatalogPreviewsKt.FilledButton") } ?: ids.first()
+      var warm = false
+      for (attempt in 1..4) {
+        when (val r = host.render(warmId, PreviewOverrides())) {
+          is RenderOutcome.Ok -> {
+            warm = true
+            break
+          }
+          else -> System.err.println("[android daemon] warm-up attempt $attempt: $r")
+        }
+      }
+      // A daemon that never warms is an environment signal (a box too slow/small to cold-start
+      // Robolectric), NOT a pass — mark it SKIPPED via Assume so it can't masquerade as green while
+      // the per-variant assertions below never ran.
+      org.junit.jupiter.api.Assumptions.assumeTrue(
+        warm,
+        "android daemon never warmed after 4 render attempts (cold Robolectric start too slow " +
+          "for this box) — skipping the per-variant SVG assertions",
+      )
+
+      // Slug-sharing state pairs that the baked per-slug SVG collapses; each must now differ.
+      // The `off` / `disabled` halves are `@OverrideVariant` captures riding the primary function,
+      // so they are `<fn>_VARIANT_<name>` rather than separate `*Off` / `*Disabled` functions —
+      // naming those long-deleted wrappers made every pair `continue` past its assertion.
+      val pairs =
+        listOf(
+          "CatalogPreviewsKt.FilledButton" to "CatalogPreviewsKt.FilledButton_VARIANT_disabled",
+          "CatalogPreviewsKt.SwitchButtonOn" to "CatalogPreviewsKt.SwitchButtonOn_VARIANT_off",
+        )
+      var checked = 0
+      for ((aSuffix, bSuffix) in pairs) {
+        val aId = ids.firstOrNull { it.endsWith(aSuffix) } ?: continue
+        val bId = ids.firstOrNull { it.endsWith(bSuffix) } ?: continue
+        val a = host.renderSvg(aId, PreviewOverrides())
+        val b = host.renderSvg(bId, PreviewOverrides())
+        assertTrue(a is SvgOutcome.Ok, "SVG render of $aId should succeed, got $a")
+        assertTrue(b is SvgOutcome.Ok, "SVG render of $bId should succeed, got $b")
+        val aBytes = a.svg
+        val bBytes = b.svg
+        assertTrue(aBytes.isNotEmpty() && bBytes.isNotEmpty(), "SVGs must be non-empty")
+        // Optional: dump the rendered vectors so a human can eyeball the per-variant difference.
+        System.getProperty("composeai.test.svgDumpDir")
+          ?.takeIf { it.isNotBlank() }
+          ?.let { dir ->
+            File(dir).mkdirs()
+            File(dir, "$aSuffix.svg").writeBytes(aBytes)
+            File(dir, "$bSuffix.svg").writeBytes(bBytes)
+          }
+        assertTrue(
+          !aBytes.contentEquals(bBytes),
+          "per-variant SVG regression: $aSuffix and $bSuffix rendered byte-identical SVGs " +
+            "(the daemon collapsed the state variant)",
+        )
+        checked++
+      }
+      assertTrue(checked > 0, "expected at least one slug-sharing state pair in the wear bundle")
+    }
+  }
+
+  /**
+   * Locates the bundle + sidecars and calls [ServeBundleDaemon.materialize] into a fresh temp dir
+   * under [label], or logs why and returns `null` so the caller self-skips.
+   */
+  private fun materializeOrSkip(label: String): ServeSessionState? {
+    val bundlePath = System.getProperty(BUNDLE_PATH_PROPERTY) ?: DEFAULT_BUNDLE_PATH
+    val bundleFile = File(bundlePath)
+    if (!bundleFile.isFile) {
+      System.err.println(
+        "[ServeBundleDaemonTest] skipping ($label) — no bundle at $bundlePath. Pack one via " +
+          "`compose-preview bundle pack --module :samples:design-catalog-m3 -o $bundlePath`."
+      )
+      return null
+    }
+
+    ensureAppHomeConfigured()
+
+    val destDir = Files.createTempDirectory("serve-bundle-daemon-test-$label").toFile()
+    val state = ServeBundleDaemon.materialize(bundleFile, destDir, "compose-m3")
+    if (state == null) {
+      System.err.println(
+        "[ServeBundleDaemonTest] skipping ($label) — materialize returned null (see log above); " +
+          "likely missing lib-daemon-desktop/lib-renderer sidecars. Run `:cli:installDist` and/or " +
+          "pass -Dcomposeai.cli.appHome=<install-root>."
+      )
+      return null
+    }
+    return state
+  }
+
+  /**
+   * If no explicit `-Dcomposeai.cli.appHome` override is set, point it at this checkout's own
+   * `cli/build/install/compose-preview/` when that `:cli:installDist` output exists — lets the test
+   * run end to end in a normal dev/CI checkout without extra flags, while still respecting an
+   * explicit override.
+   */
+  private fun ensureAppHomeConfigured() {
+    if (System.getProperty(APP_HOME_PROPERTY) != null) return
+    val installDir = File(locateRepoRoot(), "cli/build/install/compose-preview")
+    if (installDir.isDirectory) {
+      System.setProperty(APP_HOME_PROPERTY, installDir.absolutePath)
+    }
+  }
+
+  /** Walk up from the test JVM's working dir to find the repo root (has `settings.gradle.kts`). */
+  private fun locateRepoRoot(): File {
+    var dir: File? = File(".").canonicalFile
+    while (dir != null) {
+      if (File(dir, "settings.gradle.kts").isFile) return dir
+      dir = dir.parentFile
+    }
+    error("Could not locate repo root above ${File(".").canonicalFile}")
+  }
+
+  private companion object {
+    const val BUNDLE_PATH_PROPERTY = "composeai.test.bundlePath"
+    const val ANDROID_BUNDLE_PATH_PROPERTY = "composeai.test.androidBundlePath"
+    const val ANDROID_COMPATIBILITY_BUNDLE_PATH_PROPERTY =
+      "composeai.test.androidCompatibilityBundlePath"
+    const val ANDROID_COMPATIBILITY_PREVIEW_CONTAINS_PROPERTY =
+      "composeai.test.androidCompatibilityPreviewContains"
+    const val APP_HOME_PROPERTY = "composeai.cli.appHome"
+    const val DEFAULT_BUNDLE_PATH = "/tmp/m3-bundle.png"
+
+    val descriptorJson = Json { ignoreUnknownKeys = true }
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonWeightTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonWeightTest.kt
@@ -1,0 +1,90 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.DaemonLaunchDescriptor
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.serialization.json.Json
+
+/**
+ * Guards [ServeBundleDaemon.liveSeatWeightForDescriptor] — the backend-weight detector for the
+ * Gradle **source-build** catalog path, which has no bundle `manifest.backend` to read and instead
+ * sniffs the built daemon descriptor's `robolectric.*` sysprops. Without this, a source-served
+ * Android catalog would be charged as a cheap desktop daemon and undercut the live-seat budget's
+ * OOM protection.
+ */
+class ServeBundleDaemonWeightTest {
+
+  private val json = Json { encodeDefaults = true }
+
+  private fun descriptorFile(
+    systemProperties: Map<String, String>,
+    jvmArgs: List<String> = emptyList(),
+  ): File {
+    val descriptor =
+      DaemonLaunchDescriptor(
+        schemaVersion = 2,
+        modulePath = ":catalog",
+        variant = "debug",
+        enabled = true,
+        mainClass = "ee.schimke.composeai.daemon.DaemonMain",
+        classpath = listOf("app.jar"),
+        jvmArgs = jvmArgs,
+        systemProperties = systemProperties,
+        workingDirectory = ".",
+        manifestPath = "previews.json",
+      )
+    return File.createTempFile("daemon-launch", ".json").apply {
+      deleteOnExit()
+      writeText(json.encodeToString(DaemonLaunchDescriptor.serializer(), descriptor))
+    }
+  }
+
+  @Test
+  fun `an Android descriptor (robolectric sysprops) is charged the Android weight`() {
+    val file =
+      descriptorFile(
+        systemProperties =
+          mapOf("robolectric.graphicsMode" to "NATIVE", "robolectric.looperMode" to "PAUSED")
+      )
+    assertEquals(
+      ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT,
+      ServeBundleDaemon.liveSeatWeightForDescriptor(file),
+    )
+  }
+
+  @Test
+  fun `robolectric flags carried as jvm args are also detected`() {
+    val file =
+      descriptorFile(
+        systemProperties = emptyMap(),
+        jvmArgs =
+          listOf(
+            "-Drobolectric.graphicsMode=NATIVE",
+            "--add-opens=java.base/java.lang=ALL-UNNAMED",
+          ),
+      )
+    assertEquals(
+      ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT,
+      ServeBundleDaemon.liveSeatWeightForDescriptor(file),
+    )
+  }
+
+  @Test
+  fun `a desktop descriptor (no robolectric) keeps weight 1`() {
+    val file =
+      descriptorFile(
+        systemProperties = mapOf("composeai.daemon.userClassDirs" to "classes"),
+        jvmArgs = listOf("--enable-native-access=ALL-UNNAMED"),
+      )
+    assertEquals(1, ServeBundleDaemon.liveSeatWeightForDescriptor(file))
+  }
+
+  @Test
+  fun `a missing or unreadable descriptor defaults to weight 1`() {
+    assertEquals(
+      1,
+      ServeBundleDaemon.liveSeatWeightForDescriptor(File("/no/such/daemon-launch.json")),
+    )
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeDesignAnnotationsTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeDesignAnnotationsTest.kt
@@ -1,0 +1,476 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsInsets
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsNode
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsTokens
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsTypography
+import ee.schimke.composeai.data.layoutinspector.LayoutInspectorBounds
+import ee.schimke.composeai.data.layoutinspector.LayoutInspectorGradient
+import ee.schimke.composeai.data.layoutinspector.LayoutInspectorNode
+import ee.schimke.composeai.data.layoutinspector.LayoutInspectorPayload
+import ee.schimke.composeai.data.layoutinspector.LayoutInspectorSize
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The viewer's derived inspection layers (issue #4328).
+ *
+ * The theme layer used to quote eight of the ~18 tokens a capture resolves and there was no
+ * code-side layout layer at all, so the redline values a layout diff is argued in — the box's own
+ * size, its padding, the arrangement gap — had no surface. These tests pin what each layer says
+ * about a node, since a wrong-but-plausible label looks exactly like a right one on screen.
+ */
+class ServeDesignAnnotationsTest {
+
+  private fun node(
+    nodeId: String = "1",
+    bounds: String = "0,0,100,50",
+    tokens: ComposeSemanticsTokens? = null,
+    role: String? = null,
+    typography: ComposeSemanticsTypography? = null,
+    placed: Boolean = true,
+    children: List<ComposeSemanticsNode> = emptyList(),
+  ) =
+    ComposeSemanticsNode(
+      nodeId = nodeId,
+      boundsInRoot = bounds,
+      role = role,
+      typography = typography,
+      tokens = tokens,
+      placed = placed,
+      children = children,
+    )
+
+  private fun annotationsOf(root: ComposeSemanticsNode) =
+    ServeDesignAnnotations.annotations(ComposeSemanticsPayload(root))
+
+  /** A `LayoutNode` as `layout/inspector` reports it: no semantics needed, and none implied. */
+  private fun layoutNode(
+    nodeId: String = "1",
+    component: String = "Box",
+    displayName: String? = null,
+    bounds: LayoutInspectorBounds = LayoutInspectorBounds(0, 0, 100, 50),
+    tokens: ComposeSemanticsTokens? = null,
+    placed: Boolean = true,
+    children: List<LayoutInspectorNode> = emptyList(),
+  ) =
+    LayoutInspectorNode(
+      nodeId = nodeId,
+      component = component,
+      displayName = displayName,
+      bounds = bounds,
+      size = LayoutInspectorSize(bounds.right - bounds.left, bounds.bottom - bounds.top),
+      placed = placed,
+      tokens = tokens,
+      children = children,
+    )
+
+  /** The projection as the render host drives it: a semantics tree AND a layout tree. */
+  private fun annotationsOf(semantics: ComposeSemanticsNode, layout: LayoutInspectorNode) =
+    ServeDesignAnnotations.annotations(
+      ComposeSemanticsPayload(semantics),
+      layout = LayoutInspectorPayload(layout),
+    )
+
+  private fun themeOf(root: ComposeSemanticsNode) =
+    annotationsOf(root).single { it.kind == AnnotationKind.THEME }
+
+  private fun layoutOf(root: ComposeSemanticsNode) =
+    annotationsOf(root).filter { it.kind == AnnotationKind.LAYOUT }
+
+  @Test
+  fun `theme label carries the shadow, alpha and clip the old subset dropped`() {
+    val annotation =
+      themeOf(
+        node(
+          role = "Button",
+          tokens =
+            ComposeSemanticsTokens(
+              backgroundColor = "#FF6750A4",
+              cornerRadius = "20.0dp",
+              elevation = "6.0dp",
+              opacity = 0.5,
+              clipsContent = true,
+            ),
+        )
+      )
+
+    assertEquals(
+      "fill #FF6750A4 · radius 20.0dp · elevation 6.0dp · alpha 0.5 · clip",
+      annotation.label,
+    )
+    assertEquals("Button", annotation.role)
+    assertEquals("6.0dp", annotation.detail["elevation"])
+    assertEquals("0.5", annotation.detail["opacity"])
+    assertEquals("true", annotation.detail["clipsContent"])
+  }
+
+  @Test
+  fun `a fully opaque node says nothing about its alpha`() {
+    // `alpha 1` on every second box is noise: it is the value a reader already assumes.
+    val annotation =
+      themeOf(node(tokens = ComposeSemanticsTokens(backgroundColor = "#FF000000", opacity = 1.0)))
+
+    assertEquals("fill #FF000000", annotation.label)
+    assertEquals("1", annotation.detail["opacity"])
+  }
+
+  @Test
+  fun `a gradient is named by its stops rather than the bare word`() {
+    val annotation =
+      themeOf(
+        node(
+          tokens =
+            ComposeSemanticsTokens(
+              backgroundGradient =
+                LayoutInspectorGradient(
+                  colors = listOf("#FF6750A4", "#FF625B71"),
+                  stops = listOf(0f, 1f),
+                )
+            )
+        )
+      )
+
+    assertEquals("fill gradient #FF6750A4→#FF625B71", annotation.label)
+    assertEquals(
+      "#FF6750A4@0 → #FF625B71@1 (horizontal)",
+      annotation.detail["backgroundGradient"],
+    )
+  }
+
+  @Test
+  fun `theme anchors to the box the paint actually landed in`() {
+    // `padding(4.dp).clip(…).background(…)` paints inside the placement box; outlining the
+    // placement box reports a radius against geometry that was never painted.
+    val annotation =
+      themeOf(
+        node(
+          bounds = "0,0,100,50",
+          tokens =
+            ComposeSemanticsTokens(
+              backgroundColor = "#FF000000",
+              paintBox = LayoutInspectorBounds(left = 4, top = 4, right = 96, bottom = 46),
+            ),
+        )
+      )
+
+    assertEquals(AnnotationBounds(x = 4, y = 4, width = 92, height = 42), annotation.bounds)
+    assertEquals("paint", annotation.detail["box"])
+  }
+
+  @Test
+  fun `theme falls back to the placement box when no paint box was captured`() {
+    // And says nothing about which box: `box placement` on every ordinary container is a row that
+    // carries no information. The key marks the exception, not the rule.
+    val annotation = themeOf(node(tokens = ComposeSemanticsTokens(backgroundColor = "#FF000000")))
+
+    assertEquals(AnnotationBounds(x = 0, y = 0, width = 100, height = 50), annotation.bounds)
+    assertNull(annotation.detail["box"])
+  }
+
+  @Test
+  fun `a paint box identical to the placement box is not called out either`() {
+    val annotation =
+      themeOf(
+        node(
+          bounds = "0,0,100,50",
+          tokens =
+            ComposeSemanticsTokens(
+              backgroundColor = "#FF000000",
+              paintBox = LayoutInspectorBounds(left = 0, top = 0, right = 100, bottom = 50),
+            ),
+        )
+      )
+
+    assertEquals(AnnotationBounds(x = 0, y = 0, width = 100, height = 50), annotation.bounds)
+    assertNull(annotation.detail["box"])
+  }
+
+  @Test
+  fun `a node declaring no container tokens contributes no theme box`() {
+    assertTrue(annotationsOf(node()).none { it.kind == AnnotationKind.THEME })
+  }
+
+  @Test
+  fun `layout quotes the box size and the tokens that shaped it`() {
+    val annotation =
+      layoutOf(
+          node(
+            bounds = "10,20,130,68",
+            tokens =
+              ComposeSemanticsTokens(
+                padding = ComposeSemanticsInsets(start = "16.0dp", top = "16.0dp"),
+                gap = "8.0dp",
+                minWidth = "48.0dp",
+                minHeight = "48.0dp",
+              ),
+          )
+        )
+        .single()
+
+    assertEquals(
+      "120×48px · pad 16.0dp 0.0dp 0.0dp 16.0dp · gap 8.0dp · min 48.0dp×48.0dp",
+      annotation.label,
+    )
+    assertEquals("120px", annotation.detail["width"])
+    assertEquals("48px", annotation.detail["height"])
+    assertEquals("10px", annotation.detail["x"])
+    assertEquals("top 16.0dp, start 16.0dp", annotation.detail["padding"])
+  }
+
+  @Test
+  fun `a uniform padding reads as one number and a symmetric one as two`() {
+    val uniform = ComposeSemanticsInsets("8.0dp", "8.0dp", "8.0dp", "8.0dp")
+    val symmetric =
+      ComposeSemanticsInsets(start = "16.0dp", top = "8.0dp", end = "16.0dp", bottom = "8.0dp")
+
+    assertEquals(
+      "100×50px · pad 8.0dp",
+      layoutOf(node(tokens = ComposeSemanticsTokens(padding = uniform))).single().label,
+    )
+    assertEquals(
+      "100×50px · pad 8.0dp/16.0dp",
+      layoutOf(node(tokens = ComposeSemanticsTokens(padding = symmetric))).single().label,
+    )
+  }
+
+  @Test
+  fun `every nested slot box gets a layout row`() {
+    // The value of a redline is the nesting: a component 4px wider than the kit is only
+    // diagnosable when the slot boxes inside it are on screen too.
+    val boxes =
+      layoutOf(
+        node(
+          bounds = "0,0,200,100",
+          children =
+            listOf(
+              node(nodeId = "2", bounds = "8,8,100,60"),
+              node(nodeId = "3", bounds = "108,8,192,60"),
+            ),
+        )
+      )
+
+    assertEquals(listOf("200×100px", "92×52px", "84×52px"), boxes.map { it.label })
+  }
+
+  @Test
+  fun `a wrapper that reproduces its parent's box exactly is not drawn twice`() {
+    val boxes =
+      layoutOf(
+        node(
+          bounds = "0,0,200,100",
+          children = listOf(node(nodeId = "2", bounds = "0,0,200,100")),
+        )
+      )
+
+    assertEquals(1, boxes.size)
+  }
+
+  @Test
+  fun `a wrapper on its parent's box still counts when it declares layout tokens`() {
+    // Same pixels, different fact: the inner node is where the 16dp inset comes from.
+    val boxes =
+      layoutOf(
+        node(
+          bounds = "0,0,200,100",
+          children =
+            listOf(
+              node(
+                nodeId = "2",
+                bounds = "0,0,200,100",
+                tokens = ComposeSemanticsTokens(padding = ComposeSemanticsInsets(start = "16.0dp")),
+              )
+            ),
+        )
+      )
+
+    assertEquals(2, boxes.size)
+    assertTrue(boxes[1].label.contains("pad"))
+  }
+
+  @Test
+  fun `a node with no drawable box contributes nothing at all`() {
+    assertTrue(annotationsOf(node(bounds = "10,10,10,10")).isEmpty())
+    assertTrue(annotationsOf(node(bounds = "nonsense")).isEmpty())
+  }
+
+  @Test
+  fun `pixel corners are reported when a dp radius cannot express them`() {
+    val annotation =
+      themeOf(
+        node(
+          tokens = ComposeSemanticsTokens(backgroundColor = "#FF000000", cornerRadiusPx = "20.0px")
+        )
+      )
+
+    assertTrue(annotation.label.contains("radius 20.0px"))
+    assertEquals("20.0px", annotation.detail["cornerRadiusPx"])
+    assertNull(annotation.detail["cornerRadius"])
+  }
+
+  @Test
+  fun `the layout tree supplies containers the semantics tree cannot see`() {
+    // The case the layer exists for: `Column(Modifier.padding(16.dp), Arrangement.spacedBy(8.dp))`
+    // declares no semantics at all, so walking the semantics tree finds only the text inside it and
+    // the very padding and gap this layer advertises are silently absent.
+    val semantics = node(bounds = "16,16,184,64")
+    val layout =
+      layoutNode(
+        component = "Column",
+        bounds = LayoutInspectorBounds(0, 0, 200, 100),
+        tokens =
+          ComposeSemanticsTokens(
+            padding = ComposeSemanticsInsets("16.0dp", "16.0dp", "16.0dp", "16.0dp"),
+            gap = "8.0dp",
+          ),
+        children =
+          listOf(layoutNode(nodeId = "2", bounds = LayoutInspectorBounds(16, 16, 184, 64))),
+      )
+
+    val boxes = annotationsOf(semantics, layout).filter { it.kind == AnnotationKind.LAYOUT }
+
+    assertEquals(listOf("200×100px · pad 16.0dp · gap 8.0dp", "168×48px"), boxes.map { it.label })
+    assertEquals("Column", boxes[0].role)
+  }
+
+  @Test
+  fun `container layers come from ONE tree, never both`() {
+    // Both trees carry the same mirrored tokens, so projecting both would draw every container
+    // twice — two boxes and two legend rows for one rectangle.
+    val tokens = ComposeSemanticsTokens(backgroundColor = "#FF6750A4")
+    val all =
+      annotationsOf(
+        node(bounds = "0,0,100,50", tokens = tokens),
+        layoutNode(bounds = LayoutInspectorBounds(0, 0, 100, 50), tokens = tokens),
+      )
+
+    assertEquals(1, all.count { it.kind == AnnotationKind.THEME })
+    assertEquals(1, all.count { it.kind == AnnotationKind.LAYOUT })
+  }
+
+  @Test
+  fun `a capture with no layout tree still gets both container layers`() {
+    // A daemon too old to know `layout/inspector` must not lose the layers entirely: the semantics
+    // tree mirrors the same tokens, so it falls back to fewer boxes rather than none.
+    val all = annotationsOf(node(tokens = ComposeSemanticsTokens(backgroundColor = "#FF6750A4")))
+
+    assertEquals(1, all.count { it.kind == AnnotationKind.THEME })
+    assertEquals(1, all.count { it.kind == AnnotationKind.LAYOUT })
+  }
+
+  @Test
+  fun `an unplaced semantics subtree describes nowhere on the frame`() {
+    // Wear's `AlertDialogContent` subcomposes a full trial copy of the dialog to decide whether
+    // its content has to scroll. That copy is measured and never placed, so every node in it
+    // reports the ORIGIN — and the typography layer drew a second title stacked in the frame's
+    // top-left corner (yschimke/wear-m3-catalog#77).
+    val title = ComposeSemanticsTypography(fontSize = "16.0sp", fontFamily = "Roboto Flex")
+    val boxes =
+      annotationsOf(
+          node(
+            bounds = "0,0,384,384",
+            children =
+              listOf(
+                node(nodeId = "2", bounds = "68,101,316,175", typography = title),
+                node(
+                  nodeId = "3",
+                  bounds = "0,0,384,354",
+                  placed = false,
+                  children = listOf(node(nodeId = "4", bounds = "0,0,248,74", typography = title)),
+                ),
+              ),
+          )
+        )
+        .filter { it.kind == AnnotationKind.TYPOGRAPHY }
+
+    assertEquals(listOf(AnnotationBounds(68, 101, 248, 74)), boxes.map { it.bounds })
+  }
+
+  @Test
+  fun `an unplaced layout node describes nowhere on the frame`() {
+    // Measured but never positioned: its bounds point at a rectangle the render does not contain.
+    val boxes =
+      annotationsOf(
+          node(),
+          layoutNode(
+            bounds = LayoutInspectorBounds(0, 0, 200, 100),
+            children =
+              listOf(
+                layoutNode(
+                  nodeId = "2",
+                  bounds = LayoutInspectorBounds(0, 0, 40, 40),
+                  placed = false,
+                )
+              ),
+          ),
+        )
+        .filter { it.kind == AnnotationKind.LAYOUT }
+
+    assertEquals(listOf("200×100px"), boxes.map { it.label })
+  }
+
+  @Test
+  fun `an unplaced layout node takes its whole subtree with it`() {
+    // Suppressing only the unplaced node's own box left any descendant still flagged placed free
+    // to draw one — and nothing under a node that was never positioned is on the frame, whatever
+    // its own flag says.
+    val boxes =
+      annotationsOf(
+          node(),
+          layoutNode(
+            bounds = LayoutInspectorBounds(0, 0, 200, 100),
+            children =
+              listOf(
+                layoutNode(
+                  nodeId = "2",
+                  bounds = LayoutInspectorBounds(0, 0, 40, 40),
+                  placed = false,
+                  children =
+                    listOf(layoutNode(nodeId = "3", bounds = LayoutInspectorBounds(0, 0, 20, 20))),
+                )
+              ),
+          ),
+        )
+        .filter { it.kind == AnnotationKind.LAYOUT }
+
+    assertEquals(listOf("200×100px"), boxes.map { it.label })
+  }
+
+  @Test
+  fun `a layout node is named by its friendly label before its own class`() {
+    val boxes =
+      annotationsOf(
+          node(),
+          layoutNode(component = "Box", displayName = "IconButton"),
+        )
+        .filter { it.kind == AnnotationKind.LAYOUT }
+
+    assertEquals("IconButton", boxes.single().role)
+  }
+
+  @Test
+  fun `two gradients that differ only in direction do not project identically`() {
+    fun detailFor(endX: Float, endY: Float) =
+      themeOf(
+          node(
+            tokens =
+              ComposeSemanticsTokens(
+                backgroundGradient =
+                  LayoutInspectorGradient(
+                    colors = listOf("#FF000000", "#FFFFFFFF"),
+                    endX = endX,
+                    endY = endY,
+                  )
+              )
+          )
+        )
+        .detail["backgroundGradient"]
+
+    assertEquals("#FF000000 → #FFFFFFFF (horizontal)", detailFor(endX = 1f, endY = 0f))
+    assertEquals("#FF000000 → #FFFFFFFF (vertical)", detailFor(endX = 0f, endY = 1f))
+    assertEquals("#FF000000 → #FFFFFFFF (0,0 → 1,1)", detailFor(endX = 1f, endY = 1f))
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvgWebModeTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvgWebModeTest.kt
@@ -1,0 +1,193 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.bundle.downscaleRaster
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import okio.Path.Companion.toPath
+
+/**
+ * Unit tests for the `?mode=web` figma-svg transform ([webModeSvg] / [googleFontsImportUrl]): the
+ * base64 `@font-face` blocks a self-contained export embeds are swapped for an external Google
+ * Fonts `@import`, so a browser viewing the `.svg` directly pulls the faces from Google. Pure
+ * string transform — no served host needed.
+ */
+class ServeFigmaSvgWebModeTest {
+
+  private fun face(family: String, weight: Int, italic: Boolean = false, b64: String = "AAAA") =
+    "@font-face{font-family:'$family';font-style:${if (italic) "italic" else "normal"};" +
+      "font-weight:$weight;src:url(data:font/woff2;base64,$b64)format('woff2');}"
+
+  private fun svg(vararg faces: String, body: String = "<text font-family=\"Roboto\">Hi</text>") =
+    "<svg xmlns=\"http://www.w3.org/2000/svg\"><defs><style>${faces.joinToString("")}" +
+      "</style></defs>$body</svg>"
+
+  @Test
+  fun `webModeSvg strips embedded faces and injects a Google Fonts import`() {
+    val input = svg(face("Roboto", 400), face("Roboto", 500))
+    val out = webModeSvg(input)
+    // No base64 font bytes survive.
+    assertFalse(out.contains("base64,"))
+    assertFalse(out.contains("@font-face"))
+    // A single @import covers both weights of the one family; the URL's `&` is XML-escaped so the
+    // image/svg+xml document stays well-formed (no raw `&` entity starts).
+    assertTrue(
+      out.contains(
+        "@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&amp;display=swap');"
+      )
+    )
+    // The raw (unescaped) separator must not appear — that would be a malformed entity start.
+    assertFalse(out.contains("&display=swap"))
+    // The text node's family is untouched, so the browser resolves it from the imported sheet.
+    assertTrue(out.contains("font-family=\"Roboto\""))
+  }
+
+  @Test
+  fun `webModeSvg leaves a vector-only svg untouched`() {
+    val input = "<svg><text font-family=\"Roboto, sans-serif\">Hi</text></svg>"
+    assertEquals(input, webModeSvg(input))
+  }
+
+  @Test
+  fun `googleFontsImportUrl groups families, sorts and dedups weights`() {
+    val url =
+      googleFontsImportUrl(
+        listOf(
+          WebFontFace("Space Grotesk", 600, false),
+          WebFontFace("Orbitron", 700, false),
+          WebFontFace("Orbitron", 500, false),
+          WebFontFace("Orbitron", 500, false), // dup
+        )
+      )
+    // Families alphabetical; spaces → +; weights sorted & de-duplicated.
+    assertEquals(
+      "https://fonts.googleapis.com/css2?family=Orbitron:wght@500;700&family=Space+Grotesk:wght@600&display=swap",
+      url,
+    )
+  }
+
+  @Test
+  fun `googleFontsImportUrl uses the ital,wght axis when a family has any italic`() {
+    val url =
+      googleFontsImportUrl(
+        listOf(WebFontFace("Inter", 400, italic = false), WebFontFace("Inter", 700, italic = true))
+      )
+    assertEquals(
+      "https://fonts.googleapis.com/css2?family=Inter:ital,wght@0,400;1,700&display=swap",
+      url,
+    )
+  }
+
+  @Test
+  fun `googleFontsImportUrl rounds Compose intermediate weights`() {
+    val url =
+      googleFontsImportUrl(
+        listOf(
+          WebFontFace("Roboto", 599, italic = false),
+          WebFontFace("Roboto", 550, italic = true),
+        )
+      )
+    assertEquals(
+      "https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,600;1,600&display=swap",
+      url,
+    )
+  }
+
+  @Test
+  fun `generic families are not sent to Google Fonts`() {
+    assertNull(googleFontsImportUrl(listOf(WebFontFace("sans-serif", 400, false))))
+    // A mix keeps only the real family.
+    val url =
+      googleFontsImportUrl(
+        listOf(WebFontFace("monospace", 400, false), WebFontFace("Roboto Mono", 500, false))
+      )
+    assertEquals("https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@500&display=swap", url)
+  }
+
+  @Test
+  fun `linkFigmaRasters rewrites crop hrefs onto the base url`() {
+    val svg =
+      "<svg><image href=\"ideal__default__dark__compact.figma-raster/232.png\" x=\"1\"/></svg>"
+    val base =
+      "https://raw.githubusercontent.com/joreilly/Confetti/design-artifacts/confetti-mobile/figma/speakerdetails/"
+    val linked = linkFigmaRasters(svg, base)
+    assertTrue(
+      linked.contains(
+        "href=\"https://raw.githubusercontent.com/joreilly/Confetti/design-artifacts/" +
+          "confetti-mobile/figma/speakerdetails/ideal__default__dark__compact.figma-raster/232.png\""
+      ),
+      linked,
+    )
+  }
+
+  @Test
+  fun `linkFigmaRasters leaves traversing or absolute hrefs untouched`() {
+    val traversal = "<svg><image href=\"x.figma-raster/../../secret.png\"/></svg>"
+    assertEquals(traversal, linkFigmaRasters(traversal, "https://example.com/figma"))
+    val absolute = "<svg><image href=\"https://evil.example/x.figma-raster/n.png\"/></svg>"
+    assertEquals(absolute, linkFigmaRasters(absolute, "https://example.com/figma"))
+    val vectorOnly = "<svg><rect/></svg>"
+    assertEquals(vectorOnly, linkFigmaRasters(vectorOnly, "https://example.com/figma"))
+  }
+
+  @Test
+  fun `downscaleRaster caps the longest edge and preserves aspect`() {
+    val big = java.awt.image.BufferedImage(2048, 1024, java.awt.image.BufferedImage.TYPE_INT_ARGB)
+    big.createGraphics().run {
+      color = java.awt.Color(0x12, 0x34, 0x56)
+      fillRect(0, 0, 2048, 1024)
+      dispose()
+    }
+    val out = java.io.ByteArrayOutputStream()
+    javax.imageio.ImageIO.write(big, "png", out)
+    val png = out.toByteArray()
+
+    val bounded = downscaleRaster(png, 1024)
+    val decoded = javax.imageio.ImageIO.read(java.io.ByteArrayInputStream(bounded))
+    assertEquals(1024, decoded.width)
+    assertEquals(512, decoded.height)
+    assertTrue(bounded.size < png.size, "downscale must actually shrink the payload")
+  }
+
+  @Test
+  fun `downscaleRaster leaves a small or undecodable png untouched`() {
+    val small = java.awt.image.BufferedImage(64, 64, java.awt.image.BufferedImage.TYPE_INT_ARGB)
+    val out = java.io.ByteArrayOutputStream()
+    javax.imageio.ImageIO.write(small, "png", out)
+    val png = out.toByteArray()
+    assertTrue(png.contentEquals(downscaleRaster(png, 1024)), "within the cap → original bytes")
+
+    val junk = byteArrayOf(1, 2, 3)
+    assertTrue(junk.contentEquals(downscaleRaster(junk, 1024)), "undecodable → original bytes")
+  }
+
+  @Test
+  fun `inlineFigmaRasters embeds a downscaled crop for an oversized raster`() {
+    val dir = java.nio.file.Files.createTempDirectory("figma").toFile().also { it.deleteOnExit() }
+    val rasterDir = java.io.File(dir, "figma-raster").apply { mkdirs() }
+    val big = java.awt.image.BufferedImage(4096, 2048, java.awt.image.BufferedImage.TYPE_INT_ARGB)
+    javax.imageio.ImageIO.write(big, "png", java.io.File(rasterDir, "n.png"))
+    val svg = "<svg><image href=\"figma-raster/n.png\" x=\"0\" width=\"4096\"/></svg>"
+
+    val inlined =
+      inlineFigmaRasters(ee.schimke.composeai.io.SystemFileSystem, dir.absolutePath.toPath(), svg)
+    val b64 = Regex("data:image/png;base64,([^\"]+)").find(inlined)?.groupValues?.get(1)
+    assertTrue(b64 != null, "raster must be inlined: $inlined")
+    val decoded =
+      javax.imageio.ImageIO.read(
+        java.io.ByteArrayInputStream(java.util.Base64.getDecoder().decode(b64))
+      )
+    assertEquals(1024, decoded.width, "longest edge capped at MAX_INLINE_RASTER_EDGE_PX")
+    assertEquals(512, decoded.height)
+  }
+
+  @Test
+  fun `webModeSvg with only generic faces keeps the svg self-describing (no import, faces dropped)`() {
+    // A `sans-serif` @font-face (Roboto stand-in) yields no Google URL, so the transform makes no
+    // claim it can't back — it returns the input unchanged rather than emit a broken @import.
+    val input = svg(face("sans-serif", 400))
+    assertEquals(input, webModeSvg(input))
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeOverridesTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeOverridesTest.kt
@@ -1,0 +1,817 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.GestureKindOverride
+import ee.schimke.composeai.daemon.protocol.Orientation
+import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
+import ee.schimke.composeai.daemon.protocol.RemoteComposeProfile
+import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
+import ee.schimke.composeai.daemon.protocol.UiMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ServeOverridesTest {
+
+  private fun ok(
+    params: Map<String, String>
+  ): ee.schimke.composeai.daemon.protocol.PreviewOverrides {
+    val parsed = ServeOverrides.parse(params)
+    assertTrue(parsed is OverrideParse.Ok, "expected Ok, got $parsed")
+    return parsed.overrides
+  }
+
+  @Test
+  fun `empty params leave every field null`() {
+    val o = ok(emptyMap())
+    assertNull(o.uiMode)
+    assertNull(o.device)
+    assertNull(o.localeTag)
+    assertNull(o.fontScale)
+    assertNull(o.orientation)
+    assertNull(o.widthPx)
+    assertNull(o.heightPx)
+    assertNull(o.density)
+    assertNull(o.inspectionMode)
+    assertNull(o.slotMode)
+    assertNull(o.talkBack)
+    assertNull(o.touchOverlay)
+    assertNull(o.themeProvider)
+    assertNull(o.focus)
+    assertNull(o.clearBackground)
+  }
+
+  @Test
+  fun `a themeProvider the catalog declares is accepted`() {
+    val parsed =
+      ServeOverrides.parse(
+        mapOf("themeProvider" to "com.example.BrandDarkThemeCatalog"),
+        declaredThemeFqns =
+          setOf("com.example.BrandLightThemeCatalog", "com.example.BrandDarkThemeCatalog"),
+      )
+    assertTrue(parsed is OverrideParse.Ok, "expected Ok, got $parsed")
+    assertEquals("com.example.BrandDarkThemeCatalog", parsed.overrides.themeProvider)
+  }
+
+  @Test
+  fun `a themeProvider the catalog does not declare is rejected, not silently defaulted`() {
+    val parsed =
+      ServeOverrides.parse(
+        mapOf("themeProvider" to "com.example.TotallyBogusThemeCatalog"),
+        declaredThemeFqns = setOf("com.example.BrandDarkThemeCatalog"),
+      )
+    assertTrue(parsed is OverrideParse.Invalid, "expected Invalid, got $parsed")
+    assertTrue(
+      parsed.message.contains("com.example.TotallyBogusThemeCatalog"),
+      "message should name the rejected provider: ${parsed.message}",
+    )
+    assertTrue(
+      parsed.message.contains("com.example.BrandDarkThemeCatalog"),
+      "message should list what the catalog does declare: ${parsed.message}",
+    )
+  }
+
+  @Test
+  fun `a themeProvider against a catalog that declares none is rejected`() {
+    val parsed =
+      ServeOverrides.parse(
+        mapOf("themeProvider" to "com.example.BrandDarkThemeCatalog"),
+        declaredThemeFqns = emptySet(),
+      )
+    assertTrue(parsed is OverrideParse.Invalid, "expected Invalid, got $parsed")
+    assertTrue(
+      parsed.message.contains("declares no"),
+      "message should say the catalog declares none: ${parsed.message}",
+    )
+  }
+
+  @Test
+  fun `a caller that does not know the session themes skips validation`() {
+    // `declaredThemeFqns = null` is the default — the pre-existing behaviour for callers with no
+    // session in hand. Covered so the back-compat default can't be tightened by accident.
+    val o = ok(mapOf("themeProvider" to "com.example.AnythingThemeCatalog"))
+    assertEquals("com.example.AnythingThemeCatalog", o.themeProvider)
+  }
+
+  @Test
+  fun `focus tab index maps to a focus override with the overlay drawn`() {
+    val o = ok(mapOf("focus" to "2"))
+    assertEquals(2, o.focus?.tabIndex)
+    assertEquals(true, o.focus?.overlay)
+  }
+
+  @Test
+  fun `a malformed focus index is rejected`() {
+    for (bad in listOf("focus" to "yes", "focus" to "-1", "focus" to "1.5")) {
+      val parsed = ServeOverrides.parse(mapOf(bad))
+      assertTrue(parsed is OverrideParse.Invalid, "expected Invalid for $bad, got $parsed")
+    }
+  }
+
+  @Test
+  fun `cache key differs when a focus override is applied`() {
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("focus" to "0"))),
+      ServeOverrides.cacheKey("preview.A", ok(emptyMap())),
+    )
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("focus" to "0"))),
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("focus" to "1"))),
+    )
+  }
+
+  @Test
+  fun `empty params leave the gesture override null`() {
+    assertNull(ok(emptyMap()).gestures)
+  }
+
+  @Test
+  fun `gestures true shows the hint affordance`() {
+    val o = ok(mapOf("gestures" to "true"))
+    assertEquals(true, o.gestures?.showHints)
+    assertEquals(true, ok(mapOf("gestures" to "1")).gestures?.showHints)
+  }
+
+  @Test
+  fun `gestures false clears the hint affordance`() {
+    val o = ok(mapOf("gestures" to "false"))
+    assertEquals(false, o.gestures?.showHints)
+    assertEquals(false, ok(mapOf("gestures" to "0")).gestures?.showHints)
+  }
+
+  @Test
+  fun `a malformed gestures value is rejected`() {
+    for (bad in listOf("gestures" to "yes", "gestures" to "maybe", "gestures" to "2")) {
+      val parsed = ServeOverrides.parse(mapOf(bad))
+      assertTrue(parsed is OverrideParse.Invalid, "expected Invalid for $bad, got $parsed")
+    }
+  }
+
+  @Test
+  fun `gestureInvoke names the gesture the daemon fires`() {
+    // Issue #5102: the hint could be shown and then never taken up, because a double pinch and a
+    // wrist turn are sensor events with no pointer standing in for them.
+    assertEquals(
+      GestureKindOverride.PRIMARY,
+      ok(mapOf("gestureInvoke" to "primary")).gestures?.invoke,
+    )
+    assertEquals(
+      GestureKindOverride.DISMISS,
+      ok(mapOf("gestureInvoke" to "dismiss")).gestures?.invoke,
+    )
+    assertEquals(
+      GestureKindOverride.SCROLL,
+      ok(mapOf("gestureInvoke" to "scroll")).gestures?.invoke,
+    )
+    assertEquals(GestureKindOverride.PAGE, ok(mapOf("gestureInvoke" to "page")).gestures?.invoke)
+    // Case-insensitive, like every other friendly spelling here.
+    assertEquals(
+      GestureKindOverride.PRIMARY,
+      ok(mapOf("gestureInvoke" to "Primary")).gestures?.invoke,
+    )
+  }
+
+  @Test
+  fun `hints and an invocation ride the same override, so both can apply to one render`() {
+    // "Play the hint, then take it up" is one render, not two.
+    val o = ok(mapOf("gestures" to "true", "gestureInvoke" to "primary"))
+
+    assertEquals(true, o.gestures?.showHints)
+    assertEquals(GestureKindOverride.PRIMARY, o.gestures?.invoke)
+  }
+
+  @Test
+  fun `an invocation alone leaves the hint affordance untouched`() {
+    // Not `showHints = false`: the viewer's hint checkbox and its fire buttons are separate
+    // controls, and firing must not silently clear a hint the visitor asked for.
+    val o = ok(mapOf("gestureInvoke" to "dismiss"))
+
+    assertNotNull(o.gestures)
+    assertNull(o.gestures?.showHints)
+  }
+
+  @Test
+  fun `a malformed gestureInvoke value is rejected rather than firing something else`() {
+    for (bad in listOf("gestureInvoke" to "yes", "gestureInvoke" to "double-pinch")) {
+      val parsed = ServeOverrides.parse(mapOf(bad))
+      assertTrue(parsed is OverrideParse.Invalid, "expected Invalid for $bad, got $parsed")
+    }
+  }
+
+  @Test
+  fun `cache key differs when a gesture is fired, so an invocation is not served from cache`() {
+    // An invocation changes what the render shows; sharing a key with the un-fired render would
+    // hand back the frame from before the handler ran.
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("gestureInvoke" to "primary"))),
+      ServeOverrides.cacheKey("preview.A", ok(emptyMap())),
+    )
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("gestureInvoke" to "primary"))),
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("gestureInvoke" to "dismiss"))),
+    )
+  }
+
+  @Test
+  fun `cache key differs when a gesture override is applied`() {
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("gestures" to "true"))),
+      ServeOverrides.cacheKey("preview.A", ok(emptyMap())),
+    )
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("gestures" to "true"))),
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("gestures" to "false"))),
+    )
+  }
+
+  @Test
+  fun `maps each field`() {
+    val o =
+      ok(
+        mapOf(
+          "uiMode" to "dark",
+          "device" to "id:pixel_5",
+          "localeTag" to "ja-JP",
+          "fontScale" to "1.3",
+          "density" to "2.0",
+          "widthPx" to "400",
+          "heightPx" to "800",
+          "orientation" to "landscape",
+          "inspectionMode" to "true",
+          "slotMode" to "true",
+          "placeholderActive" to "true",
+          "talkBack" to "true",
+          "touchOverlay" to "1",
+          "themeProvider" to "com.example.BrandDarkThemeCatalog",
+        )
+      )
+    assertEquals(UiMode.DARK, o.uiMode)
+    assertEquals("id:pixel_5", o.device)
+    assertEquals("ja-JP", o.localeTag)
+    assertEquals(1.3f, o.fontScale)
+    assertEquals(2.0f, o.density)
+    assertEquals(400, o.widthPx)
+    assertEquals(800, o.heightPx)
+    assertEquals(Orientation.LANDSCAPE, o.orientation)
+    assertEquals(true, o.inspectionMode)
+    assertEquals(true, o.slotMode)
+    assertEquals(true, o.placeholderActive)
+    assertEquals(true, o.talkBack)
+    assertEquals(true, o.touchOverlay)
+    assertEquals("com.example.BrandDarkThemeCatalog", o.themeProvider)
+  }
+
+  @Test
+  fun `blank values are treated as absent`() {
+    val o = ok(mapOf("uiMode" to "", "device" to "", "fontScale" to ""))
+    assertNull(o.uiMode)
+    assertNull(o.device)
+    assertNull(o.fontScale)
+  }
+
+  @Test
+  fun `invalid enums and numbers are rejected with a reason`() {
+    for (bad in
+      listOf(
+        mapOf("uiMode" to "purple"),
+        mapOf("orientation" to "sideways"),
+        mapOf("fontScale" to "huge"),
+        mapOf("fontScale" to "-1"),
+        mapOf("density" to "0"),
+        mapOf("widthPx" to "wide"),
+        mapOf("widthPx" to "-5"),
+        mapOf("inspectionMode" to "maybe"),
+        mapOf("slotMode" to "maybe"),
+        mapOf("placeholderActive" to "maybe"),
+        mapOf("talkBack" to "maybe"),
+        mapOf("touchOverlay" to "maybe"),
+        mapOf("background" to "polkadot"),
+        mapOf("clearBackground" to "maybe"),
+      )) {
+      val parsed = ServeOverrides.parse(bad)
+      assertTrue(parsed is OverrideParse.Invalid, "expected Invalid for $bad, got $parsed")
+      assertTrue(parsed.message.isNotBlank())
+    }
+  }
+
+  @Test
+  fun `background clear aliases map to clearBackground true`() {
+    for (v in listOf("clear", "transparent", "none", "off", "CLEAR")) {
+      assertEquals(true, ok(mapOf("background" to v)).clearBackground, "background=$v")
+    }
+    for (v in listOf("default", "show", "on")) {
+      assertEquals(false, ok(mapOf("background" to v)).clearBackground, "background=$v")
+    }
+    // Raw boolean spelling.
+    assertEquals(true, ok(mapOf("clearBackground" to "true")).clearBackground)
+    assertEquals(false, ok(mapOf("clearBackground" to "false")).clearBackground)
+    // `background` wins over `clearBackground` when both are present.
+    assertEquals(
+      true,
+      ok(mapOf("background" to "clear", "clearBackground" to "false")).clearBackground,
+    )
+    // Absent leaves it null (discovery-time background).
+    assertNull(ok(emptyMap()).clearBackground)
+  }
+
+  @Test
+  fun `cache key differs when clearBackground changes`() {
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(emptyMap())),
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("background" to "clear"))),
+    )
+  }
+
+  @Test
+  fun `cache key is stable for equal overrides and order-independent`() {
+    val a = ok(mapOf("uiMode" to "dark", "device" to "id:pixel_5", "fontScale" to "1.3"))
+    val b = ok(mapOf("fontScale" to "1.3", "device" to "id:pixel_5", "uiMode" to "dark"))
+    assertEquals(ServeOverrides.cacheKey("preview.A", a), ServeOverrides.cacheKey("preview.A", b))
+  }
+
+  @Test
+  fun `cache key differs by preview id and by any override field`() {
+    val base = ok(mapOf("uiMode" to "light"))
+    val dark = ok(mapOf("uiMode" to "dark"))
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", base),
+      ServeOverrides.cacheKey("preview.A", dark),
+    )
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", base),
+      ServeOverrides.cacheKey("preview.B", base),
+    )
+    // slotMode participates, so a slot-map render isn't coalesced onto the normal render's cache.
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("slotMode" to "true"))),
+      ServeOverrides.cacheKey("preview.A", ok(emptyMap())),
+    )
+    // Placeholder state participates: the loading and loaded renders of one preview are different
+    // pixels and must not share a cache entry (issue #2646).
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("placeholderActive" to "true"))),
+      ServeOverrides.cacheKey("preview.A", ok(emptyMap())),
+    )
+    // The live overlay flags participate too, so a crafted /render?talkBack / ?touchOverlay can't
+    // collide with the baked render's cache entry.
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("talkBack" to "true"))),
+      ServeOverrides.cacheKey("preview.A", ok(emptyMap())),
+    )
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("touchOverlay" to "true"))),
+      ServeOverrides.cacheKey("preview.A", ok(emptyMap())),
+    )
+    // A themeProvider selection participates, so rendering a preview under two different declared
+    // themes (or a theme vs the default) doesn't coalesce onto one cache entry.
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("themeProvider" to "com.example.BrandDark"))),
+      ServeOverrides.cacheKey("preview.A", ok(emptyMap())),
+    )
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("themeProvider" to "com.example.BrandDark"))),
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("themeProvider" to "com.example.BrandLight"))),
+    )
+  }
+
+  @Test
+  fun `knob params parse to typed named overrides`() {
+    val o =
+      ok(
+        mapOf(
+          "knob.label" to "string:Tap me",
+          "knob.count" to "int:3",
+          "knob.weight" to "float:1.5",
+          "knob.enabled" to "bool:true",
+          "knob.tint" to "color:#FF0000",
+        )
+      )
+    val named = o.namedOverrides
+    assertNotNull(named)
+    assertEquals(PreviewOverrideValue.StringValue("Tap me"), named["label"])
+    assertEquals(PreviewOverrideValue.IntValue(3), named["count"])
+    assertEquals(PreviewOverrideValue.FloatValue(1.5f), named["weight"])
+    assertEquals(PreviewOverrideValue.BooleanValue(true), named["enabled"])
+    assertEquals(PreviewOverrideValue.ColorValue("#FF0000"), named["tint"])
+  }
+
+  @Test
+  fun `bool knob accepts 1 and is false otherwise`() {
+    val o = ok(mapOf("knob.a" to "bool:1", "knob.b" to "bool:0", "knob.c" to "bool:nope"))
+    assertEquals(PreviewOverrideValue.BooleanValue(true), o.namedOverrides!!["a"])
+    assertEquals(PreviewOverrideValue.BooleanValue(false), o.namedOverrides!!["b"])
+    assertEquals(PreviewOverrideValue.BooleanValue(false), o.namedOverrides!!["c"])
+  }
+
+  @Test
+  fun `indexed knob key keeps its bracketed wire key`() {
+    val o = ok(mapOf("knob.rowLabel[2]" to "string:Hi"))
+    assertEquals(PreviewOverrideValue.StringValue("Hi"), o.namedOverrides!!["rowLabel[2]"])
+  }
+
+  @Test
+  fun `no knob params leave named overrides null`() {
+    val o = ok(mapOf("uiMode" to "dark"))
+    assertNull(o.namedOverrides)
+  }
+
+  @Test
+  fun `a blank knob key is ignored`() {
+    assertNull(ok(mapOf("knob." to "string:x")).namedOverrides)
+  }
+
+  @Test
+  fun `an empty value is a real seed for a string knob`() {
+    // `knob.label=` is an EDIT, not a missing param: clearing a label is something a viewer must be
+    // able to express, and an `@OverrideVariant` can seed one deliberately (`strings = ["label="]`,
+    // which discovery preserves). Dropping it rendered the author default instead — the seeded
+    // variant's whole point inverted, and on the Wasm tier there is no baked artifact to mask it.
+    assertEquals(
+      PreviewOverrideValue.StringValue(""),
+      ok(mapOf("knob.label" to "")).namedOverrides!!["label"],
+      "an undeclared knob types as a string, so its empty value is kept",
+    )
+    val declared = ServeOverrides.parse(mapOf("knob.label" to ""), mapOf("label" to "string"))
+    assertEquals(
+      PreviewOverrideValue.StringValue(""),
+      (declared as OverrideParse.Ok).overrides.namedOverrides!!["label"],
+    )
+    // Whitespace is a string too — `isBlank` would have swallowed a single-space label.
+    assertEquals(
+      PreviewOverrideValue.StringValue(" "),
+      ok(mapOf("knob.label" to " ")).namedOverrides!!["label"],
+    )
+    // An explicit legacy prefix with nothing after it is the same empty string.
+    assertEquals(
+      PreviewOverrideValue.StringValue(""),
+      ok(mapOf("knob.label" to "string:")).namedOverrides!!["label"],
+    )
+  }
+
+  @Test
+  fun `an empty value is skipped for a knob that cannot parse one`() {
+    // An emptied number/colour field has nothing to seed. Skipped rather than Invalid: the viewer
+    // itself builds these URLs, and a 400 on a half-typed field would break the page it came from.
+    val kinds = mapOf("count" to "int", "weight" to "float", "tint" to "color", "on" to "bool")
+    val parsed =
+      ServeOverrides.parse(
+        mapOf("knob.count" to "", "knob.weight" to "", "knob.tint" to "", "knob.on" to ""),
+        kinds,
+      )
+    assertNull((parsed as OverrideParse.Ok).overrides.namedOverrides)
+  }
+
+  @Test
+  fun `bare knob value without a kind prefix parses as a string`() {
+    // A colon-less value (the viewer's default wire form) is a string when nothing types it.
+    val o = ok(mapOf("knob.label" to "Tap me"))
+    assertEquals(PreviewOverrideValue.StringValue("Tap me"), o.namedOverrides!!["label"])
+    // A value whose prefix is not a recognised kind is taken whole, not split on the colon.
+    val o2 = ok(mapOf("knob.label" to "mystery:y"))
+    assertEquals(PreviewOverrideValue.StringValue("mystery:y"), o2.namedOverrides!!["label"])
+  }
+
+  @Test
+  fun `bare knob value is typed from the declared kinds`() {
+    val kinds = mapOf("count" to "int", "weight" to "float", "enabled" to "bool", "tint" to "color")
+    val o =
+      (ServeOverrides.parse(
+          mapOf(
+            "knob.count" to "3",
+            "knob.weight" to "1.5",
+            "knob.enabled" to "true",
+            "knob.tint" to "#FF0000",
+          ),
+          kinds,
+        ) as OverrideParse.Ok)
+        .overrides
+    val named = o.namedOverrides!!
+    assertEquals(PreviewOverrideValue.IntValue(3), named["count"])
+    assertEquals(PreviewOverrideValue.FloatValue(1.5f), named["weight"])
+    assertEquals(PreviewOverrideValue.BooleanValue(true), named["enabled"])
+    assertEquals(PreviewOverrideValue.ColorValue("#FF0000"), named["tint"])
+  }
+
+  @Test
+  fun `an explicit kind prefix still wins for an undeclared knob`() {
+    // Legacy `<kind>:<value>` links keep working when nothing declares the knob's type.
+    val o = ok(mapOf("knob.count" to "int:7"))
+    assertEquals(PreviewOverrideValue.IntValue(7), o.namedOverrides!!["count"])
+  }
+
+  @Test
+  fun `a declared string knob keeps a value that looks like a typed prefix`() {
+    // A string knob edited to `int:3` / `color:#fff` must survive verbatim: the prefix does not
+    // match the declared kind, so it is not stripped or retyped.
+    val kinds = mapOf("label" to "string")
+    val o =
+      (ServeOverrides.parse(
+          mapOf("knob.label" to "int:3", "knob.label2" to "color:#fff"),
+          kinds + ("label2" to "string"),
+        ) as OverrideParse.Ok)
+        .overrides
+    val named = o.namedOverrides!!
+    assertEquals(PreviewOverrideValue.StringValue("int:3"), named["label"])
+    assertEquals(PreviewOverrideValue.StringValue("color:#fff"), named["label2"])
+  }
+
+  @Test
+  fun `a matching kind prefix on a declared knob is still honoured`() {
+    // An old `knob.label=string:Hi` link (prefix matches the declared kind) keeps meaning "Hi".
+    val o =
+      (ServeOverrides.parse(mapOf("knob.count" to "int:7"), mapOf("count" to "int"))
+          as OverrideParse.Ok)
+        .overrides
+    assertEquals(PreviewOverrideValue.IntValue(7), o.namedOverrides!!["count"])
+  }
+
+  @Test
+  fun `malformed typed knob values are rejected with a reason`() {
+    for (bad in
+      listOf(
+        mapOf("knob.count" to "int:three"), // explicit int, not an integer
+        mapOf("knob.weight" to "float:heavy"), // explicit float, not a number
+      )) {
+      val parsed = ServeOverrides.parse(bad)
+      assertTrue(parsed is OverrideParse.Invalid, "expected Invalid for $bad, got $parsed")
+      assertTrue(parsed.message.isNotBlank())
+    }
+  }
+
+  @Test
+  fun `a bare value declared as a number must still be numeric`() {
+    val parsed = ServeOverrides.parse(mapOf("knob.count" to "three"), mapOf("count" to "int"))
+    assertTrue(parsed is OverrideParse.Invalid, "expected Invalid, got $parsed")
+  }
+
+  @Test
+  fun `cache key differs when a knob value changes`() {
+    val a = ok(mapOf("knob.label" to "string:Tap me"))
+    val b = ok(mapOf("knob.label" to "string:Press me"))
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", a),
+      ServeOverrides.cacheKey("preview.A", b),
+    )
+  }
+
+  @Test
+  fun `cache key is knob-order independent`() {
+    val a = ok(mapOf("knob.label" to "string:Hi", "knob.count" to "int:2"))
+    val b = ok(mapOf("knob.count" to "int:2", "knob.label" to "string:Hi"))
+    assertEquals(ServeOverrides.cacheKey("preview.A", a), ServeOverrides.cacheKey("preview.A", b))
+  }
+
+  @Test
+  fun `size-bound params parse to the min-max fields`() {
+    val o =
+      ok(
+        mapOf(
+          "minWidthPx" to "120",
+          "minHeightPx" to "48",
+          "maxWidthPx" to "400",
+          "maxHeightPx" to "800",
+        )
+      )
+    assertEquals(120, o.minWidthPx)
+    assertEquals(48, o.minHeightPx)
+    assertEquals(400, o.maxWidthPx)
+    assertEquals(800, o.maxHeightPx)
+  }
+
+  @Test
+  fun `empty params leave the size bounds null`() {
+    val o = ok(emptyMap())
+    assertNull(o.minWidthPx)
+    assertNull(o.minHeightPx)
+    assertNull(o.maxWidthPx)
+    assertNull(o.maxHeightPx)
+  }
+
+  @Test
+  fun `a non-positive or malformed size bound is rejected`() {
+    for (bad in
+      listOf(
+        mapOf("minWidthPx" to "0"),
+        mapOf("minHeightPx" to "-3"),
+        mapOf("maxWidthPx" to "wide"),
+        mapOf("maxHeightPx" to "1.5"),
+      )) {
+      val parsed = ServeOverrides.parse(bad)
+      assertTrue(parsed is OverrideParse.Invalid, "expected Invalid for $bad, got $parsed")
+      assertTrue(parsed.message.isNotBlank())
+    }
+  }
+
+  @Test
+  fun `a min bound above the max on the same axis is rejected`() {
+    assertTrue(
+      ServeOverrides.parse(mapOf("minWidthPx" to "500", "maxWidthPx" to "200"))
+        is OverrideParse.Invalid
+    )
+    assertTrue(
+      ServeOverrides.parse(mapOf("minHeightPx" to "900", "maxHeightPx" to "300"))
+        is OverrideParse.Invalid
+    )
+    // Equal bounds are a degenerate-but-valid fixed range.
+    assertTrue(
+      ServeOverrides.parse(mapOf("minWidthPx" to "200", "maxWidthPx" to "200")) is OverrideParse.Ok
+    )
+  }
+
+  @Test
+  fun `cache key differs when a size bound changes`() {
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("maxWidthPx" to "300"))),
+      ServeOverrides.cacheKey("preview.A", ok(emptyMap())),
+    )
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("minWidthPx" to "100"))),
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("minWidthPx" to "200"))),
+    )
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("minHeightPx" to "100"))),
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("maxHeightPx" to "100"))),
+    )
+  }
+
+  @Test
+  fun `preview mode parses known wire values`() {
+    assertEquals(PreviewMode.SNAPSHOT, PreviewMode.parse("snapshot"))
+    assertEquals(PreviewMode.LIVE, PreviewMode.parse("live"))
+    assertNull(PreviewMode.parse("bogus"))
+    assertNull(PreviewMode.parse(null))
+  }
+
+  @Test
+  fun `no remote compose params leaves the facet null`() {
+    assertNull(ok(emptyMap()).remoteCompose)
+    // A generic knob alone must NOT synthesise a remoteCompose facet.
+    assertNull(ok(mapOf("knob.label" to "Hi")).remoteCompose)
+  }
+
+  @Test
+  fun `rc named seeds map to typed remote named values`() {
+    val rc =
+      ok(
+          mapOf(
+            "rc.label" to "Tap me",
+            "rc.count" to "int:3",
+            "rc.ratio" to "float:0.5",
+            "rc.gap" to "dp:8",
+            "rc.on" to "bool:true",
+            "rc.stopColor" to "color:#FF8800",
+          )
+        )
+        .remoteCompose
+    assertNotNull(rc)
+    assertEquals(RemoteNamedValue.StringValue("Tap me"), rc.namedValues["label"])
+    assertEquals(RemoteNamedValue.IntValue(3), rc.namedValues["count"])
+    assertEquals(RemoteNamedValue.FloatValue(0.5f), rc.namedValues["ratio"])
+    assertEquals(RemoteNamedValue.DpValue(8f), rc.namedValues["gap"])
+    assertEquals(RemoteNamedValue.BooleanValue(true), rc.namedValues["on"])
+    assertEquals(RemoteNamedValue.ColorValue("#FF8800"), rc.namedValues["stopColor"])
+    assertNull(rc.profile)
+  }
+
+  @Test
+  fun `a bare rc value is a string`() {
+    val rc = ok(mapOf("rc.label" to "Ship it")).remoteCompose
+    assertEquals(RemoteNamedValue.StringValue("Ship it"), rc?.namedValues?.get("label"))
+  }
+
+  @Test
+  fun `an unknown rc kind prefix is treated as part of the string`() {
+    // `weird` isn't a known kind, so the whole value is the string — never a hard error.
+    val rc = ok(mapOf("rc.label" to "weird:value")).remoteCompose
+    assertEquals(RemoteNamedValue.StringValue("weird:value"), rc?.namedValues?.get("label"))
+  }
+
+  @Test
+  fun `a malformed typed rc value is rejected`() {
+    for (bad in listOf("rc.count" to "int:x", "rc.ratio" to "float:nan!", "rc.gap" to "dp:big")) {
+      val parsed = ServeOverrides.parse(mapOf(bad))
+      assertTrue(parsed is OverrideParse.Invalid, "expected Invalid for $bad, got $parsed")
+    }
+  }
+
+  @Test
+  fun `blank rc name or value is skipped`() {
+    // `rc.` with no name, and a present-but-blank value, both drop out rather than seeding.
+    assertNull(ok(mapOf("rc." to "x", "rc.label" to "")).remoteCompose)
+  }
+
+  @Test
+  fun `rc profile parses known wire names and rejects unknown`() {
+    assertEquals(
+      RemoteComposeProfile.ANDROIDX,
+      ok(mapOf("rcProfile" to "androidx")).remoteCompose?.profile,
+    )
+    assertEquals(
+      RemoteComposeProfile.WEAR_WIDGETS,
+      ok(mapOf("rcProfile" to "wearWidgets")).remoteCompose?.profile,
+    )
+    // Case-insensitive on the wire name.
+    assertEquals(
+      RemoteComposeProfile.WIDGETS_V6,
+      ok(mapOf("rcProfile" to "WIDGETSV6")).remoteCompose?.profile,
+    )
+    assertTrue(ServeOverrides.parse(mapOf("rcProfile" to "bogus")) is OverrideParse.Invalid)
+  }
+
+  @Test
+  fun `rc profile alone populates the facet`() {
+    val rc = ok(mapOf("rcProfile" to "androidx9")).remoteCompose
+    assertNotNull(rc)
+    assertEquals(RemoteComposeProfile.ANDROIDX9, rc.profile)
+    assertTrue(rc.namedValues.isEmpty())
+  }
+
+  @Test
+  fun `isOverrideParam accepts fixed rc and knob keys and rejects others`() {
+    assertTrue(ServeOverrides.isOverrideParam("uiMode"))
+    assertTrue(ServeOverrides.isOverrideParam("rcProfile"))
+    assertTrue(ServeOverrides.isOverrideParam("rc.label"))
+    assertTrue(ServeOverrides.isOverrideParam("knob.count"))
+    assertTrue(!ServeOverrides.isOverrideParam("cacheBuster"))
+  }
+
+  @Test
+  fun `cache key differs when a remote compose facet changes`() {
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("rc.label" to "A"))),
+      ServeOverrides.cacheKey("preview.A", ok(emptyMap())),
+    )
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("rc.label" to "A"))),
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("rc.label" to "B"))),
+    )
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("rcProfile" to "androidx"))),
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("rcProfile" to "androidx9"))),
+    )
+    // Order-independent + stable for equal seeds.
+    assertEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("rc.a" to "1", "rc.b" to "2"))),
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("rc.b" to "2", "rc.a" to "1"))),
+    )
+  }
+
+  @Test
+  fun `rcPlayer maps a server-side backend id onto the remote-compose player kind`() {
+    // Both the backend wire id (`java` / `cmp-android`) and the daemon-native player-kind spelling
+    // (`view` / `embedded`) resolve to the same RemoteComposePlayerKind.
+    assertEquals(
+      ee.schimke.composeai.daemon.protocol.RemoteComposePlayerKind.VIEW,
+      ok(mapOf("rcPlayer" to "java")).remoteCompose?.player,
+    )
+    assertEquals(
+      ee.schimke.composeai.daemon.protocol.RemoteComposePlayerKind.VIEW,
+      ok(mapOf("rcPlayer" to "view")).remoteCompose?.player,
+    )
+    assertEquals(
+      ee.schimke.composeai.daemon.protocol.RemoteComposePlayerKind.EMBEDDED,
+      ok(mapOf("rcPlayer" to "cmp-android")).remoteCompose?.player,
+    )
+    assertEquals(
+      ee.schimke.composeai.daemon.protocol.RemoteComposePlayerKind.EMBEDDED,
+      ok(mapOf("rcPlayer" to "embedded")).remoteCompose?.player,
+    )
+  }
+
+  @Test
+  fun `a client-side or unavailable rcPlayer value is rejected, not silently defaulted`() {
+    // `js` replays the doc in the browser and `cmp-jvm` has no draw path, so neither is a valid
+    // server-side render backend — and any unknown value is a hard Invalid.
+    for (bad in listOf("js", "cmp-jvm", "wasm", "nonsense")) {
+      val parsed = ServeOverrides.parse(mapOf("rcPlayer" to bad))
+      assertTrue(parsed is OverrideParse.Invalid, "expected Invalid for '$bad', got $parsed")
+    }
+  }
+
+  @Test
+  fun `an absent rcPlayer leaves the remote-compose override untouched`() {
+    // No rcPlayer, no other rc facet ⇒ no remoteCompose payload at all (byte-identical wire shape).
+    assertNull(ok(emptyMap()).remoteCompose)
+    // rcPlayer folds into the same override as the profile/named-value facets.
+    val both = ok(mapOf("rcPlayer" to "cmp-android", "rcProfile" to "androidx"))
+    assertEquals(
+      ee.schimke.composeai.daemon.protocol.RemoteComposePlayerKind.EMBEDDED,
+      both.remoteCompose?.player,
+    )
+    assertEquals(RemoteComposeProfile.ANDROIDX, both.remoteCompose?.profile)
+  }
+
+  @Test
+  fun `cache key differs when the rc render backend changes`() {
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("rcPlayer" to "java"))),
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("rcPlayer" to "cmp-android"))),
+    )
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("rcPlayer" to "java"))),
+      ServeOverrides.cacheKey("preview.A", ok(emptyMap())),
+    )
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeParameterRowsTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeParameterRowsTest.kt
@@ -1,0 +1,171 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.previewdata.Capture
+import ee.schimke.composeai.previewdata.PreviewInfo
+import ee.schimke.composeai.previewdata.PreviewParams
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+
+/**
+ * Coverage for the `serve` half of issue #3749: a screen whose states come from a
+ * `@PreviewParameter` provider must list every state, not just value 0.
+ *
+ * Discovery can't enumerate a provider, so the row set is read back off the fan-out the render pass
+ * wrote. These tests drive [ServeParameterRows] against a [FakeFileSystem] so the filename rules
+ * are pinned without a render.
+ */
+class ServeParameterRowsTest {
+
+  private val moduleDir = "/mod".toPath()
+  private val rendersDir = "/mod/build/compose-previews/renders".toPath()
+
+  private val fs = FakeFileSystem().also { it.createDirectories(rendersDir) }
+
+  private fun touch(name: String) {
+    fs.write(rendersDir / name) { writeUtf8("png") }
+  }
+
+  private fun preview(
+    id: String,
+    output: String = "renders/$id.png",
+    parameterized: Boolean = true,
+  ) =
+    PreviewInfo(
+      id = id,
+      functionName = id.substringBefore('_'),
+      className = "com.example.PreviewsKt",
+      params =
+        PreviewParams(
+          previewParameterProviderClassName =
+            if (parameterized) "com.example.SwatchProvider" else null
+        ),
+      captures = listOf(Capture(renderOutput = output)),
+    )
+
+  private fun rows(target: PreviewInfo, vararg all: PreviewInfo) =
+    ServeParameterRows.rowsFor(
+      preview = target,
+      moduleDir = moduleDir,
+      siblingOutputs = ServeParameterRows.claimedOutputs(all.toList().ifEmpty { listOf(target) }),
+      fileSystem = fs,
+    )
+
+  /** The reporter's case: four provider values, four servable ids. */
+  @Test
+  fun `a labelled fan-out becomes one row per value`() {
+    val swatch = preview("SwatchPreview")
+    touch("SwatchPreview.png")
+    listOf("Crimson", "Teal", "Amber", "Violet").forEach { touch("SwatchPreview_$it.png") }
+
+    assertEquals(
+      listOf(
+        "SwatchPreview_Amber",
+        "SwatchPreview_Crimson",
+        "SwatchPreview_Teal",
+        "SwatchPreview_Violet",
+      ),
+      rows(swatch).map { it.id },
+    )
+    assertEquals(listOf("Amber", "Crimson", "Teal", "Violet"), rows(swatch).map { it.label })
+  }
+
+  /** `PARAM_10` sorts after `PARAM_2`, not before it as lexicographic order would. */
+  @Test
+  fun `index rows order numerically and come before labelled ones`() {
+    val p = preview("Foo")
+    listOf("PARAM_0", "PARAM_2", "PARAM_10").forEach { touch("Foo_$it.png") }
+    touch("Foo_Zed.png")
+
+    assertEquals(
+      listOf("Foo_PARAM_0", "Foo_PARAM_2", "Foo_PARAM_10", "Foo_Zed"),
+      rows(p).map { it.id },
+    )
+  }
+
+  /**
+   * `Foo` and `Foo_Dark` are both real previews when a multi-preview annotation is in play, so
+   * `renders/Foo_Dark.png` belongs to the latter and must not be read as a row of the former.
+   */
+  @Test
+  fun `a sibling preview's own render is not a row`() {
+    val foo = preview("Foo")
+    val fooDark = preview("Foo_Dark", output = "renders/Foo_Dark.png")
+    touch("Foo_Dark.png")
+    touch("Foo_Crimson.png")
+
+    assertEquals(listOf("Foo_Crimson"), rows(foo, foo, fooDark).map { it.id })
+  }
+
+  /**
+   * Issue #3819. A *longer-stemmed* sibling owns its own fan-out: with `Foo` and `Foo_Dark` both
+   * real previews, `Foo_Dark_Alice.png` is `Foo_Dark`'s row, not `Foo`'s row `Dark_Alice`. The
+   * builder that feeds `show` / `list` / `render` always applied that rule
+   * (`parameterFanoutOwnedBySibling`) and this glob didn't — the exact drift that makes two
+   * derivations of one id dangerous: `serve` would list a row id that resolves to a different
+   * preview's render everywhere else. Both now go through `PreviewParameterFanout`.
+   */
+  @Test
+  fun `a longer-stemmed sibling's fan-out is not a row of the shorter one`() {
+    val foo = preview("Foo")
+    val fooDark = preview("Foo_Dark", output = "renders/Foo_Dark.png")
+    touch("Foo_Dark.png")
+    touch("Foo_Dark_Alice.png")
+    touch("Foo_Crimson.png")
+
+    assertEquals(listOf("Foo_Crimson"), rows(foo, foo, fooDark).map { it.id })
+    assertEquals(listOf("Foo_Dark_Alice"), rows(fooDark, foo, fooDark).map { it.id })
+  }
+
+  /** A preview's own non-row captures (scroll variants) are claimed by it, so they're excluded. */
+  @Test
+  fun `the preview's own extra captures are not rows`() {
+    val p =
+      preview("Foo")
+        .copy(
+          captures =
+            listOf(
+              Capture(renderOutput = "renders/Foo.png"),
+              Capture(renderOutput = "renders/Foo_SCROLL_end.png"),
+            )
+        )
+    touch("Foo_SCROLL_end.png")
+    touch("Foo_Crimson.png")
+
+    assertEquals(listOf("Foo_Crimson"), rows(p).map { it.id })
+  }
+
+  /** No provider means no rows — an ordinary preview keeps exactly its old single entry. */
+  @Test
+  fun `a preview with no provider never expands`() {
+    val plain = preview("Plain", parameterized = false)
+    touch("Plain_Crimson.png")
+
+    assertTrue(rows(plain).isEmpty())
+  }
+
+  /**
+   * A `serve` run that didn't render (bundle-backed, or a render that failed) has no fan-out on
+   * disk. Expanding to nothing keeps the base id listed rather than emptying the viewer.
+   */
+  @Test
+  fun `a missing fan-out expands to nothing`() {
+    val p = preview("Ghost")
+    assertTrue(rows(p).isEmpty())
+
+    val noDir = ServeParameterRows.rowsFor(p, "/nope".toPath(), emptySet(), fs)
+    assertTrue(noDir.isEmpty())
+  }
+
+  /** Only files sharing the template's extension count — a GIF sibling isn't a PNG row. */
+  @Test
+  fun `only the template extension matches`() {
+    val p = preview("Foo")
+    touch("Foo_Crimson.png")
+    touch("Foo_Animated.gif")
+
+    assertEquals(listOf("Foo_Crimson"), rows(p).map { it.id })
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRcCompareTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRcCompareTest.kt
@@ -1,0 +1,193 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * The serve side of the published Remote Compose player comparison: re-keying a delivery branch's
+ * `rc-compare-summary.json` onto catalog ids, planning the lane images to stage, and reading the
+ * staged result back.
+ */
+class ServeRcCompareTest {
+
+  /** A summary in the exact shape `rc-compare.mjs` writes, trimmed to the fields serve reads. */
+  private val summaryJson =
+    """
+    {
+      "system": "remote-m3",
+      "threshold": 0.1,
+      "meanMismatchPct": 1.21,
+      "rows": [
+        {
+          "id": "com.example.CatalogPreviewsKt.AppCardRemote_width_320dp",
+          "rendered": true, "mismatchPct": 2.96, "mismatchPx": 9116,
+          "width": 640, "height": 480, "note": null, "referenceBlank": false,
+          "embeddedRendered": true, "embeddedMismatchPct": 0.007, "embeddedMismatchPx": 24,
+          "embeddedNote": null,
+          "androidxEmbeddedRendered": true, "androidxEmbeddedMismatchPct": 0.5,
+          "androidxEmbeddedMismatchPx": 1700, "androidxEmbeddedNote": null,
+          "cmpWasmRendered": false, "cmpWasmMismatchPct": null, "cmpWasmMismatchPx": null,
+          "cmpWasmNote": "Unsupported operation at byte 110"
+        },
+        {
+          "id": "com.example.CatalogPreviewsKt.BlankRemote_width_200dp",
+          "rendered": true, "mismatchPct": null, "mismatchPx": null,
+          "width": 400, "height": 400, "note": null, "referenceBlank": true,
+          "embeddedRendered": true, "embeddedMismatchPct": null, "embeddedMismatchPx": null,
+          "embeddedNote": null,
+          "androidxEmbeddedRendered": false, "androidxEmbeddedMismatchPct": null,
+          "androidxEmbeddedMismatchPx": null, "androidxEmbeddedNote": "upstream render failed",
+          "cmpWasmRendered": false, "cmpWasmNote": "no render"
+        },
+        {
+          "id": "com.example.CatalogPreviewsKt.UnpublishedRemote_width_100dp",
+          "rendered": true, "mismatchPct": 1.0, "mismatchPx": 10,
+          "width": 100, "height": 100, "referenceBlank": false
+        }
+      ]
+    }
+    """
+      .trimIndent()
+
+  private val alias =
+    mapOf(
+      "appcard__ideal__default__compact" to
+        "com.example.CatalogPreviewsKt.AppCardRemote_width_320dp",
+      "blank__ideal__default__compact" to "com.example.CatalogPreviewsKt.BlankRemote_width_200dp",
+      // No summary row — an Android-only catalog id, which must simply not appear.
+      "switch__ideal__default__compact" to "com.example.CatalogPreviewsKt.SwitchRemote",
+    )
+
+  private fun plan(): RcComparePlan {
+    val summary = assertNotNull(ServeRcCompare.parseSummary(summaryJson.encodeToByteArray()))
+    return assertNotNull(ServeRcCompare.plan(summary, alias))
+  }
+
+  @Test
+  fun `re-keys published rows onto catalog ids and drops unmatched ones`() {
+    val manifest = plan().manifest
+    assertEquals(
+      listOf("appcard__ideal__default__compact", "blank__ideal__default__compact"),
+      manifest.rows.map { it.previewId },
+    )
+    assertEquals(0.1, manifest.threshold)
+    assertEquals(640, manifest.rows[0].width)
+    assertTrue(manifest.rows[1].referenceBlank)
+  }
+
+  @Test
+  fun `keeps only the lanes the run actually covered`() {
+    // The published run had no cmp-jvm player, so that column does not exist at all — an empty
+    // column would read as "the player rendered nothing", which is a different claim.
+    assertEquals(
+      listOf("baked", "js", "embedded", "androidx-embedded", "cmp-wasm"),
+      plan().manifest.lanes.map { it.id },
+    )
+  }
+
+  @Test
+  fun `plans one fetch per rendered lane, keyed by lane and slot`() {
+    val plan = plan()
+    assertEquals(
+      "rc/com.example.CatalogPreviewsKt.AppCardRemote_width_320dp.png",
+      plan.assets.entries.first { it.value == "js/0.png" }.key,
+    )
+    assertEquals(
+      "rc-diff/com.example.CatalogPreviewsKt.AppCardRemote_width_320dp.png",
+      plan.assets.entries.first { it.value == "js-diff/0.png" }.key,
+    )
+    // A lane that could not render the document costs no round-trip at all.
+    assertFalse(plan.assets.values.any { it.startsWith("cmp-wasm/") })
+    // …and its reason travels instead of an image.
+    val wasm = plan.manifest.rows[0].lanes.getValue("cmp-wasm")
+    assertFalse(wasm.rendered)
+    assertEquals("Unsupported operation at byte 110", wasm.note)
+    val upstream = plan.manifest.rows[1].lanes.getValue("androidx-embedded")
+    assertFalse(upstream.rendered)
+    assertEquals("upstream render failed", upstream.note)
+  }
+
+  @Test
+  fun `an unscorable row keeps its renders but carries no score`() {
+    val blank = plan().manifest.rows[1]
+    val js = blank.lanes.getValue("js")
+    assertTrue(js.rendered)
+    assertEquals("js/1.png", js.render)
+    // Nothing was diffed against a blank baked capture, so there is no diff and no percentage —
+    // a 0.00% here would be a green band for a comparison that never happened.
+    assertEquals("", js.diff)
+    assertNull(js.mismatchPct)
+  }
+
+  @Test
+  fun `drops cells whose image never landed, and the manifest when none did`() {
+    val plan = plan()
+    val partial =
+      assertNotNull(ServeRcCompare.retainStaged(plan.manifest, setOf("baked/0.png", "js/0.png")))
+    assertEquals("js/0.png", partial.rows[0].lanes.getValue("js").render)
+    // The render landed but its diff didn't: the cell stays, and the page falls back to diffing it.
+    assertEquals("", partial.rows[0].lanes.getValue("js").diff)
+    val gone = partial.rows[1].lanes.getValue("js")
+    assertFalse(gone.rendered)
+    assertEquals("render was not published", gone.note)
+    assertNull(ServeRcCompare.retainStaged(plan.manifest, emptySet()))
+  }
+
+  @Test
+  fun `serves only names from the fixed lane vocabulary`(@TempDir dir: File) {
+    val root = File(dir, ServeRcCompare.DIRECTORY)
+    File(root, "js").mkdirs()
+    File(root, "js/0.png").writeBytes(byteArrayOf(1, 2, 3))
+    File(dir, "secret.txt").writeText("nope")
+    val store = ServeRcCompareStore.load(dir)
+
+    assertEquals(listOf<Byte>(1, 2, 3), store.image("js/0.png")!!.toList())
+    assertNull(store.image("js/1.png"), "an unstaged slot")
+    assertNull(store.image("nope/0.png"), "an unknown lane")
+    assertNull(store.image("js/../../secret.txt"), "a traversing name")
+    assertNull(store.image("../secret.txt"), "an escaping name")
+    assertNull(store.image("js/0.png/x"), "a name with extra segments")
+  }
+
+  @Test
+  fun `the manifest resolves only once the staging lane has written it`(@TempDir dir: File) {
+    val store = ServeRcCompareStore.load(dir)
+    // The lane PNGs are fetched in the background, so a host built before they land must keep
+    // looking rather than caching "this catalog has no comparison" for its whole lifetime.
+    assertNull(store.manifest())
+    val manifest = ServeRcCompare.retainStaged(plan().manifest, plan().assets.values.toSet())!!
+    val index = File(dir, "${ServeRcCompare.DIRECTORY}/${ServeRcCompare.INDEX_FILE}")
+    index.parentFile.mkdirs()
+    index.writeText(Json.encodeToString(RcCompareManifest.serializer(), manifest))
+    assertEquals(2, store.manifest()?.rows?.size)
+  }
+
+  @Test
+  fun `a settled catalog with no comparison is not pending`(@TempDir dir: File) {
+    // "The lane hasn't finished" and "this catalog publishes none" both show the older in-browser
+    // lane, but only the first makes the page's shape provisional — and only that one must stay out
+    // of caches, or the pre-manifest page is pinned at the edge after the lanes land.
+    val store = ServeRcCompareStore.load(dir)
+    assertTrue(store.pending())
+    val index = File(dir, "${ServeRcCompare.DIRECTORY}/${ServeRcCompare.INDEX_FILE}")
+    index.parentFile.mkdirs()
+    index.writeText(Json.encodeToString(RcCompareManifest.serializer(), ServeRcCompare.NONE))
+    assertFalse(store.pending())
+    assertNull(store.manifest(), "an empty manifest is a settled absence, not a view")
+  }
+
+  @Test
+  fun `a summary with no rows, or one nothing matches, yields no view`() {
+    assertNull(ServeRcCompare.parseSummary("""{"rows":[]}""".encodeToByteArray()))
+    assertNull(ServeRcCompare.parseSummary("not json".encodeToByteArray()))
+    val summary = assertNotNull(ServeRcCompare.parseSummary(summaryJson.encodeToByteArray()))
+    assertNull(ServeRcCompare.plan(summary, mapOf("x" to "y")))
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostStreamTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostStreamTest.kt
@@ -1,0 +1,108 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.StreamCodec
+import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+import java.io.File
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ServeRenderHostStreamTest {
+
+  private val previewId = "com.example.Red"
+
+  private fun newRenderRoot(): File =
+    java.nio.file.Files.createTempDirectory("serve-host-stream").toFile().also { it.deleteOnExit() }
+
+  private fun host(session: FakeRenderSession): ServeRenderHost =
+    ServeRenderHost(session, listOf(ServePreview(previewId, "Red")), renderTimeoutSeconds = 30)
+
+  @Test
+  fun `startStream returns null when the backend does not support streaming`() {
+    val session = FakeRenderSession(newRenderRoot()) // streaming = false
+    host(session).use { h -> assertNull(h.startStream(previewId, PreviewOverrides()) {}) }
+  }
+
+  @Test
+  fun `startStream forwards frames for its own frameStreamId only`() {
+    val session = FakeRenderSession(newRenderRoot(), streaming = true)
+    host(session).use { h ->
+      val frames = CopyOnWriteArrayList<StreamFrameParams>()
+      val handle = assertNotNull(h.startStream(previewId, PreviewOverrides()) { frames.add(it) })
+      val fsid = assertNotNull(session.lastFrameStreamId)
+
+      session.emitStreamFrame(fsid, seq = 0, payloadBase64 = "AAAA")
+      session.emitStreamFrame("some-other-stream", seq = 1, payloadBase64 = "BBBB")
+
+      assertEquals(1, frames.size, "only this stream's frames should be delivered")
+      assertEquals(0L, frames[0].seq)
+      handle.close()
+    }
+  }
+
+  @Test
+  fun `closing the handle stops the stream and unsubscribes`() {
+    val session = FakeRenderSession(newRenderRoot(), streaming = true)
+    host(session).use { h ->
+      val frames = CopyOnWriteArrayList<StreamFrameParams>()
+      val handle = assertNotNull(h.startStream(previewId, PreviewOverrides()) { frames.add(it) })
+      val fsid = assertNotNull(session.lastFrameStreamId)
+
+      handle.input(InteractiveInputKind.CLICK, pixelX = 3, pixelY = 4)
+      assertEquals(1, session.interactiveInputs.size)
+      assertEquals(InteractiveInputKind.CLICK, session.interactiveInputs[0].kind)
+
+      handle.close()
+      assertEquals(listOf(fsid), session.streamStops)
+
+      session.emitStreamFrame(fsid, seq = 9, payloadBase64 = "CCCC")
+      assertTrue(frames.isEmpty(), "frames after close must not be delivered")
+    }
+  }
+
+  @Test
+  fun `unknown preview id yields no stream`() {
+    val session = FakeRenderSession(newRenderRoot(), streaming = true)
+    host(session).use { h ->
+      assertNull(h.startStream("com.example.Missing", PreviewOverrides()) {})
+    }
+  }
+
+  @Test
+  fun `a keyframe emitted before stream-start returns is not lost`() {
+    // The daemon's frame loop can emit the initial keyframe before stream/start's RPC response —
+    // the listener must already be registered (and buffer it) so it isn't dropped.
+    val session =
+      FakeRenderSession(newRenderRoot(), streaming = true, emitKeyframeOnStart = "KEYFRAME")
+    host(session).use { h ->
+      val frames = CopyOnWriteArrayList<StreamFrameParams>()
+      assertNotNull(h.startStream(previewId, PreviewOverrides()) { frames.add(it) })
+      assertEquals(1, frames.size, "the pre-response keyframe must be replayed, not lost")
+      assertEquals(0L, frames[0].seq)
+    }
+  }
+
+  @Test
+  fun `codec and maxFps are forwarded to stream start`() {
+    val session = FakeRenderSession(newRenderRoot(), streaming = true)
+    host(session).use { h ->
+      assertNotNull(h.startStream(previewId, PreviewOverrides(), StreamCodec.WEBP, 30) {})
+      assertEquals(StreamCodec.WEBP, session.lastCodec)
+      assertEquals(30, session.lastMaxFps)
+    }
+  }
+
+  @Test
+  fun `no held session falls back (null) and stops the stream`() {
+    val session = FakeRenderSession(newRenderRoot(), streaming = true, heldSession = false)
+    host(session).use { h ->
+      assertNull(h.startStream(previewId, PreviewOverrides()) {})
+      assertEquals(1, session.streamStops.size, "the frameless stream must be torn down")
+    }
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
@@ -1,0 +1,937 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.DataFetchParams
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.UiMode
+import ee.schimke.composeai.data.layoutinspector.ComposeFigmaSvgProduct
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsProduct
+import ee.schimke.composeai.data.layoutinspector.PreviewSlots
+import ee.schimke.composeai.data.layoutinspector.PreviewSlotsPayload
+import ee.schimke.composeai.data.layoutinspector.SlotBounds
+import ee.schimke.composeai.data.theme.Material3ThemeProduct
+import ee.schimke.composeai.render.session.RenderSession
+import java.io.File
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+class ServeRenderHostTest {
+
+  private val previewId = "com.example.Red"
+
+  private fun newRenderRoot(): File =
+    java.nio.file.Files.createTempDirectory("serve-host").toFile().also { it.deleteOnExit() }
+
+  private fun host(session: RenderSession): ServeRenderHost =
+    ServeRenderHost(
+      session = session,
+      previews =
+        listOf(
+          ServePreview(previewId, "Red", dataProductKinds = setOf(ServeRenderHost.SCROLL_LONG_KIND))
+        ),
+      renderTimeoutSeconds = 30,
+    )
+
+  @Test
+  fun `identical requests are served from cache after one render`() {
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      val first = h.render(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      val second = h.render(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      assertTrue(first is RenderOutcome.Ok)
+      assertTrue(second is RenderOutcome.Ok)
+      assertContentEquals(first.png, second.png)
+      assertEquals(1, session.renderCount.get(), "second identical request must hit the cache")
+    }
+  }
+
+  @Test
+  fun `renderFailed completes the wait immediately instead of sleeping out the budget`() {
+    // Regression for the serve cold-render investigation: only `renderFinished` completed the
+    // pending latch, so a preview whose render body threw (daemon sends `renderFailed` within
+    // seconds) left the host sleeping out its ENTIRE render budget under renderLock — 180s per
+    // broken-preview render on the CLI, 900s on the public server. Profiled on confetti-mobile:
+    // this single behaviour was the whole "cold Android renders take minutes" symptom.
+    lateinit var session: FakeRenderSession
+    session =
+      FakeRenderSession(
+        newRenderRoot(),
+        renderHook = { _, _ -> session.emitFailed(previewId, "java.lang.NullPointerException") },
+      )
+    host(session).use { h ->
+      val startedMs = System.currentTimeMillis()
+      val outcome = h.render(previewId, PreviewOverrides())
+      val tookMs = System.currentTimeMillis() - startedMs
+      assertTrue(outcome is RenderOutcome.Failed, "expected Failed, got $outcome")
+      assertTrue(
+        outcome.reason.contains("NullPointerException"),
+        "failure reason should carry the daemon's error message, got '${outcome.reason}'",
+      )
+      // The host is built with renderTimeoutSeconds = 30; anything near that means we slept out
+      // the budget rather than completing on the failure event.
+      assertTrue(tookMs < 10_000, "render should fail fast on renderFailed, took ${tookMs}ms")
+      // A failed render proves nothing about warmth: the next render must still get the cold
+      // budget, and a subsequent success must work unaffected.
+      val ok =
+        FakeRenderSession(newRenderRoot()).let { fresh ->
+          host(fresh).use { it2 -> it2.render(previewId, PreviewOverrides()) }
+        }
+      assertTrue(ok is RenderOutcome.Ok)
+    }
+  }
+
+  @Test
+  fun `a fatal linkage failure trips the breaker instead of being retried forever`() {
+    // Issue #3448: an UnsatisfiedLinkError — a JVM linkage failure that cannot succeed on retry,
+    // ever, for any input — was retried 3794 times in ~14 minutes. The daemon must be asked once.
+    val linkage =
+      "UnsatisfiedLinkError: 'long org.jetbrains.skia.PathBuilderKt.PathBuilder_nMakeFromPath(long)'"
+    lateinit var session: FakeRenderSession
+    session =
+      FakeRenderSession(
+        newRenderRoot(),
+        renderHook = { _, _ -> session.emitFailed(previewId, linkage) },
+      )
+    host(session).use { h ->
+      assertTrue(h.hasLiveStream, "a healthy host advertises its live lane")
+      assertTrue(h.degradations.isEmpty())
+
+      val first = h.render(previewId, PreviewOverrides())
+      assertTrue(first is RenderOutcome.Failed, "expected Failed, got $first")
+
+      // Every subsequent render is answered from the breaker without touching the daemon.
+      repeat(20) { i ->
+        val outcome = h.render(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+        assertTrue(outcome is RenderOutcome.Failed, "render $i: expected Failed, got $outcome")
+        assertTrue(
+          outcome.reason.contains("UnsatisfiedLinkError"),
+          "the caller must be told the real fault, not 'busy; retry shortly': ${outcome.reason}",
+        )
+      }
+      assertEquals(1, session.renderCount.get(), "the daemon must be asked exactly once")
+
+      // The lane stops advertising itself as live, publishes why, and latches every preview so the
+      // HTTP layer answers terminally instead of sending the browser round the retry loop.
+      assertFalse(h.hasLiveStream, "a broken lane must stop advertising live")
+      val degradation = h.degradations.single()
+      assertEquals(ServeDegradation.RENDER_LANE_BROKEN, degradation.code)
+      assertTrue(degradation.detail.contains("UnsatisfiedLinkError"))
+      assertNotNull(h.renderFailureLatch(previewId, PreviewOverrides()))
+
+      val breaker = assertNotNull(h.renderBreaker())
+      assertTrue(breaker.fatal)
+      assertEquals(20, breaker.shortCircuitedRenders)
+      val stats = assertNotNull(h.renderPerfStats())
+      assertEquals(20, stats.shortCircuited, "refused renders are counted apart from failures")
+      assertEquals(1, stats.failed, "the short-circuits must not inflate the failure count")
+      assertNotNull(stats.breaker)
+    }
+  }
+
+  @Test
+  fun `different overrides each render`() {
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      h.render(previewId, PreviewOverrides(uiMode = UiMode.LIGHT))
+      h.render(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      assertEquals(2, session.renderCount.get())
+    }
+  }
+
+  @Test
+  fun `a render backs off to Busy when the daemon lock is held, not blocking the render budget`() {
+    // The host is built with renderTimeoutSeconds = 30. A cold render holding the per-daemon lock
+    // for that long must NOT make a concurrent render block for the whole budget (which, on the
+    // live server, pins a shared HTTP render slot and saturates the queue). It must back off to
+    // Busy near the bounded wait instead.
+    val firstHoldsLock = CountDownLatch(1)
+    val release = CountDownLatch(1)
+    val session =
+      FakeRenderSession(
+        newRenderRoot(),
+        renderHook = { call, emit ->
+          if (call == 1) {
+            // We're inside renderNow, i.e. under renderLock — signal, then block to model a slow
+            // cold render holding the lock.
+            firstHoldsLock.countDown()
+            release.await(30, TimeUnit.SECONDS)
+          }
+          emit("png-$call".toByteArray())
+        },
+      )
+    host(session).use { h ->
+      val pool = Executors.newSingleThreadExecutor()
+      try {
+        // Thread A: grabs the lock and blocks in its render.
+        pool.submit { h.render(previewId, PreviewOverrides(uiMode = UiMode.LIGHT)) }
+        assertTrue(firstHoldsLock.await(10, TimeUnit.SECONDS), "first render should take the lock")
+
+        // Thread B (this thread): a DIFFERENT override, so no cache hit — it must contend for the
+        // lock and back off rather than wait out the 30s budget.
+        val startNs = System.nanoTime()
+        val outcome = h.render(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+        val elapsedMs = (System.nanoTime() - startNs) / 1_000_000
+
+        assertTrue(
+          outcome is RenderOutcome.Busy,
+          "a render blocked on the busy daemon must back off to Busy, got $outcome",
+        )
+        assertTrue(
+          elapsedMs < 10_000,
+          "Busy must return near the bounded wait (~2s), not the 30s budget; took ${elapsedMs}ms",
+        )
+      } finally {
+        release.countDown()
+        pool.shutdown()
+        pool.awaitTermination(30, TimeUnit.SECONDS)
+      }
+    }
+  }
+
+  @Test
+  fun `gesturesRenderable follows the daemon's advertised gesture capability`() {
+    // An Android-style backend advertises "gestures" ⇒ the viewer offers the hint control.
+    host(FakeRenderSession(newRenderRoot(), supportedOverrides = listOf("gestures"))).use { h ->
+      assertTrue(h.gesturesRenderable, "gestures in supportedOverrides ⇒ renderable")
+    }
+    // A desktop-style backend advertises none ⇒ the control is gated off (would be a dead toggle).
+    host(FakeRenderSession(newRenderRoot())).use { h ->
+      assertFalse(h.gesturesRenderable, "no gesture capability ⇒ not renderable")
+    }
+  }
+
+  @Test
+  fun `hasSvgExport enables the daemon's figma-svg data products on open`() {
+    // The daemon registers compose/figma-svg (+ -long) inactive; without this enable an
+    // override-bearing .svg render fails "-32020 kind not advertised". Assert the host activates
+    // them on open and advertises the SVG export.
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      assertTrue(h.hasSvgExport, "a figma-svg-capable daemon advertises SVG export")
+      assertTrue(
+        session.enabledExtensionIds.containsAll(
+          listOf(
+            ComposeFigmaSvgProduct.KIND,
+            ComposeFigmaSvgProduct.KIND_LONG,
+            ServeRenderHost.SCROLL_EXTENSION_ID,
+          )
+        ),
+        "the host enables the viewport and full-page export products on open",
+      )
+      assertTrue(h.hasScrollExport, "the daemon advertises full-page PNG export")
+      assertTrue(h.hasScrollExportFor(previewId), "the annotated preview offers full-page export")
+    }
+  }
+
+  @Test
+  fun `full-page export is hidden for a preview without long-scroll metadata`() {
+    val session = FakeRenderSession(newRenderRoot())
+    ServeRenderHost(
+        session = session,
+        previews = listOf(ServePreview(previewId, "Red")),
+        renderTimeoutSeconds = 30,
+      )
+      .use { h ->
+        assertTrue(h.hasScrollExport, "the daemon supports the scroll producer")
+        assertFalse(h.hasScrollExportFor(previewId), "the preview did not declare LONG capture")
+      }
+  }
+
+  @Test
+  fun `hasSvgExport is false when the daemon lacks figma-svg`() {
+    // A backend without the figma-svg producer reports the ids as unknown; the host must then offer
+    // no SVG export rather than dead-ending an override .svg in a 500.
+    host(FakeRenderSession(newRenderRoot(), figmaSvgAvailable = false)).use { h ->
+      assertFalse(h.hasSvgExport, "no figma-svg producer ⇒ no advertised SVG export")
+      assertTrue(h.hasScrollExport, "full-page PNG remains available without figma-svg")
+      assertTrue(
+        h.renderScrollPng(previewId, PreviewOverrides()) is RenderOutcome.Ok,
+        "PNG tall capture must not depend on the SVG producer",
+      )
+    }
+  }
+
+  @Test
+  fun `renderSvg short-circuits to NotFound when figma-svg is unavailable`() {
+    // Without the producer the SVG render methods must NOT hit fetchData (which would 500 with
+    // `-32020 kind not advertised`); they return NotFound (a 404) to match the advertised no-SVG
+    // lane. Guards the Codex P2 on the availability gate.
+    val session = FakeRenderSession(newRenderRoot(), figmaSvgAvailable = false)
+    host(session).use { h ->
+      assertEquals(
+        SvgOutcome.NotFound,
+        h.renderSvg(previewId, PreviewOverrides(uiMode = UiMode.DARK)),
+      )
+      assertEquals(SvgOutcome.NotFound, h.renderScrollSvg(previewId, PreviewOverrides()))
+      assertEquals(
+        0,
+        session.renderCount.get(),
+        "no render/fetch is attempted for an SVG-less host",
+      )
+    }
+  }
+
+  @Test
+  fun `renderSvg returns the figma-svg for the given overrides`() {
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      val out = h.renderSvg(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      assertTrue(out is SvgOutcome.Ok)
+      assertEquals("svg:DARK:null:null", out.svg.decodeToString())
+    }
+  }
+
+  @Test
+  fun `renderScrollSvg returns the full-page figma-svg-long export`() {
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      val out = h.renderScrollSvg(previewId, PreviewOverrides())
+      assertTrue(out is SvgOutcome.Ok)
+      assertEquals(
+        "svg-long:$previewId:null:null:null",
+        out.svg.decodeToString(),
+      )
+      // The fetch carries the force flag + a serialized overrides bag (default here).
+      val params = session.lastScrollFetchParams as JsonObject
+      assertEquals(JsonPrimitive(true), params[DataFetchParams.PARAM_FORCE_RERENDER])
+      assertNotNull(params[DataFetchParams.PARAM_OVERRIDES])
+    }
+  }
+
+  @Test
+  fun `renderScrollSvg serves identical requests from cache`() {
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      val a = h.renderScrollSvg(previewId, PreviewOverrides())
+      val b = h.renderScrollSvg(previewId, PreviewOverrides())
+      assertTrue(a is SvgOutcome.Ok && b is SvgOutcome.Ok)
+      assertContentEquals(a.svg, b.svg)
+      assertEquals(
+        1,
+        session.scrollFetchCount.get(),
+        "identical overrides ⇒ one fetch, then cached",
+      )
+    }
+  }
+
+  @Test
+  fun `renderScrollSvg is override-aware — distinct overrides re-render and don't collide in cache`() {
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      val dark = h.renderScrollSvg(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      val light = h.renderScrollSvg(previewId, PreviewOverrides(uiMode = UiMode.LIGHT))
+      assertTrue(dark is SvgOutcome.Ok && light is SvgOutcome.Ok)
+      assertEquals(
+        "svg-long:$previewId:DARK:null:null",
+        dark.svg.decodeToString(),
+      )
+      assertEquals(
+        "svg-long:$previewId:LIGHT:null:null",
+        light.svg.decodeToString(),
+      )
+      assertEquals(2, session.scrollFetchCount.get(), "each distinct override re-renders")
+      // Re-requesting the dark capsule is a cache hit — no third fetch, and its bytes are intact.
+      val darkAgain = h.renderScrollSvg(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      assertContentEquals(dark.svg, (darkAgain as SvgOutcome.Ok).svg)
+      assertEquals(
+        2,
+        session.scrollFetchCount.get(),
+        "the repeat dark request is served from cache",
+      )
+    }
+  }
+
+  @Test
+  fun `renderScrollSvg 404s an unknown preview`() {
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      assertTrue(h.renderScrollSvg("no.such.Preview", PreviewOverrides()) is SvgOutcome.NotFound)
+    }
+  }
+
+  @Test
+  fun `renderScrollPng returns an override-aware full-page PNG and caches it`() {
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      val dark = h.renderScrollPng(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      val light = h.renderScrollPng(previewId, PreviewOverrides(uiMode = UiMode.LIGHT))
+      val darkAgain = h.renderScrollPng(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+
+      assertEquals(
+        "png-long:$previewId:DARK:null:null",
+        (dark as RenderOutcome.Ok).png.decodeToString(),
+      )
+      assertEquals(
+        "png-long:$previewId:LIGHT:null:null",
+        (light as RenderOutcome.Ok).png.decodeToString(),
+      )
+      assertContentEquals(dark.png, (darkAgain as RenderOutcome.Ok).png)
+      assertEquals(RenderOutcome.Generation.DAEMON_CACHE, darkAgain.generation)
+      assertEquals(2, session.scrollPngFetchCount.get())
+      val params = session.lastScrollPngFetchParams as JsonObject
+      assertEquals(JsonPrimitive(true), params[DataFetchParams.PARAM_FORCE_RERENDER])
+      assertNotNull(params[DataFetchParams.PARAM_OVERRIDES])
+    }
+  }
+
+  @Test
+  fun `renderScrollPng 404s an unknown preview`() {
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      assertEquals(RenderOutcome.NotFound, h.renderScrollPng("no.such.Preview", PreviewOverrides()))
+    }
+  }
+
+  @Test
+  fun `renderSvg serves identical requests from cache`() {
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      val first = h.renderSvg(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      val second = h.renderSvg(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      assertEquals(1, session.renderCount.get(), "second identical SVG request must hit the cache")
+      // The vector lane reports the same generation ladder as the raster one — it rides the
+      // `X-Compose-Preview-Generation` header, so a cache hit must not claim to be a fresh render.
+      assertEquals(
+        RenderOutcome.Generation.DAEMON,
+        (first as SvgOutcome.Ok).generation,
+        "the first SVG export really was rendered",
+      )
+      assertEquals(
+        RenderOutcome.Generation.DAEMON_CACHE,
+        (second as SvgOutcome.Ok).generation,
+        "the second came from the SVG cache",
+      )
+    }
+  }
+
+  @Test
+  fun `renderSvg is not stale when the png for those overrides is already cached`() {
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      // Cache the dark PNG, then render light — the shared per-preview SVG file is now light's.
+      h.render(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      h.render(previewId, PreviewOverrides(uiMode = UiMode.LIGHT))
+      // A dark SVG request must re-render dark, not return the shared file's stale light SVG.
+      val out = h.renderSvg(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      assertTrue(out is SvgOutcome.Ok)
+      assertEquals("svg:DARK:null:null", out.svg.decodeToString())
+    }
+  }
+
+  @Test
+  fun `renderSlots returns the declared dp-slot markers for the given overrides`() {
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      val out = h.renderSlots(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      assertTrue(out is SlotsOutcome.Ok)
+      val payload =
+        Json.decodeFromString(
+          PreviewSlotsPayload.serializer(),
+          out.json.decodeToString(),
+        )
+      assertEquals(previewId, payload.previewId)
+      assertEquals(listOf("leadingIcon", "supporting"), payload.slots.map { it.name })
+      assertEquals(SlotBounds(8, 8, 40, 40), payload.slots.first().bounds)
+      assertEquals(32, payload.slots.first().width)
+    }
+  }
+
+  @Test
+  fun `renderSlots serves identical requests from cache`() {
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      h.renderSlots(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      h.renderSlots(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      assertEquals(
+        1,
+        session.renderCount.get(),
+        "second identical slots request must hit the cache",
+      )
+    }
+  }
+
+  @Test
+  fun `renderAnnotations projects the semantics tree into typography and theme layers`() {
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      val out = h.renderAnnotations(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      assertTrue(out is AnnotationsOutcome.Ok)
+      val payload = Json.parseToJsonElement(out.json.decodeToString()).jsonObject
+      assertEquals(previewId, payload["previewId"]?.jsonPrimitive?.content)
+      val annotations =
+        Json.decodeFromJsonElement(
+          ListSerializer(DesignAnnotation.serializer()),
+          payload.getValue("annotations"),
+        )
+      val typography = annotations.single { it.kind == AnnotationKind.TYPOGRAPHY }
+      // Size over line height, the shortened face, then the weight — the one line a designer reads
+      // off a type ramp. The face is shortened from the resolved font FILE the daemon reports.
+      assertEquals("14.0sp/20.0sp · Roboto-Medium.ttf · 500", typography.label)
+      assertEquals("Supporting text", typography.role)
+      assertEquals(AnnotationBounds(x = 48, y = 44, width = 144, height = 20), typography.bounds)
+      assertEquals("14.0sp", typography.detail["fontSize"])
+
+      val theme = annotations.single { it.kind == AnnotationKind.THEME }
+      assertEquals("fill #FF6750A4 · radius 12.0dp · border 1.0dp #FF79747E", theme.label)
+      assertEquals(AnnotationBounds(x = 8, y = 8, width = 32, height = 32), theme.bounds)
+      assertEquals("#FF6750A4", theme.detail["background"])
+
+      // The tag index rides the SAME response, off the SAME semantics payload, under the same
+      // render lock. That co-location is the contract: a parity element gate compares a recorded
+      // tag box against a current one, so an index built by a second render would report movement
+      // that never happened.
+      val tags =
+        Json.decodeFromJsonElement(
+          MapSerializer(String.serializer(), ServeSemanticsTags.TagEntry.serializer()),
+          payload.getValue("tags"),
+        )
+      assertEquals(
+        setOf(
+          "${PreviewSlots.SLOT_TAG_PREFIX}leadingIcon",
+          "${PreviewSlots.SLOT_TAG_PREFIX}supporting",
+        ),
+        tags.keys,
+      )
+      val icon = tags.getValue("${PreviewSlots.SLOT_TAG_PREFIX}leadingIcon")
+      assertEquals(1, icon.count)
+      // Same box the theme annotation reports for that node — one coordinate space, not two.
+      assertEquals(theme.bounds, icon.bounds)
+    }
+  }
+
+  @Test
+  fun `renderAnnotations joins Material typography consumers to semantics by node id`() {
+    val theme =
+      Json.parseToJsonElement(
+        """
+        {
+          "resolvedTokens": {
+            "colorScheme": {"primary": "#FF000000"},
+            "typography": {"labelLarge": {"fontSize": 14.0, "fontSizeUnit": "sp"}},
+            "shapes": {}
+          },
+          "consumers": [{"nodeId": "2", "tokens": ["primary", "labelLarge"]}]
+        }
+        """
+          .trimIndent()
+      )
+    val session =
+      FakeRenderSession(
+        newRenderRoot(),
+        fetchDataHook = { _, kind ->
+          if (kind == Material3ThemeProduct.KIND) {
+            DataFetchResult(
+              kind = kind,
+              schemaVersion = Material3ThemeProduct.SCHEMA_VERSION,
+              payload = theme,
+            )
+          } else {
+            null
+          }
+        },
+      )
+    host(session).use { h ->
+      val out = h.renderAnnotations(previewId, PreviewOverrides())
+      assertTrue(out is AnnotationsOutcome.Ok)
+      val payload = Json.parseToJsonElement(out.json.decodeToString()).jsonObject
+      val annotations =
+        Json.decodeFromJsonElement(
+          ListSerializer(DesignAnnotation.serializer()),
+          payload.getValue("annotations"),
+        )
+      val typography = annotations.single { it.kind == AnnotationKind.TYPOGRAPHY }
+
+      assertEquals("labelLarge", typography.detail["token"])
+      assertEquals(
+        "MaterialTheme.typography.labelLarge · 14.0sp/20.0sp · Roboto-Medium.ttf · 500",
+        typography.label,
+      )
+      assertTrue(Material3ThemeProduct.KIND !in session.subscribedDataKinds)
+      assertTrue(Material3ThemeProduct.KIND in session.unsubscribedDataKinds)
+      val themeOverrides =
+        session.lastThemeFetchParams?.jsonObject?.get(DataFetchParams.PARAM_OVERRIDES)?.let {
+          Json.decodeFromJsonElement(PreviewOverrides.serializer(), it)
+        }
+      assertEquals(PreviewOverrides(), themeOverrides)
+      assertTrue(ComposeSemanticsProduct.KIND in session.enabledExtensionIds)
+      assertTrue(ServeRenderHost.THEME_EXTENSION_ID in session.enabledExtensionIds)
+    }
+  }
+
+  @Test
+  fun `renderAnnotations serves identical requests from cache`() {
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      h.renderAnnotations(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      h.renderAnnotations(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      assertEquals(
+        1,
+        session.renderCount.get(),
+        "second identical annotations request must hit the cache",
+      )
+    }
+  }
+
+  @Test
+  fun `renderA11y merges the hierarchy with ATF findings and touch targets`() {
+    val session =
+      FakeRenderSession(
+        newRenderRoot(),
+        fetchDataHook = { _, kind ->
+          when (kind) {
+            ServeRenderHost.A11Y_HIERARCHY_KIND ->
+              a11yFetch(kind, """{"nodes":[{"label":"Follow","boundsInScreen":"0,0,48,24"}]}""")
+            ServeRenderHost.A11Y_ATF_KIND ->
+              a11yFetch(
+                kind,
+                """{"findings":[{"level":"ERROR","type":"SpeakableTextPresentCheck","message":"no label"}]}""",
+              )
+            ServeRenderHost.A11Y_TOUCH_TARGETS_KIND ->
+              a11yFetch(
+                kind,
+                """{"targets":[{"nodeId":"7","boundsInScreen":"0,0,48,24","widthDp":24.0,"heightDp":12.0,"findings":["TouchTargetTooSmall"]}]}""",
+              )
+            else -> null
+          }
+        },
+      )
+    host(session).use { h ->
+      val out = h.renderA11y(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      assertTrue(out is A11yOutcome.Ok)
+      val payload = Json.parseToJsonElement(out.json.decodeToString()).jsonObject
+      assertEquals(previewId, payload["previewId"]?.jsonPrimitive?.content)
+      assertEquals(1, payload.getValue("nodes").jsonArray.size)
+      assertEquals(1, payload.getValue("findings").jsonArray.size)
+      assertEquals(1, payload.getValue("touchTargets").jsonArray.size)
+    }
+  }
+
+  @Test
+  fun `renderA11y still draws the focus map when the backend has no ATF products`() {
+    // The desktop backend advertises no `a11y/touchTargets` at all and answers `a11y/atf` with
+    // empty findings — the overlay must still be worth drawing from the hierarchy alone rather
+    // than failing the whole request because an optional product wasn't there.
+    val session =
+      FakeRenderSession(
+        newRenderRoot(),
+        fetchDataHook = { _, kind ->
+          when (kind) {
+            ServeRenderHost.A11Y_HIERARCHY_KIND ->
+              a11yFetch(kind, """{"nodes":[{"label":"Follow","boundsInScreen":"0,0,48,24"}]}""")
+            ServeRenderHost.A11Y_ATF_KIND,
+            ServeRenderHost.A11Y_TOUCH_TARGETS_KIND -> error("kind not advertised")
+            else -> null
+          }
+        },
+      )
+    host(session).use { h ->
+      val out = h.renderA11y(previewId, PreviewOverrides())
+      assertTrue(out is A11yOutcome.Ok)
+      val payload = Json.parseToJsonElement(out.json.decodeToString()).jsonObject
+      assertEquals(1, payload.getValue("nodes").jsonArray.size)
+      assertTrue(payload.getValue("findings").jsonArray.isEmpty())
+      assertTrue(payload.getValue("touchTargets").jsonArray.isEmpty())
+    }
+  }
+
+  @Test
+  fun `renderA11y enables the daemon's inactive a11y extension before fetching`() {
+    // The bug behind "the a11y overlay doesn't work" on a served catalog. The daemon registers its
+    // inspection products INACTIVE, so a `data/fetch` on a session nobody enabled fails `-32020
+    // kind not advertised`. `renderA11y` read no capability of its own, so nothing ran the enable:
+    // on a host whose flags were never asked for — the per-preview daemons `ServeCatalogLiveHost`
+    // routes this lane to, while answering `hasA11yOverlayFor` from the SHARED one — every
+    // accessibility fetch 500'd, until an unrelated SVG or scroll request happened to enable that
+    // daemon and the same URL silently started working.
+    lateinit var session: FakeRenderSession
+    session =
+      FakeRenderSession(
+        newRenderRoot(),
+        fetchDataHook = { _, kind ->
+          when (kind) {
+            ServeRenderHost.A11Y_HIERARCHY_KIND,
+            ServeRenderHost.A11Y_ATF_KIND,
+            ServeRenderHost.A11Y_TOUCH_TARGETS_KIND -> {
+              // Model the daemon: an un-enabled extension's kinds are simply not advertised.
+              check(ServeRenderHost.A11Y_EXTENSION_ID in session.enabledExtensionIds) {
+                "data/fetch: kind not advertised: $kind"
+              }
+              if (kind == ServeRenderHost.A11Y_HIERARCHY_KIND)
+                a11yFetch(kind, """{"nodes":[{"label":"Follow","boundsInScreen":"0,0,48,24"}]}""")
+              else a11yFetch(kind, "{}")
+            }
+            else -> null
+          }
+        },
+      )
+    host(session).use { h ->
+      // Nothing has read a capability flag — exactly the state a freshly-leased per-preview daemon
+      // is in when the viewer asks it for the overlay.
+      val out = h.renderA11y(previewId, PreviewOverrides())
+      assertTrue(out is A11yOutcome.Ok, "expected Ok, got $out")
+      assertTrue(
+        ServeRenderHost.A11Y_EXTENSION_ID in session.enabledExtensionIds,
+        "the a11y lane must enable the extension it fetches from",
+      )
+    }
+  }
+
+  @Test
+  fun `renderA11y is NotFound rather than a 500 when the backend has no a11y extension`() {
+    // Mirrors `renderSvg` on a backend without figma-svg: a host that reports the extension unknown
+    // cannot produce the hierarchy at all, so the lane 404s cleanly instead of fetching into a
+    // `-32020` the viewer surfaces as a 500.
+    val session =
+      FakeRenderSession(
+        newRenderRoot(),
+        unknownExtensionIds = setOf(ServeRenderHost.A11Y_EXTENSION_ID),
+        fetchDataHook = { _, kind ->
+          if (kind.startsWith("a11y/")) error("kind not advertised: $kind") else null
+        },
+      )
+    host(session).use { h ->
+      assertFalse(h.hasA11yOverlay)
+      assertTrue(h.renderA11y(previewId, PreviewOverrides()) is A11yOutcome.NotFound)
+    }
+  }
+
+  @Test
+  fun `renderA11y reports a daemon that cannot be opened instead of throwing`() {
+    // Forcing the enable moved the daemon OPEN into this lane, and that open is deliberately
+    // outside the enable's own `runCatching` so a transient failure leaves the lazy uninitialized
+    // and the next caller retries. It must not escape as an exception: the route only translates
+    // outcome values, so a throw would skip its 500-with-reason and its log line entirely.
+    val logged = CopyOnWriteArrayList<String>()
+    val opens = AtomicInteger(0)
+    // Not `use {}`: a host whose open failed has no subprocess to reap, and `close()` reaches for
+    // the session again to find that out — which would re-throw the stubbed failure from the
+    // cleanup and mask the outcome this test is about.
+    val h =
+      ServeRenderHost(
+        openSession = {
+          opens.incrementAndGet()
+          throw IllegalStateException("daemon handshake timed out")
+        },
+        previews = listOf(ServePreview(previewId, "Red")),
+        onLog = { logged += it },
+      )
+    val out = h.renderA11y(previewId, PreviewOverrides())
+    assertTrue(out is A11yOutcome.Failed, "expected Failed, got $out")
+    assertTrue(
+      out.reason.contains("daemon handshake timed out"),
+      "the failure must carry the open's reason, got '${out.reason}'",
+    )
+    assertTrue(logged.any { it.contains("daemon handshake timed out") }, "logged: $logged")
+
+    // Nothing was cached, so a later request still tries — the whole point of leaving the lazy
+    // uninitialized.
+    h.renderA11y(previewId, PreviewOverrides())
+    assertEquals(2, opens.get(), "a failed open must not be remembered as the answer")
+  }
+
+  @Test
+  fun `renderA11y is NotFound for an unknown preview`() {
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      assertTrue(h.renderA11y("nope", PreviewOverrides()) is A11yOutcome.NotFound)
+    }
+  }
+
+  private fun a11yFetch(kind: String, json: String) =
+    ee.schimke.composeai.daemon.protocol.DataFetchResult(
+      kind = kind,
+      schemaVersion = 1,
+      payload = Json.parseToJsonElement(json),
+    )
+
+  @Test
+  fun `renderSlots is NotFound for an unknown preview`() {
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      assertTrue(h.renderSlots("nope", PreviewOverrides()) is SlotsOutcome.NotFound)
+    }
+  }
+
+  @Test
+  fun `renderSvg inlines hybrid figma-raster crops as data URIs`() {
+    val session = FakeRenderSession(newRenderRoot(), hybridSvg = true)
+    host(session).use { h ->
+      val out = h.renderSvg(previewId, PreviewOverrides())
+      assertTrue(out is SvgOutcome.Ok)
+      val svg = out.svg.decodeToString()
+      val expected = java.util.Base64.getEncoder().encodeToString(byteArrayOf(1, 2, 3))
+      assertTrue(svg.contains("data:image/png;base64,$expected"), "raster inlined: $svg")
+      assertTrue(!svg.contains("figma-raster/"), "no dangling external ref remains: $svg")
+    }
+  }
+
+  @Test
+  fun `concurrent identical requests coalesce to a single render`() {
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      val threads = 16
+      val pool = Executors.newFixedThreadPool(threads)
+      val start = CountDownLatch(1)
+      val results = CopyOnWriteArrayList<RenderOutcome>()
+      repeat(threads) {
+        pool.submit {
+          start.await()
+          results.add(h.render(previewId, PreviewOverrides(uiMode = UiMode.DARK)))
+        }
+      }
+      start.countDown()
+      pool.shutdown()
+      assertTrue(pool.awaitTermination(60, TimeUnit.SECONDS), "renders did not finish")
+
+      assertEquals(threads, results.size)
+      assertTrue(results.all { it is RenderOutcome.Ok })
+      assertEquals(1, session.renderCount.get(), "identical concurrent renders must coalesce")
+    }
+  }
+
+  @Test
+  fun `unknown preview id is NotFound without rendering`() {
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      assertEquals(RenderOutcome.NotFound, h.render("com.example.Missing", PreviewOverrides()))
+      assertEquals(0, session.renderCount.get())
+    }
+  }
+
+  @Test
+  fun `a coalesced override render is retried until accepted, not failed`() {
+    // The daemon coalesce-rejects an override-bearing render whose previewId is already in flight,
+    // expecting the client to resubmit. ServeRenderHost must retry rather than surface a 500.
+    val session = FakeRenderSession(newRenderRoot(), coalescedOverrideRejections = 2)
+    host(session).use { h ->
+      val outcome = h.render(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      assertTrue(outcome is RenderOutcome.Ok, "coalesced rejections must be retried until accepted")
+      // 2 coalesced rejections + 1 accepted render = 3 renderNow calls.
+      assertEquals(3, session.renderCount.get())
+    }
+  }
+
+  @Test
+  fun `a late renderFinished from a timed-out render does not corrupt the next render`() {
+    // Render 1 emits nothing → it times out (the daemon still owes a late renderFinished). Render 2
+    // (the daemon catching up) emits the timed-out render's STALE event first, then its own FRESH
+    // event. The stale one must be drained, not cached/served under render 2's override key.
+    val session =
+      FakeRenderSession(
+        newRenderRoot(),
+        renderHook = { call, emit ->
+          if (call == 2) {
+            emit("STALE".toByteArray())
+            emit("FRESH".toByteArray())
+          }
+          // call 1: emit nothing → render times out
+        },
+      )
+    ServeRenderHost(
+        session = session,
+        previews = listOf(ServePreview(previewId, "Red")),
+        renderTimeoutSeconds = 1,
+      )
+      .use { h ->
+        val first = h.render(previewId, PreviewOverrides(uiMode = UiMode.LIGHT))
+        assertTrue(first is RenderOutcome.Failed, "first render should time out, got $first")
+
+        val second = h.render(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+        assertTrue(second is RenderOutcome.Ok, "second render should succeed, got $second")
+        assertEquals(
+          "FRESH",
+          second.png.decodeToString(),
+          "stale event from the timed-out render must not be served for the new overrides",
+        )
+      }
+  }
+
+  @Test
+  fun `interrupting a bounded render quarantines its late daemon event`() {
+    val firstSubmitted = CountDownLatch(1)
+    val session =
+      FakeRenderSession(
+        newRenderRoot(),
+        renderHook = { call, emit ->
+          if (call == 1) firstSubmitted.countDown()
+          if (call == 2) {
+            emit("STALE".toByteArray())
+            emit("FRESH".toByteArray())
+          }
+        },
+      )
+    ServeRenderHost(
+        session = session,
+        previews = listOf(ServePreview(previewId, "Red")),
+        renderTimeoutSeconds = 60,
+      )
+      .use { h ->
+        var first: RenderOutcome? = null
+        val thread = Thread { first = h.render(previewId, PreviewOverrides(uiMode = UiMode.LIGHT)) }
+        thread.start()
+        assertTrue(firstSubmitted.await(5, TimeUnit.SECONDS))
+        thread.interrupt()
+        thread.join(5_000)
+        assertEquals(RenderOutcome.Busy, first)
+
+        val second = h.render(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+        assertTrue(second is RenderOutcome.Ok, "second render should succeed, got $second")
+        assertEquals("FRESH", second.png.decodeToString())
+      }
+  }
+
+  @Test
+  fun `interrupt after terminal event does not quarantine the next render`() {
+    val session =
+      FakeRenderSession(
+        newRenderRoot(),
+        renderHook = { call, emit ->
+          emit(if (call == 1) "FIRST".toByteArray() else "SECOND".toByteArray())
+          if (call == 1) Thread.currentThread().interrupt()
+        },
+      )
+    ServeRenderHost(
+        session = session,
+        previews = listOf(ServePreview(previewId, "Red")),
+        renderTimeoutSeconds = 1,
+      )
+      .use { h ->
+        var first: RenderOutcome? = null
+        val thread = Thread { first = h.render(previewId, PreviewOverrides(uiMode = UiMode.LIGHT)) }
+        thread.start()
+        thread.join(5_000)
+        assertEquals(RenderOutcome.Busy, first)
+
+        val second = h.render(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+        assertTrue(second is RenderOutcome.Ok, "the next terminal event must not be discarded")
+        assertEquals("SECOND", second.png.decodeToString())
+      }
+  }
+
+  @Test
+  fun `a rejected render surfaces as Failed`() {
+    val session = FakeRenderSession(newRenderRoot(), rejectAll = true)
+    host(session).use { h ->
+      val outcome = h.render(previewId, PreviewOverrides())
+      assertTrue(outcome is RenderOutcome.Failed, "expected Failed, got $outcome")
+    }
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSemanticsTagsTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSemanticsTagsTest.kt
@@ -1,0 +1,243 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsNode
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * The tag index is the element identity a scoped parity acceptance resolves against, so the
+ * uniqueness signal ([ServeSemanticsTags.TagEntry.count]) has to be trustworthy in the cases that
+ * would otherwise report a duplicate as unique. Those are what these cover.
+ */
+class ServeSemanticsTagsTest {
+
+  private fun node(
+    id: String,
+    bounds: String,
+    testTag: String? = null,
+    placed: Boolean = true,
+    children: List<ComposeSemanticsNode> = emptyList(),
+  ) =
+    ComposeSemanticsNode(
+      nodeId = id,
+      boundsInRoot = bounds,
+      testTag = testTag,
+      placed = placed,
+      children = children,
+    )
+
+  @Test
+  fun `a trial-measured copy of a tag is not a second use of it`() {
+    // A `SubcomposeLayout` measuring a trial copy of its content to choose a layout (Wear
+    // `AlertDialogContent`) duplicates every tag in the tree. The copy was never placed, so it is
+    // not on the frame — counting it reports `count = 2` for a tag that identifies exactly one
+    // node, and a scoped parity acceptance then rejects it as ambiguous.
+    val root =
+      node(
+        "root",
+        "0,0,200,200",
+        children =
+          listOf(
+            node("real", "10,10,60,40", testTag = "submit"),
+            node(
+              "trial",
+              "0,0,120,60",
+              placed = false,
+              children = listOf(node("trial-child", "0,0,50,30", testTag = "submit")),
+            ),
+          ),
+      )
+
+    val entry = index(root)["submit"]
+
+    assertEquals(1, entry?.count)
+    assertEquals(AnnotationBounds(10, 10, 50, 30), entry?.bounds)
+  }
+
+  private fun index(root: ComposeSemanticsNode) =
+    ServeSemanticsTags.index(ComposeSemanticsPayload(root))
+
+  @Test
+  fun `a unique tag reports count one and its render-pixel box`() {
+    val tags = index(node("0", "0,0,100,100", children = listOf(node("1", "24,24,48,48", "glyph"))))
+    assertEquals(setOf("glyph"), tags.keys)
+    assertEquals(1, tags.getValue("glyph").count)
+    assertEquals(
+      AnnotationBounds(x = 24, y = 24, width = 24, height = 24),
+      tags.getValue("glyph").bounds,
+    )
+  }
+
+  @Test
+  fun `a repeated tag reports every occurrence`() {
+    val tags =
+      index(
+        node(
+          "0",
+          "0,0,100,100",
+          children =
+            listOf(
+              node("1", "0,0,20,20", "row"),
+              node("2", "0,20,20,40", "row"),
+              node("3", "0,40,20,60", "row"),
+            ),
+        )
+      )
+    assertEquals(3, tags.getValue("row").count)
+  }
+
+  /**
+   * The case the whole field exists for: a zero-area duplicate must not be dropped, because
+   * dropping it reports `count = 1` for a tag two nodes carry and an acceptance would resolve it as
+   * unique.
+   */
+  @Test
+  fun `a duplicate with no usable bounds still raises the count`() {
+    val tags =
+      index(
+        node(
+          "0",
+          "0,0,100,100",
+          children =
+            listOf(
+              node("1", "10,10,30,30", "chip"),
+              node("2", "40,40,40,40", "chip"), // zero area
+              node("3", "not,a,box", "chip"), // unparseable
+            ),
+        )
+      )
+    assertEquals(3, tags.getValue("chip").count)
+    // The first usable box wins, so the reported geometry is still the drawable node's.
+    assertEquals(
+      AnnotationBounds(x = 10, y = 10, width = 20, height = 20),
+      tags.getValue("chip").bounds,
+    )
+  }
+
+  @Test
+  fun `a tag whose only node has no usable bounds reports a count and no box`() {
+    val tags = index(node("0", "0,0,100,100", children = listOf(node("1", "5,5,5,5", "ghost"))))
+    assertEquals(1, tags.getValue("ghost").count)
+    assertNull(tags.getValue("ghost").bounds)
+  }
+
+  /** Depth-first, so "first usable box" means the same thing in both engines. */
+  @Test
+  fun `the first usable box in depth-first order is the one reported`() {
+    val tags =
+      index(
+        node(
+          "0",
+          "0,0,100,100",
+          children =
+            listOf(
+              node("1", "0,0,50,50", children = listOf(node("2", "1,1,11,11", "dup"))),
+              node("3", "50,50,90,90", "dup"),
+            ),
+        )
+      )
+    assertEquals(2, tags.getValue("dup").count)
+    assertEquals(
+      AnnotationBounds(x = 1, y = 1, width = 10, height = 10),
+      tags.getValue("dup").bounds,
+    )
+  }
+
+  /**
+   * A tag is matched by Compose as the exact string, so the index must not normalise it. Trimming
+   * would merge these two distinct tags into one `count = 2` entry — false ambiguity for `"pad"`,
+   * and no key at all for an acceptance recording `" pad "`.
+   */
+  @Test
+  fun `a tag is keyed verbatim, not trimmed`() {
+    val tags =
+      index(
+        node(
+          "0",
+          "0,0,100,100",
+          children = listOf(node("1", "0,0,10,10", "pad"), node("2", "20,20,30,30", " pad ")),
+        )
+      )
+    assertEquals(setOf("pad", " pad "), tags.keys)
+    assertEquals(1, tags.getValue("pad").count)
+    assertEquals(1, tags.getValue(" pad ").count)
+  }
+
+  @Test
+  fun `blank and absent tags are not keys`() {
+    val tags =
+      index(
+        node(
+          "0",
+          "0,0,100,100",
+          children =
+            listOf(
+              node("1", "0,0,10,10"),
+              node("2", "0,0,10,10", ""),
+              node("3", "0,0,10,10", "   "),
+            ),
+        )
+      )
+    assertTrue(tags.isEmpty(), "expected no keys, got ${tags.keys}")
+  }
+
+  /**
+   * The space is on the wire because the design doc and this producer currently disagree about
+   * whether the index is canonical-plane or render-pixel. A consumer must be able to tell without
+   * guessing, since treating render pixels as canonical is exactly what produces a wrong
+   * `element-moved` verdict.
+   */
+  @Test
+  fun `every entry names its coordinate space`() {
+    val tags = index(node("0", "0,0,64,64", "tagged"))
+    assertEquals(ServeSemanticsTags.RENDER_PIXELS, tags.getValue("tagged").space)
+  }
+
+  /**
+   * Asserted on the **raw JSON**, not on a decoded [ServeSemanticsTags.TagEntry]. Decoding restores
+   * the Kotlin default, so a round-trip test passes even when the field never reached the wire —
+   * which is exactly what happened: the host serialises with `encodeDefaults = false`, and without
+   * `@EncodeDefault` the discriminator was dropped while every Kotlin-side assertion still saw it.
+   * A browser reading the response is the consumer that matters here.
+   */
+  @Test
+  fun `the coordinate space survives serialisation under encodeDefaults false`() {
+    val json = Json { ignoreUnknownKeys = true } // the host's config: encodeDefaults defaults false
+    val encoded =
+      json.encodeToString(
+        MapSerializer(String.serializer(), ServeSemanticsTags.TagEntry.serializer()),
+        index(node("0", "0,0,64,64", "tagged")),
+      )
+    val space =
+      json
+        .parseToJsonElement(encoded)
+        .jsonObject
+        .getValue("tagged")
+        .jsonObject["space"]
+        ?.jsonPrimitive
+        ?.content
+    assertEquals(
+      ServeSemanticsTags.RENDER_PIXELS,
+      space,
+      "the space discriminator must be present in the encoded JSON, not just in the Kotlin default",
+    )
+  }
+
+  @Test
+  fun `a tagged root is indexed like any other node`() {
+    val tags = index(node("0", "0,0,64,64", "root-tag"))
+    assertEquals(1, tags.getValue("root-tag").count)
+    assertEquals(
+      AnnotationBounds(x = 0, y = 0, width = 64, height = 64),
+      tags.getValue("root-tag").bounds,
+    )
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTagIndexStoreTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTagIndexStoreTest.kt
@@ -1,0 +1,133 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import okio.FileSystem
+
+/**
+ * The published tag index is third-party data read at staging time, and an acceptance that cannot
+ * find its tag degrades to no element gate. So every failure mode here must drop to "no index"
+ * rather than take the catalog down — the same posture as [ServeAnnotationStoreTest].
+ */
+class ServeTagIndexStoreTest {
+  private fun store(json: String?): ServeTagIndexStore {
+    val root = Files.createTempDirectory("tags").toFile().also { it.deleteOnExit() }
+    if (json != null) {
+      File(root, ServeTagIndexStore.DIRECTORY).mkdirs()
+      File(root, "${ServeTagIndexStore.DIRECTORY}/${ServeTagIndexStore.INDEX_FILE}").writeText(json)
+    }
+    return ServeTagIndexStore.load(root, FileSystem.SYSTEM)
+  }
+
+  private val valid =
+    """
+    {"schema":"compose-preview-tags/v1","previews":{
+      "button-filled__ideal__default__light":{
+        "glyph":{"count":1,"bounds":{"x":8,"y":8,"width":32,"height":32},"space":"render-pixels"},
+        "row":{"count":3,"space":"render-pixels"}
+      }}}
+    """
+
+  @Test
+  fun `no index yields an empty store`() {
+    assertTrue(store(null).isEmpty)
+  }
+
+  @Test
+  fun `malformed json is ignored rather than thrown`() {
+    assertTrue(store("{ not json").isEmpty)
+  }
+
+  @Test
+  fun `an index from a future schema is ignored`() {
+    assertTrue(store(valid.replace("compose-preview-tags/v1", "compose-preview-tags/v99")).isEmpty)
+  }
+
+  @Test
+  fun `a valid index is keyed by served preview id`() {
+    val tags = store(valid).forPreview("button-filled__ideal__default__light")
+    assertEquals(setOf("glyph", "row"), tags.keys)
+    assertEquals(1, tags.getValue("glyph").count)
+    assertEquals(
+      AnnotationBounds(x = 8, y = 8, width = 32, height = 32),
+      tags.getValue("glyph").bounds,
+    )
+    assertEquals(ServeSemanticsTags.RENDER_PIXELS, tags.getValue("glyph").space)
+  }
+
+  /**
+   * A tag whose every node had unusable bounds still counts — that is what makes an ambiguity check
+   * work — so an absent box must not be mistaken for a broken entry and dropped.
+   */
+  @Test
+  fun `a counted tag with no bounds survives`() {
+    val tags = store(valid).forPreview("button-filled__ideal__default__light")
+    assertEquals(3, tags.getValue("row").count)
+    assertEquals(null, tags.getValue("row").bounds)
+  }
+
+  @Test
+  fun `an unknown preview has no tags rather than throwing`() {
+    assertTrue(store(valid).forPreview("nothing-published-here").isEmpty())
+  }
+
+  @Test
+  fun `a zero-area box is dropped, and a preview left with nothing drops with it`() {
+    val json =
+      """{"schema":"compose-preview-tags/v1","previews":{"p":{
+         "flat":{"count":1,"bounds":{"x":0,"y":0,"width":0,"height":10},"space":"render-pixels"}}}}"""
+    assertTrue(store(json).isEmpty, "a preview whose only entry is unusable should not be listed")
+  }
+
+  @Test
+  fun `an oversized index is refused wholesale`() {
+    val previews =
+      (0..ServeTagIndexStore.MAX_PREVIEWS).joinToString(",") {
+        """"p$it":{"t":{"count":1,"space":"render-pixels"}}"""
+      }
+    assertTrue(store("""{"schema":"compose-preview-tags/v1","previews":{$previews}}""").isEmpty)
+  }
+
+  @Test
+  fun `unknown keys are tolerated so a newer producer does not break an older host`() {
+    val json =
+      """{"schema":"compose-preview-tags/v1","generatedAt":"2026-01-01","previews":{"p":{
+         "t":{"count":2,"space":"render-pixels","somethingNew":true}}}}"""
+    assertEquals(2, store(json).forPreview("p").getValue("t").count)
+  }
+
+  /**
+   * The discriminator has to be *declared*, not inferred. Defaulting a missing `space` would make
+   * an index that stated no coordinate space indistinguishable from one that stated render pixels,
+   * and a later element gate would compare bounds in a plane nobody declared.
+   */
+  @Test
+  fun `an entry with no declared space is refused`() {
+    val json =
+      """{"schema":"compose-preview-tags/v1","previews":{"p":{
+         "t":{"count":1,"bounds":{"x":0,"y":0,"width":8,"height":8}}}}}"""
+    assertTrue(store(json).isEmpty, "a missing space must not default to render-pixels")
+  }
+
+  /**
+   * An unknown space is refused too — a future canonical producer must not read as render-pixel.
+   */
+  @Test
+  fun `an entry with an unrecognised space is refused`() {
+    val json =
+      """{"schema":"compose-preview-tags/v1","previews":{"p":{
+         "t":{"count":1,"space":"canonical-plane"}}}}"""
+    assertTrue(store(json).isEmpty)
+  }
+
+  @Test
+  fun `a non-positive count is refused`() {
+    val json =
+      """{"schema":"compose-preview-tags/v1","previews":{"p":{
+         "t":{"count":0,"space":"render-pixels"}}}}"""
+    assertTrue(store(json).isEmpty)
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/SkikoNativePairingTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/SkikoNativePairingTest.kt
@@ -1,0 +1,258 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.daemon.protocol.DaemonLaunchDescriptor
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlinx.serialization.json.Json
+
+/**
+ * The split-Skiko repair from #4220: a bundle's recorded coordinates name the bindings but not the
+ * platform native they link against, and serve promotes those bindings ahead of its own daemon
+ * sidecar. Unpaired, they link against the server's older `libskiko` and every render dies with
+ * `UnsatisfiedLinkError`.
+ */
+class SkikoNativePairingTest {
+
+  private fun maven(artifact: String, version: String, group: String = "org.jetbrains.skiko") =
+    BundleReader.ClasspathEntry.Maven(
+      group = group,
+      artifact = artifact,
+      version = version,
+      type = "jar",
+      sha256 = null,
+    )
+
+  @Test
+  fun `host runtime artifact covers every target skiko publishes`() {
+    assertEquals("linux-x64", SkikoNativePairing.hostRuntimeArtifact("Linux", "amd64")?.suffix())
+    assertEquals(
+      "linux-arm64",
+      SkikoNativePairing.hostRuntimeArtifact("Linux", "aarch64")?.suffix(),
+    )
+    assertEquals(
+      "macos-arm64",
+      SkikoNativePairing.hostRuntimeArtifact("Mac OS X", "aarch64")?.suffix(),
+    )
+    assertEquals(
+      "macos-x64",
+      SkikoNativePairing.hostRuntimeArtifact("Mac OS X", "x86_64")?.suffix(),
+    )
+    assertEquals(
+      "windows-x64",
+      SkikoNativePairing.hostRuntimeArtifact("Windows 11", "amd64")?.suffix(),
+    )
+    assertEquals(
+      "windows-arm64",
+      SkikoNativePairing.hostRuntimeArtifact("Windows 11", "arm64")?.suffix(),
+    )
+    // A host Skiko publishes no native for: there is nothing useful to add, so say so rather than
+    // synthesizing a coordinate that can only 404.
+    assertNull(SkikoNativePairing.hostRuntimeArtifact("SunOS", "sparc"))
+    assertNull(SkikoNativePairing.hostRuntimeArtifact("Linux", "riscv64"))
+  }
+
+  private fun String.suffix() = removePrefix("skiko-awt-runtime-")
+
+  /**
+   * The exact m3-catalog shape that took the public server's live lane down: `skiko-awt:0.148.2`
+   * and no runtime artifact at all, because the six platform natives reach a Gradle-resolved
+   * classpath through `strictly` constraints rather than as recorded coordinates.
+   */
+  @Test
+  fun `bindings recorded without their native synthesize the host runtime coordinate`() {
+    val coords =
+      listOf(
+        maven("material3-desktop", "1.12.0-alpha02", group = "org.jetbrains.compose.material3"),
+        maven("skiko-awt", "0.148.2"),
+      )
+
+    val repair = SkikoNativePairing.missingHostRuntime(coords, "Linux", "amd64")
+
+    assertEquals("org.jetbrains.skiko", repair?.group)
+    assertEquals("skiko-awt-runtime-linux-x64", repair?.artifact)
+    assertEquals("0.148.2", repair?.version)
+    assertEquals("jar", repair?.type)
+    // The bundle never recorded a hash for an artifact it never listed; claiming one would be a
+    // lie the resolver would then "verify".
+    assertNull(repair?.sha256)
+  }
+
+  @Test
+  fun `a bundle that already carries the host native is left alone`() {
+    val coords =
+      listOf(maven("skiko-awt", "0.148.2"), maven("skiko-awt-runtime-linux-x64", "0.148.2"))
+
+    assertNull(SkikoNativePairing.missingHostRuntime(coords, "Linux", "amd64"))
+  }
+
+  /**
+   * A native for the *wrong* platform (a bundle packed on a mac, served on Linux) is not the pair
+   * this host needs — that is the same skew wearing a matching version number, and it must still be
+   * repaired.
+   */
+  @Test
+  fun `a native for another platform does not count as paired`() {
+    val coords =
+      listOf(maven("skiko-awt", "0.148.2"), maven("skiko-awt-runtime-macos-arm64", "0.148.2"))
+
+    assertEquals(
+      "skiko-awt-runtime-linux-x64",
+      SkikoNativePairing.missingHostRuntime(coords, "Linux", "amd64")?.artifact,
+    )
+  }
+
+  /**
+   * A stale native at a different version is exactly the split — repair to the bindings' version.
+   */
+  @Test
+  fun `a host native at a different version is repaired to the bindings version`() {
+    val coords =
+      listOf(maven("skiko-awt", "0.148.2"), maven("skiko-awt-runtime-linux-x64", "0.144.6"))
+
+    assertEquals(
+      "0.148.2",
+      SkikoNativePairing.missingHostRuntime(coords, "Linux", "amd64")?.version,
+    )
+  }
+
+  @Test
+  fun `a bundle with no skiko at all is untouched`() {
+    val coords =
+      listOf(
+        maven("robolectric", "4.16", group = "org.robolectric"),
+        maven("okio", "3.20.0", group = "com.squareup.okio"),
+      )
+
+    assertNull(SkikoNativePairing.missingHostRuntime(coords, "Linux", "amd64"))
+  }
+
+  /**
+   * The backstop reads the pair that will actually LOAD, which classpath order decides — the
+   * bindings are classes and `libskiko-<target>.so` is a root resource, both plain classloader
+   * lookups. A promoted 0.148.2 bindings jar ahead of the server sidecar's 0.144.6 native is
+   * exactly the m3-catalog outage.
+   */
+  @Test
+  fun `classpath skew names the pair that will actually load`() {
+    val skewed =
+      listOf(
+        "/cache/org.jetbrains.skiko/skiko-awt/0.148.2/skiko-awt-0.148.2.jar",
+        "/opt/serve/lib-daemon-desktop/skiko-awt-0.144.6.jar",
+        "/opt/serve/lib-daemon-desktop/skiko-awt-runtime-linux-x64-0.144.6.jar",
+      )
+
+    val warning = SkikoNativePairing.classpathSkew(skewed)
+
+    assertNotNull(warning)
+    assertContains(warning, "bindings 0.148.2")
+    assertContains(warning, "libskiko 0.144.6")
+  }
+
+  @Test
+  fun `a repaired classpath reports no skew`() {
+    val repaired =
+      listOf(
+        "/cache/org.jetbrains.skiko/skiko-awt/0.148.2/skiko-awt-0.148.2.jar",
+        "/cache/org.jetbrains.skiko/skiko-awt-runtime-linux-x64/0.148.2/skiko-awt-runtime-linux-x64-0.148.2.jar",
+        // The sidecar's older pair is still present, and still shadowed by the two above.
+        "/opt/serve/lib-daemon-desktop/skiko-awt-0.144.6.jar",
+        "/opt/serve/lib-daemon-desktop/skiko-awt-runtime-linux-x64-0.144.6.jar",
+      )
+
+    assertNull(SkikoNativePairing.classpathSkew(repaired))
+  }
+
+  @Test
+  fun `a fatal Skia link error is answered with the skew its daemon classpath carries`() {
+    val descriptor =
+      writeDescriptor(
+        listOf(
+          "/cache/org.jetbrains.skiko/skiko-awt/0.148.2/skiko-awt-0.148.2.jar",
+          "/opt/serve/lib-daemon-desktop/skiko-awt-runtime-linux-x64-0.144.6.jar",
+        )
+      )
+
+    val diagnosis =
+      assertNotNull(
+        SkikoNativePairing.linkageDiagnosis(
+          "render failed: UnsatisfiedLinkError: 'int " +
+            "org.jetbrains.skia.paragraph.ParagraphKt._nGetUnresolvedCodepointsCount(long)'",
+          descriptor,
+        )
+      )
+
+    assertContains(diagnosis, "bindings 0.148.2")
+    assertContains(diagnosis, "libskiko 0.144.6")
+  }
+
+  @Test
+  fun `a link error with nothing to add says nothing`() {
+    val coherent =
+      writeDescriptor(
+        listOf("/cache/skiko-awt-0.148.2.jar", "/cache/skiko-awt-runtime-linux-x64-0.148.2.jar")
+      )
+    val skewed =
+      writeDescriptor(
+        listOf("/cache/skiko-awt-0.148.2.jar", "/cache/skiko-awt-runtime-linux-x64-0.144.6.jar")
+      )
+    val skiaFailure =
+      "render failed: UnsatisfiedLinkError: 'int org.jetbrains.skia.paragraph.ParagraphKt._n(long)'"
+
+    assertNull(
+      SkikoNativePairing.linkageDiagnosis(skiaFailure, coherent),
+      "a matched pair means this link error has some other cause — don't invent one",
+    )
+    assertNull(
+      SkikoNativePairing.linkageDiagnosis(
+        "render failed: UnsatisfiedLinkError: 'void com.example.Native.init()'",
+        skewed,
+      ),
+      "a link error that is not Skia's says nothing about the Skiko pair",
+    )
+    assertNull(
+      SkikoNativePairing.linkageDiagnosis(skiaFailure, File("/no/such/daemon-launch.json")),
+      "an unreadable descriptor says nothing rather than guessing",
+    )
+  }
+
+  private fun writeDescriptor(classpath: List<String>): File {
+    val dir = Files.createTempDirectory("skiko-linkage-diagnosis").toFile()
+    val file = File(dir, "daemon-launch.json")
+    file.writeText(
+      Json.encodeToString(
+        DaemonLaunchDescriptor.serializer(),
+        DaemonLaunchDescriptor(
+          schemaVersion = 2,
+          modulePath = ":catalog",
+          variant = "desktop",
+          enabled = true,
+          mainClass = "ee.schimke.composeai.daemon.DaemonMain",
+          classpath = classpath,
+          jvmArgs = emptyList(),
+          systemProperties = emptyMap(),
+          workingDirectory = dir.absolutePath,
+          manifestPath = File(dir, "previews.json").absolutePath,
+        ),
+      )
+    )
+    return file
+  }
+
+  /** Nothing to compare is not a skew — an Android (Robolectric) daemon carries no Skiko at all. */
+  @Test
+  fun `a classpath missing one half reports nothing`() {
+    assertNull(
+      SkikoNativePairing.classpathSkew(listOf("/opt/serve/lib-daemon-android/robolectric-4.16.jar"))
+    )
+    assertNull(
+      SkikoNativePairing.classpathSkew(listOf("/cache/skiko-awt-0.148.2.jar")),
+      "bindings with no native on the classpath at all is a different failure, diagnosed elsewhere",
+    )
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/SvgSanitizerTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/SvgSanitizerTest.kt
@@ -1,0 +1,195 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * [SvgSanitizer] is the trust boundary for the one place this server puts third-party markup into
+ * the document tree, so these tests are two lists: what a design export legitimately needs and must
+ * therefore survive, and what nothing needs and must therefore not.
+ *
+ * The second list is the load-bearing half. Each case below is a way markup becomes behaviour, and
+ * the allowlist exists because that set is not closed — a denylist would have to have anticipated
+ * `<set attributeName="href">`, and the next one after it.
+ */
+class SvgSanitizerTest {
+
+  private fun clean(svg: String): String? = SvgSanitizer.sanitize(svg)
+
+  private fun wrap(body: String): String =
+    """<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">$body</svg>"""
+
+  @Test
+  fun `a design export keeps its shapes, paint and node ids`() {
+    val out =
+      assertNotNull(
+        clean(
+          wrap(
+            """<defs><linearGradient id="g0"><stop offset="0" stop-color="#fff"/></linearGradient>
+               <clipPath id="c0"><rect width="10" height="10"/></clipPath></defs>
+               <g data-node-id="58548:7249" clip-path="url(#c0)" opacity="0.5">
+                 <path d="M0 0 L10 10" fill="url(#g0)" stroke-width="2"/>
+                 <text x="1" y="9" font-family="Roboto" font-size="4">Circle</text>
+               </g>"""
+          )
+        )
+      )
+    assertTrue(out.contains("data-node-id=\"58548:7249\""))
+    assertTrue(out.contains("linearGradient"))
+    assertTrue(out.contains("clip-path=\"url(#c0)\""))
+    assertTrue(out.contains("Circle"))
+  }
+
+  @Test
+  fun `script is removed with its contents`() {
+    val out =
+      assertNotNull(clean(wrap("""<script>alert(1)</script><rect width="1" height="1"/>""")))
+    assertFalse(out.contains("script"))
+    assertFalse(out.contains("alert"))
+    assertTrue(out.contains("rect"))
+  }
+
+  @Test
+  fun `event handlers go before the allowlist is even consulted`() {
+    val out =
+      assertNotNull(clean(wrap("""<rect width="1" height="1" onload="alert(1)" onclick="x()"/>""")))
+    assertFalse(out.contains("onload"))
+    assertFalse(out.contains("onclick"))
+    assertTrue(out.contains("width=\"1\""))
+  }
+
+  @Test
+  fun `foreignObject is removed WITH its subtree, never unwrapped`() {
+    // Its children are HTML. Promoting them into the parent — the usual "keep the content" instinct
+    // — would keep exactly the payload the removal was for.
+    val out =
+      assertNotNull(
+        clean(wrap("""<foreignObject><div onclick="alert(1)">hi</div></foreignObject>"""))
+      )
+    assertFalse(out.contains("foreignObject"))
+    assertFalse(out.contains("div"))
+    assertFalse(out.contains("alert"))
+  }
+
+  @Test
+  fun `animation elements that rewrite attributes are removed`() {
+    // `<animate attributeName="href">` rewrites a link after load; `<set>` does it with no
+    // animation at all. Neither is anything a specimen sheet needs.
+    val out =
+      assertNotNull(
+        clean(
+          wrap(
+            """<a href="#x"><set attributeName="href" to="javascript:alert(1)"/>
+               <animate attributeName="fill" to="red"/></a>"""
+          )
+        )
+      )
+    assertFalse(out.contains("<a"))
+    assertFalse(out.contains("set"))
+    assertFalse(out.contains("animate"))
+    assertFalse(out.contains("javascript"))
+  }
+
+  @Test
+  fun `an href is judged by value, not by name`() {
+    // `url(#…)` internal references are how every export clips and gradients, so the name cannot be
+    // the check. Off-document targets are the ones that matter.
+    val out =
+      assertNotNull(
+        clean(
+          wrap(
+            """<use href="#g0"/>
+               <image href="https://example.test/pixel.png" width="1" height="1"/>
+               <image href="//example.test/pixel.png" width="1" height="1"/>
+               <image href="data:image/png;base64,iVBORw0KGgo=" width="1" height="1"/>"""
+          )
+        )
+      )
+    assertTrue(out.contains("href=\"#g0\""))
+    assertTrue(out.contains("data:image/png;base64"))
+    assertFalse(out.contains("example.test"))
+  }
+
+  @Test
+  fun `a data URI carrying SVG is refused — the allowlist would stop at the first hop`() {
+    val out =
+      assertNotNull(
+        clean(
+          wrap(
+            """<image href="data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=" width="1" height="1"/>"""
+          )
+        )
+      )
+    assertFalse(out.contains("svg+xml"))
+  }
+
+  @Test
+  fun `a style attribute reaching off-document is dropped, an internal one survives`() {
+    val out =
+      assertNotNull(
+        clean(
+          wrap(
+            """<rect width="1" height="1" style="mix-blend-mode:multiply"/>
+               <rect width="2" height="2" style="fill:url(https://example.test/x)"/>
+               <rect width="3" height="3" style="filter:url(#f0)"/>"""
+          )
+        )
+      )
+    assertTrue(out.contains("mix-blend-mode:multiply"))
+    assertTrue(out.contains("filter:url(#f0)"))
+    assertFalse(out.contains("example.test"))
+  }
+
+  @Test
+  fun `a DOCTYPE with an external entity does not read a file off this host`() {
+    val bomb =
+      """<?xml version="1.0"?>
+         <!DOCTYPE svg [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
+         <svg xmlns="http://www.w3.org/2000/svg"><text>&xxe;</text></svg>"""
+    val out = clean(bomb)
+    // Either the parse is refused outright (DOCTYPEs are disallowed) or the entity resolves to
+    // nothing. Both are correct; what must never happen is the file's contents appearing.
+    if (out != null) assertFalse(out.contains("root:"))
+  }
+
+  @Test
+  fun `markup that is not an SVG document is refused`() {
+    assertNull(clean("<html><body>nope</body></html>"))
+    assertNull(clean("not xml at all"))
+    assertNull(clean(""))
+  }
+
+  @Test
+  fun `an oversized export is refused rather than parsed into a DOM`() {
+    val huge = "<svg xmlns=\"http://www.w3.org/2000/svg\">" + " ".repeat(SvgSanitizer.MAX_BYTES)
+    assertNull(clean(huge))
+  }
+
+  @Test
+  fun `a fourteen megabyte maximum-node design page is accepted`() {
+    // m3-catalog's 500-node Buttons export is 14,576,730 bytes. The old 12 MiB ceiling silently
+    // dropped that page even though the node boundary itself is inclusive.
+    val body = " ".repeat(14 * 1024 * 1024)
+    assertNotNull(clean(wrap(body)))
+  }
+
+  @Test
+  fun `the output has no XML prologue — it is spliced into an HTML document`() {
+    val out =
+      assertNotNull(clean("""<?xml version="1.0"?>${wrap("<rect width=\"1\" height=\"1\"/>")}"""))
+    assertFalse(out.contains("<?xml"))
+    assertEquals("<svg", out.take(4))
+  }
+
+  @Test
+  fun `comments and processing instructions are dropped`() {
+    val out =
+      assertNotNull(clean(wrap("""<!-- secret --><?php echo 1;?><rect width="1" height="1"/>""")))
+    assertFalse(out.contains("secret"))
+    assertFalse(out.contains("php"))
+  }
+}

--- a/render-host/src/testFixtures/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
+++ b/render-host/src/testFixtures/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
@@ -1,0 +1,591 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.ChangeType
+import ee.schimke.composeai.daemon.protocol.DataFetchParams
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.daemon.protocol.DataSubscribeResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsDisableResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsEnableResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsListResult
+import ee.schimke.composeai.daemon.protocol.FileKind
+import ee.schimke.composeai.daemon.protocol.HistoryDiffMode
+import ee.schimke.composeai.daemon.protocol.HistoryDiffResult
+import ee.schimke.composeai.daemon.protocol.HistoryListParams
+import ee.schimke.composeai.daemon.protocol.HistoryListResult
+import ee.schimke.composeai.daemon.protocol.HistoryReadResultDto
+import ee.schimke.composeai.daemon.protocol.InitializeResult
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.InteractiveInputParams
+import ee.schimke.composeai.daemon.protocol.Manifest
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.RecordingEncodeResult
+import ee.schimke.composeai.daemon.protocol.RecordingFormat
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+import ee.schimke.composeai.daemon.protocol.RecordingStartResult
+import ee.schimke.composeai.daemon.protocol.RecordingStopResult
+import ee.schimke.composeai.daemon.protocol.RejectedRender
+import ee.schimke.composeai.daemon.protocol.RenderNowResult
+import ee.schimke.composeai.daemon.protocol.RenderTier
+import ee.schimke.composeai.daemon.protocol.ServerCapabilities
+import ee.schimke.composeai.daemon.protocol.StreamCodec
+import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+import ee.schimke.composeai.daemon.protocol.StreamStartResult
+import ee.schimke.composeai.data.layoutinspector.ComposeFigmaSvgProduct
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsNode
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsProduct
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsTokens
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsTypography
+import ee.schimke.composeai.data.layoutinspector.PreviewSlots
+import ee.schimke.composeai.data.theme.Material3ThemeProduct
+import ee.schimke.composeai.render.session.NotificationListener
+import ee.schimke.composeai.render.session.RenderSession
+import ee.schimke.composeai.render.session.RenderSessionBackend
+import java.io.File
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Shared test [RenderSession]: each [renderNow] writes a PNG (bytes encode the overrides, so
+ * distinct overrides → distinct bytes) and synchronously emits the `renderFinished` callers await.
+ *
+ * [renderHook] (when set) overrides the default emit-immediately behaviour: it receives the 1-based
+ * call index and an `emit` that writes given bytes to a fresh PNG and fires `renderFinished`. A
+ * hook that emits nothing models a render that times out (the daemon owes a late event), which
+ * drives the stale-event path. [rejectAll] rejects every render.
+ */
+public class FakeRenderSession(
+  private val renderRoot: File,
+  private val rejectAll: Boolean = false,
+  private val renderHook: ((call: Int, emit: (ByteArray) -> Unit) -> Unit)? = null,
+  /** When false (default), the streaming methods throw (mimicking a non-streaming backend). */
+  private val streaming: Boolean = false,
+  /**
+   * `StreamStartResult.heldSession` value when [streaming]; false models a non-interactive host.
+   */
+  private val heldSession: Boolean = true,
+  /**
+   * `StreamStartResult.fallbackReason` — the daemon's real acquisition failure when [heldSession]
+   * is false (e.g. `interactive session already held`). Null models a daemon that sent none.
+   */
+  private val heldFallbackReason: String? = null,
+  /** When set, [streamStart] emits a keyframe with this base64 payload *before* it returns. */
+  private val emitKeyframeOnStart: String? = null,
+  /**
+   * Reject the first N override-bearing [renderNow]s with the daemon's `coalesced` reason (then
+   * serve normally), modelling the override-in-flight coalescing the serve host must retry through.
+   */
+  private val coalescedOverrideRejections: Int = 0,
+  /**
+   * When true, the figma-svg written per render is a hybrid: an `<image href="figma-raster/…">`
+   * plus the sibling crop on disk, to exercise serve-side raster inlining.
+   */
+  private val hybridSvg: Boolean = false,
+  /**
+   * The overrides the modelled daemon advertises in its capabilities — drives
+   * [ServeRenderHost.gesturesRenderable] (`"gestures" in supportedOverrides`). Empty by default (a
+   * desktop-style backend that honours no feature overrides).
+   */
+  private val supportedOverrides: List<String> = emptyList(),
+  /**
+   * Whether the modelled daemon has the `compose/figma-svg` (+ `-long`) data products —
+   * [ServeRenderHost] enables them on open and gates [ServeRenderHost.hasSvgExport] on the result.
+   * True by default (a desktop-style backend that exports figma-svg); false models a backend
+   * without it (the ids come back in [ExtensionsEnableResult.unknown]).
+   */
+  private val figmaSvgAvailable: Boolean = true,
+  /**
+   * Extension ids the modelled daemon does not carry — [enableExtensions] returns them in
+   * [ExtensionsEnableResult.unknown] (e.g. a backend with no Remote Compose runtime rejects
+   * `data/remotecompose`). Empty by default.
+   */
+  private val unknownExtensionIds: Set<String> = emptySet(),
+  /**
+   * Include named override values in fake PNG/SVG bytes so payload-bearing adapters are testable.
+   */
+  private val includeNamedOverridesInArtifacts: Boolean = false,
+  /**
+   * Stubs [fetchData] for kinds this fake doesn't model natively (e.g.
+   * `compose/remotecompose-doc`). Consulted first; a non-null return short-circuits the built-in
+   * figma-svg / semantics handling.
+   */
+  private val fetchDataHook: ((previewId: String, kind: String) -> DataFetchResult?)? = null,
+) : RenderSession {
+  val renderCount = AtomicInteger(0)
+
+  /**
+   * Count of `figma-svg-long` fetches + the `params` bag of the last one — for scroll-lane asserts.
+   */
+  val scrollFetchCount = AtomicInteger(0)
+  @Volatile var lastScrollFetchParams: JsonElement? = null
+
+  val scrollPngFetchCount = AtomicInteger(0)
+  @Volatile var lastScrollPngFetchParams: JsonElement? = null
+
+  /** Extension ids passed to [enableExtensions], in call order — for assertions. */
+  val enabledExtensionIds = CopyOnWriteArrayList<String>()
+  val subscribedDataKinds = CopyOnWriteArrayList<String>()
+  val unsubscribedDataKinds = CopyOnWriteArrayList<String>()
+  @Volatile var lastThemeFetchParams: JsonElement? = null
+  private val coalesceRemaining = AtomicInteger(coalescedOverrideRejections)
+  private val listeners = CopyOnWriteArrayList<NotificationListener>()
+  private val counter = AtomicInteger(0)
+
+  // Streaming spies (only meaningful when streaming = true).
+  val streamStarts = AtomicInteger(0)
+  val interactiveInputs = CopyOnWriteArrayList<InteractiveInputParams>()
+  val streamStops = CopyOnWriteArrayList<String>()
+  /** Every `stream/visibility` the lane sent: (frameStreamId, visible, fps). */
+  val streamVisibilities = CopyOnWriteArrayList<Triple<String, Boolean, Int?>>()
+  /**
+   * The overrides the most recent `stream/start` carried — what the live lane actually asked the
+   * daemon to compose, as opposed to what the viewer typed. The snapshot lane's twin is already
+   * observable through [renderNow]'s PNG bytes; this is the streaming half.
+   */
+  @Volatile
+  var lastStreamOverrides: PreviewOverrides? = null
+    private set
+
+  @Volatile
+  var lastRenderOverrides: PreviewOverrides? = null
+    private set
+
+  @Volatile
+  var lastFrameStreamId: String? = null
+    private set
+
+  @Volatile
+  var lastCodec: StreamCodec? = null
+    private set
+
+  @Volatile
+  var lastMaxFps: Int? = null
+    private set
+
+  private val streamJson = Json { ignoreUnknownKeys = true }
+
+  /** Fire a `streamFrame` notification to registered listeners (test driver for the live lane). */
+  fun emitStreamFrame(
+    frameStreamId: String,
+    seq: Long,
+    payloadBase64: String?,
+    codec: StreamCodec = StreamCodec.PNG,
+  ) {
+    val params =
+      streamJson
+        .encodeToJsonElement(
+          StreamFrameParams.serializer(),
+          StreamFrameParams(
+            frameStreamId = frameStreamId,
+            seq = seq,
+            ptsMillis = 0,
+            widthPx = 2,
+            heightPx = 2,
+            codec = codec,
+            payloadBase64 = payloadBase64,
+          ),
+        )
+        .jsonObject
+    listeners.forEach { it.onNotification("streamFrame", params) }
+  }
+
+  private fun emitFinished(id: String, bytes: ByteArray) {
+    renderRoot.mkdirs()
+    val file = File(renderRoot, "$id-${counter.incrementAndGet()}.png").apply { writeBytes(bytes) }
+    val params = buildJsonObject {
+      put("id", id)
+      put("pngPath", file.absolutePath)
+    }
+    listeners.forEach { it.onNotification("renderFinished", params) }
+  }
+
+  /**
+   * Fire a `renderFailed` notification — the daemon's terminal event when the render body threw
+   * (e.g. a preview whose composition NPEs). Wire shape mirrors the daemon's `RenderFailedParams`
+   * (`{id, error: {kind, message}}`). Public so a [renderHook] can model a broken preview; the host
+   * must fail that render immediately instead of sleeping out its render budget.
+   */
+  fun emitFailed(id: String, message: String) {
+    val params = buildJsonObject {
+      put("id", id)
+      put(
+        "error",
+        buildJsonObject {
+          put("kind", "renderBody")
+          put("message", message)
+        },
+      )
+    }
+    listeners.forEach { it.onNotification("renderFailed", params) }
+  }
+
+  override val workspaceRoot: String = renderRoot.absolutePath
+  override val modulePath: String = ":sample"
+  override val initializeResult: InitializeResult =
+    InitializeResult(
+      protocolVersion = 2,
+      daemonVersion = "fake",
+      pid = 0,
+      capabilities =
+        ServerCapabilities(
+          incrementalDiscovery = false,
+          sandboxRecycle = false,
+          leakDetection = emptyList(),
+          supportedOverrides = supportedOverrides,
+        ),
+      classpathFingerprint = "",
+      manifest = Manifest(path = "", previewCount = 0),
+    )
+  override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
+
+  override fun setVisible(previewIds: List<String>) = Unit
+
+  override fun setFocus(previewIds: List<String>) = Unit
+
+  override fun fileChanged(path: String, kind: FileKind, changeType: ChangeType) = Unit
+
+  override fun renderNow(
+    previewIds: List<String>,
+    tier: RenderTier,
+    reason: String?,
+    overrides: PreviewOverrides?,
+    timeout: kotlin.time.Duration,
+  ): RenderNowResult {
+    lastRenderOverrides = overrides
+    val call = renderCount.incrementAndGet()
+    val id = previewIds.single()
+    if (rejectAll) {
+      return RenderNowResult(queued = emptyList(), rejected = listOf(RejectedRender(id, "nope")))
+    }
+    if (overrides != null && coalesceRemaining.getAndUpdate { (it - 1).coerceAtLeast(0) } > 0) {
+      return RenderNowResult(
+        queued = emptyList(),
+        rejected =
+          listOf(
+            RejectedRender(
+              id,
+              "coalesced: override-bearing render already in flight for this previewId",
+            )
+          ),
+      )
+    }
+    val hook = renderHook
+    if (hook != null) {
+      hook(call) { bytes -> emitFinished(id, bytes) }
+    } else {
+      val content =
+        "png:${overrides?.uiMode}:${overrides?.localeTag}:${overrides?.device}" +
+          namedOverrideSuffix(overrides)
+      emitFinished(id, content.toByteArray())
+      // Model the daemon writing the figma-svg to a shared per-preview path as a side effect of the
+      // same render — overwritten each time, so distinct overrides overwrite one another's SVG.
+      writeFigmaSvg(id, overrides)
+      // Likewise the compose/semantics tree, carrying two `dp-slot:` markers so the slots lane has
+      // something to extract.
+      writeSemantics(id)
+    }
+    return RenderNowResult(queued = previewIds, rejected = emptyList())
+  }
+
+  private fun writeFigmaSvg(id: String, overrides: PreviewOverrides?) {
+    val previewDir = File(renderRoot, id).apply { mkdirs() }
+    if (hybridSvg) {
+      File(previewDir, "figma-raster").mkdirs()
+      File(previewDir, "figma-raster/node0.png").writeBytes(byteArrayOf(1, 2, 3))
+      File(previewDir, ComposeFigmaSvgProduct.FILE_SVG)
+        .writeText("<svg><image href=\"figma-raster/node0.png\"/></svg>")
+    } else {
+      val svg =
+        "svg:${overrides?.uiMode}:${overrides?.localeTag}:${overrides?.device}" +
+          namedOverrideSuffix(overrides)
+      File(previewDir, ComposeFigmaSvgProduct.FILE_SVG).writeText(svg)
+    }
+  }
+
+  private fun namedOverrideSuffix(overrides: PreviewOverrides?): String =
+    if (includeNamedOverridesInArtifacts) ":${overrides?.namedOverrides.orEmpty()}" else ""
+
+  private fun writeSemantics(id: String) {
+    val previewDir = File(renderRoot, id).apply { mkdirs() }
+    val payload =
+      ComposeSemanticsPayload(
+        root =
+          ComposeSemanticsNode(
+            nodeId = "0",
+            boundsInRoot = "0,0,200,100",
+            children =
+              listOf(
+                ComposeSemanticsNode(
+                  nodeId = "1",
+                  boundsInRoot = "8,8,40,40",
+                  testTag = "${PreviewSlots.SLOT_TAG_PREFIX}leadingIcon",
+                  // Container tokens: the theme inspection layer's input.
+                  tokens =
+                    ComposeSemanticsTokens(
+                      backgroundColor = "#FF6750A4",
+                      cornerRadius = "12.0dp",
+                      borderColor = "#FF79747E",
+                      borderWidth = "1.0dp",
+                    ),
+                ),
+                ComposeSemanticsNode(
+                  nodeId = "2",
+                  boundsInRoot = "48,44,192,64",
+                  testTag = "${PreviewSlots.SLOT_TAG_PREFIX}supporting",
+                  // Resolved type: the typography inspection layer's input.
+                  text = "Supporting text",
+                  typography =
+                    ComposeSemanticsTypography(
+                      fontSize = "14.0sp",
+                      lineHeight = "20.0sp",
+                      fontFamily = "/fonts/Roboto-Medium.ttf",
+                      fontWeight = 500,
+                    ),
+                ),
+              ),
+          )
+      )
+    File(previewDir, ComposeSemanticsProduct.FILE)
+      .writeText(streamJson.encodeToString(ComposeSemanticsPayload.serializer(), payload))
+  }
+
+  override fun fetchData(
+    previewId: String,
+    kind: String,
+    inline: Boolean,
+    params: JsonElement?,
+    timeout: kotlin.time.Duration,
+  ): DataFetchResult {
+    if (kind == Material3ThemeProduct.KIND) lastThemeFetchParams = params
+    fetchDataHook?.invoke(previewId, kind)?.let {
+      return it
+    }
+    if (kind == ComposeFigmaSvgProduct.KIND) {
+      val file = File(renderRoot, "$previewId/${ComposeFigmaSvgProduct.FILE_SVG}")
+      return DataFetchResult(
+        kind = kind,
+        schemaVersion = ComposeFigmaSvgProduct.SCHEMA_VERSION,
+        path = file.absolutePath,
+      )
+    }
+    if (kind == ComposeFigmaSvgProduct.KIND_LONG) {
+      // Model the daemon's `requiresRerender` full-page export: the fetch itself produces the file,
+      // reflecting the overrides threaded through the `params` bag (as the real re-render does) so
+      // the serve host's override-awareness is observable.
+      scrollFetchCount.incrementAndGet()
+      lastScrollFetchParams = params
+      val o =
+        params?.jsonObject?.get(DataFetchParams.PARAM_OVERRIDES)?.let {
+          Json.decodeFromJsonElement(PreviewOverrides.serializer(), it)
+        }
+      val previewDir = File(renderRoot, previewId).apply { mkdirs() }
+      val file = File(previewDir, ComposeFigmaSvgProduct.FILE_SVG_LONG)
+      file.writeText("svg-long:$previewId:${o?.uiMode}:${o?.localeTag}:${o?.device}")
+      return DataFetchResult(
+        kind = kind,
+        schemaVersion = ComposeFigmaSvgProduct.SCHEMA_VERSION,
+        path = file.absolutePath,
+      )
+    }
+    if (kind == ServeRenderHost.SCROLL_LONG_KIND) {
+      scrollPngFetchCount.incrementAndGet()
+      lastScrollPngFetchParams = params
+      val o =
+        params?.jsonObject?.get(DataFetchParams.PARAM_OVERRIDES)?.let {
+          Json.decodeFromJsonElement(PreviewOverrides.serializer(), it)
+        }
+      val file = File(renderRoot, "scroll-long/$previewId.png")
+      file.parentFile.mkdirs()
+      file.writeText("png-long:$previewId:${o?.uiMode}:${o?.localeTag}:${o?.device}")
+      return DataFetchResult(kind = kind, schemaVersion = 1, path = file.absolutePath)
+    }
+    if (kind == ComposeSemanticsProduct.KIND) {
+      val file = File(renderRoot, "$previewId/${ComposeSemanticsProduct.FILE}")
+      return DataFetchResult(
+        kind = kind,
+        schemaVersion = ComposeSemanticsProduct.SCHEMA_VERSION,
+        path = file.absolutePath,
+      )
+    }
+    error("unused")
+  }
+
+  override fun subscribeData(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    timeout: kotlin.time.Duration,
+  ): DataSubscribeResult {
+    subscribedDataKinds += kind
+    return DataSubscribeResult.OK
+  }
+
+  override fun unsubscribeData(
+    previewId: String,
+    kind: String,
+    timeout: kotlin.time.Duration,
+  ): DataSubscribeResult {
+    subscribedDataKinds.remove(kind)
+    unsubscribedDataKinds += kind
+    return DataSubscribeResult.OK
+  }
+
+  override fun listExtensions(timeout: kotlin.time.Duration): ExtensionsListResult = error("unused")
+
+  override fun enableExtensions(
+    ids: List<String>,
+    timeout: kotlin.time.Duration,
+  ): ExtensionsEnableResult {
+    enabledExtensionIds.addAll(ids)
+    val figmaKinds = setOf(ComposeFigmaSvgProduct.KIND, ComposeFigmaSvgProduct.KIND_LONG)
+    // A backend without figma-svg reports those ids as unknown, as does any id in
+    // [unknownExtensionIds]; everything else enables.
+    val unknown = ids.filter {
+      it in unknownExtensionIds || (!figmaSvgAvailable && it in figmaKinds)
+    }
+    val enabled = ids - unknown.toSet()
+    val dataProducts =
+      if (ServeRenderHost.SCROLL_EXTENSION_ID in enabled) {
+        listOf(
+          DataProductCapability(
+            kind = ServeRenderHost.SCROLL_LONG_KIND,
+            schemaVersion = 1,
+            transport = DataProductTransport.PATH,
+            attachable = false,
+            fetchable = true,
+            requiresRerender = true,
+          )
+        )
+      } else {
+        emptyList()
+      }
+    return ExtensionsEnableResult(
+      newlyEnabled = enabled,
+      unknown = unknown,
+      dataProducts = dataProducts,
+    )
+  }
+
+  override fun disableExtensions(
+    ids: List<String>,
+    timeout: kotlin.time.Duration,
+  ): ExtensionsDisableResult = error("unused")
+
+  override fun historyList(
+    params: HistoryListParams,
+    timeout: kotlin.time.Duration,
+  ): HistoryListResult = error("unused")
+
+  override fun historyRead(
+    entryId: String,
+    inline: Boolean,
+    timeout: kotlin.time.Duration,
+  ): HistoryReadResultDto = error("unused")
+
+  override fun historyDiff(
+    fromId: String,
+    toId: String,
+    mode: HistoryDiffMode,
+    timeout: kotlin.time.Duration,
+  ): HistoryDiffResult = error("unused")
+
+  override fun recordingStart(
+    previewId: String,
+    fps: Int?,
+    scale: Float?,
+    overrides: PreviewOverrides?,
+    timeout: kotlin.time.Duration,
+  ): RecordingStartResult = error("unused")
+
+  override fun recordingScript(recordingId: String, events: List<RecordingScriptEvent>) =
+    error("unused")
+
+  override fun recordingStop(
+    recordingId: String,
+    timeout: kotlin.time.Duration,
+  ): RecordingStopResult = error("unused")
+
+  override fun recordingEncode(
+    recordingId: String,
+    format: RecordingFormat,
+    timeout: kotlin.time.Duration,
+  ): RecordingEncodeResult = error("unused")
+
+  override fun streamStart(
+    previewId: String,
+    codec: StreamCodec?,
+    maxFps: Int?,
+    overrides: PreviewOverrides?,
+    timeout: kotlin.time.Duration,
+  ): StreamStartResult {
+    if (!streaming) throw UnsupportedOperationException("streaming not supported")
+    val fsid = "fs-${streamStarts.incrementAndGet()}"
+    lastFrameStreamId = fsid
+    lastCodec = codec
+    lastMaxFps = maxFps
+    lastStreamOverrides = overrides
+    // Model a daemon that emits the initial keyframe before the RPC response returns.
+    emitKeyframeOnStart?.let { emitStreamFrame(fsid, seq = 0, payloadBase64 = it) }
+    return StreamStartResult(
+      frameStreamId = fsid,
+      codec = codec ?: StreamCodec.PNG,
+      heldSession = heldSession,
+      fallbackReason = heldFallbackReason,
+    )
+  }
+
+  override fun streamStop(frameStreamId: String) {
+    streamStops.add(frameStreamId)
+  }
+
+  override fun streamVisibility(frameStreamId: String, visible: Boolean, fps: Int?) {
+    streamVisibilities.add(Triple(frameStreamId, visible, fps))
+  }
+
+  override fun interactiveInput(
+    frameStreamId: String,
+    kind: InteractiveInputKind,
+    pixelX: Int?,
+    pixelY: Int?,
+    pointerId: Int?,
+    scrollDeltaY: Float?,
+    keyCode: String?,
+    text: String?,
+    pointerType: String?,
+  ) {
+    interactiveInputs.add(
+      InteractiveInputParams(
+        frameStreamId = frameStreamId,
+        kind = kind,
+        pixelX = pixelX,
+        pixelY = pixelY,
+        pointerId = pointerId,
+        scrollDeltaY = scrollDeltaY,
+        keyCode = keyCode,
+        text = text,
+        pointerType = pointerType,
+      )
+    )
+  }
+
+  override fun onNotification(listener: NotificationListener): AutoCloseable {
+    listeners.add(listener)
+    return AutoCloseable { listeners.remove(listener) }
+  }
+
+  /** Set by [close] so a test can assert the session was actually reaped. */
+  @Volatile
+  var closed: Boolean = false
+    private set
+
+  override fun close() {
+    closed = true
+  }
+}

--- a/scripts/daemon-launch-schema-allowlist.json
+++ b/scripts/daemon-launch-schema-allowlist.json
@@ -69,6 +69,12 @@
       "why": "`:render-session-subprocess` writes its own descriptors for the bundle daemons it spawns, stamping this private copy, and since #5105 `SubprocessRenderSessions.open` also refuses an on-disk descriptor whose version is not this one. It is one of the twelve published contract modules an extracted preview server links against (#3824), so post-split a stale mirror here is cross-repo version skew no compiler sees."
     },
     {
+      "file": "render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt",
+      "symbol": "DAEMON_LAUNCH_SCHEMA_VERSION",
+      "role": "third writer",
+      "why": "`ServeBundleDaemon` writes its own descriptors for the bundle daemons it spawns. This entry existed until the preview server left the repository in #4732, and the `writerEncoders` note below still records its removal as a gap nothing closed. It is registered again because the render host came home (yschimke/compose-preview-server#180) \u2014 the mirror is back in a tree this check can see, so it is gated again rather than trusted. Note the spelling differs from the other two: the constant is `DAEMON_LAUNCH_SCHEMA_VERSION`, not `*_DESCRIPTOR_SCHEMA_VERSION`, so the name-based mirror scan never finds it and only discovery-by-use does."
+    },
+    {
       "file": "cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt",
       "symbol": "EXPECTED_DESCRIPTOR_SCHEMA_VERSION",
       "role": "doctor",
@@ -139,8 +145,11 @@
         "prettyPrint": "true",
         "encodeDefaults": "true",
         "explicitNulls": "true"
+      },
+      "render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt": {
+        "encodeDefaults": "true"
       }
     },
-    "why": "Every production writer's `Json`, recorded per file because they are not identical. The two Gradle-plugin writers pretty-print and force explicit nulls. The settings that DO change the wire (a `namingStrategy`, or `encodeDefaults = false` dropping defaulted fields) live in the same block, so they are recorded rather than assumed. Serve's writer (`ServeBundleDaemon`, compact, relying on kotlinx's `explicitNulls = true` default) was registered here until the server left the repository in #4732; it is now a cross-repo mirror this check cannot see, which is residual item 1 on that issue \u2014 a `daemon-launch.json` shape change here no longer fails the server's build, and nothing yet makes it."
+    "why": "Every production writer's `Json`, recorded per file because they are not identical. The two Gradle-plugin writers pretty-print and force explicit nulls. The settings that DO change the wire (a `namingStrategy`, or `encodeDefaults = false` dropping defaulted fields) live in the same block, so they are recorded rather than assumed. Serve's writer (`ServeBundleDaemon`, compact, relying on kotlinx's `explicitNulls = true` default) was registered here, then left with the server in #4732, and is registered again now that the render host came home (yschimke/compose-preview-server#180). It is deliberately NOT identical to the two Gradle-plugin writers: it does not pretty-print, and it leans on kotlinx's `explicitNulls = true` default rather than stating it. Both are recorded rather than normalised, because this block exists to make the differences visible, not to assert they should not exist. Residual item 1 on #4732 \u2014 that a shape change here no longer fails the server's build \u2014 is narrowed rather than closed: the writer is gated again, but the server's own image still passes descriptor keys this check cannot see."
   }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -766,6 +766,17 @@ include(":mcp")
 // consumer (CLI, MCP server, third-party tooling) compiles against; `:render-session-subprocess`
 // is the daemon-subprocess-backed implementation. Future `:render-session-embedded` will host the
 // in-process Robolectric driver once that's viable.
+// The render host, the bundle daemon and the git-backed preview history — daemon-backed rendering,
+// packed-bundle materialisation and manifest reads, with no web server underneath.
+//
+// Moved here from yschimke/compose-preview-server, where it published as
+// `compose-preview-render-host`. It is offline behaviour, which `docs/design/REPOSITORY_LAYERS.md`
+// places in layer 1, and it had zero project dependencies inside the server — it lived there only
+// because it was written inside the `serve` package and went along when the server was extracted.
+// Depending on it from `:cli` is half of the dependency cycle in
+// yschimke/compose-preview-server#180, and the half with no reason to exist.
+include(":render-host")
+
 include(":render-session-api")
 
 project(":render-session-api").projectDir = file("render-session/api")


### PR DESCRIPTION
Step 2 of [compose-preview-server#180](https://github.com/yschimke/compose-preview-server/issues/180), and the first half of a two-repository handover. Follows [#5129](https://github.com/yschimke/compose-ai-tools/pull/5129) (the layer rule) and [#5135](https://github.com/yschimke/compose-ai-tools/pull/5135) (the gate).

## Why

The render host, the bundle daemon and the git-backed preview history were written inside the `serve` package, so when the server was extracted they went with it. That left `:cli` reaching across a repository boundary for them: `bundle render`, `render matrix`, `history manifest` and the missing-render report are **offline** commands that open no socket, yet depended on an artifact published by the repository that owns the web server.

That is one of the two edges of the cycle, and the half with no reason to exist. The evidence is mechanical: **the module has zero project dependencies inside the server** — its entire dependency block is compose-ai-tools and contracts coordinates. `docs/design/REPOSITORY_LAYERS.md` settles it: layer 1 is behaviour that opens no socket, and this renders.

## What moved

81 Kotlin files (48 main / 17.8k lines, 32 test, 1 test fixture), one package, unchanged.

**Sources are unchanged, package included** (`ee.schimke.composeai.cli.serve`), so the move is source-compatible — call sites don't change, they resolve from a module in the right repository. The package rename stays a separately reviewed change in both repos.

**Dependencies are not unchanged, and that is the point.** Seven published coordinates become project dependencies:

| was | is |
| --- | --- |
| `libs.composeai.preview.data.api` | `project(":preview-data-api")` |
| `libs.composeai.bundle.format` | `project(":bundle-format")` |
| `libs.composeai.bundle.coordinates` | `project(":bundle-coordinates")` |
| `libs.composeai.daemon.core` | `project(":daemon:core")` |
| `libs.composeai.render.session.api` | `project(":render-session-api")` |
| `libs.composeai.render.session.subprocess` | `project(":render-session-subprocess")` |
| `libs.composeai.data.remotecompose.core` | `project(":data-remotecompose-core")` |

The contracts coordinates (layer 0) stay published in both repositories — that direction is what the layer rule allows. `parity-issues-protocol` is added to the catalog; it's the one alias this repo didn't already have.

The render host is now compiled and tested against the source tree it ships beside, instead of against whichever compose-ai-tools release the server happened to pin. **The skew that made #180 worth filing — built against 1.62.0, run against `main` — cannot recur from this side.**

## The coordinate changes: `render-host`, not `compose-preview-render-host`

Keeping the old coordinate would put one artifact on two version lines from two repositories, and a 1.x release sorts **below** the 2.x the server already shipped — a downgrade to every resolver and to Renovate. The new name matches this repository's own convention (`bundle-format`, `daemon-core`, `render-session-api`), and the old coordinate stays resolvable at its final 2.x for anyone pinned to it.

## Two things the move earns

- **The test-fixtures capability workaround is gone.** In the server the project was named `render-host` but published as `compose-preview-render-host`, so `java-test-fixtures` derived a capability that didn't match what `testFixtures(...)` asks for — a block of variant configuration plus a `checkTestFixturesCapabilities` guard to reconcile them. Here the project name and artifactId are the same string. Verified in the published module metadata rather than assumed:
  ```
  testFixturesApiElements      -> ee.schimke.composeai:render-host-test-fixtures
  testFixturesRuntimeElements  -> ee.schimke.composeai:render-host-test-fixtures
  testFixturesSourcesElements  -> ee.schimke.composeai:render-host-test-fixtures
  ```
- **`checkRenderHostIsServerFree` comes along**, because "no web server" is now this repository's *layer-1 test* rather than the server's internal boundary. It is narrower than `checkLayerBoundary`: that one asks where a coordinate comes from, this asks what kind of thing it is.

## What this PR deliberately does *not* do

`:cli` is **not** switched to the new module. It still depends on `compose-preview-serve`, whose POM names the published `compose-preview-render-host`, so wiring `project(":render-host")` in as well would put the same classes from `ee.schimke.composeai.cli.serve` on one classpath twice.

The order is: this lands and releases → the server adopts `ee.schimke.composeai:render-host` and deletes its copy → `:cli` swaps over and two entries leave `CheckLayerBoundary.knownLayerTwoEdges`. Until then the two copies coexist, which is why the window should be short.

## Test plan

- `./gradlew :render-host:compileKotlin` — green. Worth stating plainly: the moved sources compile against compose-ai-tools `main` unmodified, so the pinned-version skew had not yet become a source incompatibility.
- `./gradlew :render-host:test --rerun-tasks` — **452 tests across 33 classes, 0 failures.**
- `./gradlew :render-host:check` — green, including `checkRenderHostIsServerFree` and the new `checkLayerBoundary`.
- `./gradlew :render-host:publishToMavenLocal` — publishes `ee.schimke.composeai:render-host:1.75.1-SNAPSHOT` with jar, sources, javadoc and test-fixtures; capability metadata quoted above.
- `./gradlew :render-host:ktfmtCheck` — green.

Non-visual change; no render evidence applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014NtzoUCr4pou3y1qRDxcpZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014NtzoUCr4pou3y1qRDxcpZ)_