### PR TITLE
fix(renderer-android): resolve Glance's preview composer against the project's Glance

### DIFF
--- a/docs/RENDERER_COMPATIBILITY.md
+++ b/docs/RENDERER_COMPATIBILITY.md
@@ -253,6 +253,43 @@ to ship the higher floor on-device. We deliberately do **not** override this
 silently — that would mask the conflict for the consumer's own unit tests and
 let a genuinely API-35 library link against a lower-minSdk module unnoticed.
 
+### Glance app-widget previews: the composer is resolved, not linked
+
+`androidx.glance:glance-appwidget` is `compileOnly` in the renderer and pinned
+at 1.2.0 in [`gradle/libs.versions.toml`](../gradle/libs.versions.toml), but the
+render runs against the **consumer's** Glance. Those two facts collided:
+`composeForPreview(GlanceAppWidget, Context, Int, AppWidgetProviderInfo)` was
+added in Glance 1.2.0, and the renderer called it as an ordinary compiled call
+site — so on a project pinned to 1.0.0/1.1.x every app-widget preview died with
+
+```
+java.lang.NoSuchMethodError: 'java.lang.Object
+  androidx.glance.appwidget.AppWidgetComposerKt.composeForPreview(...)'
+  at ee.schimke.composeai.renderer.GlanceAppWidgetPreviewRendererKt…
+```
+
+`NoSuchMethodError` rather than `ClassNotFoundException` is the tell: the class
+resolved, the signature did not (compose-ai-tools#5056).
+
+[`GlanceComposeForPreview.kt`](../renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/GlanceComposeForPreview.kt)
+now resolves the composer reflectively off the render classpath and fills its
+parameters **by type**, so an added or dropped argument in a later release still
+resolves:
+
+| Consumer's Glance | Resolved entry point | Composes through |
+| --- | --- | --- |
+| 1.2.0, 1.3.0-alpha | `composeForPreview(…, widgetCategory, info)` | `providePreview` |
+| 1.0.0 – 1.1.1 | `compose(…, size, …)` — the only one there is | `provideGlance` |
+| neither matches | `GlanceComposerUnavailableException` | — |
+
+The synthetic widget provides the same content from both entry points, so the
+capture does not depend on which one the consumer's version offers. When nothing
+matches, the failure is bounded and named: the exception's message reaches the
+card as the sidecar's `diagnosis` field rather than as a stack trace pointing
+into our renderer. **Adding a new Glance version to the table is a code change
+in one place** — `argumentFor` in that file, plus a fixture shape in
+`GlanceComposerFixtures.kt`.
+
 ## Tile-rendering defaults
 
 Tile previews render on an opaque black background and pick up the round

--- a/renderers/android/build.gradle.kts
+++ b/renderers/android/build.gradle.kts
@@ -133,6 +133,12 @@ dependencies {
   // already have `androidx.glance:glance-appwidget` on their compile classpath, which then flows
   // onto the test classpath via the discovery → render fanout.
   compileOnly(libs.glance.appwidget)
+  // `GlanceComposeForPreviewTest` reflects over the *compiled* composer signatures — the version
+  // shapes in `GlanceComposerFixtures.kt` extend `GlanceAppWidget` and take `GlanceId`, and one
+  // test resolves against the real 1.2.0 so a Glance bump that moves the signature is caught here
+  // rather than in someone's import (compose-ai-tools#5056). Same precedent as coil above: the
+  // artefact stays off consumers' classpaths, it is only our own tests that need it.
+  testImplementation(libs.glance.appwidget)
   // Coil — `CoilPreviewSupport` swaps the singleton `ImageLoader` for an inline-dispatcher one so
   // `AsyncImage` resolves before the capture instead of leaving a blank, layout-collapsing hole
   // (issue #2952). Both majors are `compileOnly`: they are separate package trees (`coil.*` vs

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/GlanceAppWidgetPreviewRenderer.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/GlanceAppWidgetPreviewRenderer.kt
@@ -11,12 +11,13 @@ import androidx.compose.runtime.currentComposer
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.glance.GlanceId
 import androidx.glance.appwidget.GlanceAppWidget
-import androidx.glance.appwidget.composeForPreview
 import androidx.glance.appwidget.provideContent
+import ee.schimke.composeai.renderer.GlanceComposeForPreview.compose
 import kotlinx.coroutines.runBlocking
 
 /**
@@ -29,8 +30,11 @@ import kotlinx.coroutines.runBlocking
  * 1. Build a [SyntheticGlanceAppWidget] whose `providePreview(...)` invokes the user's
  *    `@Composable` via [resolveNoArgComposableMethod] inside `provideContent { ... }` — the Glance
  *    composition block where `@GlanceComposable` calls resolve.
- * 2. `composeForPreview(context, widgetCategory, info)` runs the composition and materialises a
- *    `RemoteViews` tree (Glance 1.2.0+).
+ * 2. The composer [GlanceComposeForPreview] resolved against the *project's* Glance runs the
+ *    composition and materialises a `RemoteViews` tree — `composeForPreview(context,
+ *    widgetCategory, info)` on Glance 1.2.0+, the `compose(context, …, size, …)` extension on
+ *    1.0.0-1.1.x, which has no `composeForPreview` at all. Resolution is reflective because the
+ *    render classpath is the imported project's, not ours (compose-ai-tools#5056).
  * 3. `RemoteViews.apply(context, parent)` inflates the tree into a `View` we host inside the
  *    `AndroidView` factory — the same path `AppWidgetHost.createView(...)` walks on-device.
  *
@@ -66,11 +70,14 @@ fun GlanceAppWidgetPreviewComposable(
           minWidth = with(density) { widthDp.dp.toPx() }.toInt()
           minHeight = with(density) { heightDp.dp.toPx() }.toInt()
         }
+      val plan = GlanceComposeForPreview.resolve(widget.javaClass.classLoader)
       val remoteViews = runBlocking {
-        widget.composeForPreview(
+        plan.compose(
+          widget = widget,
           context = context,
           widgetCategory = AppWidgetProviderInfo.WIDGET_CATEGORY_HOME_SCREEN,
           info = info,
+          size = DpSize(widthDp.dp, heightDp.dp),
         )
       }
       val view = remoteViews.apply(context, parent)
@@ -104,8 +111,12 @@ fun GlanceAppWidgetPreviewComposable(
  * static methods on the file's synthetic `FooKt` class) and class-hosted previews (e.g. inside a
  * `class ScreenshotTest`) both work.
  *
- * `provideGlance(...)` is a no-op — the production runtime path is invoked when the launcher binds
- * a real widget, not when rendering an off-device preview.
+ * `providePreview(...)` and `provideGlance(...)` share one body. The production runtime path is
+ * invoked when the launcher binds a real widget, never when rendering an off-device preview — but
+ * `provideGlance` is also what Glance's pre-1.2.0 `compose(…)` extension composes through, and that
+ * is the fallback [GlanceComposeForPreview] resolves on a project whose Glance has no
+ * `composeForPreview` (compose-ai-tools#5056). Providing the same content from both keeps the
+ * preview identical whichever entry point the project's Glance version offers.
  */
 private class SyntheticGlanceAppWidget(
   private val className: String,
@@ -113,6 +124,14 @@ private class SyntheticGlanceAppWidget(
   private val classLoader: ClassLoader?,
 ) : GlanceAppWidget() {
   override suspend fun providePreview(context: android.content.Context, widgetCategory: Int) {
+    providePreviewContent()
+  }
+
+  /**
+   * The user's `@Composable`, provided as this widget's content. Never returns, by Glance's
+   * contract for `provideContent`: it suspends until the composition session ends.
+   */
+  private suspend fun providePreviewContent(): Nothing {
     provideContent {
       val cls =
         Class.forName(className, true, classLoader ?: Thread.currentThread().contextClassLoader)
@@ -135,6 +154,10 @@ private class SyntheticGlanceAppWidget(
   }
 
   override suspend fun provideGlance(context: android.content.Context, id: GlanceId) {
-    // Production runtime not exercised by previews.
+    // Not the production runtime path — a preview never binds a real widget. It is the entry point
+    // Glance's pre-1.2.0 `compose(…)` extension composes through, though, since `providePreview`
+    // only exists from 1.2.0 on, so it provides the same content rather than doing nothing
+    // (compose-ai-tools#5056). On 1.2.0+ this is dead code and `providePreview` above runs instead.
+    providePreviewContent()
   }
 }

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/GlanceComposeForPreview.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/GlanceComposeForPreview.kt
@@ -1,0 +1,265 @@
+package ee.schimke.composeai.renderer
+
+import android.appwidget.AppWidgetProviderInfo
+import android.content.Context
+import android.widget.RemoteViews
+import androidx.compose.ui.unit.DpSize
+import androidx.glance.appwidget.GlanceAppWidget
+import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+
+/**
+ * Resolves the Glance entry point that turns a [GlanceAppWidget] into `RemoteViews`, reflectively,
+ * against whatever `androidx.glance:glance-appwidget` the *rendered project* brought — not the
+ * version this module compiled against.
+ *
+ * Why reflection at all. `GlanceAppWidgetPreviewRenderer` used to call
+ * `widget.composeForPreview(context, widgetCategory, info)` as an ordinary compiled call site,
+ * linked against the `glance-appwidget = "1.2.0"` pin in `gradle/libs.versions.toml`. Under the
+ * import model the render runs against the project's Glance, and `composeForPreview` **did not
+ * exist before 1.2.0** — so every Glance app-widget preview in a project on 1.1.x died with
+ * `NoSuchMethodError: androidx.glance.appwidget.AppWidgetComposerKt.composeForPreview(...)`, an
+ * error naming our renderer rather than anything the project did (compose-ai-tools#5056).
+ *
+ * What the API actually looks like, read off the published AARs:
+ * ```
+ * 1.0.0   compose-1pU2XAk(Context, GlanceId, SizeMode, DpSize, Bundle, Any, ConfigManager, content)
+ *         compose-DR8WL-M(GlanceAppWidget, Context, GlanceId, Bundle, DpSize, Any)
+ * 1.1.0   compose-DR8WL-M(…)                      runComposition(…): Flow<RemoteViews>
+ * 1.1.1   compose-DR8WL-M(…)                      runComposition(…): Flow<RemoteViews>
+ * 1.2.0   compose-DR8WL-M(…)  composeForPreview(GlanceAppWidget, Context, int, AppWidgetProviderInfo)
+ * 1.3.0-α compose-DR8WL-M(…)  composeForPreview(GlanceAppWidget, Context, int, AppWidgetProviderInfo)
+ * ```
+ *
+ * So the resolution order is: `composeForPreview` when the classpath has it (1.2.0+, the preview
+ * path proper — it honours `widgetCategory` and `PreviewSizeMode` and drives
+ * `GlanceAppWidget.providePreview`), else the `compose` extension present since 1.0.0, which drives
+ * `provideGlance` instead — hence [SyntheticGlanceAppWidget] provides the same content from both.
+ *
+ * Arguments are matched **by parameter type, not position**, so a future release that adds or drops
+ * an argument still resolves as long as the added type is one we know how to fill. A method whose
+ * middle parameters contain a type this file cannot supply is not a candidate; when nothing is left
+ * we throw [GlanceComposerUnavailableException], whose message names the Glance version floor and
+ * reaches the panel as the sidecar's `diagnosis` field (see [RenderErrorSidecar]) — a bounded,
+ * actionable failure instead of a `NoSuchMethodError` pointing at line 71 of our renderer.
+ */
+internal object GlanceComposeForPreview {
+
+  /** The Kotlin file class holding both `composeForPreview` and the `compose` extension. */
+  const val COMPOSER_CLASS_NAME: String = "androidx.glance.appwidget.AppWidgetComposerKt"
+
+  private const val GLANCE_APP_WIDGET = "androidx.glance.appwidget.GlanceAppWidget"
+  private const val CONTEXT = "android.content.Context"
+  private const val CONTINUATION = "kotlin.coroutines.Continuation"
+  private const val COMPOSE_FOR_PREVIEW = "composeForPreview"
+  private const val COMPOSE = "compose"
+
+  /**
+   * One parameter of a resolved composer method, identified by what the renderer puts in it rather
+   * than by where it sits. [ABSENT] covers the parameters we deliberately pass `null` for — the
+   * `GlanceId`, the options `Bundle`, the widget state — which every overload declares as nullable
+   * with a `null` default.
+   */
+  enum class Argument {
+    WIDGET,
+    CONTEXT,
+    WIDGET_CATEGORY,
+    PROVIDER_INFO,
+    SIZE,
+    ABSENT,
+  }
+
+  /** A composer method plus how to fill its parameters. Produced by [resolve] / [resolveIn]. */
+  class Plan(val method: Method, val arguments: List<Argument>) {
+
+    /**
+     * True when this plan calls `composeForPreview` — the 1.2.0+ path, which composes through
+     * `GlanceAppWidget.providePreview`. False means the `compose` fallback, which composes through
+     * `provideGlance`.
+     */
+    val composesPreview: Boolean
+      get() = baseName(method.name) == COMPOSE_FOR_PREVIEW
+
+    /** Parameters the renderer supplies a real value for — the tie-break in [resolveIn]. */
+    internal val suppliedArgumentCount: Int
+      get() = arguments.count { it != Argument.ABSENT }
+
+    /** `composeForPreview(WIDGET, CONTEXT, WIDGET_CATEGORY, PROVIDER_INFO)` — for diagnostics. */
+    fun describe(): String = "${method.name}(${arguments.joinToString(", ")})"
+  }
+
+  /**
+   * Resolve against the Glance on [classLoader] — the render classpath's loader, so the imported
+   * project's `glance-appwidget` wins over ours.
+   *
+   * @throws GlanceComposerUnavailableException when Glance is absent, or present with no signature
+   *   this renderer can call.
+   */
+  fun resolve(classLoader: ClassLoader?): Plan {
+    val loader = classLoader ?: GlanceComposeForPreview::class.java.classLoader
+    val composerClass =
+      try {
+        Class.forName(COMPOSER_CLASS_NAME, false, loader)
+      } catch (e: ClassNotFoundException) {
+        throw GlanceComposerUnavailableException(
+          "Glance app-widget previews need androidx.glance:glance-appwidget on the render " +
+            "classpath, and $COMPOSER_CLASS_NAME did not load. Add the dependency to the module " +
+            "under render, or drop the Glance previews from the selection.",
+          e,
+        )
+      }
+    return resolveIn(composerClass)
+  }
+
+  /**
+   * The seam [resolve] is built on: pick a plan out of an already-loaded composer class. Exposed so
+   * `GlanceComposeForPreviewTest` can drive the 1.0.0 / 1.1.x / 1.2.0 / future / unsupported shapes
+   * without six Glance versions on one test classpath.
+   */
+  fun resolveIn(composerClass: Class<*>): Plan {
+    val plans = composerClass.methods.mapNotNull { planFor(it) }
+    val best =
+      plans
+        .sortedWith(
+          compareBy(
+            { if (it.composesPreview) 0 else 1 },
+            { -it.suppliedArgumentCount },
+            { it.method.name },
+          )
+        )
+        .firstOrNull()
+    if (best != null) return best
+
+    val seen =
+      composerClass.methods
+        .filter { Modifier.isStatic(it.modifiers) && !it.name.contains("\$default") }
+        .map { it.name }
+        .distinct()
+        .sorted()
+    throw GlanceComposerUnavailableException(
+      "No usable Glance app-widget composer on the render classpath. " +
+        "$COMPOSER_CLASS_NAME${codeSourceSuffix(composerClass)} declares ${seen.joinToString()}, " +
+        "and none of them matches a signature this renderer can call. " +
+        "composeForPreview(GlanceAppWidget, Context, Int, AppWidgetProviderInfo) arrived in " +
+        "androidx.glance:glance-appwidget 1.2.0 — upgrade the rendered project's Glance to 1.2.0 " +
+        "or newer to render its app-widget previews."
+    )
+  }
+
+  /**
+   * Compose [widget] through this plan. [widgetCategory] and [info] land only in the parameters the
+   * resolved overload actually declares; [size] is used by the pre-1.2.0 `compose` fallback, which
+   * takes the composition size directly instead of deriving it from an `AppWidgetProviderInfo`.
+   */
+  suspend fun Plan.compose(
+    widget: GlanceAppWidget,
+    context: Context,
+    widgetCategory: Int,
+    info: AppWidgetProviderInfo,
+    size: DpSize,
+  ): RemoteViews {
+    val args = arguments.map {
+      when (it) {
+        Argument.WIDGET -> widget
+        Argument.CONTEXT -> context
+        Argument.WIDGET_CATEGORY -> widgetCategory
+        Argument.PROVIDER_INFO -> info
+        Argument.SIZE -> size
+        Argument.ABSENT -> null
+      }
+    }
+    val result = invokeSuspending(method, args)
+    return result as? RemoteViews
+      ?: throw GlanceComposerUnavailableException(
+        "${describe()} returned ${result?.javaClass?.name ?: "null"} rather than RemoteViews. " +
+          "The Glance on the render classpath" +
+          "${codeSourceSuffix(method.declaringClass)} is not one this renderer understands."
+      )
+  }
+
+  /**
+   * A candidate must be a static `(GlanceAppWidget, Context, …, Continuation)` — the JVM shape of a
+   * suspend extension on `GlanceAppWidget` — whose middle parameters are all types [argumentFor]
+   * knows how to fill. Kotlin's `$default` bridges are skipped: they take a bitmask and a marker we
+   * would have to synthesise, and the real method is always right beside them.
+   */
+  private fun planFor(method: Method): Plan? {
+    if (!Modifier.isStatic(method.modifiers)) return null
+    if (method.name.contains("\$default")) return null
+    val base = baseName(method.name)
+    if (base != COMPOSE_FOR_PREVIEW && base != COMPOSE) return null
+    val params = method.parameterTypes
+    if (params.size < 3) return null
+    if (params[0].name != GLANCE_APP_WIDGET) return null
+    if (params[1].name != CONTEXT) return null
+    if (params[params.size - 1].name != CONTINUATION) return null
+    val middle = mutableListOf<Argument>()
+    for (i in 2 until params.size - 1) {
+      middle += argumentFor(params[i]) ?: return null
+    }
+    return Plan(method, listOf(Argument.WIDGET, Argument.CONTEXT) + middle)
+  }
+
+  /** What the renderer would pass in a parameter of [type], or null when it has nothing to pass. */
+  private fun argumentFor(type: Class<*>): Argument? =
+    when (type.name) {
+      "int",
+      "java.lang.Integer" -> Argument.WIDGET_CATEGORY
+      "android.appwidget.AppWidgetProviderInfo" -> Argument.PROVIDER_INFO
+      "androidx.compose.ui.unit.DpSize" -> Argument.SIZE
+      // Nullable-with-default parameters across every published overload: the GlanceId the widget
+      // would be bound to, the options Bundle the host would have supplied, and the widget state.
+      // A preview has none of them, and Glance's own preview path passes null for all three.
+      "androidx.glance.GlanceId",
+      "android.os.Bundle",
+      "java.lang.Object" -> Argument.ABSENT
+      else -> null
+    }
+
+  /**
+   * Kotlin mangles the JVM name of a function taking a value class — `DpSize` makes `compose`
+   * compile to `compose-DR8WL-M`. Match on the part before the hyphen so the mangling, which is a
+   * hash of the signature and therefore free to change between releases, is never load-bearing.
+   */
+  private fun baseName(name: String): String = name.substringBefore('-')
+
+  /** ` (loaded from …/glance-appwidget-1.1.1.jar)`, best effort — empty when the JVM won't say. */
+  private fun codeSourceSuffix(cls: Class<*>): String {
+    val location =
+      try {
+        cls.protectionDomain?.codeSource?.location?.toString()
+      } catch (_: SecurityException) {
+        null
+      }
+    return location?.let { " (loaded from $it)" }.orEmpty()
+  }
+
+  /**
+   * Call a suspend function reflectively. A `suspend fun` compiles to a method taking an extra
+   * `Continuation` and returning either its result or the `COROUTINE_SUSPENDED` sentinel — which is
+   * exactly the contract [suspendCoroutineUninterceptedOrReturn] implements, so handing it our own
+   * continuation and returning whatever `invoke` returned bridges the two without a wrapper
+   * coroutine. Reflection's `InvocationTargetException` is unwrapped so a throw from inside the
+   * user's `@Composable` reaches the sidecar as itself.
+   */
+  private suspend fun invokeSuspending(method: Method, args: List<Any?>): Any? =
+    suspendCoroutineUninterceptedOrReturn { continuation ->
+      runCatching { method.isAccessible = true }
+      try {
+        method.invoke(null, *(args.toTypedArray() + continuation))
+      } catch (e: InvocationTargetException) {
+        throw e.cause ?: e
+      }
+    }
+}
+
+/**
+ * The render classpath has no Glance app-widget composer this renderer can call — Glance missing
+ * entirely, or a version whose API predates `composeForPreview` and whose `compose` overload does
+ * not match either. Carries the upgrade instruction; [RenderErrorSidecar] lifts the message into
+ * the sidecar's `diagnosis` field so the panel shows it on the card.
+ */
+internal class GlanceComposerUnavailableException(message: String, cause: Throwable? = null) :
+  RuntimeException(message, cause)

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RenderErrorSidecar.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RenderErrorSidecar.kt
@@ -51,6 +51,7 @@ internal object RenderErrorSidecar {
         sb.append("\"function\":").append(jsonString(top.function))
         sb.append("},")
       }
+      diagnose(e)?.let { sb.append("\"diagnosis\":").append(jsonString(it)).append(',') }
       // Which JVM ran the render, and what it would have searched for native libraries. Same
       // block the desktop renderer writes (see `NativeLoadDiagnosis.runtimeSnapshot`), because the
       // question it answers is the same on both backends: with several JDKs installed, nothing
@@ -75,6 +76,29 @@ internal object RenderErrorSidecar {
         "Failed to write render-error sidecar for ${pngFile.name}: ${sidecarWriteFailure.message}"
       )
     }
+  }
+
+  /**
+   * One actionable sentence for a failure that is about the *render classpath* rather than about
+   * the preview's own code, or null for an ordinary preview throw — which is the overwhelming
+   * majority. Mirrors what the desktop renderer puts in this field for a native-load failure
+   * (`renderer-desktop/.../NativeLoadDiagnosis.kt`); the plugin surfaces it on the card
+   * ([`PreviewRenderError.diagnosis`]).
+   *
+   * The classpath-version case worth carrying here is Glance's: a project whose
+   * `androidx.glance:glance-appwidget` predates 1.2.0 has no `composeForPreview`, which took out
+   * every app-widget preview in the module at once with an error naming our renderer
+   * (compose-ai-tools#5056). [GlanceComposerUnavailableException] already carries the sentence — a
+   * failure class this broad deserves to reach the card as more than a stack trace, so lift it.
+   */
+  private fun diagnose(e: Throwable): String? {
+    var t: Throwable? = e
+    val seen = mutableSetOf<Throwable>()
+    while (t != null && seen.add(t)) {
+      if (t is GlanceComposerUnavailableException) return t.message
+      t = t.cause
+    }
+    return null
   }
 
   /**

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/GlanceComposeForPreviewTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/GlanceComposeForPreviewTest.kt
@@ -1,0 +1,248 @@
+package ee.schimke.composeai.renderer
+
+import android.appwidget.AppWidgetProviderInfo
+import android.content.Context
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.glance.GlanceId
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.test.core.app.ApplicationProvider
+import ee.schimke.composeai.renderer.GlanceComposeForPreview.Argument
+import ee.schimke.composeai.renderer.GlanceComposeForPreview.compose
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Coverage of [GlanceComposeForPreview] — the reflective resolution that lets the Glance app-widget
+ * renderer run against whatever `androidx.glance:glance-appwidget` the *rendered project* brought,
+ * rather than the 1.2.0 this module compiles against.
+ *
+ * The regression: `composeForPreview` did not exist before Glance 1.2.0, so a compiled call site
+ * took out every app-widget preview in a project on 1.1.x with `NoSuchMethodError` naming line 71
+ * of our own renderer (compose-ai-tools#5056). The version shapes under test are transcribed from
+ * the published AARs into `GlanceComposerFixtures.kt`.
+ *
+ * Robolectric because half of this is invocation, and `RemoteViews` / `AppWidgetProviderInfo` are
+ * not constructible against the stub `android.jar`.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class GlanceComposeForPreviewTest {
+
+  private class TestWidget : GlanceAppWidget() {
+    override suspend fun provideGlance(context: Context, id: GlanceId) = Unit
+  }
+
+  private val context: Context
+    get() = ApplicationProvider.getApplicationContext()
+
+  private val info
+    get() =
+      AppWidgetProviderInfo().apply {
+        minWidth = 300
+        minHeight = 200
+      }
+
+  @Before fun setUp() = GlanceComposerCalls.reset()
+
+  @Test
+  fun `resolves composeForPreview on the Glance 1_2_0 shape`() {
+    val plan = GlanceComposeForPreview.resolveIn(Glance120ComposerFixture::class.java)
+
+    assertTrue("composeForPreview is the preview path proper", plan.composesPreview)
+    assertEquals(
+      listOf(Argument.WIDGET, Argument.CONTEXT, Argument.WIDGET_CATEGORY, Argument.PROVIDER_INFO),
+      plan.arguments,
+    )
+  }
+
+  @Test
+  fun `falls back to compose on a Glance version that predates composeForPreview`() {
+    val plan = GlanceComposeForPreview.resolveIn(Glance11xComposerFixture::class.java)
+
+    assertFalse("1.1.x has no composeForPreview at all", plan.composesPreview)
+    assertEquals(
+      listOf(
+        Argument.WIDGET,
+        Argument.CONTEXT,
+        Argument.ABSENT, // GlanceId — a preview binds no widget
+        Argument.ABSENT, // options Bundle
+        Argument.SIZE,
+        Argument.ABSENT, // state
+      ),
+      plan.arguments,
+    )
+  }
+
+  @Test
+  fun `matches the compose extension through its value-class name mangling`() {
+    // `DpSize` is a value class, so Kotlin compiles `compose` to `compose-<hash>`. The hash is a
+    // function of the signature and free to change between releases — matching it would be the
+    // same brittleness in a new costume.
+    val plan = GlanceComposeForPreview.resolveIn(Glance11xComposerFixture::class.java)
+
+    assertTrue(
+      "expected a mangled `compose-…`, got ${plan.method.name}",
+      plan.method.name.startsWith("compose"),
+    )
+    assertFalse(plan.method.name.contains("\$default"))
+  }
+
+  @Test
+  fun `prefers composeForPreview when both entry points are present`() {
+    val plan = GlanceComposeForPreview.resolveIn(Glance120ComposerFixture::class.java)
+
+    assertEquals("composeForPreview", plan.method.name)
+  }
+
+  @Test
+  fun `resolves a later signature that grows a parameter it knows how to fill`() {
+    val plan = GlanceComposeForPreview.resolveIn(FutureComposerFixture::class.java)
+
+    assertTrue(plan.composesPreview)
+    assertEquals(
+      listOf(
+        Argument.WIDGET,
+        Argument.CONTEXT,
+        Argument.WIDGET_CATEGORY,
+        Argument.PROVIDER_INFO,
+        Argument.SIZE,
+      ),
+      plan.arguments,
+    )
+  }
+
+  @Test
+  fun `refuses a composer whose parameters it cannot fill, naming the version floor`() {
+    try {
+      GlanceComposeForPreview.resolveIn(UnsupportedComposerFixture::class.java)
+      fail("a composer taking a type we cannot supply must not resolve")
+    } catch (e: GlanceComposerUnavailableException) {
+      val message = e.message.orEmpty()
+      assertTrue("names the version floor: $message", message.contains("1.2.0"))
+      assertTrue("names what it did find: $message", message.contains("composeForPreview"))
+    }
+  }
+
+  @Test
+  fun `reports a render classpath with no Glance at all`() {
+    // A loader that delegates only to the bootstrap classpath — no androidx anywhere.
+    val bare = object : ClassLoader(null) {}
+
+    try {
+      GlanceComposeForPreview.resolve(bare)
+      fail("a classpath without glance-appwidget must not resolve")
+    } catch (e: GlanceComposerUnavailableException) {
+      assertTrue(e.message.orEmpty().contains("glance-appwidget"))
+      assertTrue(e.cause is ClassNotFoundException)
+    }
+  }
+
+  @Test
+  fun `fills composeForPreview by parameter type and returns its RemoteViews`() {
+    val plan = GlanceComposeForPreview.resolveIn(Glance120ComposerFixture::class.java)
+
+    val views = runBlocking {
+      plan.compose(
+        widget = TestWidget(),
+        context = context,
+        widgetCategory = AppWidgetProviderInfo.WIDGET_CATEGORY_HOME_SCREEN,
+        info = info,
+        size = DpSize(300.dp, 200.dp),
+      )
+    }
+
+    assertNotNull(views)
+    assertEquals(
+      listOf(
+        "composeForPreview(widget=TestWidget, " +
+          "widgetCategory=${AppWidgetProviderInfo.WIDGET_CATEGORY_HOME_SCREEN}, info=300x200)"
+      ),
+      GlanceComposerCalls.recorded,
+    )
+  }
+
+  @Test
+  fun `hands the pre-1_2_0 compose fallback the size and nulls the rest`() {
+    val plan = GlanceComposeForPreview.resolveIn(Glance11xComposerFixture::class.java)
+
+    runBlocking {
+      plan.compose(
+        widget = TestWidget(),
+        context = context,
+        widgetCategory = AppWidgetProviderInfo.WIDGET_CATEGORY_HOME_SCREEN,
+        info = info,
+        size = DpSize(300.dp, 200.dp),
+      )
+    }
+
+    assertEquals(
+      listOf("compose(id=null, options=null, size=${DpSize(300.dp, 200.dp)}, state=null)"),
+      GlanceComposerCalls.recorded,
+    )
+  }
+
+  @Test
+  fun `propagates a throw from the composition as itself, not wrapped in reflection`() {
+    val plan = GlanceComposeForPreview.resolveIn(ThrowingComposerFixture::class.java)
+
+    try {
+      runBlocking {
+        plan.compose(
+          widget = TestWidget(),
+          context = context,
+          widgetCategory = AppWidgetProviderInfo.WIDGET_CATEGORY_HOME_SCREEN,
+          info = info,
+          size = DpSize(300.dp, 200.dp),
+        )
+      }
+      fail("the preview's own exception must reach the sidecar")
+    } catch (e: IllegalStateException) {
+      // An InvocationTargetException here would put reflection's frames on the sidecar's
+      // `topAppFrame` and bury the message the preview author needs.
+      assertTrue(e.message.orEmpty().startsWith("preview threw"))
+    }
+  }
+
+  @Test
+  fun `refuses a composer that returns something other than RemoteViews`() {
+    val plan = GlanceComposeForPreview.resolveIn(WrongReturnComposerFixture::class.java)
+
+    try {
+      runBlocking {
+        plan.compose(
+          widget = TestWidget(),
+          context = context,
+          widgetCategory = AppWidgetProviderInfo.WIDGET_CATEGORY_HOME_SCREEN,
+          info = info,
+          size = DpSize(300.dp, 200.dp),
+        )
+      }
+      fail("a non-RemoteViews return must be reported, not ClassCastException'd downstream")
+    } catch (e: GlanceComposerUnavailableException) {
+      assertTrue(e.message.orEmpty().contains("java.lang.String"))
+    }
+  }
+
+  @Test
+  fun `resolves against the real Glance on this module's classpath`() {
+    // The pin in gradle/libs.versions.toml is 1.2.0, so the preview path is what we expect here —
+    // and this is the one test that would notice the day a Glance bump changes the signature.
+    val plan = GlanceComposeForPreview.resolve(GlanceAppWidget::class.java.classLoader)
+
+    assertTrue("real Glance ${plan.describe()}", plan.composesPreview)
+    assertEquals(
+      listOf(Argument.WIDGET, Argument.CONTEXT, Argument.WIDGET_CATEGORY, Argument.PROVIDER_INFO),
+      plan.arguments,
+    )
+  }
+}

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/GlanceComposerFixtures.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/GlanceComposerFixtures.kt
@@ -1,0 +1,146 @@
+package ee.schimke.composeai.renderer
+
+import android.appwidget.AppWidgetProviderInfo
+import android.content.Context
+import android.os.Bundle
+import android.widget.RemoteViews
+import androidx.compose.ui.unit.DpSize
+import androidx.glance.GlanceId
+import androidx.glance.appwidget.GlanceAppWidget
+
+/**
+ * Compiled stand-ins for `androidx.glance.appwidget.AppWidgetComposerKt` as it is shaped in each
+ * Glance release [GlanceComposeForPreview] has to cope with. Reflection over *compiled* signatures
+ * is the point — a hand-written `Method` stub could not reproduce Kotlin's suspend calling
+ * convention or the value-class name mangling that turns `compose` into `compose-DR8WL-M` — and
+ * putting six Glance versions on one test classpath is not possible at all.
+ *
+ * The shapes below are transcribed from `javap` over the published AARs:
+ * ```
+ * 1.0.0/1.1.x  compose-DR8WL-M(GlanceAppWidget, Context, GlanceId, Bundle, DpSize, Object)
+ * 1.2.0+       …the same, plus
+ *              composeForPreview(GlanceAppWidget, Context, int, AppWidgetProviderInfo)
+ * ```
+ *
+ * Each fixture records what it was handed so the invocation tests can assert the renderer filled
+ * the parameters by *type*, not by position.
+ */
+object GlanceComposerCalls {
+  /** `"composeForPreview(widgetCategory=1, info=…)"`-ish trace of the last call, per fixture. */
+  val recorded: MutableList<String> = mutableListOf()
+
+  fun reset() = recorded.clear()
+}
+
+/** Glance 1.2.0 and 1.3.0-alpha: `composeForPreview` beside the older `compose` extension. */
+object Glance120ComposerFixture {
+
+  @JvmStatic
+  @Suppress("unused")
+  suspend fun GlanceAppWidget.composeForPreview(
+    context: Context,
+    widgetCategory: Int,
+    info: AppWidgetProviderInfo? = null,
+  ): RemoteViews {
+    GlanceComposerCalls.recorded +=
+      "composeForPreview(widget=${javaClass.simpleName}, widgetCategory=$widgetCategory, " +
+        "info=${info?.minWidth}x${info?.minHeight})"
+    return RemoteViews(context.packageName, 0)
+  }
+
+  @JvmStatic
+  @Suppress("unused")
+  suspend fun GlanceAppWidget.compose(
+    context: Context,
+    id: GlanceId? = null,
+    options: Bundle? = null,
+    size: DpSize? = null,
+    state: Any? = null,
+  ): RemoteViews {
+    GlanceComposerCalls.recorded += "compose(id=$id, options=$options, size=$size, state=$state)"
+    return RemoteViews(context.packageName, 0)
+  }
+}
+
+/**
+ * Glance 1.0.0 through 1.1.1: no `composeForPreview` at all. `AppWidgetComposerKt` still resolves,
+ * which is why the old compiled call site failed with `NoSuchMethodError` rather than
+ * `ClassNotFoundException` (compose-ai-tools#5056).
+ */
+object Glance11xComposerFixture {
+
+  @JvmStatic
+  @Suppress("unused")
+  suspend fun GlanceAppWidget.compose(
+    context: Context,
+    id: GlanceId? = null,
+    options: Bundle? = null,
+    size: DpSize? = null,
+    state: Any? = null,
+  ): RemoteViews {
+    GlanceComposerCalls.recorded += "compose(id=$id, options=$options, size=$size, state=$state)"
+    return RemoteViews(context.packageName, 0)
+  }
+
+  /** 1.1.0's other public entry point. Not suspend, returns a stream — never a candidate. */
+  @JvmStatic
+  @Suppress("unused")
+  fun GlanceAppWidget.runComposition(context: Context, id: GlanceId? = null): List<RemoteViews> {
+    GlanceComposerCalls.recorded += "runComposition($context, $id)"
+    return emptyList()
+  }
+}
+
+/** A hypothetical later release that grows a parameter whose type we already know how to fill. */
+object FutureComposerFixture {
+
+  @JvmStatic
+  @Suppress("unused")
+  suspend fun GlanceAppWidget.composeForPreview(
+    context: Context,
+    widgetCategory: Int,
+    info: AppWidgetProviderInfo? = null,
+    size: DpSize? = null,
+  ): RemoteViews {
+    GlanceComposerCalls.recorded += "composeForPreview(widgetCategory=$widgetCategory, size=$size)"
+    return RemoteViews(context.packageName, 0)
+  }
+}
+
+/** A release whose composer needs something the renderer has no value for. */
+object UnsupportedComposerFixture {
+
+  /** Stands in for a type this renderer cannot synthesise — a session, a host, a state store. */
+  class SomethingWeCannotSupply
+
+  @JvmStatic
+  @Suppress("unused")
+  suspend fun GlanceAppWidget.composeForPreview(
+    context: Context,
+    host: SomethingWeCannotSupply,
+  ): RemoteViews = RemoteViews(context.packageName, 0)
+}
+
+/** The composer throws from inside the user's composition — the ordinary preview-bug path. */
+object ThrowingComposerFixture {
+
+  @JvmStatic
+  @Suppress("unused")
+  suspend fun GlanceAppWidget.composeForPreview(
+    context: Context,
+    widgetCategory: Int,
+    info: AppWidgetProviderInfo? = null,
+  ): RemoteViews = throw IllegalStateException("preview threw at $widgetCategory")
+}
+
+/** A composer that hands back something that is not `RemoteViews`. */
+object WrongReturnComposerFixture {
+
+  @JvmStatic
+  @Suppress("unused")
+  suspend fun GlanceAppWidget.composeForPreview(
+    context: Context,
+    widgetCategory: Int,
+    info: AppWidgetProviderInfo? = null,
+  ): String = "not a RemoteViews"
+}

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/RenderErrorSidecarDiagnosisTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/RenderErrorSidecarDiagnosisTest.kt
@@ -1,0 +1,64 @@
+package ee.schimke.composeai.renderer
+
+import java.io.File
+import java.nio.file.Files
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The Android sidecar's `diagnosis` field — the one actionable sentence for a failure that is about
+ * the *render classpath* rather than about the preview's own code.
+ *
+ * The desktop renderer has carried this field since the native-load work (issue #3690); the Android
+ * path wrote every failure as bare exception + stack trace. That reads badly for the Glance
+ * version-floor failure (compose-ai-tools#5056), which takes out every app-widget preview in a
+ * module at once and whose stack trace points at our renderer rather than at anything the project
+ * did — exactly the case a one-line diagnosis exists for.
+ */
+class RenderErrorSidecarDiagnosisTest {
+
+  private fun writeSidecar(e: Throwable): String {
+    val dir = Files.createTempDirectory("render-error-sidecar").toFile()
+    val png = File(dir, "GlanceWidget.png")
+    RenderErrorSidecar.write(png, e)
+    return RenderErrorSidecar.pathFor(png).readText()
+  }
+
+  @Test
+  fun `carries the Glance version-floor sentence as the diagnosis`() {
+    val json =
+      writeSidecar(
+        GlanceComposerUnavailableException(
+          "No usable Glance app-widget composer on the render classpath. Upgrade to 1.2.0."
+        )
+      )
+
+    assertTrue(json, json.contains("\"diagnosis\":\"No usable Glance app-widget composer"))
+    assertTrue(json, json.contains("Upgrade to 1.2.0."))
+    assertTrue(json, json.contains("\"exception\":\"ee.schimke.composeai.renderer."))
+  }
+
+  @Test
+  fun `finds the diagnosis through a wrapping exception`() {
+    // The renderer wraps per-preview failures on the way out of the Robolectric harness; a
+    // diagnosis buried one cause deep is still the diagnosis.
+    val json =
+      writeSidecar(
+        RuntimeException(
+          "Failed to render GlanceWidget",
+          GlanceComposerUnavailableException("Upgrade glance-appwidget to 1.2.0 or newer."),
+        )
+      )
+
+    assertTrue(json, json.contains("\"diagnosis\":\"Upgrade glance-appwidget to 1.2.0 or newer.\""))
+  }
+
+  @Test
+  fun `leaves the field off an ordinary preview throw`() {
+    val json = writeSidecar(IllegalStateException("lateinit property viewModel is not initialized"))
+
+    assertFalse(json, json.contains("\"diagnosis\""))
+    assertTrue(json, json.contains("lateinit property viewModel"))
+  }
+}


### PR DESCRIPTION
Fixes #5056.

## The defect

`GlanceAppWidgetPreviewRenderer` called `composeForPreview(context, widgetCategory, info)` as an ordinary compiled call site, linked against the `glance-appwidget = "1.2.0"` pin in `gradle/libs.versions.toml`. Under the import model the render runs against the *project's* Glance — and `composeForPreview` **did not exist before 1.2.0**, so every app-widget preview in a project on 1.0.0/1.1.x died with `NoSuchMethodError` naming line 71 of our renderer rather than anything the project did.

I checked what actually changed in that API, which the issue asked for first, by `javap`-ing the published AARs:

| Version | `AppWidgetComposerKt` static entry points taking a `GlanceAppWidget` receiver |
| --- | --- |
| 1.0.0 | `compose-DR8WL-M(GlanceAppWidget, Context, GlanceId, Bundle, DpSize, Object)` |
| 1.1.0, 1.1.1 | `compose-DR8WL-M(…)` — plus `runComposition(…): Flow<RemoteViews>` |
| 1.2.0 | `compose-DR8WL-M(…)`, **`composeForPreview(GlanceAppWidget, Context, int, AppWidgetProviderInfo)`** |
| 1.3.0-alpha01/02 | identical to 1.2.0 |

So `composeForPreview` is not a *changed* signature — it is simply absent below 1.2.0, which is why the class resolved and the method did not. `GlanceAppWidget.providePreview` and `PreviewSizeMode` arrived in the same release; `provideContent` and the `compose` extension have been stable since 1.0.0.

## The change

- **`GlanceComposeForPreview.kt`** (new) resolves the composer reflectively off the render classpath and fills its parameters **by type, not by position**, so a later release that adds or drops an argument still resolves as long as the type is one we can supply. Resolution order is `composeForPreview` (the preview path proper — honours `widgetCategory` and `PreviewSizeMode`), else the `compose` extension present since 1.0.0. `compose` is matched through Kotlin's value-class name mangling (`DpSize` makes it `compose-DR8WL-M`) on the part before the hyphen, since that hash is a function of the signature and free to move between releases.
- **Suspend bridging** goes through `suspendCoroutineUninterceptedOrReturn`, which implements exactly the `(…, Continuation) -> result | COROUTINE_SUSPENDED` contract a `suspend fun` compiles to. `InvocationTargetException` is unwrapped so a throw from inside the user's `@Composable` reaches the sidecar as itself, with the preview author's frames on `topAppFrame`.
- **`SyntheticGlanceAppWidget` provides the same content from `providePreview` and `provideGlance`.** The 1.2.0+ path composes through the former, the pre-1.2.0 `compose` fallback through the latter; sharing one body keeps the capture identical whichever entry point the project's Glance offers. `provideGlance` is dead code on 1.2.0+, as before.
- **Bounded failure when nothing matches.** `GlanceComposerUnavailableException` names the methods it did find, where the jar was loaded from, and the 1.2.0 floor. `RenderErrorSidecar` now emits the `diagnosis` field the schema has carried since #3690 (searching the cause chain), so that sentence lands on the card instead of a stack trace pointing into our renderer.
- **`docs/RENDERER_COMPATIBILITY.md`** gains a "Known findings" entry with the version table and where to edit when a new Glance shape appears.
- `testImplementation(libs.glance.appwidget)` — the fixtures extend `GlanceAppWidget`; the artefact stays `compileOnly` for consumers, same precedent as the coil pair above it.

Not in scope: `:glance-preview-runtime`'s `GlanceAppWidgetContent` has the same compiled call site, but it declares `api(libs.glance.appwidget)`, so Gradle's conflict resolution floors its consumers at 1.2.0 — it is not the reported failure and I left it alone.

## Test plan

- `GlanceComposeForPreviewTest` (12 tests, Robolectric) drives the version shapes compiled into `GlanceComposerFixtures.kt` — transcribed from the AARs above, because reflection over *compiled* signatures is the point and six Glance versions cannot share one classpath. It covers: resolving `composeForPreview` on the 1.2.0 shape; falling back to `compose` on 1.1.x; matching through the value-class mangling; preferring `composeForPreview` when both exist; resolving a future signature that grows a `DpSize`; refusing a composer whose parameters we cannot fill (message names the 1.2.0 floor); a classpath with no Glance at all; filling arguments by type on invocation; passing the size and nulling the rest on the fallback; propagating the composition's own exception unwrapped; refusing a non-`RemoteViews` return — plus one test that resolves against the **real** pinned Glance, so a version bump that moves the signature fails here rather than in someone's import.
- `RenderErrorSidecarDiagnosisTest` (3 tests): the sentence lands in `diagnosis`, is found through a wrapping exception, and the field stays off an ordinary preview throw.
- `./gradlew ktfmtCheckAll` — clean.
- End-to-end: `./gradlew :samples:android:composePreviewRender --preview NativeGlanceWidgetPreview --preview DefaultedGlanceWidgetPreview` renders both, no error sidecars.

**Visual evidence — deliberately none, and here is the proof it is correct.** On the pinned Glance 1.2.0 the resolver selects the same `composeForPreview` the old compiled call site linked, so the pixels must not move. I rendered the sample's two Glance previews on `origin/main` and on this branch and compared the PNGs byte-for-byte:

```
IDENTICAL DefaultedGlanceWidgetPreview-81c975f6.png
IDENTICAL NativeGlanceWidgetPreview-2226727b.png
```

The behaviour change is only visible on a Glance version this repository does not build against, which is exactly what the fixtures stand in for.

## Follow-up

The five `home-assistant/android` previews (`ScreenPreview`, `ScreenPreviewEmpty`, `ScreenPreviewEmptyItems`, `ScreenPreviewLoading`, `ScreenPreviewOutOfSync`) are excluded in `imports/home-assistant-android/import.json` in `yschimke/compose-preview-imports` for this defect. That repository is not in this session's scope, so restoring them is a separate change there — worth re-running that import once this lands to confirm which path their Glance resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjUL47DkAeSr9MTEybg29C

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjUL47DkAeSr9MTEybg29C)_