### PR TITLE
feat(build-host): serve the server's Gradle work over a process boundary

### DIFF
--- a/api/build-host-protocol/api/build-host-protocol.api
+++ b/api/build-host-protocol/api/build-host-protocol.api
@@ -1,0 +1,522 @@
+public final class ee/schimke/composeai/buildhost/BuildHostCodec {
+	public static final field INSTANCE Lee/schimke/composeai/buildhost/BuildHostCodec;
+	public final fun decode (Ljava/lang/String;)Lee/schimke/composeai/buildhost/BuildHostEnvelope;
+	public final fun encode (Lee/schimke/composeai/buildhost/BuildHostEnvelope;)Ljava/lang/String;
+	public final fun getJson ()Lkotlinx/serialization/json/Json;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostEnvelope {
+	public static final field Companion Lee/schimke/composeai/buildhost/BuildHostEnvelope$Companion;
+	public fun <init> (JLee/schimke/composeai/buildhost/BuildHostRequest;Lee/schimke/composeai/buildhost/BuildHostResponse;Lee/schimke/composeai/buildhost/BuildHostEvent;)V
+	public synthetic fun <init> (JLee/schimke/composeai/buildhost/BuildHostRequest;Lee/schimke/composeai/buildhost/BuildHostResponse;Lee/schimke/composeai/buildhost/BuildHostEvent;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()Lee/schimke/composeai/buildhost/BuildHostRequest;
+	public final fun component3 ()Lee/schimke/composeai/buildhost/BuildHostResponse;
+	public final fun component4 ()Lee/schimke/composeai/buildhost/BuildHostEvent;
+	public final fun copy (JLee/schimke/composeai/buildhost/BuildHostRequest;Lee/schimke/composeai/buildhost/BuildHostResponse;Lee/schimke/composeai/buildhost/BuildHostEvent;)Lee/schimke/composeai/buildhost/BuildHostEnvelope;
+	public static synthetic fun copy$default (Lee/schimke/composeai/buildhost/BuildHostEnvelope;JLee/schimke/composeai/buildhost/BuildHostRequest;Lee/schimke/composeai/buildhost/BuildHostResponse;Lee/schimke/composeai/buildhost/BuildHostEvent;ILjava/lang/Object;)Lee/schimke/composeai/buildhost/BuildHostEnvelope;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEvent ()Lee/schimke/composeai/buildhost/BuildHostEvent;
+	public final fun getId ()J
+	public final fun getRequest ()Lee/schimke/composeai/buildhost/BuildHostRequest;
+	public final fun getResponse ()Lee/schimke/composeai/buildhost/BuildHostResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/buildhost/BuildHostEnvelope$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/buildhost/BuildHostEnvelope$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/buildhost/BuildHostEnvelope;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/buildhost/BuildHostEnvelope;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostEnvelope$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class ee/schimke/composeai/buildhost/BuildHostEvent {
+	public static final field Companion Lee/schimke/composeai/buildhost/BuildHostEvent$Companion;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostEvent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostEvent$Log : ee/schimke/composeai/buildhost/BuildHostEvent {
+	public static final field Companion Lee/schimke/composeai/buildhost/BuildHostEvent$Log$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/buildhost/BuildHostEvent$Log;
+	public static synthetic fun copy$default (Lee/schimke/composeai/buildhost/BuildHostEvent$Log;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/buildhost/BuildHostEvent$Log;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLine ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/buildhost/BuildHostEvent$Log$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/buildhost/BuildHostEvent$Log$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/buildhost/BuildHostEvent$Log;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/buildhost/BuildHostEvent$Log;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostEvent$Log$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostProtocol {
+	public static final field INSTANCE Lee/schimke/composeai/buildhost/BuildHostProtocol;
+	public static final field STDIO_FLAG Ljava/lang/String;
+	public static final field VERSION I
+}
+
+public abstract interface class ee/schimke/composeai/buildhost/BuildHostRequest {
+	public static final field Companion Lee/schimke/composeai/buildhost/BuildHostRequest$Companion;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostRequest$AutoInjectInitScriptArgs : ee/schimke/composeai/buildhost/BuildHostRequest {
+	public static final field Companion Lee/schimke/composeai/buildhost/BuildHostRequest$AutoInjectInitScriptArgs$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/buildhost/BuildHostRequest$AutoInjectInitScriptArgs;
+	public static synthetic fun copy$default (Lee/schimke/composeai/buildhost/BuildHostRequest$AutoInjectInitScriptArgs;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/buildhost/BuildHostRequest$AutoInjectInitScriptArgs;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getProjectRoot ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/buildhost/BuildHostRequest$AutoInjectInitScriptArgs$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/buildhost/BuildHostRequest$AutoInjectInitScriptArgs$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/buildhost/BuildHostRequest$AutoInjectInitScriptArgs;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/buildhost/BuildHostRequest$AutoInjectInitScriptArgs;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostRequest$AutoInjectInitScriptArgs$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostRequest$DiscoverAndBuild : ee/schimke/composeai/buildhost/BuildHostRequest {
+	public static final field Companion Lee/schimke/composeai/buildhost/BuildHostRequest$DiscoverAndBuild$Companion;
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lee/schimke/composeai/buildhost/BuildHostRequest$DiscoverAndBuild;
+	public static synthetic fun copy$default (Lee/schimke/composeai/buildhost/BuildHostRequest$DiscoverAndBuild;ZILjava/lang/Object;)Lee/schimke/composeai/buildhost/BuildHostRequest$DiscoverAndBuild;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSilenceStdout ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/buildhost/BuildHostRequest$DiscoverAndBuild$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/buildhost/BuildHostRequest$DiscoverAndBuild$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/buildhost/BuildHostRequest$DiscoverAndBuild;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/buildhost/BuildHostRequest$DiscoverAndBuild;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostRequest$DiscoverAndBuild$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostRequest$GradleBuildArgs : ee/schimke/composeai/buildhost/BuildHostRequest {
+	public static final field Companion Lee/schimke/composeai/buildhost/BuildHostRequest$GradleBuildArgs$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lee/schimke/composeai/buildhost/BuildHostRequest$GradleBuildArgs;
+	public static synthetic fun copy$default (Lee/schimke/composeai/buildhost/BuildHostRequest$GradleBuildArgs;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/buildhost/BuildHostRequest$GradleBuildArgs;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExtra ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/buildhost/BuildHostRequest$GradleBuildArgs$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/buildhost/BuildHostRequest$GradleBuildArgs$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/buildhost/BuildHostRequest$GradleBuildArgs;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/buildhost/BuildHostRequest$GradleBuildArgs;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostRequest$GradleBuildArgs$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostRequest$GradleProjectRoot : ee/schimke/composeai/buildhost/BuildHostRequest {
+	public static final field INSTANCE Lee/schimke/composeai/buildhost/BuildHostRequest$GradleProjectRoot;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostRequest$GradleProjects : ee/schimke/composeai/buildhost/BuildHostRequest {
+	public static final field INSTANCE Lee/schimke/composeai/buildhost/BuildHostRequest$GradleProjects;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostRequest$GradleVariantArgs : ee/schimke/composeai/buildhost/BuildHostRequest {
+	public static final field INSTANCE Lee/schimke/composeai/buildhost/BuildHostRequest$GradleVariantArgs;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostRequest$Handshake : ee/schimke/composeai/buildhost/BuildHostRequest {
+	public static final field Companion Lee/schimke/composeai/buildhost/BuildHostRequest$Handshake$Companion;
+	public fun <init> ()V
+	public fun <init> (I)V
+	public synthetic fun <init> (IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun copy (I)Lee/schimke/composeai/buildhost/BuildHostRequest$Handshake;
+	public static synthetic fun copy$default (Lee/schimke/composeai/buildhost/BuildHostRequest$Handshake;IILjava/lang/Object;)Lee/schimke/composeai/buildhost/BuildHostRequest$Handshake;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getProtocolVersion ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/buildhost/BuildHostRequest$Handshake$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/buildhost/BuildHostRequest$Handshake$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/buildhost/BuildHostRequest$Handshake;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/buildhost/BuildHostRequest$Handshake;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostRequest$Handshake$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostRequest$RunGradleTasks : ee/schimke/composeai/buildhost/BuildHostRequest {
+	public static final field Companion Lee/schimke/composeai/buildhost/BuildHostRequest$RunGradleTasks$Companion;
+	public fun <init> (Ljava/util/List;Ljava/util/List;Z)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Z
+	public final fun copy (Ljava/util/List;Ljava/util/List;Z)Lee/schimke/composeai/buildhost/BuildHostRequest$RunGradleTasks;
+	public static synthetic fun copy$default (Lee/schimke/composeai/buildhost/BuildHostRequest$RunGradleTasks;Ljava/util/List;Ljava/util/List;ZILjava/lang/Object;)Lee/schimke/composeai/buildhost/BuildHostRequest$RunGradleTasks;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArguments ()Ljava/util/List;
+	public final fun getSilenceStdout ()Z
+	public final fun getTasks ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/buildhost/BuildHostRequest$RunGradleTasks$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/buildhost/BuildHostRequest$RunGradleTasks$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/buildhost/BuildHostRequest$RunGradleTasks;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/buildhost/BuildHostRequest$RunGradleTasks;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostRequest$RunGradleTasks$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class ee/schimke/composeai/buildhost/BuildHostResponse {
+	public static final field Companion Lee/schimke/composeai/buildhost/BuildHostResponse$Companion;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostResponse$BuildResult : ee/schimke/composeai/buildhost/BuildHostResponse {
+	public static final field Companion Lee/schimke/composeai/buildhost/BuildHostResponse$BuildResult$Companion;
+	public fun <init> (Z)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lee/schimke/composeai/buildhost/BuildHostResponse$BuildResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/buildhost/BuildHostResponse$BuildResult;ZILjava/lang/Object;)Lee/schimke/composeai/buildhost/BuildHostResponse$BuildResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBuildOk ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/buildhost/BuildHostResponse$BuildResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/buildhost/BuildHostResponse$BuildResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/buildhost/BuildHostResponse$BuildResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/buildhost/BuildHostResponse$BuildResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostResponse$BuildResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostResponse$Discovery : ee/schimke/composeai/buildhost/BuildHostResponse {
+	public static final field Companion Lee/schimke/composeai/buildhost/BuildHostResponse$Discovery$Companion;
+	public fun <init> (ZLjava/util/List;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (ZLjava/util/List;)Lee/schimke/composeai/buildhost/BuildHostResponse$Discovery;
+	public static synthetic fun copy$default (Lee/schimke/composeai/buildhost/BuildHostResponse$Discovery;ZLjava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/buildhost/BuildHostResponse$Discovery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBuildOk ()Z
+	public final fun getManifests ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/buildhost/BuildHostResponse$Discovery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/buildhost/BuildHostResponse$Discovery$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/buildhost/BuildHostResponse$Discovery;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/buildhost/BuildHostResponse$Discovery;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostResponse$Discovery$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostResponse$Failure : ee/schimke/composeai/buildhost/BuildHostResponse {
+	public static final field Companion Lee/schimke/composeai/buildhost/BuildHostResponse$Failure$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/buildhost/BuildHostResponse$Failure;
+	public static synthetic fun copy$default (Lee/schimke/composeai/buildhost/BuildHostResponse$Failure;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/buildhost/BuildHostResponse$Failure;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/buildhost/BuildHostResponse$Failure$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/buildhost/BuildHostResponse$Failure$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/buildhost/BuildHostResponse$Failure;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/buildhost/BuildHostResponse$Failure;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostResponse$Failure$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostResponse$Handshake : ee/schimke/composeai/buildhost/BuildHostResponse {
+	public static final field Companion Lee/schimke/composeai/buildhost/BuildHostResponse$Handshake$Companion;
+	public fun <init> (ILjava/lang/String;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (ILjava/lang/String;)Lee/schimke/composeai/buildhost/BuildHostResponse$Handshake;
+	public static synthetic fun copy$default (Lee/schimke/composeai/buildhost/BuildHostResponse$Handshake;ILjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/buildhost/BuildHostResponse$Handshake;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHostVersion ()Ljava/lang/String;
+	public final fun getProtocolVersion ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/buildhost/BuildHostResponse$Handshake$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/buildhost/BuildHostResponse$Handshake$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/buildhost/BuildHostResponse$Handshake;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/buildhost/BuildHostResponse$Handshake;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostResponse$Handshake$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostResponse$Modules : ee/schimke/composeai/buildhost/BuildHostResponse {
+	public static final field Companion Lee/schimke/composeai/buildhost/BuildHostResponse$Modules$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lee/schimke/composeai/buildhost/BuildHostResponse$Modules;
+	public static synthetic fun copy$default (Lee/schimke/composeai/buildhost/BuildHostResponse$Modules;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/buildhost/BuildHostResponse$Modules;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getModules ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/buildhost/BuildHostResponse$Modules$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/buildhost/BuildHostResponse$Modules$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/buildhost/BuildHostResponse$Modules;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/buildhost/BuildHostResponse$Modules;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostResponse$Modules$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostResponse$Path : ee/schimke/composeai/buildhost/BuildHostResponse {
+	public static final field Companion Lee/schimke/composeai/buildhost/BuildHostResponse$Path$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/buildhost/BuildHostResponse$Path;
+	public static synthetic fun copy$default (Lee/schimke/composeai/buildhost/BuildHostResponse$Path;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/buildhost/BuildHostResponse$Path;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/buildhost/BuildHostResponse$Path$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/buildhost/BuildHostResponse$Path$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/buildhost/BuildHostResponse$Path;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/buildhost/BuildHostResponse$Path;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostResponse$Path$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostResponse$Strings : ee/schimke/composeai/buildhost/BuildHostResponse {
+	public static final field Companion Lee/schimke/composeai/buildhost/BuildHostResponse$Strings$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lee/schimke/composeai/buildhost/BuildHostResponse$Strings;
+	public static synthetic fun copy$default (Lee/schimke/composeai/buildhost/BuildHostResponse$Strings;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/buildhost/BuildHostResponse$Strings;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValues ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/buildhost/BuildHostResponse$Strings$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/buildhost/BuildHostResponse$Strings$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/buildhost/BuildHostResponse$Strings;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/buildhost/BuildHostResponse$Strings;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/BuildHostResponse$Strings$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/WireModule {
+	public static final field Companion Lee/schimke/composeai/buildhost/WireModule$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/buildhost/WireModule;
+	public static synthetic fun copy$default (Lee/schimke/composeai/buildhost/WireModule;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/buildhost/WireModule;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGradlePath ()Ljava/lang/String;
+	public final fun getProjectDir ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun toPreviewModule ()Lee/schimke/composeai/previewdata/PreviewModule;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/buildhost/WireModule$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/buildhost/WireModule$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/buildhost/WireModule;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/buildhost/WireModule;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/WireModule$Companion {
+	public final fun from (Lee/schimke/composeai/previewdata/PreviewModule;)Lee/schimke/composeai/buildhost/WireModule;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public final fun wirePath (Ljava/io/File;)Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/buildhost/WireModuleManifest {
+	public static final field Companion Lee/schimke/composeai/buildhost/WireModuleManifest$Companion;
+	public fun <init> (Lee/schimke/composeai/buildhost/WireModule;Lee/schimke/composeai/previewdata/PreviewManifest;)V
+	public final fun component1 ()Lee/schimke/composeai/buildhost/WireModule;
+	public final fun component2 ()Lee/schimke/composeai/previewdata/PreviewManifest;
+	public final fun copy (Lee/schimke/composeai/buildhost/WireModule;Lee/schimke/composeai/previewdata/PreviewManifest;)Lee/schimke/composeai/buildhost/WireModuleManifest;
+	public static synthetic fun copy$default (Lee/schimke/composeai/buildhost/WireModuleManifest;Lee/schimke/composeai/buildhost/WireModule;Lee/schimke/composeai/previewdata/PreviewManifest;ILjava/lang/Object;)Lee/schimke/composeai/buildhost/WireModuleManifest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getManifest ()Lee/schimke/composeai/previewdata/PreviewManifest;
+	public final fun getModule ()Lee/schimke/composeai/buildhost/WireModule;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/buildhost/WireModuleManifest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/buildhost/WireModuleManifest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/buildhost/WireModuleManifest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/buildhost/WireModuleManifest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/buildhost/WireModuleManifest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+

--- a/api/build-host-protocol/build.gradle.kts
+++ b/api/build-host-protocol/build.gradle.kts
@@ -1,0 +1,51 @@
+// The wire contract between a preview server and a Gradle build host process.
+//
+// See `BuildHostProtocol`'s KDoc for what it is and
+// `docs/design/BUILD_HOST_PROTOCOL_PREVIEWMODULE.md` for why it is published from this repository
+// rather than from compose-preview-contracts.
+//
+// Shape and framing only: no Gradle, no process spawning, no IO beyond turning a line into a
+// message. The Tooling API lives in `:cli`, which implements this, and the server links only what
+// is here. That is the whole point — a module a preview server can depend on without acquiring a
+// build tool.
+plugins {
+  id("composeai.base-conventions")
+  id("composeai.jvm-conventions")
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+  // `PreviewModule` and `PreviewManifest` appear in this module's own public signatures:
+  // `WireModule` converts to and from the former, and `WireModuleManifest` carries the latter
+  // as-is. Reusing them rather than redeclaring them is the reason this module is here and not in
+  // contracts — see the design doc.
+  api(project(":preview-data-api"))
+  api(libs.kotlinx.serialization.json)
+
+  testImplementation(kotlin("test"))
+}
+
+kotlin {
+  // A published contract two repositories compile against, so every declaration states its
+  // visibility and every public one its return type.
+  explicitApi()
+
+  @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class) abiValidation()
+}
+
+// `checkKotlinAbi` is not wired into `check` by the Kotlin Gradle plugin.
+tasks.named("check") { dependsOn("checkKotlinAbi") }
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "build-host-protocol",
+    displayName = "Compose Preview — Build Host Protocol",
+    description =
+      "The wire contract between a Compose Preview server and a Gradle build host process: the " +
+        "seven build operations a server needs, framed as newline-delimited JSON, so the server " +
+        "can ask for Gradle work without linking the Gradle Tooling API.",
+  )
+  inceptionYear.set("2026")
+}

--- a/api/build-host-protocol/src/main/kotlin/ee/schimke/composeai/buildhost/BuildHostCodec.kt
+++ b/api/build-host-protocol/src/main/kotlin/ee/schimke/composeai/buildhost/BuildHostCodec.kt
@@ -1,0 +1,41 @@
+package ee.schimke.composeai.buildhost
+
+import kotlinx.serialization.json.Json
+
+/**
+ * Reads and writes the framed form, so neither end hand-rolls it.
+ *
+ * A shared codec rather than a documented convention because there are two implementations in two
+ * repositories on two release cadences, and a framing they each re-derive is a framing that
+ * eventually disagrees.
+ */
+public object BuildHostCodec {
+
+  /**
+   * The one configuration both ends use.
+   *
+   * `ignoreUnknownKeys` so a host from a newer release can add a field without breaking an older
+   * server *within* a protocol version — the version bump is for changes that alter meaning, and
+   * making every additive field a breaking change would mean nobody ever adds one.
+   *
+   * `encodeDefaults` because a defaulted field that is simply absent reads as "unset" to anything
+   * inspecting the wire — a person debugging the pipe, or a future non-Kotlin implementation with
+   * different defaults. Writing it costs a few bytes on a channel that carries build output.
+   *
+   * `explicitNulls = false` so an absent envelope slot is omitted rather than written as `null`:
+   * three of the four fields are null in every message, and this is a line-per-message protocol a
+   * human is expected to be able to read.
+   */
+  public val json: Json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = true
+    explicitNulls = false
+    classDiscriminator = "kind"
+  }
+
+  /** One line, no trailing newline — the writer supplies the framing. */
+  public fun encode(envelope: BuildHostEnvelope): String = json.encodeToString(envelope)
+
+  /** Parses one framed line. Throws on anything malformed; the caller answers with a failure. */
+  public fun decode(line: String): BuildHostEnvelope = json.decodeFromString(line)
+}

--- a/api/build-host-protocol/src/main/kotlin/ee/schimke/composeai/buildhost/BuildHostMessages.kt
+++ b/api/build-host-protocol/src/main/kotlin/ee/schimke/composeai/buildhost/BuildHostMessages.kt
@@ -1,0 +1,197 @@
+package ee.schimke.composeai.buildhost
+
+import ee.schimke.composeai.previewdata.PreviewManifest
+import ee.schimke.composeai.previewdata.PreviewModule
+import java.io.File
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * A module that declares previews, as it crosses the wire.
+ *
+ * The mirror of [PreviewModule], and it exists for one reason: that type carries a `java.io.File`,
+ * and a file handle is meaningless in another process. [projectDir] is its path.
+ *
+ * **Absolute and normalised, always.** The build host runs in the user's project and the server may
+ * not share its working directory — it can be started from anywhere, and in the deployed case is
+ * not started by a human at all. A relative path would resolve against whichever process happened
+ * to read it, which is the kind of bug that reproduces on one machine in ten. [from] resolves
+ * before sending rather than trusting the caller, so a relative `projectDir` cannot reach the wire
+ * even if one is constructed.
+ *
+ * Normalised because absolute is not enough to compare: the CLI's project-root discovery
+ * legitimately produces paths like `/w/project/.`, which is the same directory as `/w/project` and
+ * not the same string. A server keying anything by module directory would see two. [normalize] is
+ * lexical, so unlike `canonicalPath` it does not resolve symlinks — a project reached through a
+ * symlinked home keeps the path the user recognises.
+ */
+@Serializable
+public data class WireModule(val gradlePath: String, val projectDir: String) {
+
+  /** The in-process form, for a JVM consumer that wants the original type back. */
+  public fun toPreviewModule(): PreviewModule =
+    PreviewModule(gradlePath = gradlePath, projectDir = File(projectDir))
+
+  public companion object {
+    public fun from(module: PreviewModule): WireModule =
+      WireModule(gradlePath = module.gradlePath, projectDir = wirePath(module.projectDir))
+
+    /** The one place a path becomes wire-shaped, so both ends agree on what that means. */
+    public fun wirePath(file: File): String = file.absoluteFile.normalize().path
+  }
+}
+
+/** A module paired with the manifest its build produced. */
+@Serializable
+public data class WireModuleManifest(val module: WireModule, val manifest: PreviewManifest)
+
+/**
+ * What the server asks the build host to do — the seven `ServeBuildHost` operations, plus a
+ * handshake.
+ *
+ * Sealed and polymorphic: a request the host does not know is a deserialisation failure, which is
+ * the behaviour worth having. The alternative — a string `op` field with a `when` — turns an
+ * unknown operation into a silent default at exactly the moment the two sides have skewed.
+ */
+@Serializable
+public sealed interface BuildHostRequest {
+
+  /** First message on the connection. The host answers [BuildHostResponse.Handshake] or fails. */
+  @Serializable
+  @SerialName("handshake")
+  public data class Handshake(val protocolVersion: Int = BuildHostProtocol.VERSION) :
+    BuildHostRequest
+
+  /**
+   * Init-script arguments to add for [projectRoot], if any.
+   *
+   * Build work despite reading like a flag: it decides whether to inject the preview plugin into a
+   * project that does not declare it. The host holds the invocation's own argv, which is what lets
+   * it tell an explicit `--init-script` from an injected one; the server cannot compute this.
+   */
+  @Serializable
+  @SerialName("autoInjectInitScriptArgs")
+  public data class AutoInjectInitScriptArgs(val projectRoot: String) : BuildHostRequest
+
+  /** The Gradle project root, or null when there is no `gradlew` above the host. */
+  @Serializable
+  @SerialName("gradleProjectRoot")
+  public data object GradleProjectRoot : BuildHostRequest
+
+  /** `-PcomposePreview.variant=…`, if the host was given `--variant`. */
+  @Serializable
+  @SerialName("gradleVariantArgs")
+  public data object GradleVariantArgs : BuildHostRequest
+
+  /** The build arguments this invocation implies, including `--force` and data extensions. */
+  @Serializable
+  @SerialName("gradleBuildArgs")
+  public data class GradleBuildArgs(val extra: List<String> = emptyList()) : BuildHostRequest
+
+  /** Every Gradle project in the build that declares previews. */
+  @Serializable @SerialName("gradleProjects") public data object GradleProjects : BuildHostRequest
+
+  /**
+   * Run [tasks] in the project's Gradle build.
+   *
+   * [silenceStdout] is carried rather than applied by the host: it decides whether
+   * [BuildHostEvent.Log] events are emitted at all. Dropping them here rather than at the server
+   * keeps a long build from writing megabytes into a pipe nobody reads.
+   */
+  @Serializable
+  @SerialName("runGradleTasks")
+  public data class RunGradleTasks(
+    val tasks: List<String>,
+    val arguments: List<String> = emptyList(),
+    val silenceStdout: Boolean = false,
+  ) : BuildHostRequest
+
+  /** Discover and build the selected modules so their manifests exist on disk. */
+  @Serializable
+  @SerialName("discoverAndBuild")
+  public data class DiscoverAndBuild(val silenceStdout: Boolean = false) : BuildHostRequest
+}
+
+/** The host's answer to one [BuildHostRequest]. */
+@Serializable
+public sealed interface BuildHostResponse {
+
+  @Serializable
+  @SerialName("handshake")
+  public data class Handshake(val protocolVersion: Int, val hostVersion: String) : BuildHostResponse
+
+  /** Answer to the three argument-list operations. */
+  @Serializable
+  @SerialName("strings")
+  public data class Strings(val values: List<String>) : BuildHostResponse
+
+  /**
+   * Answer to [BuildHostRequest.GradleProjectRoot]. Absolute when present, for [WireModule]'s
+   * reason.
+   */
+  @Serializable @SerialName("path") public data class Path(val path: String?) : BuildHostResponse
+
+  @Serializable
+  @SerialName("modules")
+  public data class Modules(val modules: List<WireModule>) : BuildHostResponse
+
+  /** Answer to [BuildHostRequest.RunGradleTasks]: whether the build succeeded. */
+  @Serializable
+  @SerialName("buildResult")
+  public data class BuildResult(val buildOk: Boolean) : BuildHostResponse
+
+  /**
+   * Answer to [BuildHostRequest.DiscoverAndBuild].
+   *
+   * Carries the manifests rather than paths to them. Both processes are on one machine and could
+   * share the files, but a path says nothing about *when* it was written — the server would have no
+   * way to tell a manifest this build produced from one left by a previous run that failed. Sending
+   * the parsed value makes the answer self-contained, and `PreviewManifest` is already
+   * `@Serializable` because it is written to disk in this same shape.
+   */
+  @Serializable
+  @SerialName("discovery")
+  public data class Discovery(val buildOk: Boolean, val manifests: List<WireModuleManifest>) :
+    BuildHostResponse
+
+  /**
+   * The operation could not be performed.
+   *
+   * Distinct from a build that ran and failed — that is [BuildResult] with `buildOk = false`. This
+   * is the host being unable to answer at all: a protocol mismatch, a malformed request, or an
+   * exception escaping the Gradle call. The distinction matters because the server's response
+   * differs: a failed build is shown to the user, a failed host means fall back to serving without
+   * one.
+   */
+  @Serializable
+  @SerialName("failure")
+  public data class Failure(val message: String) : BuildHostResponse
+}
+
+/**
+ * Something the host emits while an operation is in flight, rather than in answer to one.
+ *
+ * Events carry the id of the operation that produced them, so a server showing build progress can
+ * attribute a line to the task it came from.
+ */
+@Serializable
+public sealed interface BuildHostEvent {
+
+  /** One line of build output. Newline-free; the framing supplies the line break. */
+  @Serializable @SerialName("log") public data class Log(val line: String) : BuildHostEvent
+}
+
+/**
+ * One framed line: an id, and exactly one of the three payload kinds.
+ *
+ * A single envelope type rather than three streams because there is one pipe, and the alternative —
+ * inferring the kind from which fields are present — is the ambiguity this protocol exists to
+ * avoid.
+ */
+@Serializable
+public data class BuildHostEnvelope(
+  val id: Long,
+  val request: BuildHostRequest? = null,
+  val response: BuildHostResponse? = null,
+  val event: BuildHostEvent? = null,
+)

--- a/api/build-host-protocol/src/main/kotlin/ee/schimke/composeai/buildhost/BuildHostProtocol.kt
+++ b/api/build-host-protocol/src/main/kotlin/ee/schimke/composeai/buildhost/BuildHostProtocol.kt
@@ -1,0 +1,64 @@
+package ee.schimke.composeai.buildhost
+
+/**
+ * The wire contract between a preview server and a Gradle **build host** process.
+ *
+ * The preview server needs Gradle work done — find the project root, list the modules that declare
+ * previews, run tasks, build the manifests — and for a long time the only way to get it was for
+ * `serve` to *be* a compose-ai-tools CLI command, because the CLI's `ServeCommand` was the sole
+ * real implementation of the `ServeBuildHost` interface. That is the forward edge of the dependency
+ * cycle in yschimke/compose-preview-server#180: an offline CLI linking a web server so a web server
+ * could reach a Gradle driver.
+ *
+ * This makes the seam a **process boundary** instead of a library one. The server spawns
+ * `compose-preview build-host --stdio` and asks for the same seven operations over
+ * newline-delimited JSON; the Gradle Tooling API stays in compose-ai-tools, which is where
+ * `docs/design/REPOSITORY_LAYERS.md` puts it permanently. Without a build host the server serves
+ * published catalogs and prebuilt bundles, which stops being a stubbed-out interface and becomes an
+ * honest *no Gradle here*.
+ *
+ * ### Why this module is here and not in compose-preview-contracts
+ *
+ * Decided in `docs/design/BUILD_HOST_PROTOCOL_PREVIEWMODULE.md`. The short version: two operations
+ * carry `PreviewModule`, which lives in `:preview-data-api` here and not in contracts, and
+ * contracts carries no `ee.schimke.composeai` coordinate on any POM. Publishing from here lets a
+ * protocol change and its implementation land in one commit compiled against each other while the
+ * shape is still being learned; moving it down to contracts later, once it is settled, is
+ * mechanical.
+ *
+ * ### Framing
+ *
+ * One JSON object per line, UTF-8, on stdin (requests) and stdout (responses and events). Newline
+ * framing rather than a length prefix because the payloads are small, the channel is a pipe between
+ * two processes on one machine, and a human debugging a stuck build wants to be able to read it.
+ *
+ * **Nothing but protocol may be written to the host's stdout.** Gradle's own output is captured and
+ * forwarded as [BuildHostEvent.Log] rather than inherited, so the server can decide whether to show
+ * it (`--progress`) or drop it (`silenceStdout`) — a decision the host cannot make for it. The
+ * host's own diagnostics go to stderr, which is never framed and never parsed.
+ *
+ * ### Correlation
+ *
+ * Every request carries an [BuildHostEnvelope.id] the response repeats. Requests are answered in
+ * order — one build host serves one server, and the operations mutate a Gradle build, so
+ * interleaving them would be a bug rather than a feature — but the id is on the wire anyway,
+ * because discovering later that you need it is expensive and carrying it is free. Events emitted
+ * while an operation runs carry that operation's id, which is what lets the server attribute output
+ * to the task that produced it.
+ */
+public object BuildHostProtocol {
+
+  /**
+   * The version this build of the protocol speaks.
+   *
+   * Bumped for any change to the message set or a field's meaning. The handshake compares it
+   * exactly rather than range-checking: the server and the host are released from two repositories
+   * on two cadences, so "close enough" is precisely the state that produces a wrong answer instead
+   * of an error. A mismatch is reported by [BuildHostResponse.Failure] and the server falls back to
+   * serving without a build host.
+   */
+  public const val VERSION: Int = 1
+
+  /** The argument that puts the CLI into build-host mode, named once so both sides agree. */
+  public const val STDIO_FLAG: String = "--stdio"
+}

--- a/api/build-host-protocol/src/test/kotlin/ee/schimke/composeai/buildhost/BuildHostCodecTest.kt
+++ b/api/build-host-protocol/src/test/kotlin/ee/schimke/composeai/buildhost/BuildHostCodecTest.kt
@@ -1,0 +1,186 @@
+package ee.schimke.composeai.buildhost
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.serialization.SerializationException
+
+class BuildHostCodecTest {
+
+  private fun roundTrip(envelope: BuildHostEnvelope): BuildHostEnvelope =
+    BuildHostCodec.decode(BuildHostCodec.encode(envelope))
+
+  @Test
+  fun `every request survives a round trip`() {
+    val requests =
+      listOf(
+        BuildHostRequest.Handshake(),
+        BuildHostRequest.AutoInjectInitScriptArgs("/w/app"),
+        BuildHostRequest.GradleProjectRoot,
+        BuildHostRequest.GradleVariantArgs,
+        BuildHostRequest.GradleBuildArgs(listOf("--offline")),
+        BuildHostRequest.GradleProjects,
+        BuildHostRequest.RunGradleTasks(listOf(":app:x"), listOf("-q"), silenceStdout = true),
+        BuildHostRequest.DiscoverAndBuild(silenceStdout = true),
+      )
+    requests.forEachIndexed { index, request ->
+      val envelope = BuildHostEnvelope(id = index.toLong(), request = request)
+      assertEquals(envelope, roundTrip(envelope), "request $request did not survive")
+    }
+  }
+
+  @Test
+  fun `every response survives a round trip`() {
+    val responses =
+      listOf(
+        BuildHostResponse.Handshake(BuildHostProtocol.VERSION, "1.77.0"),
+        BuildHostResponse.Strings(listOf("--init-script", "/tmp/x.gradle")),
+        BuildHostResponse.Path("/w"),
+        BuildHostResponse.Path(null),
+        BuildHostResponse.Modules(listOf(WireModule("app", "/w/app"))),
+        BuildHostResponse.BuildResult(buildOk = true),
+        BuildHostResponse.Discovery(buildOk = false, manifests = emptyList()),
+        BuildHostResponse.Failure("nope"),
+      )
+    responses.forEachIndexed { index, response ->
+      val envelope = BuildHostEnvelope(id = index.toLong(), response = response)
+      assertEquals(envelope, roundTrip(envelope), "response $response did not survive")
+    }
+  }
+
+  @Test
+  fun `an event survives a round trip`() {
+    val envelope = BuildHostEnvelope(id = 7, event = BuildHostEvent.Log("> Task :app:compile"))
+    assertEquals(envelope, roundTrip(envelope))
+  }
+
+  /**
+   * The framing is one message per line, so a message that contains a newline would be read as two.
+   * Build output is the realistic source of one, which is why the payload here is a log line.
+   */
+  @Test
+  fun `an encoded message never contains a newline`() {
+    val encoded =
+      BuildHostCodec.encode(
+        BuildHostEnvelope(id = 1, event = BuildHostEvent.Log("first\nsecond\r\nthird"))
+      )
+    assertFalse(encoded.contains('\n'), "encoded form spans lines: $encoded")
+    assertFalse(encoded.contains('\r'), "encoded form carries a bare CR: $encoded")
+  }
+
+  /** And survives it, rather than merely escaping it on the way out. */
+  @Test
+  fun `a log line containing newlines round trips intact`() {
+    val line = "first\nsecond"
+    val envelope = BuildHostEnvelope(id = 1, event = BuildHostEvent.Log(line))
+    assertEquals(line, (roundTrip(envelope).event as BuildHostEvent.Log).line)
+  }
+
+  /**
+   * Additive fields within a protocol version must not break the older end — otherwise every new
+   * field is a version bump and nobody adds one. The version exists for changes of *meaning*.
+   */
+  @Test
+  fun `an unknown field is ignored`() {
+    val decoded =
+      BuildHostCodec.decode(
+        """{"id":3,"request":{"kind":"gradleBuildArgs","extra":["-q"],"whenAdded":"later"}}"""
+      )
+    assertEquals(BuildHostRequest.GradleBuildArgs(listOf("-q")), decoded.request)
+  }
+
+  /**
+   * An unknown *message kind* must not be ignored. This is the case a string `op` field plus a
+   * `when` would turn into a silent default at exactly the moment the two sides have skewed.
+   */
+  @Test
+  fun `an unknown message kind fails loudly`() {
+    assertFailsWith<SerializationException> {
+      BuildHostCodec.decode("""{"id":1,"request":{"kind":"rmMinusRf"}}""")
+    }
+  }
+
+  @Test
+  fun `a malformed line fails rather than decoding to something`() {
+    assertFailsWith<SerializationException> { BuildHostCodec.decode("not json") }
+  }
+
+  /**
+   * Three of the four envelope slots are empty in every message; writing them as nulls is noise.
+   */
+  @Test
+  fun `empty envelope slots are omitted`() {
+    val encoded =
+      BuildHostCodec.encode(BuildHostEnvelope(id = 1, request = BuildHostRequest.GradleProjects))
+    assertFalse(encoded.contains("null"), "envelope wrote null slots: $encoded")
+    assertContains(encoded, "gradleProjects")
+  }
+
+  /** Defaults are written, so the wire says what it means to anything reading it. */
+  @Test
+  fun `defaulted fields are written`() {
+    val encoded =
+      BuildHostCodec.encode(
+        BuildHostEnvelope(id = 1, request = BuildHostRequest.DiscoverAndBuild())
+      )
+    assertContains(encoded, "silenceStdout")
+  }
+}
+
+class WireModuleTest {
+
+  @Test
+  fun `a module round trips back to its in-process form`() {
+    val module = WireModule("auth:composables", File("/w/auth/composables").absolutePath)
+    val back = module.toPreviewModule()
+    assertEquals("auth:composables", back.gradlePath)
+    assertEquals(File("/w/auth/composables").absolutePath, back.projectDir.path)
+  }
+
+  /**
+   * The property the wire depends on: a relative `projectDir` resolves against whichever process
+   * reads it, and the two processes need not share a working directory. `from` resolves rather than
+   * trusting its input, so a relative path cannot reach the wire even when one is constructed.
+   */
+  @Test
+  fun `from makes the project directory absolute`() {
+    val relative = ee.schimke.composeai.previewdata.PreviewModule("app", File("app"))
+    assertFalse(relative.projectDir.isAbsolute, "fixture is not relative; the test proves nothing")
+
+    val wire = WireModule.from(relative)
+
+    assertTrue(File(wire.projectDir).isAbsolute, "projectDir reached the wire relative: $wire")
+    assertEquals(File("app").absolutePath, wire.projectDir)
+  }
+
+  /**
+   * Absolute is not sufficient. The CLI's project-root discovery really does produce `<root>/.`,
+   * and a server keying anything by module directory would see that as a different directory from
+   * `<root>`.
+   */
+  @Test
+  fun `from normalises a dot segment away`() {
+    val dotted = ee.schimke.composeai.previewdata.PreviewModule("app", File("/w/project/./app"))
+
+    assertEquals(File("/w/project/app").absolutePath, WireModule.from(dotted).projectDir)
+  }
+
+  @Test
+  fun `from normalises a parent segment away`() {
+    val dotted =
+      ee.schimke.composeai.previewdata.PreviewModule("app", File("/w/project/other/../app"))
+
+    assertEquals(File("/w/project/app").absolutePath, WireModule.from(dotted).projectDir)
+  }
+
+  @Test
+  fun `an already absolute project directory is unchanged`() {
+    val absolute =
+      ee.schimke.composeai.previewdata.PreviewModule("app", File("/w/app").absoluteFile)
+    assertEquals(File("/w/app").absolutePath, WireModule.from(absolute).projectDir)
+  }
+}

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -227,6 +227,15 @@ dependencies {
   // `:data-a11y-core` used for the D2.2 extraction. External consumers (contrib scripting,
   // third-party tooling) pull `:preview-data-api` directly, not transitively through `:cli`.
   api(project(":preview-data-api"))
+
+  // The wire contract `compose-preview build-host` serves. `api` because `BuildHostCommand`'s
+  // testable seam takes and returns protocol types, and the CLI's own tests drive it by them.
+  //
+  // Note the direction: this module holds shape only, so depending on it costs the CLI nothing it
+  // did not already have, and the preview server can depend on the SAME module without acquiring
+  // the Gradle Tooling API. That asymmetry is the point of the protocol
+  // (yschimke/compose-preview-server#180, #9).
+  api(project(":build-host-protocol"))
   implementation(project(":common-image-crop"))
 
   // Gradle Tooling-API render pipeline + the `GradleConnection` / `PreviewModule` /

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BuildHostCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BuildHostCommand.kt
@@ -1,0 +1,286 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.buildhost.BuildHostCodec
+import ee.schimke.composeai.buildhost.BuildHostEnvelope
+import ee.schimke.composeai.buildhost.BuildHostEvent
+import ee.schimke.composeai.buildhost.BuildHostProtocol
+import ee.schimke.composeai.buildhost.BuildHostRequest
+import ee.schimke.composeai.buildhost.BuildHostResponse
+import ee.schimke.composeai.buildhost.WireModule
+import ee.schimke.composeai.buildhost.WireModuleManifest
+import java.io.BufferedReader
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.OutputStream
+import java.io.PrintStream
+import java.io.Writer
+
+/**
+ * `compose-preview build-host --stdio` — serves the Gradle operations a preview server needs, over
+ * a pipe.
+ *
+ * The server used to get these by *being* the CLI: `ServeCommand` was the only real implementation
+ * of the server's `ServeBuildHost` interface, which is why `serve` could not leave this repository
+ * and why the standalone server binary stubbed every method. This command is the same work behind a
+ * process boundary instead of a linked interface, so the Gradle Tooling API stays here — layer 1,
+ * per `docs/design/REPOSITORY_LAYERS.md` — and the server links only `:build-host-protocol`.
+ *
+ * It is deliberately a thin adapter. Every operation delegates to the same [Command] members
+ * `ServeCommand` delegates to, so there is one implementation of "build the previews" and this
+ * translates it rather than reimplementing it.
+ */
+class BuildHostCommand(args: List<String>) : Command(args) {
+
+  override fun run() {
+    if ("--help" in args || "-h" in args) {
+      printUsage()
+      return
+    }
+    require(BuildHostProtocol.STDIO_FLAG in args) {
+      "build-host currently speaks only ${BuildHostProtocol.STDIO_FLAG}; pass it explicitly so a " +
+        "future transport can be added without changing what this invocation means."
+    }
+    // Captured before anything can replace it. `serve` writes protocol here and nowhere else.
+    val protocol = System.out
+    serve(System.`in`.bufferedReader(), PrintStream(protocol, true, Charsets.UTF_8).writer())
+  }
+
+  /**
+   * The request loop, with its channels injected so a test can drive it without a process.
+   *
+   * Requests are answered in order and one at a time. That is not a simplification to revisit: the
+   * operations mutate a Gradle build, so two in flight at once is a bug rather than throughput.
+   *
+   * **Cancellation is stdin closing.** There is no cancel message in v1, because the honest
+   * implementation of one is killing the Gradle build, and the server already has that lever —
+   * close the pipe, and the host exits. A message that only set a flag would be a cancellation that
+   * does not cancel, which is worse than not having one.
+   */
+  internal fun serve(requests: BufferedReader, responses: Writer) {
+    var handshaken = false
+    while (true) {
+      val line = requests.readLine() ?: return
+      if (line.isBlank()) continue
+
+      val envelope =
+        try {
+          BuildHostCodec.decode(line)
+        } catch (t: Throwable) {
+          // No id to correlate against — the envelope is what failed to parse — so answer on id 0
+          // and keep serving. Exiting here would turn one bad line into a dead build host.
+          write(responses, BuildHostEnvelope(id = 0, response = failure(t)))
+          continue
+        }
+
+      val request = envelope.request
+      if (request == null) {
+        write(
+          responses,
+          BuildHostEnvelope(
+            envelope.id,
+            response =
+              BuildHostResponse.Failure(
+                "envelope carried no request; the host answers requests and emits events, it does not " +
+                  "consume responses"
+              ),
+          ),
+        )
+        continue
+      }
+
+      // The handshake gates everything, so a version skew is reported once, up front, rather than
+      // as a puzzling failure several operations into a build.
+      if (!handshaken && request !is BuildHostRequest.Handshake) {
+        write(
+          responses,
+          BuildHostEnvelope(
+            envelope.id,
+            response =
+              BuildHostResponse.Failure(
+                "handshake first: this host speaks protocol ${BuildHostProtocol.VERSION}"
+              ),
+          ),
+        )
+        continue
+      }
+
+      val response =
+        try {
+          handle(request, envelope.id, responses).also {
+            if (request is BuildHostRequest.Handshake && it !is BuildHostResponse.Failure) {
+              handshaken = true
+            }
+          }
+        } catch (t: Throwable) {
+          failure(t)
+        }
+      write(responses, BuildHostEnvelope(envelope.id, response = response))
+    }
+  }
+
+  private fun handle(request: BuildHostRequest, id: Long, responses: Writer): BuildHostResponse =
+    when (request) {
+      is BuildHostRequest.Handshake ->
+        if (request.protocolVersion != BuildHostProtocol.VERSION) {
+          BuildHostResponse.Failure(
+            "protocol mismatch: the server speaks ${request.protocolVersion}, this host speaks " +
+              "${BuildHostProtocol.VERSION}. Update whichever is older; serving without a build " +
+              "host is the correct fallback until then."
+          )
+        } else {
+          BuildHostResponse.Handshake(BuildHostProtocol.VERSION, BUNDLE_VERSION)
+        }
+
+      is BuildHostRequest.AutoInjectInitScriptArgs ->
+        BuildHostResponse.Strings(
+          autoInjectInitScriptArgs(args, projectRoot = File(request.projectRoot))
+        )
+
+      BuildHostRequest.GradleProjectRoot ->
+        // Through `WireModule.wirePath` for the same reason module directories are: the server need
+        // not share this working directory, and a relative root would resolve against whichever
+        // process read it. Normalising is not cosmetic here — `findProjectRoot()` legitimately
+        // returns `<root>/.`, so without it the server would see a root that never string-matches
+        // the module directories underneath it.
+        BuildHostResponse.Path(findProjectRoot()?.let(WireModule::wirePath))
+
+      BuildHostRequest.GradleVariantArgs -> BuildHostResponse.Strings(variantGradleArgs())
+
+      is BuildHostRequest.GradleBuildArgs ->
+        BuildHostResponse.Strings(gradleArgsWithForce(request.extra))
+
+      BuildHostRequest.GradleProjects -> {
+        var found = emptyList<ee.schimke.composeai.previewdata.PreviewModule>()
+        withGradle { gradle -> found = gradle.findGradleProjects(timeoutSeconds) }
+        BuildHostResponse.Modules(found.map(WireModule::from))
+      }
+
+      is BuildHostRequest.RunGradleTasks -> {
+        var ok = false
+        streamingBuildOutput(id, responses, request.silenceStdout) {
+          withGradle(silenceStdout = request.silenceStdout) { gradle ->
+            ok = runGradle(gradle, *request.tasks.toTypedArray(), arguments = request.arguments)
+          }
+        }
+        BuildHostResponse.BuildResult(ok)
+      }
+
+      is BuildHostRequest.DiscoverAndBuild -> {
+        var outcome: RenderModulesOutcome? = null
+        streamingBuildOutput(id, responses, request.silenceStdout) {
+          outcome = renderAllModules(silenceStdout = request.silenceStdout)
+        }
+        val settled = outcome
+        if (settled == null) {
+          BuildHostResponse.Discovery(buildOk = false, manifests = emptyList())
+        } else {
+          BuildHostResponse.Discovery(
+            buildOk = settled.buildOk,
+            manifests =
+              settled.manifests.map { (module, manifest) ->
+                WireModuleManifest(WireModule.from(module), manifest)
+              },
+          )
+        }
+      }
+    }
+
+  /**
+   * Runs [block] with `System.out` diverted into [BuildHostEvent.Log] events.
+   *
+   * This is the load-bearing part of speaking a protocol on stdout. The Gradle plumbing below
+   * prints build output to `System.out`, and `System.out` is the protocol channel — inherited, that
+   * output would interleave with framed JSON and corrupt the stream on the first task that printed
+   * anything.
+   *
+   * So it is captured and reframed. The server then decides what to do with it, which is the right
+   * place for that decision: the host cannot know whether the invocation wants `--progress`.
+   *
+   * When [silenceStdout] the lines are dropped here rather than forwarded and discarded at the far
+   * end — a long build should not push megabytes into a pipe nobody reads. The same flag is passed
+   * down to the Gradle call, so most of it is never produced either; this catches what still is.
+   */
+  private fun streamingBuildOutput(
+    id: Long,
+    responses: Writer,
+    silenceStdout: Boolean,
+    block: () -> Unit,
+  ) {
+    val original = System.out
+    val sink = LineSplittingOutputStream { line ->
+      if (!silenceStdout) {
+        write(responses, BuildHostEnvelope(id, event = BuildHostEvent.Log(line)))
+      }
+    }
+    System.setOut(PrintStream(sink, true, Charsets.UTF_8))
+    try {
+      block()
+    } finally {
+      // Flush a trailing partial line before restoring, or the last line of a build that did not
+      // end in a newline is silently lost.
+      runCatching { sink.flushPartialLine() }
+      System.setOut(original)
+    }
+  }
+
+  private fun write(responses: Writer, envelope: BuildHostEnvelope) {
+    responses.write(BuildHostCodec.encode(envelope))
+    responses.write("\n")
+    responses.flush()
+  }
+
+  private fun failure(t: Throwable): BuildHostResponse.Failure =
+    BuildHostResponse.Failure(t.message?.takeIf { it.isNotBlank() } ?: t.javaClass.name)
+
+  private fun printUsage() {
+    println(
+      """
+      compose-preview build-host --stdio
+
+      Serve this project's Gradle build to a Compose Preview server over stdin/stdout, so the
+      server can discover and build previews without linking the Gradle Tooling API.
+
+      Not run by hand: the server spawns it. Protocol version ${BuildHostProtocol.VERSION},
+      newline-delimited JSON. Build output is forwarded as log events, never written to stdout.
+
+      Options:
+        --stdio           Speak the protocol on stdin/stdout. Currently required.
+        --module <path>   Narrow to one Gradle module, as `serve` does.
+        --variant <name>  Select the Android build variant used for previews.
+        --help, -h        Show this help.
+      """
+        .trimIndent()
+    )
+  }
+}
+
+/**
+ * Buffers bytes and calls [onLine] once per complete line, without the terminator.
+ *
+ * Line-oriented because the protocol is: a `Log` event carries one line, and the framing supplies
+ * the break. `\r\n` is normalised to one line so Gradle output captured on Windows does not arrive
+ * with a trailing carriage return baked into every event.
+ */
+internal class LineSplittingOutputStream(private val onLine: (String) -> Unit) : OutputStream() {
+
+  private val buffer = ByteArrayOutputStream()
+
+  override fun write(b: Int) {
+    if (b == '\n'.code) {
+      emit()
+    } else {
+      buffer.write(b)
+    }
+  }
+
+  private fun emit() {
+    val line = buffer.toString(Charsets.UTF_8).removeSuffix("\r")
+    buffer.reset()
+    onLine(line)
+  }
+
+  /** Emits whatever is buffered but unterminated. Called when the captured section ends. */
+  fun flushPartialLine() {
+    if (buffer.size() > 0) emit()
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
@@ -220,6 +220,11 @@ internal object CliFlagValidation {
             "--trust-store",
             "--wasm-dir",
           ),
+      // The flags a preview server passes when it spawns the Gradle half of `serve`. Deliberately
+      // narrow: this command is machine-facing, and every flag here is one the server has to know
+      // to send. `--stdio` selects the transport; `--module` and `--variant` are the two selectors
+      // that change what a build produces, so the server forwards its own.
+      "build-host" to setOf("--stdio", "--module", "--variant", "--verbose", "-v"),
       "share-preview" to
         setOf(
           "--allow-non-preview-branch",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliRouter.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliRouter.kt
@@ -39,7 +39,11 @@ internal object CliRouter {
           "profile",
         ),
       "capture" to listOf("render-matrix", "record", "bundle"),
-      "share" to listOf("serve", "share-preview"),
+      // `build-host` sits beside `serve` because it exists only to serve one: it is the Gradle
+      // half of `serve`, addressed over a pipe instead of linked in-process
+      // (yschimke/compose-preview-server#180). Machine-facing rather than hidden — a command a
+      // server spawns is still a command, and one that cannot be found is one nobody can debug.
+      "share" to listOf("serve", "build-host", "share-preview"),
       "setup" to listOf("update", "init-script", "pin", "auth"),
     )
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -26,6 +26,7 @@ internal val COMMANDS: Map<String, (List<String>) -> Unit> =
     "devices" to { a -> DevicesCommand(a).run() },
     "browse" to { a -> BrowseCommand(a).run() },
     "serve" to { a -> ServeCommand(a).run() },
+    "build-host" to { a -> BuildHostCommand(a).run() },
     "share-preview" to { a -> SharePreviewCommand(a).run() },
     "bundle" to { a -> BundleCommand(a).run() },
     "mcp" to { a -> McpCommand(a).run() },

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BuildHostCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BuildHostCommandTest.kt
@@ -1,0 +1,228 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.buildhost.BuildHostCodec
+import ee.schimke.composeai.buildhost.BuildHostEnvelope
+import ee.schimke.composeai.buildhost.BuildHostProtocol
+import ee.schimke.composeai.buildhost.BuildHostRequest
+import ee.schimke.composeai.buildhost.BuildHostResponse
+import java.io.StringWriter
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Drives [BuildHostCommand.serve] over string channels rather than a process.
+ *
+ * These cover the protocol behaviour — handshake gating, version skew, malformed input — which is
+ * the part that has to be right before a server in another repository depends on it. The
+ * Gradle-backed operations are exercised by the CLI's existing render tests through the same
+ * [Command] members this delegates to; re-driving a real build through the pipe here would test
+ * Gradle, not the adapter.
+ */
+class BuildHostCommandTest {
+
+  private fun exchange(vararg requests: BuildHostEnvelope): List<BuildHostEnvelope> {
+    val input = requests.joinToString("\n") { BuildHostCodec.encode(it) } + "\n"
+    return exchangeRaw(input)
+  }
+
+  private fun exchangeRaw(input: String): List<BuildHostEnvelope> {
+    val out = StringWriter()
+    BuildHostCommand(listOf(BuildHostProtocol.STDIO_FLAG)).serve(input.reader().buffered(), out)
+    return out.toString().lines().filter { it.isNotBlank() }.map(BuildHostCodec::decode)
+  }
+
+  private fun handshake(id: Long = 1) =
+    BuildHostEnvelope(id, request = BuildHostRequest.Handshake())
+
+  @Test
+  fun `a matching handshake is accepted and names the host version`() {
+    val replies = exchange(handshake())
+
+    val response = assertIs<BuildHostResponse.Handshake>(replies.single().response)
+    assertEquals(BuildHostProtocol.VERSION, response.protocolVersion)
+    assertTrue(response.hostVersion.isNotBlank(), "host version was blank")
+  }
+
+  /**
+   * The skew case the version exists for. It must be reported as a failure rather than tolerated:
+   * two ends that disagree about meaning and proceed anyway produce a wrong build, not an error.
+   */
+  @Test
+  fun `a protocol mismatch fails and names both versions`() {
+    val replies =
+      exchange(BuildHostEnvelope(1, request = BuildHostRequest.Handshake(protocolVersion = 9999)))
+
+    val failure = assertIs<BuildHostResponse.Failure>(replies.single().response)
+    assertContains(failure.message, "9999")
+    assertContains(failure.message, BuildHostProtocol.VERSION.toString())
+  }
+
+  /** A mismatch must not leave the connection usable, or the gate bought nothing. */
+  @Test
+  fun `a request after a failed handshake is still refused`() {
+    val replies =
+      exchange(
+        BuildHostEnvelope(1, request = BuildHostRequest.Handshake(protocolVersion = 9999)),
+        BuildHostEnvelope(2, request = BuildHostRequest.GradleVariantArgs),
+      )
+
+    assertIs<BuildHostResponse.Failure>(replies[0].response)
+    val second = assertIs<BuildHostResponse.Failure>(replies[1].response)
+    assertContains(second.message, "handshake first")
+  }
+
+  @Test
+  fun `an operation before any handshake is refused`() {
+    val replies = exchange(BuildHostEnvelope(1, request = BuildHostRequest.GradleVariantArgs))
+
+    val failure = assertIs<BuildHostResponse.Failure>(replies.single().response)
+    assertContains(failure.message, "handshake first")
+  }
+
+  @Test
+  fun `responses carry the id of the request they answer`() {
+    val replies =
+      exchange(
+        handshake(id = 41),
+        BuildHostEnvelope(42, request = BuildHostRequest.GradleVariantArgs),
+      )
+
+    assertEquals(listOf(41L, 42L), replies.map { it.id })
+  }
+
+  /**
+   * One unparseable line must not kill the host. A server that spawned it would otherwise see the
+   * pipe close and have to decide whether the build failed — from a line it never sent correctly.
+   */
+  @Test
+  fun `a malformed line is answered and the host keeps serving`() {
+    val replies =
+      exchangeRaw(
+        BuildHostCodec.encode(handshake()) +
+          "\n" +
+          "{ not json\n" +
+          BuildHostCodec.encode(
+            BuildHostEnvelope(3, request = BuildHostRequest.GradleVariantArgs)
+          ) +
+          "\n"
+      )
+
+    assertEquals(3, replies.size, "the host stopped serving after the bad line")
+    assertIs<BuildHostResponse.Handshake>(replies[0].response)
+    assertIs<BuildHostResponse.Failure>(replies[1].response)
+    assertEquals(0L, replies[1].id, "a line that failed to parse has no id to answer on but 0")
+    assertIs<BuildHostResponse.Strings>(replies[2].response)
+  }
+
+  /**
+   * Same reasoning as above, for a message whose *kind* is unknown rather than whose JSON is bad.
+   */
+  @Test
+  fun `an unknown message kind is answered and the host keeps serving`() {
+    val replies =
+      exchangeRaw(
+        BuildHostCodec.encode(handshake()) +
+          "\n" +
+          """{"id":2,"request":{"kind":"somethingElse"}}""" +
+          "\n" +
+          BuildHostCodec.encode(
+            BuildHostEnvelope(3, request = BuildHostRequest.GradleVariantArgs)
+          ) +
+          "\n"
+      )
+
+    assertEquals(3, replies.size)
+    assertIs<BuildHostResponse.Failure>(replies[1].response)
+    assertIs<BuildHostResponse.Strings>(replies[2].response)
+  }
+
+  @Test
+  fun `an envelope carrying no request is refused rather than ignored`() {
+    val replies = exchangeRaw(BuildHostCodec.encode(handshake()) + "\n" + """{"id":2}""" + "\n")
+
+    val failure = assertIs<BuildHostResponse.Failure>(replies[1].response)
+    assertContains(failure.message, "no request")
+  }
+
+  @Test
+  fun `blank lines are skipped`() {
+    val replies = exchangeRaw("\n\n" + BuildHostCodec.encode(handshake()) + "\n\n")
+
+    assertIs<BuildHostResponse.Handshake>(replies.single().response)
+  }
+
+  /** Closing stdin is the shutdown signal, and v1's cancellation. It must return, not block. */
+  @Test
+  fun `end of input ends the loop`() {
+    assertEquals(emptyList(), exchangeRaw(""))
+  }
+
+  /**
+   * The project root crosses the wire absolute or not at all — the server need not share this
+   * process's working directory. Null is a legitimate answer (no `gradlew` above us) and is what
+   * this test sees when the suite runs outside a Gradle project; both outcomes are asserted rather
+   * than one being assumed.
+   */
+  @Test
+  fun `the project root is absolute when there is one`() {
+    val replies =
+      exchange(handshake(), BuildHostEnvelope(2, request = BuildHostRequest.GradleProjectRoot))
+
+    val path = assertIs<BuildHostResponse.Path>(replies[1].response).path
+    if (path != null) {
+      assertTrue(java.io.File(path).isAbsolute, "project root crossed the wire relative: $path")
+    }
+  }
+}
+
+class LineSplittingOutputStreamTest {
+
+  private fun capture(text: String, flush: Boolean = true): List<String> {
+    val lines = mutableListOf<String>()
+    val stream = LineSplittingOutputStream { lines += it }
+    stream.write(text.toByteArray(Charsets.UTF_8))
+    if (flush) stream.flushPartialLine()
+    return lines
+  }
+
+  @Test
+  fun `each terminated line is emitted once, without the terminator`() {
+    assertEquals(listOf("one", "two"), capture("one\ntwo\n"))
+  }
+
+  /** Gradle output captured on Windows must not arrive with a carriage return baked into it. */
+  @Test
+  fun `a CRLF terminator does not leave a carriage return on the line`() {
+    assertEquals(listOf("one", "two"), capture("one\r\ntwo\r\n"))
+  }
+
+  /** The last line of a build that did not end in a newline would otherwise be lost silently. */
+  @Test
+  fun `an unterminated trailing line is emitted on flush`() {
+    assertEquals(listOf("done"), capture("done"))
+  }
+
+  @Test
+  fun `an unterminated trailing line is withheld until flush`() {
+    assertEquals(emptyList(), capture("partial", flush = false))
+  }
+
+  @Test
+  fun `an empty line is preserved`() {
+    assertEquals(listOf("one", "", "two"), capture("one\n\ntwo\n"))
+  }
+
+  @Test
+  fun `flushing with nothing buffered emits nothing`() {
+    assertEquals(emptyList(), capture(""))
+  }
+
+  /** Multi-byte characters must survive being written a byte at a time. */
+  @Test
+  fun `utf8 survives byte-wise writes`() {
+    assertEquals(listOf("héllo — ✓"), capture("héllo — ✓\n"))
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -286,6 +286,16 @@ project(":bundle-coordinates").projectDir = file("bundle/coordinates")
 // third-party tooling) can pull just the data shapes without dragging in `:cli`'s Gradle Tooling
 // API + scripting closure. Step A of the clean-API carve-out — issue #1084 / docs/AGENT_GUIDE.md
 // "Built-in scripts" / clean-API discussion.
+// The wire contract between a preview server and a Gradle build host process — the seven build
+// operations `ServeBuildHost` names, as messages rather than as a Kotlin interface. Lets the
+// preview server ask compose-ai-tools for Gradle work across a process boundary instead of the CLI
+// having to BE the server's build host, which is the forward edge of the dependency cycle in
+// yschimke/compose-preview-server#180. Published from here rather than from contracts because two
+// of the operations carry `PreviewModule` — docs/design/BUILD_HOST_PROTOCOL_PREVIEWMODULE.md.
+include(":build-host-protocol")
+
+project(":build-host-protocol").projectDir = file("api/build-host-protocol")
+
 include(":preview-data-api")
 
 project(":preview-data-api").projectDir = file("api/preview-data-api")


### PR DESCRIPTION
Step 3 of [compose-preview-server#180](https://github.com/yschimke/compose-preview-server/issues/180), and the decision [#5145](https://github.com/yschimke/compose-ai-tools/pull/5145) settled, implemented. Answers [compose-preview-server#9](https://github.com/yschimke/compose-preview-server/issues/9) without putting the Gradle Tooling API on the server's floor.

## Why

The preview server needs Gradle work done, and until now the only way to get it was for `serve` to **be** a compose-ai-tools CLI command: `ServeCommand` was the sole real implementation of the server's `ServeBuildHost`, and `StandaloneBuildHost` stubbed all seven methods. That is the forward edge of the cycle — an offline CLI linking a web server so a web server could reach a Gradle driver.

## What

- **`:build-host-protocol`** — the seven operations as newline-delimited JSON. Shape and framing only: no Gradle, no process spawning. A preview server can depend on it without acquiring a build tool, which is the whole point of the asymmetry.
- **`compose-preview build-host --stdio`** — serves them, delegating to the same `Command` members `ServeCommand` delegates to. One implementation of "build the previews"; this translates rather than reimplements.

Published from here rather than contracts per #5145: two operations carry `PreviewModule`, which lives here.

## Four decisions the doc parked, now made

- **Stdout is the protocol channel, so Gradle's output cannot be inherited onto it.** This is the load-bearing one — inherited, the first task that printed anything would corrupt the stream. Output is captured and reframed as log events; the server decides whether to show them, since the host cannot know if the invocation wants `--progress`. `silenceStdout` drops them at the source rather than pushing megabytes into a pipe nobody reads.
- **Paths cross the wire absolute *and normalised*.** Absolute alone is not enough, and I only found that by running the real binary: `findProjectRoot()` returns `<root>/.`, which a server keying module directories would never string-match against `<root>`. Lexical `normalize()` rather than `canonicalPath`, so a project reached through a symlinked home keeps the path the user recognises.
- **The handshake gates every other operation**, so version skew is reported once and up front rather than as a puzzling failure several operations into a build.
- **Cancellation is stdin closing.** No cancel message in v1: the honest implementation is killing the build, and the server already has that lever. A message that only set a flag would be a cancellation that does not cancel.

## What end-to-end testing caught that unit tests could not

Registering the command touched **three** registries — the dispatcher, `CliRouter.KNOWN_FLAT`, and `CliFlagValidation.BY_COMMAND`. The unit tests drive the request loop directly and never go through argv, so they were green while the built binary said `Unknown command: build-host`, and then died with `Key build-host is missing in the map`. Both were found by running the real thing.

Driving the installed binary now:

```
$ printf '...' | compose-preview build-host --stdio
{"id":1,"response":{"kind":"handshake","protocolVersion":1,"hostVersion":"1.77.1-SNAPSHOT"}}
{"id":2,"response":{"kind":"path","path":"/home/user/compose-ai-tools"}}
{"id":3,"response":{"kind":"strings","values":["--offline"]}}
{"id":4,"response":{"kind":"failure","message":"protocol mismatch: the server speaks 99, this host speaks 1. …"}}
```

(That `path` read `/home/user/compose-ai-tools/.` before the normalisation fix.)

## Test plan

- `./gradlew :build-host-protocol:check` — green. **15 tests**: every message round-trips, an encoded message never spans lines, an unknown *field* is tolerated while an unknown *kind* fails loudly, and `WireModule.from` makes paths absolute and normalises `.` / `..` away.
- `./gradlew :cli:test` — green, **833 tests**, 18 of them new: handshake gating, version skew, a malformed line and an unknown kind each answered without killing the host, id correlation, and `LineSplittingOutputStream` (CRLF, unterminated trailing line, UTF-8 across byte-wise writes).
- `./gradlew :cli:installDist` plus the transcript above — the real process, against a real Gradle project.
- `checkLayerBoundary`, `check-daemon-launch-schema.py`, `check-agent-entrypoints.sh` — all green.
- ABI dumped (`build-host-protocol.api`, `explicitApi()` + `checkKotlinAbi` wired into `check`).

## Not in this PR

Wiring the server to it — that needs a release from here first, and is where the `serve` / `browse` launchers (step 4) and the `ui` command (step 5) follow. `ServeCommand` stays as-is until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014NtzoUCr4pou3y1qRDxcpZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014NtzoUCr4pou3y1qRDxcpZ)_