### PR TITLE
fix(renderer-android): let Glance default its own composer parameters

### DIFF
--- a/docs/RENDERER_COMPATIBILITY.md
+++ b/docs/RENDERER_COMPATIBILITY.md
@@ -282,6 +282,15 @@ resolves:
 | 1.0.0 – 1.1.1 | `compose(…, size, …)` — the only one there is | `provideGlance` |
 | neither matches | `GlanceComposerUnavailableException` | — |
 
+Parameters the renderer has no value for — the `GlanceId`, the options
+`Bundle`, the widget state — are **not** passed as `null`: the call goes through
+Kotlin's `$default` bridge with a mask, so Glance substitutes its own defaults.
+That distinction is load-bearing rather than tidy. 1.1.x defaults
+`compose(id = …)` to `createFakeAppWidgetId()` and then casts it to
+`AppWidgetId`, so a hand-written `null` dies with an NPE inside
+`runComposition` — verified by forcing the sample down to `glance-appwidget`
+1.1.1 and rendering, which is the only way to exercise the fallback at all.
+
 The synthetic widget provides the same content from both entry points, so the
 capture does not depend on which one the consumer's version offers. When nothing
 matches, the failure is bounded and named: the exception's message reaches the

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/GlanceComposeForPreview.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/GlanceComposeForPreview.kt
@@ -71,8 +71,11 @@ internal object GlanceComposeForPreview {
     ABSENT,
   }
 
-  /** A composer method plus how to fill its parameters. Produced by [resolve] / [resolveIn]. */
-  class Plan(val method: Method, val arguments: List<Argument>) {
+  /**
+   * A composer method plus how to fill its parameters, and — when some of them are
+   * [Argument.ABSENT] — the `$default` bridge that lets Glance fill those itself.
+   */
+  class Plan(val method: Method, val arguments: List<Argument>, val defaults: Method?) {
 
     /**
      * True when this plan calls `composeForPreview` — the 1.2.0+ path, which composes through
@@ -85,6 +88,26 @@ internal object GlanceComposeForPreview {
     /** Parameters the renderer supplies a real value for — the tie-break in [resolveIn]. */
     internal val suppliedArgumentCount: Int
       get() = arguments.count { it != Argument.ABSENT }
+
+    /**
+     * Kotlin's defaults bitmask for the [Argument.ABSENT] parameters: bit *i* set asks the bridge
+     * to substitute the default of the *i*-th **value** parameter. The receiver is not one, so the
+     * numbering starts at the parameter after [Argument.WIDGET].
+     */
+    internal val defaultsMask: Int =
+      arguments.drop(1).foldIndexed(0) { i, mask, argument ->
+        if (argument == Argument.ABSENT) mask or (1 shl i) else mask
+      }
+
+    /**
+     * Whether [compose] goes through [defaults] rather than [method]. `null` is the wrong value for
+     * a parameter whose default is not `null` — Glance 1.1.x defaults `compose(id = …)` to
+     * `createFakeAppWidgetId()` and then casts it to `AppWidgetId`, so passing our own `null`
+     * straight to the real method died with an NPE inside `runComposition` (compose-ai-tools#5056).
+     * The bridge is what makes "leave this parameter to the library" expressible at all.
+     */
+    internal val usesDefaults: Boolean
+      get() = defaults != null && defaultsMask != 0
 
     /** `composeForPreview(WIDGET, CONTEXT, WIDGET_CATEGORY, PROVIDER_INFO)` — for diagnostics. */
     fun describe(): String = "${method.name}(${arguments.joinToString(", ")})"
@@ -119,7 +142,7 @@ internal object GlanceComposeForPreview {
    * without six Glance versions on one test classpath.
    */
   fun resolveIn(composerClass: Class<*>): Plan {
-    val plans = composerClass.methods.mapNotNull { planFor(it) }
+    val plans = composerClass.methods.mapNotNull { planFor(it, composerClass) }
     val best =
       plans
         .sortedWith(
@@ -170,7 +193,13 @@ internal object GlanceComposeForPreview {
         Argument.ABSENT -> null
       }
     }
-    val result = invokeSuspending(method, args)
+    val result =
+      if (usesDefaults) {
+        // The bridge takes (…real args…, Continuation, mask, marker); the marker is always null.
+        invokeSuspending(defaults!!, args, listOf(defaultsMask, null))
+      } else {
+        invokeSuspending(method, args)
+      }
     return result as? RemoteViews
       ?: throw GlanceComposerUnavailableException(
         "${describe()} returned ${result?.javaClass?.name ?: "null"} rather than RemoteViews. " +
@@ -185,7 +214,7 @@ internal object GlanceComposeForPreview {
    * knows how to fill. Kotlin's `$default` bridges are skipped: they take a bitmask and a marker we
    * would have to synthesise, and the real method is always right beside them.
    */
-  private fun planFor(method: Method): Plan? {
+  private fun planFor(method: Method, composerClass: Class<*>): Plan? {
     if (!Modifier.isStatic(method.modifiers)) return null
     if (method.name.contains("\$default")) return null
     val base = baseName(method.name)
@@ -199,8 +228,24 @@ internal object GlanceComposeForPreview {
     for (i in 2 until params.size - 1) {
       middle += argumentFor(params[i]) ?: return null
     }
-    return Plan(method, listOf(Argument.WIDGET, Argument.CONTEXT) + middle)
+    return Plan(
+      method,
+      listOf(Argument.WIDGET, Argument.CONTEXT) + middle,
+      defaultsFor(method, composerClass),
+    )
   }
+
+  /**
+   * The `$default` bridge beside [method], or null when the overload has no defaulted parameters at
+   * all. Kotlin emits it right next to the real method with two extra trailing parameters — the
+   * bitmask and an always-null marker — which is the shape [Plan.compose] fills.
+   */
+  private fun defaultsFor(method: Method, composerClass: Class<*>): Method? =
+    composerClass.methods.firstOrNull {
+      Modifier.isStatic(it.modifiers) &&
+        it.name == method.name + "\$default" &&
+        it.parameterCount == method.parameterCount + 2
+    }
 
   /** What the renderer would pass in a parameter of [type], or null when it has nothing to pass. */
   private fun argumentFor(type: Class<*>): Argument? =
@@ -244,15 +289,19 @@ internal object GlanceComposeForPreview {
    * coroutine. Reflection's `InvocationTargetException` is unwrapped so a throw from inside the
    * user's `@Composable` reaches the sidecar as itself.
    */
-  private suspend fun invokeSuspending(method: Method, args: List<Any?>): Any? =
-    suspendCoroutineUninterceptedOrReturn { continuation ->
-      runCatching { method.isAccessible = true }
-      try {
-        method.invoke(null, *(args.toTypedArray() + continuation))
-      } catch (e: InvocationTargetException) {
-        throw e.cause ?: e
-      }
+  private suspend fun invokeSuspending(
+    method: Method,
+    args: List<Any?>,
+    trailing: List<Any?> = emptyList(),
+  ): Any? = suspendCoroutineUninterceptedOrReturn { continuation ->
+    runCatching { method.isAccessible = true }
+    val all = (args + continuation + trailing).toTypedArray()
+    try {
+      method.invoke(null, *all)
+    } catch (e: InvocationTargetException) {
+      throw e.cause ?: e
     }
+  }
 }
 
 /**

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/GlanceComposeForPreviewTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/GlanceComposeForPreviewTest.kt
@@ -172,7 +172,11 @@ class GlanceComposeForPreviewTest {
   }
 
   @Test
-  fun `hands the pre-1_2_0 compose fallback the size and nulls the rest`() {
+  fun `hands the pre-1_2_0 compose fallback the size and defaults the rest`() {
+    // Not nulls: Glance 1.1.x defaults `compose(id = …)` to `createFakeAppWidgetId()` and then
+    // casts it to `AppWidgetId`, so our own null died with an NPE inside `runComposition` — the
+    // real 1.1.1 failure this path was written for. Going through the `${'$'}default` bridge is
+    // what lets the library fill its own parameters.
     val plan = GlanceComposeForPreview.resolveIn(Glance11xComposerFixture::class.java)
 
     runBlocking {
@@ -186,9 +190,34 @@ class GlanceComposeForPreviewTest {
     }
 
     assertEquals(
-      listOf("compose(id=null, options=null, size=${DpSize(300.dp, 200.dp)}, state=null)"),
+      listOf(
+        "compose(id=fake-widget-id, options=null, " +
+          "size=${DpSize(300.dp, 200.dp)}, state=library-default-state)"
+      ),
       GlanceComposerCalls.recorded,
     )
+  }
+
+  @Test
+  fun `masks exactly the parameters it has no value for`() {
+    val plan = GlanceComposeForPreview.resolveIn(Glance11xComposerFixture::class.java)
+
+    assertNotNull("the compose overload has defaults, so a bridge must exist", plan.defaults)
+    // Value parameters, receiver excluded: context=0, id=1, options=2, size=3, state=4. We supply
+    // context and size; the other three are the library's to fill.
+    assertEquals(0b10110, plan.defaultsMask)
+    assertTrue(plan.usesDefaults)
+  }
+
+  @Test
+  fun `calls the real method directly when it fills every parameter`() {
+    // The 1.2.0 path supplies all of context, widgetCategory and info, so there is nothing to
+    // default and the bridge stays out of it — the call is exactly what the old compiled call site
+    // made, which is why the pinned-Glance renders are byte-identical.
+    val plan = GlanceComposeForPreview.resolveIn(Glance120ComposerFixture::class.java)
+
+    assertEquals(0, plan.defaultsMask)
+    assertFalse(plan.usesDefaults)
   }
 
   @Test

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/GlanceComposerFixtures.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/GlanceComposerFixtures.kt
@@ -25,6 +25,11 @@ import androidx.glance.appwidget.GlanceAppWidget
  * Each fixture records what it was handed so the invocation tests can assert the renderer filled
  * the parameters by *type*, not by position.
  */
+/** A stand-in for the `createFakeAppWidgetId()` Glance 1.1.x defaults its `compose(id = …)` to. */
+object FixtureGlanceId : GlanceId {
+  override fun toString(): String = "fake-widget-id"
+}
+
 object GlanceComposerCalls {
   /** `"composeForPreview(widgetCategory=1, info=…)"`-ish trace of the last call, per fixture. */
   val recorded: MutableList<String> = mutableListOf()
@@ -69,14 +74,19 @@ object Glance120ComposerFixture {
  */
 object Glance11xComposerFixture {
 
+  /**
+   * `id` and `state` carry **non-null** defaults, mirroring 1.1.x's own `createFakeAppWidgetId()`:
+   * that is the difference between calling the real method with our `null` — which died in
+   * `runComposition`'s `as AppWidgetId` cast — and calling the `$default` bridge with a mask.
+   */
   @JvmStatic
   @Suppress("unused")
   suspend fun GlanceAppWidget.compose(
     context: Context,
-    id: GlanceId? = null,
+    id: GlanceId = FixtureGlanceId,
     options: Bundle? = null,
     size: DpSize? = null,
-    state: Any? = null,
+    state: Any? = "library-default-state",
   ): RemoteViews {
     GlanceComposerCalls.recorded += "compose(id=$id, options=$options, size=$size, state=$state)"
     return RemoteViews(context.packageName, 0)


### PR DESCRIPTION
Follow-up to #5149, same issue (#5056). That PR's pre-1.2.0 fallback was covered only by compiled fixtures; this is what happened the first time it ran against a **real** old Glance.

## What the real 1.1.1 run showed

Forcing `samples/android` down to `glance-appwidget:1.1.1` (renderer still compiled against 1.2.0 — exactly the import scenario) and rendering the two Glance previews:

```
java.lang.NullPointerException: null cannot be cast to non-null type
  androidx.glance.appwidget.AppWidgetId
  at AppWidgetComposerKt$runComposition$1.invokeSuspend(AppWidgetComposer.kt:84)
  at AppWidgetComposerKt.compose-DR8WL-M(AppWidgetComposer.kt:59)
  at GlanceComposeForPreview.invokeSuspending(GlanceComposeForPreview.kt:251)
```

Resolution and invocation were right — it found `compose-DR8WL-M` and called it. The **argument values** were wrong. `null` is the wrong value for a parameter whose default is not `null`, and the `$default` bridge's own bytecode says what 1.1.x actually substitutes:

```
0: iload 7; iconst_2; iand; ifeq 14
7: invokestatic  AppWidgetUtilsKt.createFakeAppWidgetId:()Landroidx/glance/appwidget/AppWidgetId;
```

Bit 1 ⇒ a *fake app-widget id*, which `runComposition` then casts. Calling the real method directly bypasses every default the library declares.

## The change

Parameters the renderer has no value for (`GlanceId`, options `Bundle`, widget state) now go through Kotlin's `$default` bridge with a mask, so Glance fills them itself rather than receiving our nulls. `Plan` gained the sibling bridge and a `defaultsMask` computed over the *value* parameters (the receiver is not one, so numbering starts after `WIDGET`).

The 1.2.0 path supplies every parameter, so its mask is zero and the bridge stays out of it — the call is byte-for-byte what the old compiled call site made.

## Test plan

- **Real Glance 1.1.1, end-to-end**: with the sample forced to 1.1.1, `NativeGlanceWidgetPreview` and `DefaultedGlanceWidgetPreview` both render, no `.error.json`, and the PNGs are **byte-identical** to the pinned-1.2.0 renders. Before this change the same run produced two error sidecars and no PNGs. (The forcing edits were experiment-only and are not in this diff; the sample's own widget also had to drop its `providePreview` override, since that method doesn't exist before 1.2.0.)
- **Pinned Glance 1.2.0**: the same two previews still render byte-identically to `main` — the mask is zero there, so nothing about that path moved.
- `GlanceComposeForPreviewTest` is now 14 tests. The 1.1.x fixture's `id`/`state` carry non-null defaults mirroring `createFakeAppWidgetId()`, so the fallback test distinguishes "the library defaulted it" from "we passed null" — the exact confusion that produced the NPE. Two new tests pin the mask (`0b10110` for the 1.1.x shape) and assert the 1.2.0 shape masks nothing.
- `RenderErrorSidecarDiagnosisTest` unchanged, 3 tests green. `./gradlew ktfmtCheckAll` clean.

Visual evidence is deliberately text: every render above is byte-identical to `main`'s, on both Glance versions, which is the claim being made.

## Note on the import

`imports/home-assistant-android/import.json` in `yschimke/compose-preview-imports` still excludes the five Glance previews. Restoring them needs a **release** carrying both this and #5149 — that pipeline installs the CLI at `latest`, and 1.78.0 predates both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjUL47DkAeSr9MTEybg29C

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjUL47DkAeSr9MTEybg29C)_