### PR TITLE
fix(cli): report a cancelled discovery as a timeout, not a missing plugin

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
@@ -113,6 +113,9 @@ internal object CliFlagValidation {
           "--plugin-version",
           "--project",
           "--report",
+          // Doctor's discovery pass runs under the same budget every other command uses, so the
+          // flag that raises it has to be accepted here too (issue #5171).
+          "--timeout",
           "--variant",
           "--verbose",
           "-v",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -407,6 +407,7 @@ abstract class Command(
           gradle.lastDiscoveryFailures,
           pluginVersion = injectedPluginVersion,
           pluginVersionSource = injectedPluginVersionSource,
+          timeoutSeconds = timeoutSeconds,
         )
         exitProcess(1)
       }
@@ -427,6 +428,7 @@ abstract class Command(
         gradle.lastDiscoveryFailures,
         pluginVersion = injectedPluginVersion,
         pluginVersionSource = injectedPluginVersionSource,
+        timeoutSeconds = timeoutSeconds,
       )
       exitProcess(1)
     }
@@ -1148,8 +1150,18 @@ internal fun printDiscoveryFailures(
   err: (String) -> Unit = System.err::println,
   pluginVersion: String? = null,
   pluginVersionSource: String? = null,
+  timeoutSeconds: Long? = null,
 ) {
   if (failures.isEmpty()) return
+  // A cancelled discovery leads, ahead of every other classification: the projects it skipped were
+  // never configured, so nothing about them — plugin applied or not, marker resolvable or not — was
+  // actually observed (issue #5171). Emitting the setup-shaped guidance first would send the user
+  // to edit build files that are already correct.
+  discoveryTimeoutGuidance(failures, timeoutSeconds)?.let {
+    err(it)
+    val matching = failures.count { f -> isDiscoveryCancellationFailure(f.message) }
+    if (matching * 2 >= failures.size) return
+  }
   // The plugin marker not resolving is never the consumer's build being wrong, so it leads —
   // ahead of the AGP guidance and the per-project list (issue #5034). It only *replaces* them
   // when it accounts for at least half the failures, the same bar [agpClassloaderGuidance] uses:
@@ -1177,6 +1189,58 @@ internal fun printDiscoveryFailures(
   )
   failures.take(limit).forEach { err("  ${it.path}: ${it.message}") }
   if (failures.size > limit) err("  … and ${failures.size - limit} more")
+}
+
+/**
+ * Recognises a project that was **cancelled** mid-configuration rather than one that failed to
+ * configure. Gradle reports these as `Build cancelled.` (and, on the CLI side of the Tooling API,
+ * `BuildCancelledException`) once [GradleConnection.runBuildAction]'s timer fires its cancellation
+ * token — so the message is distinguishable from a real configuration error (issue #5171).
+ *
+ * This matters because a cancellation carries *no* information about the project: its build script
+ * was never evaluated, so "the plugin isn't applied" is not something discovery observed. Cold
+ * configuration of a large multi-module build takes minutes, which is exactly when the first
+ * discovery pass is cancelled and every project comes back "failed".
+ */
+internal fun isDiscoveryCancellationFailure(message: String): Boolean =
+  message.contains("Build cancelled", ignoreCase = true) ||
+    message.contains("BuildCancelledException")
+
+/**
+ * When **any** project was cancelled rather than failed ([isDiscoveryCancellationFailure]), returns
+ * the timeout explanation and the one remedy that works — re-run, because the second pass reuses
+ * the configuration cache — instead of the misleading "your project is misconfigured" reading of a
+ * skipped project (issue #5171). Returns `null` when nothing was cancelled, so the AGP / marker /
+ * per-project reporting below is unchanged for genuine configuration failures.
+ *
+ * The bar is one cancellation, not the "dominates the list" bar the other guidances use: a single
+ * cancelled project already means discovery did not finish, and results from an unfinished
+ * discovery cannot be read as a complete picture of the build.
+ */
+internal fun discoveryTimeoutGuidance(
+  failures: List<ProjectDiscoveryFailure>,
+  timeoutSeconds: Long? = null,
+): String? {
+  val matching = failures.count { isDiscoveryCancellationFailure(it.message) }
+  if (matching == 0) return null
+  val budget = timeoutSeconds?.let { " after ${it}s" } ?: ""
+  return buildString {
+    appendLine(
+      "Discovery timed out$budget while Gradle was still configuring the build: " +
+        "$matching of ${failures.size} project(s) were cancelled mid-configuration " +
+        "(\"Build cancelled.\"), not misconfigured. Their previews are not listed, and whether " +
+        "they apply the plugin is unknown — discovery never got far enough to see."
+    )
+    appendLine()
+    append(
+      "A build with no configuration cache entry pays full cold configuration on the first pass, " +
+        "which on a large multi-module build can take minutes. Re-run the same command — the " +
+        "second pass reuses the cached configuration — or raise the budget with " +
+        "--timeout <seconds>" +
+        (timeoutSeconds?.let { " (e.g. --timeout ${it * 2})" } ?: "") +
+        "."
+    )
+  }
 }
 
 /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -74,6 +74,16 @@ class DoctorCommand(
   private val projectDirArg = args.flagValue("--project")
 
   /**
+   * `--timeout <seconds>` — the budget the discovery model query runs under, mirroring
+   * [Command.timeoutSeconds] so `doctor` reads the same flag as every other command. Doctor used
+   * `runBuildAction`'s 60s default and had no way to raise it, which is how a cold configuration
+   * that legitimately takes minutes came back as "no modules have the plugin applied"
+   * (issue #5171).
+   */
+  private val timeoutSeconds: Long =
+    args.flagValue("--timeout")?.toLongOrNull() ?: GradleConnection.DEFAULT_TIMEOUT_SECONDS
+
+  /**
    * Opt-in: when set, [runProjectChecks] also spawns each module's daemon JVM, completes the
    * `initialize` round-trip, and tears it down. Slow (~600ms desktop, 3-10s Robolectric per module)
    * so it's a separate flag rather than part of the default battery. `--with-daemon` is the same
@@ -368,9 +378,13 @@ class DoctorCommand(
             // project-scope checks can compare against the daemon's JDK
             // (e.g. flagging test worker mismatch in #142).
             checkGradleDaemon(gc)
-            gc.runBuildAction(GatherComposePreviewModelAction()).also {
-              gradleAccessFailure = gc.lastModelAccessFailure
-            }
+            // The caller's `--timeout` budget, not `runBuildAction`'s 60s default: discovery
+            // configures every project, and a cold multi-module configuration measured in minutes
+            // was being cancelled at 60s and then reported as a project-setup problem (issue
+            // #5171).
+            gc
+              .runBuildAction(GatherComposePreviewModelAction(), timeoutSeconds = timeoutSeconds)
+              .also { gradleAccessFailure = gc.lastModelAccessFailure }
           }
       } catch (e: Exception) {
         addCheck(
@@ -454,27 +468,79 @@ class DoctorCommand(
               if (fs.size > 10) " (… and ${fs.size - 10} more)" else ""
           }
       val raceGuidance = model.failures.firstNotNullOfOrNull { diagnosePublicationRace(it.message) }
+      // A project cancelled mid-configuration was never evaluated, so discovery did not observe
+      // anything about it — least of all that the plugin isn't applied. Reporting the cold-start
+      // timeout as a setup problem, complete with a `plugins { }` snippet, sent people off to edit
+      // build files that were already correct (issue #5171).
+      val cancelled = model.failures.count { isDiscoveryCancellationFailure(it.message) }
+      if (cancelled > 0 && raceGuidance == null) {
+        addCheck(
+          DoctorCheck(
+            id = "project.discovery-timeout",
+            category = "project",
+            status = "error",
+            message =
+              "discovery timed out after ${timeoutSeconds}s while Gradle configured the build",
+            detail =
+              "$cancelled of ${model.failures.size} project(s) were cancelled mid-configuration " +
+                "(\"Build cancelled.\") rather than failing to configure. A build with no " +
+                "configuration cache entry pays full cold configuration on the first pass, which " +
+                "on a large multi-module build can take minutes." +
+                (failureDetail?.let { " $it" } ?: ""),
+            remediation =
+              DoctorRemediation(
+                summary =
+                  "Re-run the same command — the second pass reuses the cached configuration — or " +
+                    "raise the budget with --timeout <seconds>.",
+                commands =
+                  listOf(
+                    "compose-preview doctor",
+                    "compose-preview doctor --timeout ${timeoutSeconds * 2}",
+                  ),
+              ),
+          )
+        )
+        addCheck(
+          DoctorCheck(
+            id = "project.plugin-applied",
+            category = "project",
+            status = "skipped",
+            message = "plugin application check skipped because discovery did not complete",
+          )
+        )
+        return
+      }
+      // Discovery that skipped projects can't tell "the plugin isn't applied" from "we never
+      // looked", so the honest verdict when anything failed is that discovery is incomplete — and
+      // the `plugins { }` snippet, which asserts the former, is withheld (issue #5171).
+      val incomplete = raceGuidance == null && model.failures.isNotEmpty()
       addCheck(
         DoctorCheck(
           id = "project.plugin-applied",
           category = "project",
           status = "error",
-          message = "no modules have the compose-preview plugin applied",
+          message =
+            if (incomplete)
+              "discovery did not complete — ${model.failures.size} project(s) failed to configure, " +
+                "so no modules could be inspected"
+            else "no modules have the compose-preview plugin applied",
           detail = failureDetail,
           remediation =
             DoctorRemediation(
               summary =
                 if (raceGuidance != null) raceGuidance
-                else if (failureDetail != null)
-                  "Projects failed to configure during discovery — rerun with --verbose for full " +
-                    "Gradle output. If the plugin is applied via a convention plugin, the CLI now " +
-                    "skips auto-inject automatically; otherwise apply it in your module's " +
-                    "`plugins { }` block."
+                else if (incomplete)
+                  "Fix the configuration failures above — rerun with --verbose for full Gradle " +
+                    "output. Until discovery completes the CLI cannot tell whether the plugin is " +
+                    "applied. If it is applied via a convention plugin, the CLI skips auto-inject " +
+                    "automatically."
                 else "Apply the plugin in your module's `plugins { }` block.",
               commands =
-                listOf(
-                  "id(\"ee.schimke.composeai.preview\") version \"$recommendedPluginVersion\""
-                ),
+                if (incomplete) listOf("compose-preview doctor --verbose")
+                else
+                  listOf(
+                    "id(\"ee.schimke.composeai.preview\") version \"$recommendedPluginVersion\""
+                  ),
               docs = "https://github.com/$REPO#usage",
             ),
         )

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DiscoveryFailureReportingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DiscoveryFailureReportingTest.kt
@@ -118,4 +118,85 @@ class DiscoveryFailureReportingTest {
     assertTrue(lines.any { it.contains(":lib:") }, "got $lines")
     assertEquals(null, agpClassloaderGuidance(failures))
   }
+
+  // A cold configuration cancelled by the CLI's timeout (issue #5171). Gradle words the
+  // per-project failure as "Build cancelled." behind the model-build wrapper.
+  private val cancelled =
+    "Could not build 'ee.schimke.composeai.plugin.tooling.ComposePreviewModel' model. " +
+      "Build cancelled."
+
+  @Test
+  fun `recognises a cancelled project and does not confuse it with a configuration failure`() {
+    assertTrue(isDiscoveryCancellationFailure(cancelled))
+    assertTrue(isDiscoveryCancellationFailure("BuildCancelledException: Build cancelled"))
+    assertTrue(!isDiscoveryCancellationFailure("Cannot resolve external dependency"))
+    assertTrue(
+      !isDiscoveryCancellationFailure(noClassDefFound),
+      "the AGP classloader signature is a real configuration failure, not a timeout",
+    )
+  }
+
+  @Test
+  fun `a cancelled discovery is reported as a timeout, with re-run advice and no setup guidance`() {
+    val failures =
+      listOf(
+        ProjectDiscoveryFailure(
+          ":",
+          "A problem occurred configuring root project. Build cancelled.",
+        ),
+        ProjectDiscoveryFailure(":app", cancelled),
+        ProjectDiscoveryFailure(":cli", cancelled),
+      )
+    val lines = mutableListOf<String>()
+    printDiscoveryFailures(failures, err = { lines += it }, timeoutSeconds = 120)
+    val msg = lines.joinToString("\n")
+    assertTrue(msg.contains("Discovery timed out after 120s"), msg)
+    assertTrue(msg.contains("3 of 3 project(s) were cancelled"), msg)
+    assertTrue(msg.contains("Re-run the same command"), msg)
+    assertTrue(msg.contains("--timeout 240"), msg)
+    // The whole point of #5171: no "your project is misconfigured" reading of a skipped project.
+    assertTrue(!msg.contains("plugins { }"), msg)
+    assertTrue(!msg.contains("failed to configure during discovery"), msg)
+  }
+
+  @Test
+  fun `omits the budget when the caller has no timeout to report`() {
+    val lines = mutableListOf<String>()
+    printDiscoveryFailures(
+      listOf(ProjectDiscoveryFailure(":app", cancelled)),
+      err = { lines += it },
+    )
+    val msg = lines.joinToString("\n")
+    assertTrue(msg.contains("Discovery timed out while Gradle"), msg)
+    assertTrue(!msg.contains("--timeout <seconds> (e.g."), msg)
+  }
+
+  @Test
+  fun `keeps the per-project list when cancellations are a minority of the failures`() {
+    val failures =
+      listOf(
+        ProjectDiscoveryFailure(":app", cancelled),
+        ProjectDiscoveryFailure(":lib", "Cannot resolve external dependency"),
+        ProjectDiscoveryFailure(":data", "Cannot resolve external dependency"),
+      )
+    val lines = mutableListOf<String>()
+    printDiscoveryFailures(failures, err = { lines += it }, timeoutSeconds = 600)
+    val msg = lines.joinToString("\n")
+    // The timeout still leads — discovery did not finish — but the real failures are not hidden.
+    assertTrue(msg.contains("Discovery timed out"), msg)
+    assertTrue(msg.contains("3 project(s) failed to configure"), msg)
+    assertTrue(lines.any { it.contains(":lib:") }, "got $lines")
+  }
+
+  @Test
+  fun `no timeout guidance when nothing was cancelled`() {
+    assertEquals(
+      null,
+      discoveryTimeoutGuidance(
+        listOf(ProjectDiscoveryFailure(":app", "boom")),
+        timeoutSeconds = 60,
+      ),
+    )
+    assertEquals(null, discoveryTimeoutGuidance(emptyList()))
+  }
 }


### PR DESCRIPTION
Fixes #5171.

## Summary

A cold Gradle configuration that outran the discovery budget came back from `doctor` / `list` / `show` as **"no modules have the compose-preview plugin applied"**, with a `plugins { }` snippet to paste. That is confidently wrong on a project whose build files are already correct — the plugin *is* applied, discovery just never got far enough to see it — and it is indistinguishable from a genuinely unconfigured build. Re-running the same command succeeds, because the second pass reuses the configuration cache.

The information to tell the two apart was already there: the per-project failure reads `Build cancelled.`, not a configuration error.

- **Classify cancellation separately.** `isDiscoveryCancellationFailure` recognises the `Build cancelled.` / `BuildCancelledException` message the timeout's cancellation token produces; `discoveryTimeoutGuidance` explains the timeout, advises re-running (the cheap fix) and raising `--timeout <seconds>`, and never mentions `plugins { }`. It leads the stderr report for `list` / `show` on **one** cancellation — an unfinished discovery cannot be read as a complete picture — but only *replaces* the per-project list when cancellations dominate, so genuine configuration failures alongside it are still printed.
- **`doctor` stops asserting what it did not observe.** With a cancellation it emits `project.discovery-timeout` (re-run, or `--timeout <2×budget>`) and marks `project.plugin-applied` **skipped**.
- **Suppress the remediation whenever discovery was incomplete.** Even with no cancellation, a discovery that skipped projects can't tell "the plugin isn't applied" from "we never looked", so that verdict now reads *"discovery did not complete — N project(s) failed to configure"* and withholds the `plugins { }` snippet. This is fix (3) from the issue and covers causes we haven't classified yet.
- **Give the cold pass a real budget.** `doctor` ran discovery on `runBuildAction`'s 60s default with no way to raise it — the measured cold configuration in the report was 2m21s. It now uses the caller's `--timeout` (default 600s, same as every other command) and accepts the flag.

Non-visual change: this is CLI diagnostic text, so the evidence is the expected output below plus unit tests.

Before (cold `doctor` on meshcore-mobile):

```
[project]
✗ no modules have the compose-preview plugin applied
    15 project(s) failed to configure during discovery and were skipped:
    :app: Could not build '…ComposePreviewModel' model. Build cancelled.; …
    → Projects failed to configure during discovery → rerun with --verbose …
      $ id("ee.schimke.composeai.preview") version "1.79.0"
```

After:

```
[project]
✗ discovery timed out after 600s while Gradle configured the build
    15 of 15 project(s) were cancelled mid-configuration ("Build cancelled.")
    rather than failing to configure. A build with no configuration cache entry
    pays full cold configuration on the first pass, which on a large
    multi-module build can take minutes.
    → Re-run the same command — the second pass reuses the cached configuration
      — or raise the budget with --timeout <seconds>.
      $ compose-preview doctor
      $ compose-preview doctor --timeout 1200
- plugin application check skipped because discovery did not complete
```

## Test plan

`cli/src/test/kotlin/…/DiscoveryFailureReportingTest.kt` gains five cases: the classifier (and that it does **not** match the AGP-classloader signature or an unresolved dependency), the timeout report with its re-run advice and no `plugins { }` text, the no-budget wording, that a minority of cancellations keeps the per-project list, and that nothing is emitted when nothing was cancelled.

```
./gradlew :cli:test --tests '*DiscoveryFailureReportingTest*' --tests '*PluginResolutionDiagnosisTest*'   # green
./gradlew :cli:ktfmtFormatMain :cli:ktfmtFormatTest
```

One note on running those locally: `main` currently cannot resolve `:cli:testRuntimeClasspath` — `composeai-preview-serve = "3.0.0"` (#5164) is a shared version ref, and `compose-preview-render-host` has no 3.0.0 on Central (latest is 2.23.0). I ran the tests with that ref temporarily pinned to 2.23.0 and **reverted it**; the pin is not part of this diff. That break is independent of this change and wants its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MUjGJNNMkWL5YbxceHec3

---
_Generated by [Claude Code](https://claude.ai/code/session_017MUjGJNNMkWL5YbxceHec3)_