### PR TITLE
fix(design-artifacts): warn instead of failing when the pinned driver has no theme generator

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -1779,6 +1779,26 @@ jobs:
             echo "spec declares no themes — nothing to generate"
             exit 0
           fi
+          # This step's YAML comes from the workflow's own revision, but the generator comes from
+          # the PINNED driver checkout (.github/design-artifacts-driver-pin.txt, a published
+          # release). The two are structurally allowed to disagree: a `@main` caller picks up this
+          # step the moment it merges, while the pin only advances when Renovate bumps it to the
+          # next release. So between those two events the script is simply not there.
+          #
+          # WARN AND CONTINUE, rather than fail. `themes` is an additive spec field, and every
+          # other additive field already behaves this way — a driver that predates one ignores it.
+          # Failing here instead took three previously-working imports offline entirely (no
+          # catalog at all, nightly) for a field whose absence costs only the theme chips. A
+          # catalog that publishes exactly as it did before, and gains its chips when the pin
+          # moves, is the correct degradation; a hard failure is a regression dressed as strictness.
+          generator="$GITHUB_WORKSPACE/compose-ai-tools/scripts/design-artifacts/generate-theme-catalogs.mjs"
+          if [ ! -f "$generator" ]; then
+            echo "::warning title=Declared themes not generated::$SPEC declares 'themes', but the" \
+                 "pinned export driver has no generate-theme-catalogs.mjs. The catalog publishes" \
+                 "without its theme chips until .github/design-artifacts-driver-pin.txt advances" \
+                 "to a release carrying it."
+            exit 0
+          fi
           if [ -z "${MODULE:-}" ]; then
             echo "::error::a spec declaring 'themes' must also name the 'module' the providers" \
                  "compile into — they have to see the theme composables, which repository-wide" \
@@ -1803,8 +1823,7 @@ jobs:
           # the two ship from one release, and a hardcoded version would rot at the next one.
           version="$(compose-preview --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
           [ -n "$version" ] || { echo "::error::could not read a version from 'compose-preview --version'"; exit 1; }
-          node "$GITHUB_WORKSPACE/compose-ai-tools/scripts/design-artifacts/generate-theme-catalogs.mjs" \
-            --spec "$SPEC" --module-dir "$module_dir" --annotations-version "$version"
+          node "$generator" --spec "$SPEC" --module-dir "$module_dir" --annotations-version "$version"
       - name: Build compose-preview CLI from source
         if: ${{ inputs.cli-source == 'build' }}
         working-directory: compose-ai-tools
@@ -2755,6 +2774,26 @@ jobs:
             echo "spec declares no themes — nothing to generate"
             exit 0
           fi
+          # This step's YAML comes from the workflow's own revision, but the generator comes from
+          # the PINNED driver checkout (.github/design-artifacts-driver-pin.txt, a published
+          # release). The two are structurally allowed to disagree: a `@main` caller picks up this
+          # step the moment it merges, while the pin only advances when Renovate bumps it to the
+          # next release. So between those two events the script is simply not there.
+          #
+          # WARN AND CONTINUE, rather than fail. `themes` is an additive spec field, and every
+          # other additive field already behaves this way — a driver that predates one ignores it.
+          # Failing here instead took three previously-working imports offline entirely (no
+          # catalog at all, nightly) for a field whose absence costs only the theme chips. A
+          # catalog that publishes exactly as it did before, and gains its chips when the pin
+          # moves, is the correct degradation; a hard failure is a regression dressed as strictness.
+          generator="$GITHUB_WORKSPACE/compose-ai-tools/scripts/design-artifacts/generate-theme-catalogs.mjs"
+          if [ ! -f "$generator" ]; then
+            echo "::warning title=Declared themes not generated::$SPEC declares 'themes', but the" \
+                 "pinned export driver has no generate-theme-catalogs.mjs. The catalog publishes" \
+                 "without its theme chips until .github/design-artifacts-driver-pin.txt advances" \
+                 "to a release carrying it."
+            exit 0
+          fi
           if [ -z "${MODULE:-}" ]; then
             echo "::error::a spec declaring 'themes' must also name the 'module' the providers" \
                  "compile into — they have to see the theme composables, which repository-wide" \
@@ -2779,8 +2818,7 @@ jobs:
           # the two ship from one release, and a hardcoded version would rot at the next one.
           version="$(compose-preview --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
           [ -n "$version" ] || { echo "::error::could not read a version from 'compose-preview --version'"; exit 1; }
-          node "$GITHUB_WORKSPACE/compose-ai-tools/scripts/design-artifacts/generate-theme-catalogs.mjs" \
-            --spec "$SPEC" --module-dir "$module_dir" --annotations-version "$version"
+          node "$generator" --spec "$SPEC" --module-dir "$module_dir" --annotations-version "$version"
       # ---- The two embedded player lanes' harness, when a caller asked for them ----------------
       #
       # `:third-party-rc-embedded-player` (Robolectric, both Android columns) and


### PR DESCRIPTION
## What broke

The first `Import on merge` run after #5158 and
yschimke/compose-preview-imports#77 landed
([run 47](https://github.com/yschimke/compose-preview-imports/actions/runs/33957621945)) failed all
three imports at the same step:

```
Error: Cannot find module '.../compose-ai-tools/scripts/design-artifacts/generate-theme-catalogs.mjs'
```

The step's YAML comes from the workflow's own revision — an external caller uses
`design-artifacts-reusable.yml@main`, so it picked the step up the moment #5158 merged. The
generator it calls comes from the **pinned driver checkout**
(`.github/design-artifacts-driver-pin.txt`, currently `v1.79.0`), which Renovate advances only at a
release. The two are structurally allowed to disagree, and between those two events the script
simply is not there.

I got this wrong twice over: I asserted in #5158's thread that there was no pin to advance, having
read `uses: …@main` in `import.yml` and not the driver pin behind it.

## Why warn rather than fail

Failing took pocketcasts, thunderbird-android and msasikanth-twine offline **entirely** — no
catalog published at all, and the identical failure on every nightly refresh until a release cut.
For a field whose absence costs only the theme chips, that is a regression dressed as strictness.

`themes` is an additive spec field, and every other additive field already degrades this way: a
driver predating one ignores it. So the step now warns, names the pin file and what is missing, and
exits 0. Those three catalogs publish exactly as they did before this work, and gain their chips
when the pin reaches a release carrying the generator — which is the behaviour I described in
yschimke/compose-preview-imports#77 and failed to actually implement.

## Test plan

- Extracted the step's script and ran it against thunderbird-android's real spec in both states:
  generator absent → the warning, exit 0; generator present → proceeds to generate. Both verified.
- `node --test scripts/design-artifacts/theme-adapters.test.mjs
  scripts/design-artifacts/generate-theme-catalogs.test.mjs` — 23 pass, unchanged.
- Both copies of the step (the `render-shard` and `generate` jobs) are patched; the workflow parses.

No behaviour change once the pin carries the generator — the same `node` invocation runs, through a
path resolved once instead of twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018L6iB4aN7aSjZTz2ikhmve

---
_Generated by [Claude Code](https://claude.ai/code/session_018L6iB4aN7aSjZTz2ikhmve)_