### PR TITLE
docs(build-host): decide where PreviewModule lives in the build-host protocol

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -70,6 +70,7 @@ them — `:daemon:core`'s `bta/` package and the VS Code extension's daemon clie
 The `design/` tree used to hold many speculative proposals; what remains are the
 specs the code actually depends on:
 
+- [design/BUILD_HOST_PROTOCOL_PREVIEWMODULE.md](design/BUILD_HOST_PROTOCOL_PREVIEWMODULE.md) — **decision requested**: where `PreviewModule` lives once `ServeBuildHost` becomes a wire protocol between the preview server and a `compose-preview build-host` process. Four options costed (contracts depending upward, redeclaring the shape there, moving the type down, or publishing the protocol from here), why the type's `java.io.File` and `Serializable` shape is owned by the Gradle Tooling API rather than by a wire, and a recommendation that turns on the change loop rather than on purity.
 - [design/REPOSITORY_LAYERS.md](design/REPOSITORY_LAYERS.md) — **normative**: which repository a module belongs in. Four layers (contracts = shape; compose-ai-tools = offline behaviour; compose-preview-server = HTTP and the surfaces over it; vscode/xr = leaves), a dependency may only point down, and the consequences that follow — why the Gradle Tooling API is permanently compose-ai-tools', and why a fourth repository is not the answer to a misplaced module.
 - [design/SPATIAL_SCENE_CONTRACT.md](design/SPATIAL_SCENE_CONTRACT.md) — the XR scene wire format (schema-generated Kotlin/TS/C++ mirrors).
 - [design/DESIGN_CATALOGS.md](design/DESIGN_CATALOGS.md) — the code-led sticker-sheet catalog system.

--- a/docs/design/BUILD_HOST_PROTOCOL_PREVIEWMODULE.md
+++ b/docs/design/BUILD_HOST_PROTOCOL_PREVIEWMODULE.md
@@ -1,0 +1,138 @@
+# Where `PreviewModule` lives when `ServeBuildHost` becomes a wire protocol
+
+> **Status: decision requested.** One question, blocking the build-host protocol
+> ([compose-preview-server#180](https://github.com/yschimke/compose-preview-server/issues/180)
+> step 3, [#9](https://github.com/yschimke/compose-preview-server/issues/9)). Nothing is
+> implemented; this records the options and a recommendation so the choice is made once,
+> deliberately, rather than discovered halfway through writing the module.
+
+## The plan this sits inside
+
+`ServeBuildHost` is the seam where the preview server asks for Gradle work. Today it is a Kotlin
+interface with exactly one real implementation — the CLI's `ServeCommand` — which is why `serve`
+and `browse` cannot leave compose-ai-tools and why `StandaloneBuildHost` stubs all seven methods.
+The agreed direction is to make that seam a **process boundary** rather than a library one: a small
+request/response protocol, a `compose-preview build-host` process on this side, and a server that
+spawns it when a local Gradle project is asked for. The Gradle Tooling API then stays in layer 1
+permanently, which is what `docs/design/REPOSITORY_LAYERS.md` says it is.
+
+The seam is small enough for that to be cheap: **seven methods, sixteen call sites**, all inside
+`ServeRunner`.
+
+## The question
+
+Two of the seven methods carry `PreviewModule`:
+
+```kotlin
+public fun gradleProjects(): List<PreviewModule>
+public fun discoverAndBuild(silenceStdout: Boolean): ServeDiscovery   // manifests: List<Pair<PreviewModule, PreviewManifest>>
+```
+
+`PreviewModule` is declared in **this** repository, in `:preview-data-api`, and it is small:
+
+```kotlin
+public data class PreviewModule(val gradlePath: String, val projectDir: File) : java.io.Serializable
+```
+
+The recommendation recorded on #180 was to put the protocol in `compose-preview-contracts` — layer
+0, *shape never behaviour*, already depended on by both repositories, no new release train. That
+recommendation was made without checking where `PreviewModule` lives. **It is not in contracts**,
+and contracts today has *zero* `ee.schimke.composeai` coordinates on any of its POMs. So the
+protocol cannot simply name the type, and the question has to be answered before the module exists.
+
+## Options
+
+### A. The contracts protocol module depends on `:preview-data-api`
+
+Rejected, and not marginally. `:preview-data-api` is layer 1 and contracts is layer 0, so this is
+an **upward** dependency — the exact shape `REPOSITORY_LAYERS.md` forbids and `checkLayerBoundary`
+now enforces on this side. Contracts' own `AGENTS.md` guards it independently: *"Do not add a
+dependency without asking what it does to the consumers' floor. Every `ee.schimke.composeai` module
+on a POM here is a module a client must resolve."* Today that floor is empty. Filling it to reach
+a two-field data class would be the most expensive possible way to get one.
+
+### B. Redeclare the shape inside the contracts protocol module
+
+Two fields, and `projectDir` has to change type regardless — see *The `File` problem* below — so
+the "duplication" is smaller than it sounds, and the second declaration is a genuine wire DTO
+rather than a copy.
+
+There is direct precedent: `:daemon-protocol` moved 21 types in-house for this reason, and contracts'
+`AGENTS.md` states the principle — **"a wire field's type belongs to the wire"** — recording that
+the move took a client from 9,111 lines of published ABI across five coordinates down to one
+coordinate and 5,695 lines.
+
+Cost: two declarations of one concept, and a change loop that runs through three repositories.
+
+### C. Move `PreviewModule` down into contracts, re-exported by `:preview-data-api`
+
+The tempting one, because it leaves one declaration. It should still be rejected, for a reason
+that is easy to miss: **`PreviewModule`'s shape is dictated by the Gradle Tooling API, not by a
+wire.** It is `java.io.Serializable` and carries a `java.io.File` because instances are constructed
+inside `DiscoverPreviewModulesAction` — a `BuildAction` that runs in the Gradle daemon and is
+serialised back across the Tooling-API boundary.
+
+Contracts would therefore be owning a type whose constraints come from a build tool it must never
+depend on, and freezing `java.io.File` into a repository whose rule is *shape, never behaviour*. It
+is also an ABI move affecting every existing consumer of `:preview-data-api`, paid across a release
+boundary, to serve a module that does not exist yet.
+
+### D. Publish the protocol from compose-ai-tools instead of contracts
+
+The protocol module lives here, beside the type it already owns. `PreviewModule` is reused
+directly, nothing is redeclared, and no contracts module is created.
+
+The layer question this raises answers itself: the server is layer 2 and this repository is layer 1,
+so a server that consumes the protocol is depending **downward**, which the rule allows. It is also
+not a new edge — the server already resolves thirteen coordinates from here, `:preview-data-api`
+among them. A fourteenth costs nothing that the thirteen have not already cost.
+
+## The `File` problem, which applies to B and D alike
+
+`projectDir` is a `java.io.File`. A process boundary cannot carry one, so the wire form is a path
+string and both ends convert at the adapter. This is worth stating because it is the part that makes
+"just reuse the type" incomplete under *any* option: even option D, which reuses `PreviewModule` in
+the protocol module's API, needs a serialisable form for the actual message. What D avoids is a
+second *declaration* of the concept, not the conversion.
+
+It also raises a question the protocol has to answer explicitly: a path is only meaningful relative
+to something. The build host and the server are separate processes and may not share a working
+directory. Whichever option is taken, the protocol should carry absolute paths, or paths relative to
+a root the handshake establishes — decided in the protocol, not left to whichever adapter is written
+first.
+
+## Recommendation: D
+
+Put the build-host protocol in compose-ai-tools, and revisit contracts if a third consumer appears.
+
+The reasoning is about the change loop rather than purity. This protocol is **new and will iterate** —
+the first version will be wrong about progress streaming, cancellation, or error shape, and that is
+normal for a seam being extracted from an in-process interface. In compose-ai-tools, a protocol
+change and the `compose-preview build-host` implementation of it land in **one PR, compiled against
+each other**, followed by a bump in the server. In contracts it is: change contracts, release
+contracts, bump contracts here, release here, bump here in the server — with contracts' own
+`AGENTS.md` warning that *"a change to a wire contract therefore reaches that repository only through
+a release… that is the cost the split bought, and the reason an ABI break is expensive."*
+
+Paying that cost is right for a settled wire contract. It is the wrong cost to pay while the shape
+is still being learned, and the migration from D to B later is mechanical — moving a stable DTO down
+a layer, which is exactly what contracts exists to receive.
+
+Two honest marks against D, recorded rather than argued away:
+
+- **It puts a wire protocol somewhere other than the wire-protocol repository**, which weakens
+  "contracts is where shapes live" as a rule someone can rely on without checking. Mitigated by
+  precedent rather than dismissed: contracts already publishes five modules that are *not* wire
+  contracts, because an extracted preview server needs them — that repository's bar is already
+  "what does the consumer need", not "is this a wire shape".
+- **It does not shrink the back edge.** D adds a fourteenth coordinate to server → compose-ai-tools.
+  That edge is sanctioned by the layer rule and is not the cycle — the cycle closes because the
+  *forward* edge goes when `serve` becomes a launcher — but anyone hoping this step also thins the
+  back edge should know that it does not.
+
+## What this does not decide
+
+The protocol's actual shape: the seven operations' messages, how build progress streams back, how
+cancellation and `silenceStdout` map onto a process, and what happens when no build host is present
+(today's `StandaloneBuildHost` behaviour, which stops being a stub and becomes an honest *no Gradle
+here*). Those follow the placement decision; this document exists so they are not designed twice.


### PR DESCRIPTION
A decision to make before step 3 of [compose-preview-server#180](https://github.com/yschimke/compose-preview-server/issues/180) can start. Docs only — nothing is implemented.

## Why this exists

The recommendation I recorded on #180 was to put the build-host protocol in `compose-preview-contracts`: layer 0, shape-only, already depended on by both repositories, no new release train.

**That recommendation was made without checking where `PreviewModule` lives.** It lives here, in `:preview-data-api`, and `compose-preview-contracts` has **zero** `ee.schimke.composeai` coordinates on any of its POMs. Two of the seven build-host methods carry the type:

```kotlin
public fun gradleProjects(): List<PreviewModule>
public fun discoverAndBuild(silenceStdout: Boolean): ServeDiscovery   // List<Pair<PreviewModule, PreviewManifest>>
```

So the protocol cannot just name it, and the placement has to be settled before the module exists rather than discovered halfway through writing it.

## What the doc costs out

| option | verdict |
| --- | --- |
| A. contracts protocol module depends on `:preview-data-api` | **rejected** — layer 0 → layer 1 is the upward edge `REPOSITORY_LAYERS.md` forbids and `checkLayerBoundary` now enforces; contracts' floor of composeai coordinates is currently empty |
| B. redeclare the shape in contracts | viable; precedent is `:daemon-protocol` moving 21 types in-house — *"a wire field's type belongs to the wire"* |
| C. move `PreviewModule` down into contracts | **the tempting one, and still wrong** — see below |
| D. publish the protocol from compose-ai-tools | **recommended** |

## The two things worth knowing regardless of the choice

**`PreviewModule`'s shape is owned by the Gradle Tooling API, not by a wire.** It is `java.io.Serializable` and carries a `java.io.File` because instances are constructed inside `DiscoverPreviewModulesAction` — a `BuildAction` that runs in the Gradle daemon and is serialised back across the Tooling-API boundary. Option C would have contracts owning a type whose constraints come from a build tool it must never depend on, and freeze `java.io.File` into a *shape, never behaviour* repository.

**No option escapes the `File` conversion.** A process boundary cannot carry a `java.io.File`, so the wire form is a path string either way. Even D, which reuses the type in the module's API, needs a serialisable message form — what D avoids is a second *declaration*, not the conversion. That in turn raises a question the protocol must answer explicitly: the build host and the server are separate processes that may not share a working directory, so paths must be absolute or relative to a root the handshake establishes. Decided in the protocol, not by whichever adapter gets written first.

## Why D, and what's against it

On the change loop rather than purity. This protocol is new and will iterate — the first version will be wrong about progress streaming, cancellation or error shape. Here, a protocol change and its `compose-preview build-host` implementation land in **one PR, compiled against each other**, then a bump in the server. In contracts it is change → release → bump → release → bump, a cost that repo's own `AGENTS.md` warns about explicitly. Paying it is right for a settled contract, wrong while the shape is still being learned — and D → B later is mechanical, which is exactly what contracts exists to receive.

Two marks against D, recorded rather than argued away:

- It puts a wire protocol somewhere other than the wire-protocol repository. Mitigated by precedent, not dismissed: contracts already publishes five modules that are *not* wire contracts because an extracted server needs them.
- **It does not shrink the back edge** — it adds a fourteenth coordinate to server → compose-ai-tools. That edge is sanctioned and is not the cycle (the cycle closes when the *forward* edge goes), but anyone hoping this step thins it should know it doesn't.

## Test plan

- `scripts/check-agent-entrypoints.sh` — green.
- Docs only: no Kotlin, no build files, nothing to compile or format.

Deliberately not decided here: the protocol's actual message shapes, progress streaming, cancellation, and the no-build-host-present behaviour. Those follow the placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014NtzoUCr4pou3y1qRDxcpZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014NtzoUCr4pou3y1qRDxcpZ)_