### PR TITLE
fix(cli): depend on the local :render-host instead of the retired coordinate

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -258,22 +258,24 @@ dependencies {
   api(project(":bundle-coordinates"))
 
   // The render host, the bundle daemon and the git-backed preview history — what the OFFLINE
-  // commands actually use. Split out of the server in compose-preview-server#38 (this repository's
-  // #4832) and first published in 2.2.0.
+  // commands actually use.
   //
   // Eight of the twelve serve-package symbols this module's main sources reference live here:
   // `ServeRenderHost`, `ServeBundleDaemon`, `RenderOutcome`, `SvgOutcome`, `RenderFailureFrame`,
   // `PreviewHistory`, `PreviewHistoryManifest` and `ServeParameterRows` — `bundle render`,
   // `history manifest`, `render matrix` and the missing-render report. None of them opens a socket.
   //
-  // Named here even though `compose-preview-serve` below would drag it in transitively anyway. The
-  // point is that the dependency is REAL and direct: when `serve` eventually stops being a CLI
-  // command (see below), these commands keep compiling and nobody has to work out what they were
-  // depending on through the server.
+  // A PROJECT dependency, not a published coordinate. The module was split out of the server in
+  // compose-preview-server#38 and published as `compose-preview-render-host`, but it moved into
+  // this repository in 1.77.0 (#5137) and the server now consumes it from here
+  // (compose-preview-server#289) — it had zero project dependencies inside that build and lived
+  // there only because it was written inside the `serve` package. `:cli` kept resolving the old
+  // external coordinate until compose-preview-server 3.0.0 retired it at its final 2.x, which is
+  // the second half of that move and what this line finishes.
   //
   // `api`, like the server dependency below and for the same reason: the call sites reference these
-  // types in-package (`ee.schimke.composeai.cli.serve`), which the published artifact keeps.
-  api(libs.composeai.preview.render.host)
+  // types in-package (`ee.schimke.composeai.cli.serve`).
+  api(project(":render-host"))
 
   // The preview server, published from yschimke/compose-preview-server (#4732).
   //
@@ -421,24 +423,21 @@ dependencies {
   // session rather than spawning a daemon; the fixture lives with `ServeRenderHost`, which is what
   // it fakes, and the fixture variant keeps it off both modules' runtime classpaths.
   //
-  // Plain `testFixtures(...)` again, and against `render-host` rather than the server. Both halves
-  // of that changed in 2.2.0: the fixture MOVED with `ServeRenderHost` into
-  // `compose-preview-render-host`
-  // (compose-preview-server#38), and that module declares the conventional
-  // `<artifactId>-test-fixtures` capability from its first release.
+  // `testFixtures(project(":render-host"))` — the fixture moved with `ServeRenderHost` into
+  // `:render-host` (compose-preview-server#38, then into this repository in #5137), and a project
+  // dependency sidesteps capability matching entirely.
   //
-  // What this replaces is a workaround, now retired. `java-test-fixtures` derives the capability
-  // from the *Gradle project* name, and the server is `:server` upstream while it publishes as
+  // Worth recording what that retires. `java-test-fixtures` derives the capability from the
+  // *Gradle project* name, and the server is `:server` upstream while it publishes as
   // `compose-preview-serve`, so 2.0.0 advertised `ee.schimke.composeai:server-test-fixtures` and
   // `testFixtures(...)` matched nothing:
   //
   //     Unable to find a variant of ee.schimke.composeai:compose-preview-serve:2.0.0 with the
   //     requested capability: feature 'test-fixtures'
   //
-  // We consumed it by naming that capability explicitly. Upstream has since fixed the server's
-  // spelling too (keeping the legacy name alongside, so the workaround would still resolve), but
-  // there is no reason to keep it: the fixture is not in that artifact any more.
-  testImplementation(testFixtures(libs.composeai.preview.render.host))
+  // We consumed it by naming that capability explicitly. That workaround is gone twice over: the
+  // fixture is not in the server artifact any more, and this is no longer a published coordinate.
+  testImplementation(testFixtures(project(":render-host")))
   // Gradle TestKit drives a real Gradle build inside [InitScriptExclusiveContentReproducerTest] —
   // the only way to assert that the rendered init script doesn't trip Gradle 9.3+'s
   // `exclusiveContent`-vs-`buildscript.repositories` validation when the consumer's
@@ -783,9 +782,9 @@ tasks.named("check") { dependsOn("checkCliDaemonLibraryBoundary") }
 // module of this build; a published artifact enforces the same thing structurally and in the
 // stronger direction, because nothing in `cli/serve` can reach back into `:cli` from Maven Central.
 // The surviving question that note used to end on — that most of the crossing symbols were
-// render-host and history plumbing rather than server code — has since been answered upstream:
-// compose-preview-server 2.2.0 split them into `compose-preview-render-host`, which `:cli` now
-// depends on directly (#4832). Four symbols still cross into the server proper, all of them from
+// render-host and history plumbing rather than server code — has since been answered: the server
+// split them out in 2.2.0 and they now live in this build as `:render-host` (#5137), which `:cli`
+// depends on as a project. Four symbols still cross into the server proper, all of them from
 // `ServeCommand.kt`; see the dependency block above for what that still costs and what deciding
 // it would take.
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -371,9 +371,10 @@ composeai-contracts = "2.5.0"
 #
 # 2.2.0 also brought `compose-preview-render-host` — the render host, the bundle daemon and the
 # git-backed preview history, split out of the server so a caller that only renders offline does not
-# link a web server (yschimke/compose-preview-server#38, this repository's #4832). ONE version ref
-# for both, deliberately: they are cut from one build and one tag over there, and a skew between the
-# server and the render host it sits on top of is not a state that repository can produce.
+# link a web server (yschimke/compose-preview-server#38, this repository's #4832). That artifact is
+# GONE from this catalog: the module moved here in 1.77.0 (#5137), the server now consumes it from
+# this repository (compose-preview-server#289), and 3.0.0 retired the old coordinate at its final
+# 2.x. `:cli` depends on `project(":render-host")`; there is no version ref to share any more.
 composeai-preview-serve = "3.0.0"
 
 # The Remote Compose players, published by yschimke/rc-players (the CMP player stack, the vendored
@@ -418,12 +419,6 @@ composeai-parity-issues-protocol = { module = "ee.schimke.composeai:parity-issue
 # as a Gradle feature variant, so `testFixtures(libs.composeai.preview.serve)` picks it up without
 # a second catalog entry.
 composeai-preview-serve = { module = "ee.schimke.composeai:compose-preview-serve", version.ref = "composeai-preview-serve" }
-# The render host and history plumbing, without the web server (see `composeai-preview-serve` for
-# why they share a version ref). `compose-preview-serve` depends on this, so the coordinate would
-# resolve transitively either way; `:cli` names it because `bundle render` and `history manifest`
-# depend on it DIRECTLY and should say so — the day `serve` stops being a CLI command, those
-# commands keep compiling without anyone rediscovering what they were really using.
-composeai-preview-render-host = { module = "ee.schimke.composeai:compose-preview-render-host", version.ref = "composeai-preview-serve" }
 
 # The Remote Compose players (see `rcplayers`).
 rcplayer-trace = { module = "ee.schimke.composeai:rc-player-trace", version.ref = "rcplayers" }


### PR DESCRIPTION
Unbreaks `main`.

## The failure

Every job that builds the CLI is red on `main` at `2ee93ec`:

```
Could not determine the dependencies of task ':cli:installDist'.
> Could not resolve all dependencies for configuration ':cli:runtimeClasspath'.
   > Could not find ee.schimke.composeai:compose-preview-render-host:3.0.0.
```

## Why

`compose-preview-server` [3.0.0](https://github.com/yschimke/compose-preview-server/pull/289) stopped publishing `compose-preview-render-host`. That is deliberate and is why the release was a major: the module moved into **this** repository in 1.77.0 (#5137), the server now consumes it from here, and the old coordinate stays resolvable only at its final `2.23.0`.

The move landed on both sides except for one thing — `:cli` was never repointed. It kept resolving the external artifact through a catalog entry sharing the `composeai-preview-serve` version ref:

```toml
composeai-preview-render-host = { module = "ee.schimke.composeai:compose-preview-render-host", version.ref = "composeai-preview-serve" }
```

So `:cli` was downloading a frozen copy of a module this build already compiles. That was invisible while the ref was 2.x. Renovate's bump to 3.0.0 (#5164, automerged) asked Central for a version that will never be published, and `main` went red.

`settings.gradle.kts` already described the intended end state: *"Depending on it from `:cli` is half of the dependency cycle in compose-preview-server#180, and the half with no reason to exist."*

## What changed

- `cli/build.gradle.kts` — `api(libs.composeai.preview.render.host)` → `api(project(":render-host"))`, and `testImplementation(testFixtures(...))` likewise.
- `gradle/libs.versions.toml` — `composeai-preview-render-host` deleted; nothing else referenced it. Comments on the version ref and in `cli/build.gradle.kts` updated where they still named the server as publisher.

`render-host/build.gradle.kts` already applies `java-test-fixtures` and publishes as artifactId `render-host`, so both call sites have a local equivalent. The capability workaround the old comment documented is retired twice over: the fixture left the server artifact in 2.2.0, and a project dependency does no capability matching at all.

**Not a revert of #5164.** The `composeai-preview-serve` ref is correct at 3.0.0 for the server itself; only the render-host entry riding that ref was wrong.

## Test plan

Deliberately none locally — CI is the test, at the author's direction. The local `:cli:dependencies` probe was cut short in the sandbox, so **this diff is unvalidated on my side**; the checks to watch are `Build plugin + CLI`, `Apply compose-preview` and `A11y + notification previews`, all of which fail on `main` today with the error above and must come back green here.

Non-visual change; no render evidence applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1TLkhcQFjNqeqdkDcKVkS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1TLkhcQFjNqeqdkDcKVkS)_