### PR TITLE
feat(design-artifacts): expose an imported project's themes

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -1755,7 +1755,56 @@ jobs:
           path: compose-ai-tools
           persist-credentials: false
 
-
+      # ---- Themes an imported project cannot declare for itself ---------------------------------
+      #
+      # A catalog's Theme control is fed by `@ThemeCatalog` providers, an annotation from this
+      # toolchain — so a project imported without its maintainers' involvement can never fill it,
+      # and every imported catalog served an empty control no matter how many palettes the upstream
+      # actually has (Pocket Casts nine, Twine twelve, Thunderbird's Bolt two brands). The spec
+      # describes them; this writes the providers into the throwaway checkout before anything
+      # compiles, and the rest of the pipeline sees an ordinary module that declares its themes.
+      #
+      # Runs for FIRST-PARTY callers too, and is a no-op for them: a spec that declares no `themes`
+      # exits having written nothing, so this needs no `upstream-repository` guard and a first-party
+      # catalog that ever wants a generated theme is not locked out of one.
+      - name: Generate declared theme providers
+        env:
+          SPEC: ${{ inputs.spec }}
+          MODULE: ${{ inputs.module }}
+          WORKDIR: ${{ inputs.working-directory }}
+          SOURCE_ROOT: ${{ inputs.upstream-repository != '' && 'upstream' || '' }}
+        run: |
+          set -euo pipefail
+          if ! grep -q '"themes"' "$SPEC"; then
+            echo "spec declares no themes — nothing to generate"
+            exit 0
+          fi
+          if [ -z "${MODULE:-}" ]; then
+            echo "::error::a spec declaring 'themes' must also name the 'module' the providers" \
+                 "compile into — they have to see the theme composables, which repository-wide" \
+                 "discovery cannot pick a home for."
+            exit 1
+          fi
+          # Same module-path resolution as the runtime-projects step: the derived path first, then
+          # whatever settings.gradle remaps `projectDir` to, because `project(":app").projectDir =
+          # file(...)` puts a module where its Gradle path does not say.
+          root="${SOURCE_ROOT:+$SOURCE_ROOT/}${WORKDIR:+$WORKDIR/}"
+          derived="$(printf '%s' "${MODULE#:}" | tr ':' '/')"
+          remapped="$(
+            cat "${root}settings.gradle" "${root}settings.gradle.kts" 2>/dev/null |
+              sed -n "s|.*project(['\"]${MODULE}['\"])\.projectDir[[:space:]]*=[[:space:]]*[Ff]ile(['\"]\([^'\"]*\)['\"]).*|\1|p" |
+              head -1
+          )" || true
+          if [ -n "$remapped" ]; then derived="$remapped"; fi
+          module_dir="${root}${derived}"
+          [ -d "$module_dir" ] || { echo "::error::module directory not found: $module_dir"; exit 1; }
+          # The generated providers reference @ThemeCatalog, so the module needs the annotation
+          # artifact. Pinned to the CLI actually installed rather than written here a second time:
+          # the two ship from one release, and a hardcoded version would rot at the next one.
+          version="$(compose-preview --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+          [ -n "$version" ] || { echo "::error::could not read a version from 'compose-preview --version'"; exit 1; }
+          node "$GITHUB_WORKSPACE/compose-ai-tools/scripts/design-artifacts/generate-theme-catalogs.mjs" \
+            --spec "$SPEC" --module-dir "$module_dir" --annotations-version "$version"
       - name: Build compose-preview CLI from source
         if: ${{ inputs.cli-source == 'build' }}
         working-directory: compose-ai-tools
@@ -2682,6 +2731,56 @@ jobs:
           path: compose-ai-tools
           persist-credentials: false
 
+      # ---- Themes an imported project cannot declare for itself ---------------------------------
+      #
+      # A catalog's Theme control is fed by `@ThemeCatalog` providers, an annotation from this
+      # toolchain — so a project imported without its maintainers' involvement can never fill it,
+      # and every imported catalog served an empty control no matter how many palettes the upstream
+      # actually has (Pocket Casts nine, Twine twelve, Thunderbird's Bolt two brands). The spec
+      # describes them; this writes the providers into the throwaway checkout before anything
+      # compiles, and the rest of the pipeline sees an ordinary module that declares its themes.
+      #
+      # Runs for FIRST-PARTY callers too, and is a no-op for them: a spec that declares no `themes`
+      # exits having written nothing, so this needs no `upstream-repository` guard and a first-party
+      # catalog that ever wants a generated theme is not locked out of one.
+      - name: Generate declared theme providers
+        env:
+          SPEC: ${{ inputs.spec }}
+          MODULE: ${{ inputs.module }}
+          WORKDIR: ${{ inputs.working-directory }}
+          SOURCE_ROOT: ${{ inputs.upstream-repository != '' && 'upstream' || '' }}
+        run: |
+          set -euo pipefail
+          if ! grep -q '"themes"' "$SPEC"; then
+            echo "spec declares no themes — nothing to generate"
+            exit 0
+          fi
+          if [ -z "${MODULE:-}" ]; then
+            echo "::error::a spec declaring 'themes' must also name the 'module' the providers" \
+                 "compile into — they have to see the theme composables, which repository-wide" \
+                 "discovery cannot pick a home for."
+            exit 1
+          fi
+          # Same module-path resolution as the runtime-projects step: the derived path first, then
+          # whatever settings.gradle remaps `projectDir` to, because `project(":app").projectDir =
+          # file(...)` puts a module where its Gradle path does not say.
+          root="${SOURCE_ROOT:+$SOURCE_ROOT/}${WORKDIR:+$WORKDIR/}"
+          derived="$(printf '%s' "${MODULE#:}" | tr ':' '/')"
+          remapped="$(
+            cat "${root}settings.gradle" "${root}settings.gradle.kts" 2>/dev/null |
+              sed -n "s|.*project(['\"]${MODULE}['\"])\.projectDir[[:space:]]*=[[:space:]]*[Ff]ile(['\"]\([^'\"]*\)['\"]).*|\1|p" |
+              head -1
+          )" || true
+          if [ -n "$remapped" ]; then derived="$remapped"; fi
+          module_dir="${root}${derived}"
+          [ -d "$module_dir" ] || { echo "::error::module directory not found: $module_dir"; exit 1; }
+          # The generated providers reference @ThemeCatalog, so the module needs the annotation
+          # artifact. Pinned to the CLI actually installed rather than written here a second time:
+          # the two ship from one release, and a hardcoded version would rot at the next one.
+          version="$(compose-preview --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+          [ -n "$version" ] || { echo "::error::could not read a version from 'compose-preview --version'"; exit 1; }
+          node "$GITHUB_WORKSPACE/compose-ai-tools/scripts/design-artifacts/generate-theme-catalogs.mjs" \
+            --spec "$SPEC" --module-dir "$module_dir" --annotations-version "$version"
       # ---- The two embedded player lanes' harness, when a caller asked for them ----------------
       #
       # `:third-party-rc-embedded-player` (Robolectric, both Android columns) and

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -256,6 +256,63 @@ system's own. Because M3 role labels repeat across themes, that made a system's 
 whichever sheet the bundle happened to yield last; splitting them fixed the system set as well as
 adding the themes.
 
+### Themes an imported project cannot declare (`themes` in `catalog.spec.json`)
+
+Every mechanism above starts at a `@ThemeCatalog` provider, which is an annotation from this
+toolchain. An **import** — somebody else's repository, built by
+[`compose-preview-imports`](https://github.com/yschimke/compose-preview-imports) without their
+involvement — has no dependency on it and never will. So for as long as themes were annotation-only,
+every imported catalog served an **empty Theme control**: not because the upstream had one theme, but
+because nothing could say it had more. Pocket Casts ships nine palettes, Twine twelve, and
+Thunderbird's Bolt two brands crossed with light and dark; `preview.coo.ee` could show none of them,
+even though each import now publishes an executable live bundle that could re-render under any of
+them on request.
+
+A spec's `themes[]` closes it, the same way `groups` closes the missing `@CatalogComponent`
+annotations: the inventory is written down in the import, and
+[`generate-theme-catalogs.mjs`](../../scripts/design-artifacts/generate-theme-catalogs.mjs) writes
+the providers into the **throwaway checkout** before anything compiles — beside the module's own
+sources, so an `internal` theme composable (Twine's `AppTheme`) is reachable. Discovery then scans an
+ordinary module that declares its themes, and nothing downstream learns that an import exists: the
+chips, `?theme=theme:<providerFqn>`, and one `themes/<fqn>.dtcg.json` per theme all follow.
+
+An entry is a **shape**, not a snippet, because across fifteen imports the upstreams reach for the
+same four — and a shape carries what a snippet throws away: which themes are one family, which are
+light and which dark, and what a reviewer is agreeing to in the import's pull request. The shapes are
+in [`theme-adapters.mjs`](../../scripts/design-artifacts/theme-adapters.mjs), which is pure and
+unit-tested without an `npm ci`:
+
+| `kind` | The upstream shape | Seen in |
+| --- | --- | --- |
+| `enum` | one theme composable over an enum's constants — `AppThemeWithBackground(LIGHT) { }` | Pocket Casts (9), Twine (12) |
+| `functions` | a whole composable per theme — `ThunderbirdBoltTheme { }` | Thunderbird's Bolt (2 brands) |
+| `modes` | one composable with a boolean dark parameter — `ElementTheme(darkTheme = true) { }` | Element X, Bitwarden |
+| `arguments` | one composable, a named-argument list per theme | the general form of the three above |
+| `wrapper` | a raw Kotlin body | the escape hatch |
+
+```json
+"themes": [
+  { "kind": "enum", "group": "Pocket Casts",
+    "composable": "au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground",
+    "enum": "au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType",
+    "values": ["LIGHT", "DARK", "EXTRA_DARK", "ELECTRIC"] }
+]
+```
+
+Two decisions worth stating, because both look like omissions:
+
+- **The constants are listed, not reflected.** Generation runs before the upstream compiles, so
+  there is nothing to reflect against — and a listed constant that does not exist fails the module's
+  compile *by name*, which is a better error than a catalog that is quietly one palette short.
+- **Nothing extra is baked.** The generated themes are a *live* axis: the switcher re-renders through
+  the published bundle and the serve host's theme cache, exactly as `modePriority`'s deferred
+  palettes do. Baking nine palettes × every component is the cost that design was built to avoid, and
+  an import — re-rendered nightly for a project we do not control — is the last place to pay it.
+
+First-party catalogs annotate their providers beside the code and omit `themes` entirely. The step
+runs for them too and is a no-op, so the seam is not import-only by construction; it is import-only
+by who needs it.
+
 ### Delivery-branch history
 
 Each publish **appends a commit on top of the branch tip** rather than

--- a/scripts/design-artifacts/catalog.spec.schema.json
+++ b/scripts/design-artifacts/catalog.spec.schema.json
@@ -33,6 +33,71 @@
       "description": "Informational: the theme modes the sticker sheet covers (e.g. [\"light\", \"dark\"]).",
       "items": { "type": "string" }
     },
+    "themes": {
+      "type": "array",
+      "description": "Themes an IMPORTED project has but cannot declare for itself. A first-party catalog annotates its own `PreviewWrapperProvider` classes with @ThemeCatalog / @WearThemeCatalog beside the code and omits this entirely; a project imported without its maintainers' involvement has no dependency on those annotations, so its palettes are described HERE and the providers are generated into the throwaway checkout before discovery runs (scripts/design-artifacts/generate-theme-catalogs.mjs). Each entry expands to one or more providers, which is what puts chips in the served catalog's Theme control, makes `?theme=theme:<providerFqn>` re-render under them, and publishes a `themes/<fqn>.dtcg.json` token set each. Same bargain as `groups`: the inventory is our description of somebody else's code, and it stays in our repository.",
+      "items": {
+        "type": "object",
+        "required": ["kind"],
+        "additionalProperties": false,
+        "description": "One theme shape. `kind` picks how the theme is called: the four structured kinds cover what upstreams actually do, and `wrapper` is the escape hatch for a call none of them spells.",
+        "properties": {
+          "kind": {
+            "enum": ["enum", "functions", "modes", "arguments", "wrapper"],
+            "description": "`enum`: one theme composable over an enum's constants, `AppThemeWithBackground(LIGHT) { }` — Pocket Casts' nine palettes, Twine's twelve. `functions`: a whole composable per theme, `ThunderbirdBoltTheme { }` — Bolt's two brands. `modes`: one composable with a boolean dark parameter, `ElementTheme(darkTheme = true) { }` — the single-brand light/dark pair, and the shape that gives a Theme control its two chips when the upstream bakes both into one stacked image. `arguments`: one composable and a named-argument list per theme; the general form the other three are shorthands for. `wrapper`: a raw Kotlin body."
+          },
+          "group": {
+            "type": "string",
+            "description": "Default @ThemeCatalog group for every theme this entry expands to; themes sharing a group are catalogued together. Overridable per theme."
+          },
+          "composable": {
+            "type": "string",
+            "description": "FQN of the theme composable to call. Required by `enum`, `modes` and `arguments`. It may be `internal` to the module — the generated file compiles inside that same module, which is what makes an unexported theme (Twine's `AppTheme`) reachable at all."
+          },
+          "enum": {
+            "type": "string",
+            "description": "`kind: enum` only. FQN of the enum whose constants name the themes, nested names included (e.g. \"…ui.theme.Theme.ThemeType\")."
+          },
+          "values": {
+            "type": "array",
+            "description": "`kind: enum` only. The constants to expand, each a name or a { value, name, group } object. Listed rather than reflected off the enum: generation runs before the upstream compiles, so there is nothing to reflect against — and a constant that does not exist fails the module's compile by name, which beats a silently thinner catalog.",
+            "items": { "type": ["string", "object"] }
+          },
+          "parameter": {
+            "type": "string",
+            "description": "`kind: enum` — pass the constant as this named argument rather than positionally. `kind: modes` — the boolean dark-theme parameter's name (default \"darkTheme\")."
+          },
+          "modes": {
+            "type": "array",
+            "description": "`kind: modes` only. Which of the pair to generate; both by default.",
+            "items": { "enum": ["light", "dark"] }
+          },
+          "composables": {
+            "type": "array",
+            "description": "`kind: functions` only. One FQN — or { composable, name, group } — per theme.",
+            "items": { "type": ["string", "object"] }
+          },
+          "variants": {
+            "type": "array",
+            "description": "`kind: arguments` only. One { name, args, imports, group } per theme; `args` maps a parameter name to the Kotlin expression to pass it.",
+            "items": { "type": "object" }
+          },
+          "name": {
+            "type": "string",
+            "description": "`kind: wrapper` only. The theme's label, and the stem of its generated provider class."
+          },
+          "wrapper": {
+            "type": "string",
+            "description": "`kind: wrapper` only. The Kotlin body of the provider's `Wrap`, which must call `content()` — e.g. `AppTheme(overriddenColorScheme = solarizedColorScheme(false)) { content() }`."
+          },
+          "imports": {
+            "type": "array",
+            "description": "Extra FQNs to import into the generated file, for names a `wrapper` body or an `arguments` expression uses.",
+            "items": { "type": "string" }
+          }
+        }
+      }
+    },
     "locales": {
       "type": "array",
       "description": "The locales the sticker sheet covers (e.g. [\"en\", \"ja\"]). Unlike `modes` this is not informational: a preview id ending in a declared locale is tagged with a `locale` props axis, so the arms of a locale multipreview fan-out (`Foo_en` / `Foo_ja`) are distinct renders instead of two images folding onto one output key. Match is case-insensitive and only at a segment boundary, as for `modes`. An id naming no declared locale stays untagged and remains the component's primary sticker. Omit for a single-locale catalog.",

--- a/scripts/design-artifacts/generate-theme-catalogs.mjs
+++ b/scripts/design-artifacts/generate-theme-catalogs.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * Write the `@ThemeCatalog` providers a spec's `themes[]` declares into a module's source set, and
+ * put the annotation artifact on that module's compile classpath.
+ *
+ * The I/O half of `theme-adapters.mjs` (which is pure and holds the shapes). Runs against a
+ * THROWAWAY checkout — the import pipeline's clone of somebody else's repository — before
+ * discovery, because discovery scans compiled classes and the providers have to be among them.
+ *
+ *   node scripts/design-artifacts/generate-theme-catalogs.mjs \
+ *     --spec catalog.spec.json --module-dir modules/services/compose \
+ *     --annotations-version 1.2.3
+ *
+ * Exits 0 having done nothing when the spec declares no themes, so the pipeline can call it
+ * unconditionally rather than gating on a field it would have to parse twice.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import {
+  GENERATED_PACKAGE,
+  renderKotlin,
+  resolveThemes,
+} from "./theme-adapters.mjs";
+
+/**
+ * Source sets to write into, most-specific first.
+ *
+ * `androidMain` beats `commonMain` deliberately: `PreviewWrapperProvider` is an androidx type, and
+ * a KMP module's common source set compiles for targets that have no androidx at all — Bolt and
+ * Twine are both commonMain-first modules that render on the Robolectric lane, so their generated
+ * providers belong on the Android side even though the themes they wrap are common. A module with
+ * neither is a plain Android module and takes `src/main`.
+ */
+const SOURCE_SETS = Object.freeze([
+  "src/androidMain/kotlin",
+  "src/main/kotlin",
+  "src/main/java",
+  "src/commonMain/kotlin",
+]);
+
+const BUILD_FILES = Object.freeze(["build.gradle.kts", "build.gradle"]);
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const key = argv[i];
+    if (!key.startsWith("--")) continue;
+    args[key.slice(2)] = argv[i + 1]?.startsWith("--") ? true : argv[++i];
+  }
+  return args;
+}
+
+/** The source-set directory to generate into: the override, else the first that exists. */
+export function sourceSetFor(moduleDir, override) {
+  if (override) return join(moduleDir, override);
+  const found = SOURCE_SETS.find((set) => existsSync(join(moduleDir, set)));
+  return found ? join(moduleDir, found) : join(moduleDir, SOURCE_SETS[1]);
+}
+
+/**
+ * Append the `preview-annotations` dependency to a module's build file.
+ *
+ * Appended rather than merged into an existing `dependencies { }` block for the same reason the
+ * pipeline appends its plugin configuration: parsing somebody else's Gradle script to splice into
+ * it is a losing game, and Gradle is perfectly happy with a second `dependencies { }`. Idempotent —
+ * a re-run (or a module that already depends on it) is a no-op, so a retried import does not stack
+ * duplicate blocks.
+ *
+ * @returns {"added"|"present"|"no-build-file"}
+ */
+export function ensureAnnotationsDependency(
+  moduleDir,
+  version,
+  { configuration = "implementation" } = {},
+) {
+  const buildFile = BUILD_FILES.map((f) => join(moduleDir, f)).find((f) =>
+    existsSync(f),
+  );
+  if (!buildFile) return "no-build-file";
+  const text = readFileSync(buildFile, "utf8");
+  if (text.includes("ee.schimke.composeai:preview-annotations"))
+    return "present";
+  const kts = buildFile.endsWith(".kts");
+  const coordinate = `ee.schimke.composeai:preview-annotations:${version}`;
+  const line = kts
+    ? `  ${configuration}("${coordinate}")`
+    : `  ${configuration} '${coordinate}'`;
+  writeFileSync(
+    buildFile,
+    `${text}\n\n// compose-preview import: @ThemeCatalog, for the generated theme providers under\n` +
+      `// ${GENERATED_PACKAGE}. Added to a throwaway checkout only.\ndependencies {\n${line}\n}\n`,
+  );
+  return "added";
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  const specPath = args.spec ?? "catalog.spec.json";
+  const moduleDir = args["module-dir"] ?? ".";
+  const spec = JSON.parse(readFileSync(specPath, "utf8"));
+
+  const { themes, errors } = resolveThemes(spec);
+  if (errors.length > 0) {
+    for (const error of errors) console.error(`::error::${specPath}: ${error}`);
+    return 1;
+  }
+  if (themes.length === 0) {
+    console.log(`${specPath} declares no themes; nothing to generate.`);
+    return 0;
+  }
+
+  const version = args["annotations-version"];
+  if (!version) {
+    console.error(
+      "::error::--annotations-version is required once a spec declares themes",
+    );
+    return 1;
+  }
+
+  const outFile = join(
+    sourceSetFor(moduleDir, args["source-set"]),
+    ...GENERATED_PACKAGE.split("."),
+    "ImportedThemeCatalogs.kt",
+  );
+  mkdirSync(dirname(outFile), { recursive: true });
+  writeFileSync(outFile, renderKotlin(themes));
+
+  const dependency = ensureAnnotationsDependency(moduleDir, version);
+  if (dependency === "no-build-file") {
+    console.error(
+      `::error::no build.gradle[.kts] in ${moduleDir}; cannot add preview-annotations`,
+    );
+    return 1;
+  }
+
+  console.log(`Generated ${themes.length} theme provider(s) → ${outFile}`);
+  for (const theme of themes) {
+    console.log(
+      `  ${theme.className}  ${theme.name}${theme.group ? ` (${theme.group})` : ""}`,
+    );
+  }
+  console.log(
+    `preview-annotations:${version} ${dependency === "added" ? "added to" : "already in"} ${moduleDir}`,
+  );
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) process.exit(main());

--- a/scripts/design-artifacts/generate-theme-catalogs.test.mjs
+++ b/scripts/design-artifacts/generate-theme-catalogs.test.mjs
@@ -1,0 +1,161 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  ensureAnnotationsDependency,
+  main,
+  sourceSetFor,
+} from "./generate-theme-catalogs.mjs";
+
+const scratch = () => mkdtempSync(join(tmpdir(), "theme-catalogs-"));
+
+test("sourceSetFor prefers androidMain, because PreviewWrapperProvider is androidx", () => {
+  const root = scratch();
+  mkdirSync(join(root, "src/commonMain/kotlin"), { recursive: true });
+  mkdirSync(join(root, "src/androidMain/kotlin"), { recursive: true });
+  assert.equal(sourceSetFor(root), join(root, "src/androidMain/kotlin"));
+});
+
+test("sourceSetFor falls back to src/main/kotlin when the module has no source sets yet", () => {
+  const root = scratch();
+  assert.equal(sourceSetFor(root), join(root, "src/main/kotlin"));
+  assert.equal(
+    sourceSetFor(root, "src/debug/kotlin"),
+    join(root, "src/debug/kotlin"),
+  );
+});
+
+test("the annotations dependency is appended once and is idempotent", () => {
+  const root = scratch();
+  writeFileSync(
+    join(root, "build.gradle.kts"),
+    'plugins { id("com.android.library") }\n',
+  );
+  assert.equal(ensureAnnotationsDependency(root, "1.2.3"), "added");
+  const first = readFileSync(join(root, "build.gradle.kts"), "utf8");
+  assert.match(
+    first,
+    /implementation\("ee\.schimke\.composeai:preview-annotations:1\.2\.3"\)/,
+  );
+  assert.equal(ensureAnnotationsDependency(root, "1.2.3"), "present");
+  assert.equal(
+    readFileSync(join(root, "build.gradle.kts"), "utf8"),
+    first,
+    "a re-run changes nothing",
+  );
+});
+
+test("a Groovy build file gets Groovy syntax", () => {
+  const root = scratch();
+  writeFileSync(
+    join(root, "build.gradle"),
+    "apply plugin: 'com.android.library'\n",
+  );
+  assert.equal(ensureAnnotationsDependency(root, "9.9.9"), "added");
+  assert.match(
+    readFileSync(join(root, "build.gradle"), "utf8"),
+    /implementation 'ee\.schimke\.composeai:preview-annotations:9\.9\.9'/,
+  );
+});
+
+test("end to end: a spec's themes become a compilable-looking file in the module", () => {
+  const root = scratch();
+  mkdirSync(join(root, "src/main/kotlin"), { recursive: true });
+  writeFileSync(
+    join(root, "build.gradle.kts"),
+    'plugins { id("com.android.library") }\n',
+  );
+  const spec = join(root, "catalog.spec.json");
+  writeFileSync(
+    spec,
+    JSON.stringify({
+      system: "pocketcasts",
+      themes: [
+        {
+          kind: "enum",
+          group: "Pocket Casts",
+          composable:
+            "au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground",
+          enum: "au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType",
+          values: ["LIGHT", "ELECTRIC"],
+        },
+      ],
+    }),
+  );
+  assert.equal(
+    main([
+      "--spec",
+      spec,
+      "--module-dir",
+      root,
+      "--annotations-version",
+      "1.2.3",
+    ]),
+    0,
+  );
+  const out = join(
+    root,
+    "src/main/kotlin/ee/schimke/composeai/imported/themes/ImportedThemeCatalogs.kt",
+  );
+  assert.ok(existsSync(out));
+  const kotlin = readFileSync(out, "utf8");
+  assert.match(kotlin, /class ImportedTheme_Light : PreviewWrapperProvider/);
+  assert.match(kotlin, /class ImportedTheme_Electric : PreviewWrapperProvider/);
+  assert.match(
+    kotlin,
+    /AppThemeWithBackground\(ThemeType\.ELECTRIC\) \{ content\(\) \}/,
+  );
+});
+
+test("a spec with no themes is a successful no-op, so the pipeline can call it unconditionally", () => {
+  const root = scratch();
+  const spec = join(root, "catalog.spec.json");
+  writeFileSync(spec, JSON.stringify({ system: "x" }));
+  assert.equal(main(["--spec", spec, "--module-dir", root]), 0);
+  assert.ok(!existsSync(join(root, "src")), "nothing is written");
+});
+
+test("a spec error fails the step rather than generating a thinner catalog", () => {
+  const root = scratch();
+  const spec = join(root, "catalog.spec.json");
+  writeFileSync(
+    spec,
+    JSON.stringify({
+      themes: [
+        { kind: "enum", composable: "oops", enum: "a.B", values: ["X"] },
+      ],
+    }),
+  );
+  assert.equal(
+    main([
+      "--spec",
+      spec,
+      "--module-dir",
+      root,
+      "--annotations-version",
+      "1.2.3",
+    ]),
+    1,
+  );
+});
+
+test("themes with no annotations version fail rather than writing code that cannot compile", () => {
+  const root = scratch();
+  const spec = join(root, "catalog.spec.json");
+  writeFileSync(
+    spec,
+    JSON.stringify({
+      themes: [{ kind: "wrapper", name: "T", wrapper: "T { content() }" }],
+    }),
+  );
+  assert.equal(main(["--spec", spec, "--module-dir", root]), 1);
+});

--- a/scripts/design-artifacts/theme-adapters.mjs
+++ b/scripts/design-artifacts/theme-adapters.mjs
@@ -1,0 +1,409 @@
+/**
+ * Turn an import's declared themes into the `@ThemeCatalog` providers a third-party module can
+ * never declare for itself.
+ *
+ * A catalog's theme switcher is fed by `declaredThemes` — synthesized from `@ThemeCatalog` /
+ * `@WearThemeCatalog` on a `PreviewWrapperProvider` class, an `ee.schimke.composeai.preview`
+ * annotation. A project imported without its maintainers' involvement has no such class, so every
+ * imported catalog serves an empty Theme control no matter how many palettes the upstream actually
+ * has: Pocket Casts ships nine, Twine twelve, Thunderbird's Bolt two brands crossed with light and
+ * dark, and preview.coo.ee can show none of them.
+ *
+ * The import pipeline already edits its throwaway checkout — it appends to the module's build file,
+ * adds runtime-only projects and stubs `google-services.json`. Generating the providers is the same
+ * move one level up: the spec says which themes exist, this writes the Kotlin, and everything
+ * downstream (discovery → THEME_CATALOG previews → `declaredThemes` → the header's theme chips →
+ * `?theme=theme:<fqn>` → per-theme `themes/<fqn>.dtcg.json` token sets) works unchanged. Nothing
+ * else in the pipeline learns what an import is.
+ *
+ * ## Why kinds rather than a line of Kotlin each
+ *
+ * Every theme could be a hand-written wrapper body, and the first draft of this was exactly that.
+ * But across fifteen imports the upstreams reach for the same four shapes, and a shape carries
+ * information a snippet throws away: which themes are the same family, which are light and which
+ * are dark, and what a reviewer is agreeing to when they approve the import's pull request. A
+ * `kind` is checkable — a typo'd enum constant is a spec error here rather than a Kotlin
+ * compile failure twenty minutes into a render — and it means the twelfth Twine palette costs a
+ * string in an array, not a paragraph of code.
+ *
+ * - **`enum`** — a theme composable taking one enum constant: `AppThemeWithBackground(LIGHT) {}`.
+ *   Pocket Casts (`Theme.ThemeType`, nine) and Twine (`ThemeVariant`, twelve).
+ * - **`functions`** — one composable per theme: `ThunderbirdBoltTheme {}` / `K9MailBoltTheme {}`.
+ *   Thunderbird's Bolt.
+ * - **`modes`** — one composable with a boolean dark parameter: `ElementTheme(darkTheme = true) {}`.
+ *   Element X, Bitwarden, and most single-brand Material 3 systems.
+ * - **`arguments`** — one composable, a named argument list per theme. The general form the three
+ *   above are shorthands for; use it when a theme is a call the others cannot spell.
+ * - **`wrapper`** — a raw Kotlin body, the documented escape hatch. Twine's
+ *   `overriddenColorScheme = solarizedColorScheme(isDark)` is why it exists.
+ *
+ * Pure and dependency-free (no `@design-parity/*`, no I/O) so it unit-tests without an `npm ci`,
+ * like its siblings `catalog-select.mjs` / `catalog-variants.mjs`. The file-writing half lives in
+ * `generate-theme-catalogs.mjs`.
+ */
+
+/** The `kind`s a `themes[]` entry may declare. Anything else is a spec error, not a no-op. */
+export const THEME_KINDS = Object.freeze([
+  "enum",
+  "functions",
+  "modes",
+  "arguments",
+  "wrapper",
+]);
+
+/** Package the generated providers are declared in. Its own, so it collides with no upstream. */
+export const GENERATED_PACKAGE = "ee.schimke.composeai.imported.themes";
+
+/** Imports every generated file needs regardless of shape. */
+const BASE_IMPORTS = Object.freeze([
+  "androidx.compose.runtime.Composable",
+  "androidx.compose.ui.tooling.preview.PreviewWrapperProvider",
+  "ee.schimke.composeai.preview.ThemeCatalog",
+]);
+
+/**
+ * A resolved theme: one generated provider. `name` and `group` become the `@ThemeCatalog`
+ * arguments (and so the chip's label and its grouping); `body` is the Kotlin that wraps `content()`.
+ */
+/**
+ * Resolve a spec's `themes[]` into the flat list of providers to generate.
+ *
+ * Errors are collected rather than thrown, and every one names the entry it came from: a spec is
+ * reviewed as a whole in a pull request, so reporting the first mistake and stopping would cost a
+ * round trip per typo.
+ *
+ * @param {object} spec parsed `catalog.spec.json`.
+ * @returns {{themes: Array<{name: string, group: string|null, className: string, body: string,
+ *   imports: string[]}>, errors: string[]}}
+ */
+export function resolveThemes(spec) {
+  const declared = Array.isArray(spec?.themes) ? spec.themes : [];
+  const themes = [];
+  const errors = [];
+  declared.forEach((entry, index) => {
+    const where = `themes[${index}]`;
+    const kind = entry?.kind;
+    if (!THEME_KINDS.includes(kind)) {
+      errors.push(
+        `${where}: unknown kind ${JSON.stringify(kind ?? null)} (expected one of ${THEME_KINDS.join(", ")})`,
+      );
+      return;
+    }
+    const resolved = RESOLVERS[kind](entry, where, errors);
+    for (const theme of resolved) themes.push(theme);
+  });
+  return { themes: dedupe(themes, errors), errors };
+}
+
+const RESOLVERS = {
+  enum: resolveEnum,
+  functions: resolveFunctions,
+  modes: resolveModes,
+  arguments: resolveArguments,
+  wrapper: resolveWrapper,
+};
+
+/**
+ * `{ kind: "enum", composable, enum, values }` — one provider per named constant.
+ *
+ * The constants are LISTED rather than reflected off the enum. Generation happens before the
+ * upstream is compiled, so there is nothing to reflect against; and an import's inventory is
+ * written down by the human who read the upstream anyway, which is the same bargain `groups`
+ * already makes. A listed constant that does not exist fails the module's compile with the
+ * constant's own name in the message, which is a better error than a silently thinner catalog.
+ */
+function resolveEnum(entry, where, errors) {
+  const composable = requireFqn(
+    entry?.composable,
+    `${where}.composable`,
+    errors,
+  );
+  const enumFqn = requireFqn(entry?.enum, `${where}.enum`, errors);
+  const values = Array.isArray(entry?.values) ? entry.values : [];
+  if (values.length === 0)
+    errors.push(`${where}.values: name at least one enum constant`);
+  if (!composable || !enumFqn) return [];
+  const enumName = simpleName(enumFqn);
+  const parameter =
+    typeof entry?.parameter === "string" && entry.parameter
+      ? `${entry.parameter} = `
+      : "";
+  return values
+    .map((raw) => {
+      const value = typeof raw === "string" ? { value: raw } : (raw ?? {});
+      const constant = value.value;
+      if (typeof constant !== "string" || !constant) {
+        errors.push(
+          `${where}.values: each entry is an enum constant name, or an object with one`,
+        );
+        return null;
+      }
+      return theme({
+        entry,
+        name: value.name ?? titleCase(constant),
+        group: value.group ?? entry.group,
+        body: `${simpleName(composable)}(${parameter}${enumName}.${constant}) { content() }`,
+        imports: [composable, enumFqn],
+      });
+    })
+    .filter(Boolean);
+}
+
+/** `{ kind: "functions", composables: [...] }` — a whole composable per theme, no arguments. */
+function resolveFunctions(entry, where, errors) {
+  const list = Array.isArray(entry?.composables) ? entry.composables : [];
+  if (list.length === 0)
+    errors.push(`${where}.composables: name at least one composable`);
+  return list
+    .map((raw, i) => {
+      const item = typeof raw === "string" ? { composable: raw } : (raw ?? {});
+      const fqn = requireFqn(
+        item.composable,
+        `${where}.composables[${i}]`,
+        errors,
+      );
+      if (!fqn) return null;
+      return theme({
+        entry,
+        name: item.name ?? titleCase(simpleName(fqn).replace(/Theme$/, "")),
+        group: item.group ?? entry.group,
+        body: `${simpleName(fqn)} { content() }`,
+        imports: [fqn],
+      });
+    })
+    .filter(Boolean);
+}
+
+/**
+ * `{ kind: "modes", composable, parameter }` — the single-brand light/dark pair.
+ *
+ * Worth a kind of its own even though `arguments` spells it, because it is the shape that makes a
+ * catalog's theme control *work at all* for the majority of imports: without a declared theme the
+ * control is empty, and a system whose only axis is light/dark still needs somewhere for the two
+ * chips to come from when its previews bake the pair into one stacked image (Element X) instead of
+ * two renders the fold can pair.
+ */
+function resolveModes(entry, where, errors) {
+  const composable = requireFqn(
+    entry?.composable,
+    `${where}.composable`,
+    errors,
+  );
+  if (!composable) return [];
+  const parameter =
+    typeof entry?.parameter === "string" && entry.parameter
+      ? entry.parameter
+      : "darkTheme";
+  const modes =
+    Array.isArray(entry?.modes) && entry.modes.length > 0
+      ? entry.modes
+      : ["light", "dark"];
+  return modes
+    .map((mode) => {
+      if (mode !== "light" && mode !== "dark") {
+        errors.push(
+          `${where}.modes: expected "light" or "dark", got ${JSON.stringify(mode)}`,
+        );
+        return null;
+      }
+      return theme({
+        entry,
+        // The chip label carries the word the mode inference in `ServeRenderHost.inferredThemeMode`
+        // reads, so a generated theme reports its own light/dark rather than leaving the serve host
+        // to guess from an FQN it minted itself.
+        name: `${titleCase(mode)}`,
+        group: entry.group,
+        body: `${simpleName(composable)}(${parameter} = ${mode === "dark"}) { content() }`,
+        imports: [composable],
+      });
+    })
+    .filter(Boolean);
+}
+
+/** `{ kind: "arguments", composable, variants: [{name, args}] }` — the general named-argument call. */
+function resolveArguments(entry, where, errors) {
+  const composable = requireFqn(
+    entry?.composable,
+    `${where}.composable`,
+    errors,
+  );
+  const variants = Array.isArray(entry?.variants) ? entry.variants : [];
+  if (variants.length === 0)
+    errors.push(`${where}.variants: name at least one variant`);
+  if (!composable) return [];
+  return variants
+    .map((variant, i) => {
+      const name = variant?.name;
+      if (typeof name !== "string" || !name) {
+        errors.push(`${where}.variants[${i}].name: required`);
+        return null;
+      }
+      const args = Object.entries(variant?.args ?? {})
+        .map(([key, value]) => `${key} = ${value}`)
+        .join(", ");
+      return theme({
+        entry,
+        name,
+        group: variant.group ?? entry.group,
+        body: `${simpleName(composable)}(${args}) { content() }`,
+        imports: [composable, ...(variant.imports ?? [])],
+      });
+    })
+    .filter(Boolean);
+}
+
+/** `{ kind: "wrapper", name, wrapper, imports }` — a raw Kotlin body. The escape hatch. */
+function resolveWrapper(entry, where, errors) {
+  const name = entry?.name;
+  const body = entry?.wrapper;
+  if (typeof name !== "string" || !name) errors.push(`${where}.name: required`);
+  if (typeof body !== "string" || !body)
+    errors.push(`${where}.wrapper: required`);
+  if (!name || !body) return [];
+  return [
+    theme({
+      entry,
+      name,
+      group: entry.group,
+      body,
+      imports: entry.imports ?? [],
+    }),
+  ];
+}
+
+/**
+ * An entry's own `imports` are merged into every theme it expands to, so a shape whose expressions
+ * all lean on the same handful of names — Twine's ten palettes each reaching for `ThemeVariant` and
+ * `isSystemInDarkTheme` — declares them once instead of once per theme. Unused imports are harmless
+ * in Kotlin, and the alternative is ten copies of the same three lines going stale independently.
+ */
+function theme({ entry, name, group, body, imports }) {
+  return {
+    name,
+    group: typeof group === "string" && group ? group : null,
+    className: classNameFor(name),
+    body,
+    imports: [
+      ...new Set(
+        [...imports, ...(entry?.imports ?? [])].filter(
+          (i) => typeof i === "string" && i,
+        ),
+      ),
+    ].sort(),
+  };
+}
+
+/**
+ * A generated class name is derived from the theme NAME, which is what a reviewer sees and what the
+ * serve host addresses the theme by — so two themes that would generate the same class are a spec
+ * mistake worth reporting rather than a collision to break with a counter. Reported once per
+ * colliding name, and the first occurrence is kept so the rest of the file still generates.
+ */
+function dedupe(themes, errors) {
+  const seen = new Map();
+  const out = [];
+  for (const t of themes) {
+    if (seen.has(t.className)) {
+      if (seen.get(t.className) === false) {
+        errors.push(
+          `two themes resolve to the same provider ${t.className} (from name ${JSON.stringify(t.name)})`,
+        );
+        seen.set(t.className, true);
+      }
+      continue;
+    }
+    seen.set(t.className, false);
+    out.push(t);
+  }
+  return out;
+}
+
+/**
+ * `Extra dark` → `ImportedTheme_ExtraDark`. Prefixed so it cannot shadow an upstream class.
+ *
+ * Each word is CASE-NORMALIZED, not merely capitalized, so `Extra dark`, `EXTRA DARK` and
+ * `extra-dark` all land on one class. That is what makes the collision check in [dedupe] mean
+ * "these are the same theme written twice" rather than "these happen to match character for
+ * character" — three spellings of one palette is exactly how a hand-written inventory of somebody
+ * else's nine palettes goes wrong, and it should be a spec error, not two chips for one theme.
+ */
+export function classNameFor(name) {
+  const camel = name
+    .split(/[^A-Za-z0-9]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join("");
+  return `ImportedTheme_${camel || "Unnamed"}`;
+}
+
+/** `EXTRA_DARK` → `Extra dark`; `ThunderbirdBolt` → `Thunderbird bolt`. */
+export function titleCase(raw) {
+  const words = String(raw)
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .split(/[^A-Za-z0-9]+/)
+    .filter(Boolean)
+    .map((w) => w.toLowerCase());
+  if (words.length === 0) return "";
+  return (
+    words[0].charAt(0).toUpperCase() +
+    words[0].slice(1) +
+    (words.length > 1 ? ` ${words.slice(1).join(" ")}` : "")
+  );
+}
+
+function simpleName(fqn) {
+  return fqn.slice(fqn.lastIndexOf(".") + 1);
+}
+
+function requireFqn(value, where, errors) {
+  if (typeof value !== "string" || !value.includes(".")) {
+    errors.push(
+      `${where}: expected a fully-qualified name, got ${JSON.stringify(value ?? null)}`,
+    );
+    return null;
+  }
+  return value;
+}
+
+/**
+ * Render the resolved themes as one Kotlin file.
+ *
+ * One file rather than one per theme because the whole set is generated and deleted together, and a
+ * reviewer reading the render log wants the diff of the module's themes in one place.
+ *
+ * Imports are hoisted and sorted rather than written fully-qualified inline: a `Theme.ThemeType`
+ * nested in a class cannot be spelled fully-qualified in an expression position without the
+ * enclosing class resolving first, which is exactly the case Pocket Casts hits.
+ */
+export function renderKotlin(themes, { packageName = GENERATED_PACKAGE } = {}) {
+  const imports = [
+    ...new Set([...BASE_IMPORTS, ...themes.flatMap((t) => t.imports)]),
+  ].sort();
+  const header = [
+    "// GENERATED by compose-preview from catalog.spec.json's `themes`. Do not edit.",
+    "//",
+    "// An imported project cannot declare @ThemeCatalog providers itself — it has no dependency on",
+    "// this toolchain — so its themes are described in the import's spec and the providers are",
+    "// written here, into a throwaway checkout, before discovery runs. See",
+    "// scripts/design-artifacts/theme-adapters.mjs.",
+    "",
+    `package ${packageName}`,
+    "",
+    ...imports.map((i) => `import ${i}`),
+    "",
+  ];
+  const bodies = themes.map((t) => {
+    const args = [`name = ${JSON.stringify(t.name)}`];
+    if (t.group) args.push(`group = ${JSON.stringify(t.group)}`);
+    return [
+      `@ThemeCatalog(${args.join(", ")})`,
+      `class ${t.className} : PreviewWrapperProvider {`,
+      "  @Composable",
+      "  override fun Wrap(content: @Composable () -> Unit) {",
+      `    ${t.body}`,
+      "  }",
+      "}",
+    ].join("\n");
+  });
+  return `${header.join("\n")}\n${bodies.join("\n\n")}\n`;
+}

--- a/scripts/design-artifacts/theme-adapters.test.mjs
+++ b/scripts/design-artifacts/theme-adapters.test.mjs
@@ -1,0 +1,309 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  GENERATED_PACKAGE,
+  THEME_KINDS,
+  classNameFor,
+  renderKotlin,
+  resolveThemes,
+  titleCase,
+} from "./theme-adapters.mjs";
+
+const ok = (spec) => {
+  const { themes, errors } = resolveThemes(spec);
+  assert.deepEqual(errors, []);
+  return themes;
+};
+
+test("a spec with no themes resolves to nothing, without complaint", () => {
+  assert.deepEqual(resolveThemes({}), { themes: [], errors: [] });
+  assert.deepEqual(resolveThemes({ themes: [] }), { themes: [], errors: [] });
+});
+
+test("enum fans one composable over its named constants — the Pocket Casts shape", () => {
+  const themes = ok({
+    themes: [
+      {
+        kind: "enum",
+        group: "Pocket Casts",
+        composable:
+          "au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground",
+        enum: "au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType",
+        values: ["LIGHT", "EXTRA_DARK"],
+      },
+    ],
+  });
+  assert.deepEqual(
+    themes.map((t) => [t.name, t.group, t.className, t.body]),
+    [
+      [
+        "Light",
+        "Pocket Casts",
+        "ImportedTheme_Light",
+        "AppThemeWithBackground(ThemeType.LIGHT) { content() }",
+      ],
+      [
+        "Extra dark",
+        "Pocket Casts",
+        "ImportedTheme_ExtraDark",
+        "AppThemeWithBackground(ThemeType.EXTRA_DARK) { content() }",
+      ],
+    ],
+  );
+});
+
+test("an enum value may override its own label and group", () => {
+  const [theme] = ok({
+    themes: [
+      {
+        kind: "enum",
+        composable: "com.example.AppTheme",
+        enum: "com.example.Palette",
+        values: [{ value: "ROSE", name: "Rosé", group: "Seasonal" }],
+      },
+    ],
+  });
+  assert.equal(theme.name, "Rosé");
+  assert.equal(theme.group, "Seasonal");
+});
+
+test("enum honours a named parameter when the composable does not take it positionally", () => {
+  const [theme] = ok({
+    themes: [
+      {
+        kind: "enum",
+        composable: "com.example.AppTheme",
+        enum: "com.example.Palette",
+        parameter: "palette",
+        values: ["FOREST"],
+      },
+    ],
+  });
+  assert.equal(theme.body, "AppTheme(palette = Palette.FOREST) { content() }");
+});
+
+test("functions gives a provider per composable — the Thunderbird Bolt shape", () => {
+  const themes = ok({
+    themes: [
+      {
+        kind: "functions",
+        group: "Bolt",
+        composables: [
+          "net.thunderbird.components.ui.bolt.theme.thunderbird.ThunderbirdBoltTheme",
+          {
+            composable:
+              "net.thunderbird.components.ui.bolt.theme.k9mail.K9MailBoltTheme",
+            name: "K-9 Mail",
+          },
+        ],
+      },
+    ],
+  });
+  assert.deepEqual(
+    themes.map((t) => [t.name, t.body]),
+    [
+      ["Thunderbird bolt", "ThunderbirdBoltTheme { content() }"],
+      ["K-9 Mail", "K9MailBoltTheme { content() }"],
+    ],
+  );
+});
+
+test("modes gives the light/dark pair, labelled so the serve host can infer the mode", () => {
+  const themes = ok({
+    themes: [
+      {
+        kind: "modes",
+        composable: "io.element.android.compound.theme.ElementTheme",
+        group: "Compound",
+      },
+    ],
+  });
+  assert.deepEqual(
+    themes.map((t) => [t.name, t.body]),
+    [
+      ["Light", "ElementTheme(darkTheme = false) { content() }"],
+      ["Dark", "ElementTheme(darkTheme = true) { content() }"],
+    ],
+  );
+});
+
+test("arguments spells a call the shorthands cannot", () => {
+  const [theme] = ok({
+    themes: [
+      {
+        kind: "arguments",
+        composable: "com.example.AppTheme",
+        variants: [
+          {
+            name: "Solarized",
+            args: {
+              useDarkTheme: "false",
+              overriddenColorScheme: "solarizedColorScheme(false)",
+            },
+            imports: ["com.example.solarizedColorScheme"],
+          },
+        ],
+      },
+    ],
+  });
+  assert.equal(
+    theme.body,
+    "AppTheme(useDarkTheme = false, overriddenColorScheme = solarizedColorScheme(false)) { content() }",
+  );
+  assert.ok(theme.imports.includes("com.example.solarizedColorScheme"));
+});
+
+test("wrapper carries a raw body verbatim", () => {
+  const [theme] = ok({
+    themes: [
+      {
+        kind: "wrapper",
+        name: "Automotive",
+        wrapper: "AutomotiveTheme { content() }",
+        imports: ["com.example.AutomotiveTheme"],
+      },
+    ],
+  });
+  assert.equal(theme.body, "AutomotiveTheme { content() }");
+});
+
+test("every kind is exercised above, so a new one cannot land untested", () => {
+  assert.deepEqual([...THEME_KINDS].sort(), [
+    "arguments",
+    "enum",
+    "functions",
+    "modes",
+    "wrapper",
+  ]);
+});
+
+test("errors name the entry and are collected, not thrown on the first", () => {
+  const { themes, errors } = resolveThemes({
+    themes: [
+      { kind: "nonsense" },
+      {
+        kind: "enum",
+        composable: "NotAnFqn",
+        enum: "com.example.Palette",
+        values: [],
+      },
+      { kind: "wrapper", name: "Fine", wrapper: "Theme { content() }" },
+    ],
+  });
+  assert.equal(themes.length, 1, "the valid entry still resolves");
+  assert.equal(errors.length, 3);
+  assert.match(errors[0], /themes\[0\]: unknown kind "nonsense"/);
+  assert.match(
+    errors[1],
+    /themes\[1\]\.composable: expected a fully-qualified name/,
+  );
+  assert.match(
+    errors[2],
+    /themes\[1\]\.values: name at least one enum constant/,
+  );
+});
+
+test("two themes resolving to one provider is reported once, and the first wins", () => {
+  const { themes, errors } = resolveThemes({
+    themes: [
+      { kind: "wrapper", name: "Extra Dark", wrapper: "A { content() }" },
+      { kind: "wrapper", name: "extra-dark", wrapper: "B { content() }" },
+      { kind: "wrapper", name: "EXTRA DARK", wrapper: "C { content() }" },
+    ],
+  });
+  assert.deepEqual(
+    themes.map((t) => t.body),
+    ["A { content() }"],
+  );
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /ImportedTheme_ExtraDark/);
+});
+
+test("classNameFor and titleCase round the awkward names", () => {
+  assert.equal(classNameFor("Extra dark"), "ImportedTheme_ExtraDark");
+  assert.equal(classNameFor("K-9 Mail"), "ImportedTheme_K9Mail");
+  assert.equal(classNameFor("!!!"), "ImportedTheme_Unnamed");
+  assert.equal(titleCase("EXTRA_DARK"), "Extra dark");
+  assert.equal(titleCase("ThunderbirdBolt"), "Thunderbird bolt");
+});
+
+test("the rendered file hoists sorted imports and declares one annotated provider per theme", () => {
+  const themes = ok({
+    themes: [
+      {
+        kind: "enum",
+        group: "Pocket Casts",
+        composable:
+          "au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground",
+        enum: "au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType",
+        values: ["LIGHT"],
+      },
+    ],
+  });
+  const kotlin = renderKotlin(themes);
+  assert.match(kotlin, new RegExp(`^// GENERATED by compose-preview`));
+  assert.match(kotlin, new RegExp(`\\npackage ${GENERATED_PACKAGE}\\n`));
+  // Fully-qualifying `Theme.ThemeType.LIGHT` inline does not resolve for a nested enum, which is
+  // exactly the Pocket Casts case — so the type is imported and used by simple name.
+  assert.match(
+    kotlin,
+    /\nimport au\.com\.shiftyjelly\.pocketcasts\.ui\.theme\.Theme\.ThemeType\n/,
+  );
+  assert.match(
+    kotlin,
+    /\nimport androidx\.compose\.ui\.tooling\.preview\.PreviewWrapperProvider\n/,
+  );
+  assert.match(
+    kotlin,
+    /@ThemeCatalog\(name = "Light", group = "Pocket Casts"\)/,
+  );
+  assert.match(kotlin, /class ImportedTheme_Light : PreviewWrapperProvider \{/);
+  assert.match(
+    kotlin,
+    /override fun Wrap\(content: @Composable \(\) -> Unit\) \{/,
+  );
+  const importLines = kotlin.split("\n").filter((l) => l.startsWith("import "));
+  assert.deepEqual(importLines, [...importLines].sort(), "imports are sorted");
+});
+
+test("a theme with no group omits the argument rather than passing an empty one", () => {
+  const kotlin = renderKotlin(
+    ok({
+      themes: [{ kind: "wrapper", name: "Solo", wrapper: "T { content() }" }],
+    }),
+  );
+  assert.match(kotlin, /@ThemeCatalog\(name = "Solo"\)\n/);
+});
+
+test("an entry's imports reach every theme it expands to", () => {
+  const themes = ok({
+    themes: [
+      {
+        kind: "arguments",
+        composable: "dev.sasikanth.rss.reader.ui.AppTheme",
+        imports: [
+          "androidx.compose.foundation.isSystemInDarkTheme",
+          "dev.sasikanth.rss.reader.ui.getOverriddenColorScheme",
+        ],
+        variants: [
+          {
+            name: "Solarized",
+            args: { useDarkTheme: "isSystemInDarkTheme()" },
+          },
+          { name: "Forest", args: { useDarkTheme: "isSystemInDarkTheme()" } },
+        ],
+      },
+    ],
+  });
+  for (const t of themes) {
+    assert.ok(
+      t.imports.includes("androidx.compose.foundation.isSystemInDarkTheme"),
+    );
+    assert.ok(
+      t.imports.includes(
+        "dev.sasikanth.rss.reader.ui.getOverriddenColorScheme",
+      ),
+    );
+  }
+});


### PR DESCRIPTION
## The finding

Every one of the fifteen imported catalogs has `themes` **absent** from its published
`catalog.json`, so `preview.coo.ee` serves an empty Theme control on all of them. That is
structural, not a data gap: `themes[]` is built from bundle entries whose `params.kind` is
`THEME_CATALOG` (`declaredThemesFromPreviews`, `render-host/.../ServeRenderHost.kt:441`), those come
only from `@ThemeCatalog` on a `PreviewWrapperProvider`, and that annotation ships in
`ee.schimke.composeai:preview-annotations` — which somebody else's repository has no dependency on
and never will.

Three upstreams genuinely have more than a light/dark pair, and are being flattened:

| Import | Upstream themes | Today |
| --- | --- | --- |
| pocketcasts | 9 (`Theme.ThemeType`) | 24 files fan previews over `ThemePreviewParameterProvider`; one image published per preview |
| msasikanth-twine | 12 `ThemeVariant`s × light/dark | none reachable; `AppTheme` is `internal` to `:shared` |
| thunderbird-android | 2 brands × light/dark | `PreviewWithThemesLightDark` stacks both brands into one tall PNG — no axis, no switcher |

## The change

A spec's new `themes[]` says which themes exist;
[`generate-theme-catalogs.mjs`](scripts/design-artifacts/generate-theme-catalogs.mjs) writes the
`@ThemeCatalog` providers into the **throwaway checkout** before anything compiles, beside the
module's own sources so an `internal` theme composable is reachable. Discovery then scans an
ordinary module that declares its themes, and nothing downstream learns an import exists — the
chips, `?theme=theme:<providerFqn>` and one `themes/<fqn>.dtcg.json` per theme all follow unchanged.

An entry is a **shape** rather than a Kotlin snippet, because across fifteen imports the upstreams
reach for the same few, and a shape carries what a snippet throws away — which themes are one
family, which are light and which dark, and what a reviewer is agreeing to:

| `kind` | Shape | Seen in |
| --- | --- | --- |
| `enum` | `AppThemeWithBackground(LIGHT) { }` | Pocket Casts, Twine |
| `functions` | `ThunderbirdBoltTheme { }` | Bolt |
| `modes` | `ElementTheme(darkTheme = true) { }` | Element X, Bitwarden |
| `arguments` | one composable, named args per theme | the general form |
| `wrapper` | a raw Kotlin body | the escape hatch |

Two decisions worth naming:

- **Enum constants are listed, not reflected.** Generation runs before the upstream compiles, so
  there is nothing to reflect against — and a listed constant that does not exist fails the module's
  compile *by name*, which beats a catalog that is quietly one palette short.
- **Nothing extra is baked.** Generated themes are a *live* axis, served through the published
  bundle and the theme cache exactly as `modePriority`'s deferred palettes are. Baking nine palettes
  × every component is the cost that design exists to avoid, and a nightly-refreshed import is the
  last place to pay it.

The step is unguarded and no-ops on a spec without `themes`, so first-party callers — which annotate
their providers beside the code — are unaffected.

The matching import declarations are in yschimke/compose-preview-imports#77.

## Test plan

- `node --test scripts/design-artifacts/theme-adapters.test.mjs
  scripts/design-artifacts/generate-theme-catalogs.test.mjs` — 23 pass, covering every `kind`, the
  collision and error reporting, source-set selection, the idempotent dependency append (Kotlin and
  Groovy build files), and an end-to-end generate. Both files are picked up by the existing
  `npm test` in `scripts/design-artifacts`, so CI runs them without new wiring.
- Generated against the three real upstreams' actual signatures (checked out and read), producing 9
  + 4 + 10 providers with correctly resolved imports — including `Theme.ThemeType` imported as a
  nested type, which cannot be spelled fully-qualified in expression position.
- All three import specs validate against the amended schema.

Text-only: this changes no rendered surface. The pixels it unlocks are the theme chips, which appear
once the imports rebuild against this driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018L6iB4aN7aSjZTz2ikhmve