### PR TITLE
fix(daemon): recognise Compose Multiplatform's own @Preview in incremental discovery

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/IncrementalDiscovery.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/IncrementalDiscovery.kt
@@ -398,6 +398,11 @@ public class IncrementalDiscovery(
       setOf(
         "androidx.compose.ui.tooling.preview.Preview",
         "androidx.compose.desktop.ui.tooling.preview.Preview",
+        // Compose Multiplatform's own @Preview (`compose.components.uiToolingPreview`), which the
+        // authoritative pass has recognised since `PreviewDiscovery.CMP_PREVIEW_FQN`. Without it a
+        // commonMain preview written against the CMP-bundled artifact is discovered by the gradle
+        // plugin and skipped by the daemon — the same snippet behaving differently in the editor.
+        "org.jetbrains.compose.ui.tooling.preview.Preview",
         "androidx.wear.tiles.tooling.preview.Preview",
       )
 

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/IncrementalDiscoveryTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/IncrementalDiscoveryTest.kt
@@ -41,6 +41,30 @@ class IncrementalDiscoveryTest {
     )
 
   // -----------------------------------------------------------------------
+  // DEFAULT_PREVIEW_ANNOTATION_FQNS
+  // -----------------------------------------------------------------------
+
+  /**
+   * The mirrored set has to carry every `@Preview` the authoritative `:gradle-plugin` pass reads,
+   * or the same file yields previews under Gradle and none in the editor. Asserted as literals
+   * because `:daemon:core` cannot depend on `:gradle-plugin` — see the kdoc on the set itself.
+   */
+  @Test
+  fun `default set carries the androidx, desktop and CMP Preview FQNs`() {
+    for (fqn in
+      listOf(
+        "androidx.compose.ui.tooling.preview.Preview",
+        "androidx.compose.desktop.ui.tooling.preview.Preview",
+        "org.jetbrains.compose.ui.tooling.preview.Preview",
+      )) {
+      assertTrue(
+        "the mirrored default set must recognise $fqn",
+        fqn in IncrementalDiscovery.DEFAULT_PREVIEW_ANNOTATION_FQNS,
+      )
+    }
+  }
+
+  // -----------------------------------------------------------------------
   // cheapPrefilter
   // -----------------------------------------------------------------------
 


### PR DESCRIPTION
## What was wrong

`IncrementalDiscovery.DEFAULT_PREVIEW_ANNOTATION_FQNS` is a deliberate copy of `:gradle-plugin`'s `PreviewDiscovery.PREVIEW_FQNS` (sharing would invert the daemon's layering), and it had drifted. The authoritative pass has read `org.jetbrains.compose.ui.tooling.preview.Preview` — CMP's own `@Preview`, from `compose.components.uiToolingPreview` — since `CMP_PREVIEW_FQN` was added; the daemon's copy never picked it up.

So a commonMain preview written against the CMP-bundled artifact is discovered under Gradle and skipped in the editor: the same file, two answers, which is exactly the failure mode the "duplicating ~3 FQNs is the cheap fix" comment accepts the risk of.

## What changed

One FQN added to the mirrored set, with a comment saying where it comes from and what its absence cost.

## Test plan

`./gradlew :daemon:core:test --tests '*IncrementalDiscoveryTest*'` — green.

New test asserts the mirrored set carries the androidx, desktop and CMP FQNs, as literals (the module cannot depend on `:gradle-plugin` to compare against the real set) — so the next drift in this direction fails a test rather than a user's editor.

Non-visual change — no render evidence applies.

## Related

Found while fixing the playground's copy of the same set, which had the opposite gap: yschimke/compose-preview-server#281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmbch2jodkroHf6ykRwGEo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmbch2jodkroHf6ykRwGEo)_