### PR TITLE
ci: fetch the pinned contracts reader instead of checking that repo out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -887,14 +887,24 @@ jobs:
       # install the way those are: a fallback is right for a diff that can
       # degrade to strict bytes, and wrong for the tests that prove the diff.
       # `PerceptualLibrariesTest` fails the suite if this step is ever dropped.
-      # Pinned to the RELEASE this build compiles against, not the contracts repo's default
+      # PINNED to the RELEASE this build compiles against, not the contracts repo's default
       # branch. The gate compares a source file there against bytecode resolved from
-      # `composeai-contracts` in the catalog; an unpinned checkout compares the two whenever
+      # `composeai-contracts` in the catalog; an unpinned fetch compares the two whenever
       # those diverge, which passes a writer change matching newer source but incompatible with
       # the reader actually on the classpath, and fails unrelated pull requests when external
       # `main` moves.
-      - id: contracts-ref
-        name: Resolve the pinned contracts release
+      #
+      # FETCHED, not checked out, and only the one file the gate reads — the same arrangement, for
+      # the same reason, as the preview-server mirror sources in Design Artifacts Driver Tests
+      # below. `actions/checkout` of another repository at a ref read from
+      # `gradle/libs.versions.toml`, in a job that runs ~35 script tests after it, makes every one
+      # of those a step CodeQL rates high as "cache poisoning via execution of untrusted code"
+      # (`actions/cache-poisoning/poisonable-step`) — so adding a test here used to add an alert.
+      # Downloading one file that is only ever parsed as text removes the premise rather than
+      # suppressing the finding: nothing from that repository is executed, and the worst a
+      # rewritten catalog line can do is point the gate at a different published tag, which fails
+      # loudly below.
+      - name: Fetch the pinned contracts JVM reader
         run: |
           set -euo pipefail
           version=$(sed -n 's/^composeai-contracts = "\(.*\)"$/\1/p' gradle/libs.versions.toml)
@@ -902,14 +912,12 @@ jobs:
             echo "::error::could not read composeai-contracts from gradle/libs.versions.toml"
             exit 1
           fi
-          echo "ref=v$version" >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: yschimke/compose-preview-contracts
-          ref: ${{ steps.contracts-ref.outputs.ref }}
-          persist-credentials: false
-          path: .compose-preview-contracts
-          fetch-depth: 1
+          # The half of the daemon-launch mirror that lives in the contracts repository; the gate
+          # exits non-zero if COMPOSE_PREVIEW_CONTRACTS_ROOT does not contain exactly this path.
+          rel="daemon/protocol/src/main/kotlin/ee/schimke/composeai/daemon/protocol/DaemonLaunchDescriptor.kt"
+          mkdir -p ".compose-preview-contracts/$(dirname "$rel")"
+          curl -fsSL --retry 3 -o ".compose-preview-contracts/$rel" \
+            "https://raw.githubusercontent.com/yschimke/compose-preview-contracts/v$version/$rel"
       - name: Install perceptual-diff libraries
         run: python3 -m pip install --quiet 'pixelmatch==0.4.0' 'Pillow>=10'
       - name: Run compare-previews tests


### PR DESCRIPTION
## Why

CodeQL failed on [#5160](https://github.com/yschimke/compose-ai-tools/pull/5160) with one high alert, anchored on the single step that PR added to `actions-tests`:

> **Cache Poisoning via execution of untrusted code** — Potential cache poisoning in the context of the default branch due to privilege checkout of untrusted code from `steps.contracts-ref.outputs.ref`. (`schedule`, `workflow_dispatch`)

The finding is about the job, not that step. `Actions Script Tests` checks out `yschimke/compose-preview-contracts` at a ref read from `gradle/libs.versions.toml` and then runs ~35 script tests after it, so CodeQL counts every one of them as a step that could execute untrusted code. Appending a test to that block is therefore enough to produce a new alert — which is what #5160 did, and what the next person to add a test there would hit too.

## What changed

The gate reads exactly one file from that repository — the JVM reader, `daemon/protocol/…/DaemonLaunchDescriptor.kt`. So fetch that file instead of checking the repository out, pinned to the same release the catalog names.

This is the arrangement `Design Artifacts Driver Tests` already uses for the preview-server mirror sources, for this exact finding — its comment says it plainly: *"Downloading four text files that are only ever `readFileSync`-d removes the premise rather than suppressing the finding."* Same reasoning here: nothing from that repository is executed, the worst a rewritten catalog line can do is point the gate at a different published tag, and step order in the job stops carrying a security consequence.

The pin, the gate and its loud skip-guard are unchanged. The sibling checkout in `Build CLI and bundle viewer` is untouched — it is a different job with its own shape, and out of scope here.

## Test plan

- Ran the gate the way CI now will: fetched the one file to `.compose-preview-contracts/<rel>`, then `COMPOSE_PREVIEW_CONTRACTS_ROOT=… python3 scripts/test_check_daemon_launch_schema.py -v` → **43 tests, OK**, with zero `skipped` — so the job's `grep -q "skipped"` guard, which exists to catch a failed cross-repo checkout reporting green, does not fire.
- Confirmed the file is fetchable at the pinned tag (`v2.5.0`, HTTP 200) over the same `raw.githubusercontent.com` path shape the sibling job uses.
- `ci.yml` parses; the diff is confined to the two steps being replaced by one.

Non-visual change — no render evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014m3XFG39n7TpKyVaAmKi1C

---
_Generated by [Claude Code](https://claude.ai/code/session_014m3XFG39n7TpKyVaAmKi1C)_