### PR TITLE
chore(ci): update the design-artifacts export driver to v1.76.0

### DIFF
--- a/.github/design-artifacts-driver-pin.txt
+++ b/.github/design-artifacts-driver-pin.txt
@@ -61,5 +61,5 @@
 # only ever validated its SHAPE rather than whether it was true, and a timestamp
 # that quietly stops tracking reality is worse than none: the commit and the PR
 # already record when the pin moved.
-sha=505b7be4c5799636216f60970163a0c2711d95c0
-tag=v1.75.0
+sha=1db5da43cb14f180c50c46b4f20004a8f7f9d1f5
+tag=v1.76.0


### PR DESCRIPTION
## What

Moves `.github/design-artifacts-driver-pin.txt` from `v1.75.0` / `505b7be` to `v1.76.0` / `1db5da4` — the commit the `v1.76.0` tag points at, which is the release PR's squash.

## Why now

v1.76.0 finished publishing a few minutes ago. Until it did, this bump could not land: `refresh-driver-pin.sh --check`, which `ci.yml` runs on every PR, refuses a tag whose Release is still a draft — the rule the pin file's header states, added because release-please writes the tag while the Release is still building, so a stranded draft leaves a real tag whose artifacts never shipped (v1.55.0, v1.67.0 are two).

```
# while it was still a draft
refresh-driver-pin: v1.76.0 is not a published release of yschimke/compose-ai-tools
  (HTTP 404) — a draft or missing release must not be pinned

# now
driver pin OK: 1db5da43cb14f180c50c46b4f20004a8f7f9d1f5 (v1.76.0, published)
```

Renovate owns this edit routinely and had not opened its bump when this was written, so it is done by hand through the script's `--tag`/`--sha` mode — the escape hatch the pin file's header names. The two keys keep their spelling, order and adjacency, so the `design-artifacts-driver-pin` custom manager still matches the pair. If Renovate's own PR appears, close whichever is second rather than merging both.

Titled `chore(ci)` deliberately, per the rationale in `renovate.json`: a squash merge uses the PR title as the headline, and a `fix:` title would have release-please propose a release, whose publish opens another bump.

## What moves with it

External callers of `design-artifacts-reusable.yml` — `yschimke/compose-preview-imports` among them — execute the pinned commit's `scripts/design-artifacts/`. v1.76.0 is also the release carrying #5136, so the next import run reports a missing AGP resource table as one classpath fault rather than as N individually broken previews.

## Test plan

`.github/scripts/refresh-driver-pin.sh --check` passes on the new pin (output above); it failed on the same edit while the Release was a draft, which is the gate working. Data-file change only — no source, no visual surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pu78hmRSSLNxeH5QRWYftq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pu78hmRSSLNxeH5QRWYftq)_