### PR TITLE
refactor(daemon): give the composeai.daemon.* sysprops a typed registry

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.daemon
 import ee.schimke.composeai.daemon.bridge.DaemonHostBridge
 import ee.schimke.composeai.daemon.bridge.InteractiveCommand
 import ee.schimke.composeai.daemon.bridge.SandboxSlot
+import ee.schimke.composeai.daemon.config.DaemonProperties
 import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
 import ee.schimke.composeai.daemon.protocol.InteractiveInputParams
 import ee.schimke.composeai.daemon.protocol.RemoteComposeChange
@@ -94,8 +95,7 @@ internal constructor(
    * verify the lease itself or for scenarios where an external lifecycle (e.g. a smoke test driver)
    * owns the session's close path explicitly.
    */
-  private val idleLeaseMs: Long =
-    System.getProperty(IDLE_LEASE_PROP)?.toLongOrNull() ?: DEFAULT_IDLE_LEASE_MS,
+  private val idleLeaseMs: Long = DaemonProperties.interactiveIdleLeaseMs.read(),
   /**
    * Invoked from [close] (after the bridge round-trip and `activeStreamRef` clear) so the host can
    * drop its own reference to this session — see [RobolectricHost.activeInteractiveSession]. PR C
@@ -872,7 +872,7 @@ internal constructor(
      * [DEFAULT_IDLE_LEASE_MS] of inactivity. Operators can tune this for slow networks; tests pass
      * a non-default via the constructor parameter directly.
      */
-    const val IDLE_LEASE_PROP: String = "composeai.daemon.interactive.idleLeaseMs"
+    const val IDLE_LEASE_PROP: String = DaemonProperties.Names.INTERACTIVE_IDLE_LEASE_MS
 
     /**
      * Default idle-lease timeout — 1 minute. Long enough that a user thinking about their preview

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidxTraceSections.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidxTraceSections.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.config.DaemonProperties
 import ee.schimke.composeai.data.render.PerfettoTraceDataProducer
 
 /**
@@ -32,12 +33,12 @@ import ee.schimke.composeai.data.render.PerfettoTraceDataProducer
 internal object AndroidxTraceSections : PerfettoTraceDataProducer.TraceSectionBackend {
 
   /** Sysprop turning the atrace mirror on. Default off — see the class KDoc for why. */
-  const val ENABLED_PROP: String = "composeai.daemon.atrace"
+  const val ENABLED_PROP: String = DaemonProperties.Names.ATRACE
 
   /** `android.os.Trace` truncates section names beyond this; cut cleanly instead. */
   private const val MAX_SECTION_NAME_LENGTH = 127
 
-  fun enabled(): Boolean = System.getProperty(ENABLED_PROP) == "true"
+  fun enabled(): Boolean = DaemonProperties.atrace.read()
 
   /**
    * Registers this backend on [PerfettoTraceDataProducer.sectionBackend] when [enabled]. Idempotent

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -4,6 +4,7 @@
 package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.daemon.bridge.DaemonHostBridge
+import ee.schimke.composeai.daemon.config.DaemonProperties
 import ee.schimke.composeai.daemon.devices.frameDpOverriddenBy
 import ee.schimke.composeai.daemon.history.GitProvenance
 import ee.schimke.composeai.daemon.history.GitRefHistorySource
@@ -83,7 +84,7 @@ fun main(args: Array<String>) {
   // left to serve normal renders, and a typical preview grid wants extra slots for parallel
   // renders, so default the pool to five sandboxes when warmSpare is on — one here plus four
   // worker JVMs (SANDBOX-POOL.md). Explicit `composeai.daemon.sandboxCount` still wins.
-  val warmSpareEnabled = System.getProperty(WARM_SPARE_PROP)?.toBooleanStrictOrNull() ?: true
+  val warmSpareEnabled = DaemonProperties.warmSpare.read()
   val defaultSandboxCount = if (warmSpareEnabled) 5 else 1
 
   // SANDBOX-POOL.md (Layer 3) — read the supervisor-supplied sandbox-count knob. When unset, use
@@ -756,13 +757,13 @@ private inline fun MutableList<Extension>.tryAdd(label: String, build: () -> Ext
 }
 
 /** HISTORY.md § "What this PR lands § H1" — null disables history. */
-private const val HISTORY_DIR_PROP = "composeai.daemon.historyDir"
+private const val HISTORY_DIR_PROP = DaemonProperties.Names.HISTORY_DIR
 
 /** Optional override for git-provenance resolution; defaults to JVM CWD. */
-private const val WORKSPACE_ROOT_PROP = "composeai.daemon.workspaceRoot"
+private const val WORKSPACE_ROOT_PROP = DaemonProperties.Names.WORKSPACE_ROOT
 
 /** Module project path stamped into every history entry's `module` field. */
-private const val MODULE_ID_PROP = "composeai.daemon.moduleId"
+private const val MODULE_ID_PROP = DaemonProperties.Names.MODULE_ID
 
 /**
  * Adapts [PreviewIndex] into the resolver [RobolectricHost] needs for held interactive sessions.
@@ -914,6 +915,4 @@ private fun Float.roundHalfUpPx(): Int = kotlin.math.floor(this + 0.5f).toInt().
  * replicasPerDaemon`. Default 1 preserves the pre-pool single-sandbox behaviour. Values < 1 are
  * coerced to 1.
  */
-private const val SANDBOX_COUNT_PROP = "composeai.daemon.sandboxCount"
-
-private const val WARM_SPARE_PROP = "composeai.daemon.warmSpare"
+private const val SANDBOX_COUNT_PROP = DaemonProperties.Names.SANDBOX_COUNT

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -23,6 +23,7 @@ import com.github.takahirom.roborazzi.captureRoboImage
 import ee.schimke.composeai.daemon.bridge.DaemonHostBridge
 import ee.schimke.composeai.daemon.bridge.InteractiveCommand
 import ee.schimke.composeai.daemon.bridge.SandboxSlot
+import ee.schimke.composeai.daemon.config.DaemonProperties
 import ee.schimke.composeai.daemon.pool.SandboxProcessPool
 import ee.schimke.composeai.daemon.protocol.DataExtensionDescriptor
 import ee.schimke.composeai.daemon.protocol.SemanticsInputTarget
@@ -166,9 +167,7 @@ open class RobolectricHost(
    * 1 for the rest of the daemon's lifetime — interactive capacity is one held session at a time
    * per host (INTERACTIVE-ANDROID.md § 2.1), so a single zombie burns the whole pool.
    */
-  private val interactiveIdleLeaseMs: Long =
-    System.getProperty(AndroidInteractiveSession.IDLE_LEASE_PROP)?.toLongOrNull()
-      ?: AndroidInteractiveSession.DEFAULT_IDLE_LEASE_MS,
+  private val interactiveIdleLeaseMs: Long = DaemonProperties.interactiveIdleLeaseMs.read(),
   /**
    * Issue #1204 — interactive-session lifecycle listener for the `compose/recomposition` producer
    * ([AndroidRecompositionDataProductRegistry]). Called from [acquireInteractiveSession] after the
@@ -442,9 +441,7 @@ open class RobolectricHost(
     if (sandboxCount > 1)
       SandboxProcessPool(
         workerCount = sandboxCount - 1,
-        bootTimeoutMs =
-          System.getProperty(SANDBOX_BOOT_TIMEOUT_PROP)?.toLongOrNull()
-            ?: DEFAULT_SANDBOX_BOOT_TIMEOUT_MS,
+        bootTimeoutMs = DaemonProperties.sandboxBootTimeoutMs.read(),
       )
     else null
 
@@ -530,13 +527,9 @@ open class RobolectricHost(
     // One in-process slot, always. Slots 1..N-1 live in worker JVMs and hold no bridge state here.
     DaemonHostBridge.configureSlotCount(LOCAL_SANDBOX_COUNT)
     readySlotCount.set(0)
-    val timeoutMs =
-      System.getProperty(SANDBOX_BOOT_TIMEOUT_PROP)?.toLongOrNull()
-        ?: DEFAULT_SANDBOX_BOOT_TIMEOUT_MS
+    val timeoutMs = DaemonProperties.sandboxBootTimeoutMs.read()
     // Read per-start (not at construction) so tests can flip the sysprop around start().
-    val backgroundBoot =
-      sandboxCount > 1 &&
-        (System.getProperty(BACKGROUND_BOOT_PROP)?.toBooleanStrictOrNull() ?: false)
+    val backgroundBoot = sandboxCount > 1 && DaemonProperties.backgroundSandboxBoot.read()
 
     // SANDBOX-POOL.md — slot 0 is the in-process sandbox and always boots eagerly: [start]'s
     // contract is that the host can serve a render when it returns. Slots 1..N-1 are worker JVMs,
@@ -632,8 +625,7 @@ open class RobolectricHost(
    * correctness one. Disable with `-Dcomposeai.daemon.warmRenderOnBoot=false`.
    */
   private fun warmSlotRender(slotIdx: Int) {
-    val enabled = System.getProperty(WARM_RENDER_PROP)?.toBooleanStrictOrNull() ?: true
-    if (!enabled) return
+    if (!DaemonProperties.warmRenderOnBoot.read()) return
     val id = RenderHost.nextRequestId()
     val startedAt = System.nanoTime()
     try {
@@ -2033,7 +2025,7 @@ open class RobolectricHost(
     const val ANDROID_SDK: Int = 35
 
     /** Same sysprop the desktop side uses; honoured on Android too. */
-    const val RECORDINGS_DIR_PROP: String = "composeai.daemon.recordingsDir"
+    const val RECORDINGS_DIR_PROP: String = DaemonProperties.Names.RECORDINGS_DIR
 
     /**
      * Sysprop knob for [start]'s sandbox-bootstrap deadline. Cold first run on an empty Maven local
@@ -2042,7 +2034,7 @@ open class RobolectricHost(
      * that. Warm boots (cache hit) are 5–15s and never approach this limit. Override with
      * `-Dcomposeai.daemon.sandboxBootTimeoutMs=<ms>` for slower CI runners or constrained networks.
      */
-    const val SANDBOX_BOOT_TIMEOUT_PROP: String = "composeai.daemon.sandboxBootTimeoutMs"
+    const val SANDBOX_BOOT_TIMEOUT_PROP: String = DaemonProperties.Names.SANDBOX_BOOT_TIMEOUT_MS
 
     /** 10 minutes — covers a cold-cache instrumented-android-all download + first-time scan. */
     const val DEFAULT_SANDBOX_BOOT_TIMEOUT_MS: Long = 10L * 60L * 1000L
@@ -2056,14 +2048,14 @@ open class RobolectricHost(
      * `ServeBundleDaemon` sets it for serve-spawned Android daemons and the deploy image sets it
      * via `JAVA_TOOL_OPTIONS`.
      */
-    const val BACKGROUND_BOOT_PROP: String = "composeai.daemon.backgroundSandboxBoot"
+    const val BACKGROUND_BOOT_PROP: String = DaemonProperties.Names.BACKGROUND_SANDBOX_BOOT
 
     /**
      * Sysprop gating the boot-time warm render each background-booted slot gets (see
      * [warmSlotRender]). Default **true** — only consulted when background boot is active, since
      * the warm render rides the background boot thread.
      */
-    const val WARM_RENDER_PROP: String = "composeai.daemon.warmRenderOnBoot"
+    const val WARM_RENDER_PROP: String = DaemonProperties.Names.WARM_RENDER_ON_BOOT
 
     /**
      * Budget for one boot-time warm render. Generous versus a warm frame (~seconds) because the

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunner.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunner.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.config.DaemonProperties
 import ee.schimke.composeai.renderer.ShadowFontsContractCompat
 import ee.schimke.composeai.renderer.ShadowPausedClockHardwareRenderer
 import org.junit.runners.model.FrameworkMethod
@@ -72,9 +73,7 @@ open class SandboxHoldingRunner(testClass: Class<*>) : RobolectricTestRunner(tes
   @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
   override fun buildGlobalConfig(): Config {
     val parent = super.buildGlobalConfig()
-    val useConsumerApp =
-      System.getProperty("composeai.daemon.useConsumerApplication", "false").toBoolean()
-    if (useConsumerApp) return parent
+    if (DaemonProperties.useConsumerApplication.read()) return parent
     return Config.Builder(parent).setApplication(android.app.Application::class.java).build()
   }
 
@@ -107,14 +106,7 @@ open class SandboxHoldingRunner(testClass: Class<*>) : RobolectricTestRunner(tes
     }
     // B2.0: optional user-package exclusion. Empty when sysprop is unset; existing in-process
     // tests that rely on the default sandbox-classpath path are unaffected.
-    val raw = System.getProperty("composeai.daemon.userClassPackages")
-    if (!raw.isNullOrBlank()) {
-      raw
-        .split(java.io.File.pathSeparator)
-        .map { it.trim() }
-        .filter { it.isNotEmpty() }
-        .forEach { builder.doNotAcquirePackage(it) }
-    }
+    DaemonProperties.userClassPackages.read().forEach { builder.doNotAcquirePackage(it) }
     return builder.build()
   }
 

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/pool/SandboxProcessPool.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/pool/SandboxProcessPool.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.daemon.pool
 
 import ee.schimke.composeai.daemon.RenderRequest
 import ee.schimke.composeai.daemon.RenderResult
+import ee.schimke.composeai.daemon.config.DaemonProperties
 import java.io.BufferedReader
 import java.io.BufferedWriter
 import java.io.File
@@ -331,10 +332,10 @@ class SandboxProcessPool(
   }
 
   companion object {
-    const val WORKER_PORT_PROP: String = "composeai.daemon.sandboxWorker.port"
-    const val WORKER_SLOT_PROP: String = "composeai.daemon.sandboxWorker.slot"
+    const val WORKER_PORT_PROP: String = DaemonProperties.Names.SANDBOX_WORKER_PORT
+    const val WORKER_SLOT_PROP: String = DaemonProperties.Names.SANDBOX_WORKER_SLOT
 
-    private const val SANDBOX_COUNT_PROP = "composeai.daemon.sandboxCount"
+    private const val SANDBOX_COUNT_PROP = DaemonProperties.Names.SANDBOX_COUNT
 
     private val FORWARDED_PREFIXES = listOf("composeai.", "robolectric.", "android.", "roborazzi.")
 
@@ -346,8 +347,8 @@ class SandboxProcessPool(
     private val WORKER_OVERRIDDEN_PROPS =
       setOf(
         SANDBOX_COUNT_PROP,
-        "composeai.daemon.backgroundSandboxBoot",
-        "composeai.daemon.warmRenderOnBoot",
+        DaemonProperties.Names.BACKGROUND_SANDBOX_BOOT,
+        DaemonProperties.Names.WARM_RENDER_ON_BOOT,
         WORKER_PORT_PROP,
         WORKER_SLOT_PROP,
       )

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.config.DaemonProperties
 import java.io.ByteArrayInputStream
 import java.io.File
 import javax.imageio.ImageIO
@@ -1198,7 +1199,10 @@ class RenderEngineTest {
   fun resourceReadsWriteResourcesUsedDataProduct() {
     val outputDir = tempFolder.newFolder("renders-resources")
     System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
-    System.setProperty("composeai.daemon.moduleProjectDir", File("daemon/android").absolutePath)
+    System.setProperty(
+      DaemonProperties.Names.MODULE_PROJECT_DIR,
+      File("daemon/android").absolutePath,
+    )
     System.setProperty("roborazzi.test.record", "true")
     val host = RobolectricHost()
     host.start()

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunnerApplicationOverrideTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunnerApplicationOverrideTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.config.DaemonProperties
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
@@ -24,12 +25,12 @@ class SandboxHoldingRunnerApplicationOverrideTest {
 
   @After
   fun clearSysprop() {
-    System.clearProperty("composeai.daemon.useConsumerApplication")
+    System.clearProperty(DaemonProperties.Names.USE_CONSUMER_APPLICATION)
   }
 
   @Test
   fun defaultPinsAndroidAppApplication() {
-    System.clearProperty("composeai.daemon.useConsumerApplication")
+    System.clearProperty(DaemonProperties.Names.USE_CONSUMER_APPLICATION)
     val runner = ExposedRunner(DummyTest::class.java)
     // FQN comparison (not class-identity) because the runner is constructed under Robolectric's
     // shadow-aware classloader chain; `android.app.Application::class.java` resolved here and the
@@ -45,14 +46,14 @@ class SandboxHoldingRunnerApplicationOverrideTest {
 
   @Test
   fun useConsumerApplicationFalseStillPinsStub() {
-    System.setProperty("composeai.daemon.useConsumerApplication", "false")
+    System.setProperty(DaemonProperties.Names.USE_CONSUMER_APPLICATION, "false")
     val runner = ExposedRunner(DummyTest::class.java)
     assertEquals("android.app.Application", runner.exposedGlobalConfig().application.java.name)
   }
 
   @Test
   fun useConsumerApplicationTrueRestoresParentDefault() {
-    System.setProperty("composeai.daemon.useConsumerApplication", "true")
+    System.setProperty(DaemonProperties.Names.USE_CONSUMER_APPLICATION, "true")
     val runner = ExposedRunner(DummyTest::class.java)
     // Opt-in must NOT pin android.app.Application — the consumer's manifest Application wins.
     // Robolectric's sentinel default ("look at manifest") is its own class

--- a/daemon/core/api/core.api
+++ b/daemon/core/api/core.api
@@ -984,18 +984,20 @@ public final class ee/schimke/composeai/daemon/PreviewKnobDeclarations {
 
 public final class ee/schimke/composeai/daemon/PreviewKnobDto {
 	public static final field Companion Lee/schimke/composeai/daemon/PreviewKnobDto$Companion;
-	public fun <init> (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()I
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/PreviewKnobDto;
-	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/PreviewKnobDto;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/PreviewKnobDto;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/util/List;)Lee/schimke/composeai/daemon/PreviewKnobDto;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/PreviewKnobDto;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/PreviewKnobDto;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDefault ()Ljava/lang/String;
 	public final fun getIndex ()I
 	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Ljava/util/List;
 	public final fun getType ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -1660,6 +1662,186 @@ public abstract interface class ee/schimke/composeai/daemon/XrSessions : java/la
 
 public final class ee/schimke/composeai/daemon/XrSessions$DefaultImpls {
 	public static synthetic fun open$default (Lee/schimke/composeai/daemon/XrSessions;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lee/schimke/composeai/daemon/XrFrame;
+}
+
+public final class ee/schimke/composeai/daemon/config/BooleanProperty : ee/schimke/composeai/daemon/config/DaemonProperty {
+	public fun <init> (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;)V
+	public fun getTypeLabel ()Ljava/lang/String;
+	public fun parse (Ljava/lang/String;)Ljava/lang/Boolean;
+	public synthetic fun parse (Ljava/lang/String;)Ljava/lang/Object;
+}
+
+public final class ee/schimke/composeai/daemon/config/CsvListProperty : ee/schimke/composeai/daemon/config/DaemonProperty {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun getDefaultLabel ()Ljava/lang/String;
+	public fun getTypeLabel ()Ljava/lang/String;
+	public synthetic fun parse (Ljava/lang/String;)Ljava/lang/Object;
+	public fun parse (Ljava/lang/String;)Ljava/util/List;
+}
+
+public final class ee/schimke/composeai/daemon/config/DaemonProperties {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/config/DaemonProperties;
+	public final fun getALL ()Ljava/util/List;
+	public final fun getAtrace ()Lee/schimke/composeai/daemon/config/BooleanProperty;
+	public final fun getBY_NAME ()Ljava/util/Map;
+	public final fun getBackgroundSandboxBoot ()Lee/schimke/composeai/daemon/config/BooleanProperty;
+	public final fun getBtaCompileClasspath ()Lee/schimke/composeai/daemon/config/PathListProperty;
+	public final fun getBtaCompilerPlugins ()Lee/schimke/composeai/daemon/config/PathListProperty;
+	public final fun getBtaIcWorkingDir ()Lee/schimke/composeai/daemon/config/PathProperty;
+	public final fun getBtaImplClasspath ()Lee/schimke/composeai/daemon/config/PathListProperty;
+	public final fun getBtaIneligibilityReason ()Lee/schimke/composeai/daemon/config/StringProperty;
+	public final fun getBtaModuleName ()Lee/schimke/composeai/daemon/config/StringProperty;
+	public final fun getBtaOutputDir ()Lee/schimke/composeai/daemon/config/PathProperty;
+	public final fun getBundleManifestPath ()Lee/schimke/composeai/daemon/config/PathProperty;
+	public final fun getCheapSignalFiles ()Lee/schimke/composeai/daemon/config/PathListProperty;
+	public final fun getClasspathDirtyGraceMs ()Lee/schimke/composeai/daemon/config/LongProperty;
+	public final fun getCompositionTrace ()Lee/schimke/composeai/daemon/config/BooleanProperty;
+	public final fun getDataFetchRerenderBudgetMs ()Lee/schimke/composeai/daemon/config/LongProperty;
+	public final fun getDefaultLocale ()Lee/schimke/composeai/daemon/config/StringProperty;
+	public final fun getDiscoveryWatchdogMs ()Lee/schimke/composeai/daemon/config/LongProperty;
+	public final fun getGROUPS ()Ljava/util/List;
+	public final fun getGitRefHistory ()Lee/schimke/composeai/daemon/config/CsvListProperty;
+	public final fun getGitRefHistoryDebounceMs ()Lee/schimke/composeai/daemon/config/LongProperty;
+	public final fun getGitRefHistoryPublishPolicy ()Lee/schimke/composeai/daemon/config/StringProperty;
+	public final fun getGitRefHistorySyncMode ()Lee/schimke/composeai/daemon/config/StringProperty;
+	public final fun getHistoryAutoPruneIntervalMs ()Lee/schimke/composeai/daemon/config/LongProperty;
+	public final fun getHistoryDir ()Lee/schimke/composeai/daemon/config/PathProperty;
+	public final fun getHistoryMaxAgeDays ()Lee/schimke/composeai/daemon/config/IntProperty;
+	public final fun getHistoryMaxEntriesPerPreview ()Lee/schimke/composeai/daemon/config/IntProperty;
+	public final fun getHistoryMaxTotalSizeBytes ()Lee/schimke/composeai/daemon/config/LongProperty;
+	public final fun getIdleTimeoutMs ()Lee/schimke/composeai/daemon/config/LongProperty;
+	public final fun getInteractiveIdleLeaseMs ()Lee/schimke/composeai/daemon/config/LongProperty;
+	public final fun getIrDir ()Lee/schimke/composeai/daemon/config/PathProperty;
+	public final fun getMaxHeapMb ()Lee/schimke/composeai/daemon/config/IntProperty;
+	public final fun getMaxRendersPerSandbox ()Lee/schimke/composeai/daemon/config/IntProperty;
+	public final fun getModuleId ()Lee/schimke/composeai/daemon/config/StringProperty;
+	public final fun getModulePath ()Lee/schimke/composeai/daemon/config/StringProperty;
+	public final fun getModuleProjectDir ()Lee/schimke/composeai/daemon/config/PathProperty;
+	public final fun getPerfettoTrace ()Lee/schimke/composeai/daemon/config/BooleanProperty;
+	public final fun getPreviewsJsonPath ()Lee/schimke/composeai/daemon/config/PathProperty;
+	public final fun getProtocolVersion ()Lee/schimke/composeai/daemon/config/StringProperty;
+	public final fun getRecordingsDir ()Lee/schimke/composeai/daemon/config/PathProperty;
+	public final fun getRenderTimeoutMs ()Lee/schimke/composeai/daemon/config/LongProperty;
+	public final fun getResDirs ()Lee/schimke/composeai/daemon/config/PathListProperty;
+	public final fun getSandboxBootTimeoutMs ()Lee/schimke/composeai/daemon/config/LongProperty;
+	public final fun getSandboxCount ()Lee/schimke/composeai/daemon/config/IntProperty;
+	public final fun getSandboxWorkerPort ()Lee/schimke/composeai/daemon/config/IntProperty;
+	public final fun getSandboxWorkerSlot ()Lee/schimke/composeai/daemon/config/IntProperty;
+	public final fun getStartupQuiet ()Lee/schimke/composeai/daemon/config/BooleanProperty;
+	public final fun getUseConsumerApplication ()Lee/schimke/composeai/daemon/config/BooleanProperty;
+	public final fun getUserClassDirs ()Lee/schimke/composeai/daemon/config/PathListProperty;
+	public final fun getUserClassPackages ()Lee/schimke/composeai/daemon/config/PathListProperty;
+	public final fun getWarmRenderOnBoot ()Lee/schimke/composeai/daemon/config/BooleanProperty;
+	public final fun getWarmSpare ()Lee/schimke/composeai/daemon/config/BooleanProperty;
+	public final fun getWorkspaceRoot ()Lee/schimke/composeai/daemon/config/PathProperty;
+	public final fun renderMarkdown ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/config/DaemonProperties$Names {
+	public static final field ATRACE Ljava/lang/String;
+	public static final field BACKGROUND_SANDBOX_BOOT Ljava/lang/String;
+	public static final field BTA_COMPILER_PLUGINS Ljava/lang/String;
+	public static final field BTA_COMPILE_CLASSPATH Ljava/lang/String;
+	public static final field BTA_IC_WORKING_DIR Ljava/lang/String;
+	public static final field BTA_IMPL_CLASSPATH Ljava/lang/String;
+	public static final field BTA_INELIGIBILITY_REASON Ljava/lang/String;
+	public static final field BTA_MODULE_NAME Ljava/lang/String;
+	public static final field BTA_OUTPUT_DIR Ljava/lang/String;
+	public static final field BUNDLE_MANIFEST_PATH Ljava/lang/String;
+	public static final field CHEAP_SIGNAL_FILES Ljava/lang/String;
+	public static final field CLASSPATH_DIRTY_GRACE_MS Ljava/lang/String;
+	public static final field COMPOSITION_TRACE Ljava/lang/String;
+	public static final field DATA_FETCH_RERENDER_BUDGET_MS Ljava/lang/String;
+	public static final field DEFAULT_LOCALE Ljava/lang/String;
+	public static final field DISCOVERY_WATCHDOG_MS Ljava/lang/String;
+	public static final field GIT_REF_HISTORY Ljava/lang/String;
+	public static final field GIT_REF_HISTORY_DEBOUNCE_MS Ljava/lang/String;
+	public static final field GIT_REF_HISTORY_PUBLISH_POLICY Ljava/lang/String;
+	public static final field GIT_REF_HISTORY_SYNC_MODE Ljava/lang/String;
+	public static final field HISTORY_AUTO_PRUNE_INTERVAL_MS Ljava/lang/String;
+	public static final field HISTORY_DIR Ljava/lang/String;
+	public static final field HISTORY_MAX_AGE_DAYS Ljava/lang/String;
+	public static final field HISTORY_MAX_ENTRIES_PER_PREVIEW Ljava/lang/String;
+	public static final field HISTORY_MAX_TOTAL_SIZE_BYTES Ljava/lang/String;
+	public static final field IDLE_TIMEOUT_MS Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/daemon/config/DaemonProperties$Names;
+	public static final field INTERACTIVE_IDLE_LEASE_MS Ljava/lang/String;
+	public static final field IR_DIR Ljava/lang/String;
+	public static final field MAX_HEAP_MB Ljava/lang/String;
+	public static final field MAX_RENDERS_PER_SANDBOX Ljava/lang/String;
+	public static final field MODULE_ID Ljava/lang/String;
+	public static final field MODULE_PATH Ljava/lang/String;
+	public static final field MODULE_PROJECT_DIR Ljava/lang/String;
+	public static final field PERFETTO_TRACE Ljava/lang/String;
+	public static final field PREVIEWS_JSON_PATH Ljava/lang/String;
+	public static final field PROTOCOL_VERSION Ljava/lang/String;
+	public static final field RECORDINGS_DIR Ljava/lang/String;
+	public static final field RENDER_TIMEOUT_MS Ljava/lang/String;
+	public static final field RES_DIRS Ljava/lang/String;
+	public static final field SANDBOX_BOOT_TIMEOUT_MS Ljava/lang/String;
+	public static final field SANDBOX_COUNT Ljava/lang/String;
+	public static final field SANDBOX_WORKER_PORT Ljava/lang/String;
+	public static final field SANDBOX_WORKER_SLOT Ljava/lang/String;
+	public static final field STARTUP_QUIET Ljava/lang/String;
+	public static final field USER_CLASS_DIRS Ljava/lang/String;
+	public static final field USER_CLASS_PACKAGES Ljava/lang/String;
+	public static final field USE_CONSUMER_APPLICATION Ljava/lang/String;
+	public static final field WARM_RENDER_ON_BOOT Ljava/lang/String;
+	public static final field WARM_SPARE Ljava/lang/String;
+	public static final field WORKSPACE_ROOT Ljava/lang/String;
+}
+
+public abstract class ee/schimke/composeai/daemon/config/DaemonProperty {
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getDefaultLabel ()Ljava/lang/String;
+	public final fun getDefaultValue ()Ljava/lang/Object;
+	public final fun getDoc ()Ljava/lang/String;
+	public final fun getGroup ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public abstract fun getTypeLabel ()Ljava/lang/String;
+	public abstract fun parse (Ljava/lang/String;)Ljava/lang/Object;
+	public final fun read (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static synthetic fun read$default (Lee/schimke/composeai/daemon/config/DaemonProperty;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/config/IntProperty : ee/schimke/composeai/daemon/config/DaemonProperty {
+	public fun <init> (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getTypeLabel ()Ljava/lang/String;
+	public fun parse (Ljava/lang/String;)Ljava/lang/Integer;
+	public synthetic fun parse (Ljava/lang/String;)Ljava/lang/Object;
+}
+
+public final class ee/schimke/composeai/daemon/config/LongProperty : ee/schimke/composeai/daemon/config/DaemonProperty {
+	public fun <init> (Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getTypeLabel ()Ljava/lang/String;
+	public fun parse (Ljava/lang/String;)Ljava/lang/Long;
+	public synthetic fun parse (Ljava/lang/String;)Ljava/lang/Object;
+}
+
+public final class ee/schimke/composeai/daemon/config/PathListProperty : ee/schimke/composeai/daemon/config/DaemonProperty {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun getDefaultLabel ()Ljava/lang/String;
+	public fun getTypeLabel ()Ljava/lang/String;
+	public synthetic fun parse (Ljava/lang/String;)Ljava/lang/Object;
+	public fun parse (Ljava/lang/String;)Ljava/util/List;
+}
+
+public final class ee/schimke/composeai/daemon/config/PathProperty : ee/schimke/composeai/daemon/config/DaemonProperty {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun getTypeLabel ()Ljava/lang/String;
+	public synthetic fun parse (Ljava/lang/String;)Ljava/lang/Object;
+	public fun parse (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/config/StringProperty : ee/schimke/composeai/daemon/config/DaemonProperty {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getTypeLabel ()Ljava/lang/String;
+	public synthetic fun parse (Ljava/lang/String;)Ljava/lang/Object;
+	public fun parse (Ljava/lang/String;)Ljava/lang/String;
 }
 
 public final class ee/schimke/composeai/daemon/forensics/ClassloaderForensics {

--- a/daemon/core/build.gradle.kts
+++ b/daemon/core/build.gradle.kts
@@ -150,6 +150,19 @@ kotlin {
   @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class) abiValidation()
 }
 
+// `docs/daemon/TUNABLES.md` is generated from `DaemonProperties` and gated by
+// `DaemonPropertiesDocTest`. Forward the regeneration opt-in into the test JVM so the doc can be
+// rewritten in place:
+//
+//     ./gradlew :daemon:core:test --tests '*DocTest*' -Pcomposeai.docs.regenerate=true
+//
+// Read through `providers` so the configuration cache keys on the property rather than on a
+// config-time read.
+tasks.withType<Test>().configureEach {
+  val regenerate = providers.gradleProperty("composeai.docs.regenerate").orElse("false")
+  systemProperty("composeai.docs.regenerate", regenerate.get())
+}
+
 // `checkKotlinAbi` is not wired into `check` by the Kotlin Gradle plugin, so an unrecorded surface
 // change would pass CI silently. Wire it explicitly — the gate is only worth having if it runs.
 tasks.named("check") { dependsOn("checkKotlinAbi") }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/BundleIrReplayStore.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/BundleIrReplayStore.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.config.DaemonProperties
 import ee.schimke.composeai.io.SystemFileSystem
 import java.io.File
 import kotlinx.serialization.Serializable
@@ -38,9 +39,9 @@ public object BundleIrReplayStore {
     public val resourcesBytes: ByteArray?,
   )
 
-  public const val BUNDLE_MANIFEST_PATH_PROP: String = "composeai.daemon.bundleManifestPath"
+  public const val BUNDLE_MANIFEST_PATH_PROP: String = DaemonProperties.Names.BUNDLE_MANIFEST_PATH
 
-  public const val IR_DIR_PROP: String = "composeai.daemon.irDir"
+  public const val IR_DIR_PROP: String = DaemonProperties.Names.IR_DIR
 
   @Volatile private var cached: Map<String, Entry>? = null
 
@@ -91,8 +92,8 @@ public object BundleIrReplayStore {
   }
 
   private fun load(): Map<String, Entry> {
-    val manifestPath = System.getProperty(BUNDLE_MANIFEST_PATH_PROP) ?: return emptyMap()
-    val irDirPath = System.getProperty(IR_DIR_PROP) ?: return emptyMap()
+    val manifestPath = DaemonProperties.bundleManifestPath.read() ?: return emptyMap()
+    val irDirPath = DaemonProperties.irDir.read() ?: return emptyMap()
     val manifestFile = File(manifestPath)
     val irDir = File(irDirPath)
     if (!manifestFile.isFile || !irDir.isDirectory) return emptyMap()

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/ClasspathFingerprint.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/ClasspathFingerprint.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.config.DaemonProperties
 import java.io.File
 import java.security.MessageDigest
 
@@ -121,7 +122,7 @@ public class ClasspathFingerprint(
      * (`File.pathSeparator`) list of absolute paths in the cheap-signal file set. Read by
      * [parseCheapSignalFilesSysprop] at daemon startup.
      */
-    public const val CHEAP_SIGNAL_FILES_PROP: String = "composeai.daemon.cheapSignalFiles"
+    public const val CHEAP_SIGNAL_FILES_PROP: String = DaemonProperties.Names.CHEAP_SIGNAL_FILES
 
     /** SHA-256 hash size — used by tests to assert hex-string length. */
     public const val SHA_256_HEX_LENGTH: Int = 64
@@ -139,10 +140,7 @@ public class ClasspathFingerprint(
      */
     public fun parseCheapSignalFilesSysprop(
       value: String? = System.getProperty(CHEAP_SIGNAL_FILES_PROP)
-    ): List<File> {
-      if (value.isNullOrBlank()) return emptyList()
-      return value.split(File.pathSeparator).filter { it.isNotBlank() }.map { File(it.trim()) }
-    }
+    ): List<File> = DaemonProperties.cheapSignalFiles.parse(value).map { File(it) }
 
     private fun longToBytes(v: Long): ByteArray {
       val out = ByteArray(8)

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.config.DaemonProperties
 import ee.schimke.composeai.daemon.history.HistoryDataDiff
 import ee.schimke.composeai.daemon.history.HistoryDiffArtifacts
 import ee.schimke.composeai.daemon.history.HistoryEntry
@@ -144,8 +145,7 @@ public class JsonRpcServer(
   private val host: RenderHost,
   private val daemonVersion: String = DEFAULT_DAEMON_VERSION,
   private val historyDir: String = DEFAULT_HISTORY_DIR,
-  private val idleTimeoutMs: Long =
-    System.getProperty(IDLE_TIMEOUT_PROP)?.toLongOrNull() ?: DEFAULT_IDLE_TIMEOUT_MS,
+  private val idleTimeoutMs: Long = DaemonProperties.idleTimeoutMs.read(),
   /**
    * B2.1 Tier-1 fingerprint detector. When non-null, the server captures a [Snapshot] at
    * construction time and re-checks it on every `fileChanged({ kind: "classpath" })` notification;
@@ -158,9 +158,7 @@ public class JsonRpcServer(
    * Grace window between emitting `classpathDirty` and calling [onExit]. PROTOCOL.md § 6 documents
    * this as `daemon.classpathDirtyGraceMs`, default 2000ms. Public so tests can shorten it.
    */
-  private val classpathDirtyGraceMs: Long =
-    System.getProperty(CLASSPATH_DIRTY_GRACE_PROP)?.toLongOrNull()
-      ?: DEFAULT_CLASSPATH_DIRTY_GRACE_MS,
+  private val classpathDirtyGraceMs: Long = DaemonProperties.classpathDirtyGraceMs.read(),
   /**
    * B2.2 phase 1 — the in-memory preview index, parsed from `previews.json` at daemon startup by
    * [DaemonMain]. Surfaced to clients via `initialize.manifest`. Defaults to [PreviewIndex.empty]
@@ -192,8 +190,7 @@ public class JsonRpcServer(
    * Configurable via the [DISCOVERY_WATCHDOG_PROP] sysprop; the harness lowers it to a few hundred
    * ms in scenarios that don't issue a render between the save and the assertion.
    */
-  private val discoveryWatchdogMs: Long =
-    System.getProperty(DISCOVERY_WATCHDOG_PROP)?.toLongOrNull() ?: DEFAULT_DISCOVERY_WATCHDOG_MS,
+  private val discoveryWatchdogMs: Long = DaemonProperties.discoveryWatchdogMs.read(),
   /**
    * H1+H2 — when non-null, every successful render produces a sidecar + index entry on disk
    * (HISTORY.md § "What this PR lands § H1") and emits a `historyAdded` notification. The
@@ -244,9 +241,7 @@ public class JsonRpcServer(
    * Default 30000ms per the spec. Overridable via the [DATA_FETCH_RERENDER_BUDGET_PROP] sysprop or
    * the constructor (tests pin it small).
    */
-  private val dataFetchRerenderBudgetMs: Long =
-    System.getProperty(DATA_FETCH_RERENDER_BUDGET_PROP)?.toLongOrNull()
-      ?: DEFAULT_DATA_FETCH_RERENDER_BUDGET_MS,
+  private val dataFetchRerenderBudgetMs: Long = DaemonProperties.dataFetchRerenderBudgetMs.read(),
   private val interactiveFrameIntervalMs: Long = INTERACTIVE_FRAME_INTERVAL_MS,
   private val interactiveBurstIntervalMs: Long = INTERACTIVE_BURST_INTERVAL_MS,
   private val interactiveBurstMs: Long = INTERACTIVE_BURST_MS,
@@ -378,8 +373,7 @@ public class JsonRpcServer(
    */
   @Volatile
   private var renderTimeoutMs: Long =
-    System.getProperty(RENDER_TIMEOUT_PROP)?.toLongOrNull()?.takeIf { it > 0 }
-      ?: DEFAULT_RENDER_TIMEOUT_MS
+    DaemonProperties.renderTimeoutMs.read().takeIf { it > 0 } ?: DEFAULT_RENDER_TIMEOUT_MS
 
   /**
    * D1 — sticky `(previewId, kind)` subscriptions installed by `data/subscribe`. All read / write /
@@ -4412,11 +4406,12 @@ public class JsonRpcServer(
      */
     public val EXIT_PROCESS: (Int) -> Unit = { code -> exitProcess(code) }
 
-    public const val IDLE_TIMEOUT_PROP: String = "composeai.daemon.idleTimeoutMs"
+    public const val IDLE_TIMEOUT_PROP: String = DaemonProperties.Names.IDLE_TIMEOUT_MS
     public const val DEFAULT_IDLE_TIMEOUT_MS: Long = 5_000L
 
     /** PROTOCOL.md § 6 — `daemon.classpathDirtyGraceMs`, default 2000ms. */
-    public const val CLASSPATH_DIRTY_GRACE_PROP: String = "composeai.daemon.classpathDirtyGraceMs"
+    public const val CLASSPATH_DIRTY_GRACE_PROP: String =
+      DaemonProperties.Names.CLASSPATH_DIRTY_GRACE_MS
     public const val DEFAULT_CLASSPATH_DIRTY_GRACE_MS: Long = 2_000L
 
     /**
@@ -4426,7 +4421,7 @@ public class JsonRpcServer(
      * integration tests pin it sub-second so the timeout branch is fast).
      */
     public const val DATA_FETCH_RERENDER_BUDGET_PROP: String =
-      "composeai.daemon.dataFetchRerenderBudgetMs"
+      DaemonProperties.Names.DATA_FETCH_RERENDER_BUDGET_MS
     public const val DEFAULT_DATA_FETCH_RERENDER_BUDGET_MS: Long = 30_000L
 
     /**
@@ -4437,7 +4432,7 @@ public class JsonRpcServer(
      * metadata reconcile responsive without racing fast renders. Tests override to a few hundred ms
      * via the sysprop.
      */
-    public const val DISCOVERY_WATCHDOG_PROP: String = "composeai.daemon.discoveryWatchdogMs"
+    public const val DISCOVERY_WATCHDOG_PROP: String = DaemonProperties.Names.DISCOVERY_WATCHDOG_MS
     public const val DEFAULT_DISCOVERY_WATCHDOG_MS: Long = 1_500L
 
     /**
@@ -4466,7 +4461,7 @@ public class JsonRpcServer(
      * debugging-friendly window before the client's `initialize.options.maxRenderMs` lands. Unset /
      * non-positive values keep [DEFAULT_RENDER_TIMEOUT_MS].
      */
-    public const val RENDER_TIMEOUT_PROP: String = "composeai.daemon.renderTimeoutMs"
+    public const val RENDER_TIMEOUT_PROP: String = DaemonProperties.Names.RENDER_TIMEOUT_MS
 
     /** RECORDING.md — default `recording/start.fps` when the caller doesn't specify one. */
     public const val DEFAULT_RECORDING_FPS: Int = 30

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.config.DaemonProperties
 import ee.schimke.composeai.data.overrides.OverrideVariantInteraction
 import java.nio.file.Files
 import java.nio.file.Path
@@ -765,7 +766,7 @@ internal constructor(
      * [DaemonClasspathDescriptor.systemProperties]); when unset, the daemon comes up with [empty] —
      * preserves pre-B2.2 in-process / fake-mode behaviour.
      */
-    public const val PREVIEWS_JSON_PATH_PROP: String = "composeai.daemon.previewsJsonPath"
+    public const val PREVIEWS_JSON_PATH_PROP: String = DaemonProperties.Names.PREVIEWS_JSON_PATH
 
     private val JSON: Json = Json {
       ignoreUnknownKeys = true

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/StartupTimings.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/StartupTimings.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.config.DaemonProperties
 import java.lang.management.ManagementFactory
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicBoolean
@@ -45,10 +46,10 @@ public object StartupTimings {
   public val jvmStartMs: Long = ManagementFactory.getRuntimeMXBean().startTime
 
   /** Sysprop knob to suppress stderr emission. Marks are still buffered for [summary]. */
-  public const val QUIET_PROP: String = "composeai.daemon.startupQuiet"
+  public const val QUIET_PROP: String = DaemonProperties.Names.STARTUP_QUIET
 
   private val quiet: Boolean
-    get() = System.getProperty(QUIET_PROP) == "true"
+    get() = DaemonProperties.startupQuiet.read()
 
   private val buffer = ConcurrentLinkedQueue<Mark>()
   private val summarised = AtomicBoolean(false)

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/UserClassLoaderHolder.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/UserClassLoaderHolder.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.config.DaemonProperties
 import java.lang.ref.WeakReference
 import java.net.URL
 import java.net.URLClassLoader
@@ -206,7 +207,7 @@ public class UserClassLoaderHolder(
      * — the gradle plugin's daemon launch descriptor sets it; both backends' [DaemonMain] reads it
      * and constructs a [UserClassLoaderHolder] with the resolved URLs.
      */
-    public const val USER_CLASS_DIRS_PROP: String = "composeai.daemon.userClassDirs"
+    public const val USER_CLASS_DIRS_PROP: String = DaemonProperties.Names.USER_CLASS_DIRS
 
     /**
      * Whether [name] must be resolved via the parent loader instead of child-first (used by
@@ -278,15 +279,8 @@ public class UserClassLoaderHolder(
      * ordering carries semantics we don't want to scramble.
      */
     public fun urlsFromSysprop(): List<URL> {
-      val raw = System.getProperty(USER_CLASS_DIRS_PROP) ?: return emptyList()
-      if (raw.isBlank()) return emptyList()
       val files =
-        raw
-          .split(java.io.File.pathSeparator)
-          .map { it.trim() }
-          .filter { it.isNotEmpty() }
-          .map { java.io.File(it) }
-          .filter { it.exists() }
+        DaemonProperties.userClassDirs.read().map { java.io.File(it) }.filter { it.exists() }
       return files.sortedBy { if (it.isDirectory) 0 else 1 }.map { it.toURI().toURL() }
     }
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/config/DaemonProperties.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/config/DaemonProperties.kt
@@ -1,0 +1,775 @@
+package ee.schimke.composeai.daemon.config
+
+import java.io.File
+
+/**
+ * The one place every `composeai.daemon.*` system property is declared.
+ *
+ * Before this registry each knob was a bare `System.getProperty("composeai.daemon.…")` at its point
+ * of use, with its default and its parsing inline. That made the set an *unversioned public API
+ * surface* nobody could enumerate: the names were string literals invisible to the ABI validator,
+ * and a rename was a silent behaviour change rather than a compile error.
+ *
+ * Three things follow from declaring them here instead:
+ * - **Enumerable.** [DaemonProperties.ALL] is the complete list, and `docs/daemon/TUNABLES.md` is
+ *   generated from it (see `DaemonPropertiesDocTest`) rather than hand-maintained.
+ * - **Typed.** Each entry states its type, its default and how a raw string becomes a value, so
+ *   `daemon.idleTimeoutMs` parses the same way everywhere it is read.
+ * - **Renameable.** Call sites reference `DaemonProperties.Names.…`, so a rename is a compile
+ *   error.
+ *
+ * `DaemonPropertyRegistryTest` pins the invariant that no `"composeai.daemon.…"` literal is left in
+ * `daemon/` outside this file.
+ *
+ * ### Producer-only entries
+ *
+ * Some entries are written by the Gradle plugin's daemon launch descriptor and read outside
+ * `daemon/` (the `bta.*` compile inputs, the descriptor's `maxHeapMb` / `warmSpare` echo, the data
+ * connectors' `resDirs` / `defaultLocale`). They are declared here too — the point of the registry
+ * is that the *name space* is enumerable, not just the half this module happens to read.
+ */
+public sealed class DaemonProperty<T>(
+  /** The system-property name, e.g. `composeai.daemon.idleTimeoutMs`. */
+  public val name: String,
+  /** The value used when the property is unset or unparseable. */
+  public val defaultValue: T,
+  /** One-line description, rendered into the generated tunables table. */
+  public val doc: String,
+  /** Which area of the daemon this knob belongs to; groups the generated table. */
+  public val group: String,
+) {
+  /** Type name for the generated table (`Boolean`, `Long`, `path list`, …). */
+  public abstract val typeLabel: String
+
+  /** Parses a raw property value; `null` (unset) and unparseable input both yield the default. */
+  public abstract fun parse(raw: String?): T
+
+  /** Reads and parses this property. [lookup] is a seam for tests. */
+  public fun read(lookup: (String) -> String? = System::getProperty): T = parse(lookup(name))
+
+  /** How the default renders in the generated table. */
+  public open val defaultLabel: String
+    get() = defaultValue?.let { "`$it`" } ?: "unset"
+
+  override fun toString(): String = "$typeLabel $name (default $defaultValue)"
+}
+
+/** A free-form string knob. `null` default means "unset is meaningful". */
+public class StringProperty(
+  name: String,
+  default: String? = null,
+  doc: String,
+  group: String,
+) : DaemonProperty<String?>(name, default, doc, group) {
+  override val typeLabel: String = "String"
+
+  override fun parse(raw: String?): String? = raw?.takeIf { it.isNotBlank() } ?: defaultValue
+}
+
+/** An absolute filesystem path carried as a string. Same parsing as [StringProperty]. */
+public class PathProperty(name: String, doc: String, group: String) :
+  DaemonProperty<String?>(name, null, doc, group) {
+  override val typeLabel: String = "path"
+
+  override fun parse(raw: String?): String? = raw?.takeIf { it.isNotBlank() }
+}
+
+/**
+ * A `File.pathSeparator`-delimited list of paths. Empty when unset — every consumer of these treats
+ * "unset" and "empty" alike.
+ */
+public class PathListProperty(name: String, doc: String, group: String) :
+  DaemonProperty<List<String>>(name, emptyList(), doc, group) {
+  override val typeLabel: String = "path list"
+
+  override val defaultLabel: String = "empty"
+
+  override fun parse(raw: String?): List<String> =
+    raw?.split(File.pathSeparator)?.map { it.trim() }?.filter { it.isNotEmpty() } ?: emptyList()
+}
+
+/** A comma/semicolon-separated list. Empty when unset. */
+public class CsvListProperty(name: String, doc: String, group: String) :
+  DaemonProperty<List<String>>(name, emptyList(), doc, group) {
+  override val typeLabel: String = "list"
+
+  override val defaultLabel: String = "empty"
+
+  override fun parse(raw: String?): List<String> =
+    raw?.split(',', ';')?.map { it.trim() }?.filter { it.isNotEmpty() } ?: emptyList()
+}
+
+/**
+ * A boolean knob. `true` / `false` are matched case-insensitively; anything else — including an
+ * unset property — yields [defaultValue], so a typo never silently flips a default.
+ */
+public class BooleanProperty(name: String, default: Boolean, doc: String, group: String) :
+  DaemonProperty<Boolean>(name, default, doc, group) {
+  override val typeLabel: String = "Boolean"
+
+  override fun parse(raw: String?): Boolean =
+    when {
+      raw == null -> defaultValue
+      raw.trim().equals("true", ignoreCase = true) -> true
+      raw.trim().equals("false", ignoreCase = true) -> false
+      else -> defaultValue
+    }
+}
+
+/** An integer knob, optionally floored at [min] the way the reading site already coerced it. */
+public class IntProperty(
+  name: String,
+  default: Int,
+  doc: String,
+  group: String,
+  private val min: Int? = null,
+) : DaemonProperty<Int>(name, default, doc, group) {
+  override val typeLabel: String = "Int"
+
+  override fun parse(raw: String?): Int {
+    val parsed = raw?.trim()?.toIntOrNull() ?: defaultValue
+    return min?.let { parsed.coerceAtLeast(it) } ?: parsed
+  }
+}
+
+/** A millisecond / byte-count knob, optionally floored at [min]. */
+public class LongProperty(
+  name: String,
+  default: Long,
+  doc: String,
+  group: String,
+  private val min: Long? = null,
+) : DaemonProperty<Long>(name, default, doc, group) {
+  override val typeLabel: String = "Long"
+
+  override fun parse(raw: String?): Long {
+    val parsed = raw?.trim()?.toLongOrNull() ?: defaultValue
+    return min?.let { parsed.coerceAtLeast(it) } ?: parsed
+  }
+}
+
+/**
+ * The registry itself. [Names] holds the raw names as `const val` so existing published `const val
+ * …_PROP` declarations can delegate to them without changing their ABI (a `const val` initialised
+ * from another `const val` still compiles to a `ConstantValue` field); the typed entries below
+ * carry the default, the parse and the doc.
+ */
+public object DaemonProperties {
+
+  /** Group labels — also the section headings of the generated tunables table. */
+  private const val G_LIFECYCLE = "Lifecycle and timeouts"
+  private const val G_CLASSPATH = "Classpath and discovery"
+  private const val G_HISTORY = "History"
+  private const val G_SANDBOX = "Sandbox pool"
+  private const val G_TRACING = "Tracing and diagnostics"
+  private const val G_BUNDLE = "Bundle IR replay"
+  private const val G_DATA = "Data products"
+  private const val G_DESCRIPTOR = "Launch descriptor (set by the Gradle plugin)"
+  private const val G_BTA = "In-process compile (BTA)"
+
+  /**
+   * Property names as compile-time constants.
+   *
+   * Referenced from the published `const val …_PROP` declarations that predate this registry, which
+   * must stay `const` to keep their `ConstantValue` ABI.
+   */
+  public object Names {
+    public const val IDLE_TIMEOUT_MS: String = "composeai.daemon.idleTimeoutMs"
+    public const val RENDER_TIMEOUT_MS: String = "composeai.daemon.renderTimeoutMs"
+    public const val CLASSPATH_DIRTY_GRACE_MS: String = "composeai.daemon.classpathDirtyGraceMs"
+    public const val DATA_FETCH_RERENDER_BUDGET_MS: String =
+      "composeai.daemon.dataFetchRerenderBudgetMs"
+    public const val DISCOVERY_WATCHDOG_MS: String = "composeai.daemon.discoveryWatchdogMs"
+    public const val INTERACTIVE_IDLE_LEASE_MS: String = "composeai.daemon.interactive.idleLeaseMs"
+    public const val SANDBOX_BOOT_TIMEOUT_MS: String = "composeai.daemon.sandboxBootTimeoutMs"
+
+    public const val USER_CLASS_DIRS: String = "composeai.daemon.userClassDirs"
+    public const val USER_CLASS_PACKAGES: String = "composeai.daemon.userClassPackages"
+    public const val CHEAP_SIGNAL_FILES: String = "composeai.daemon.cheapSignalFiles"
+    public const val PREVIEWS_JSON_PATH: String = "composeai.daemon.previewsJsonPath"
+
+    public const val HISTORY_DIR: String = "composeai.daemon.historyDir"
+    public const val WORKSPACE_ROOT: String = "composeai.daemon.workspaceRoot"
+    public const val MODULE_ID: String = "composeai.daemon.moduleId"
+    public const val GIT_REF_HISTORY: String = "composeai.daemon.gitRefHistory"
+    public const val GIT_REF_HISTORY_SYNC_MODE: String = "composeai.daemon.gitRefHistorySyncMode"
+    public const val GIT_REF_HISTORY_DEBOUNCE_MS: String =
+      "composeai.daemon.gitRefHistoryDebounceMs"
+    public const val GIT_REF_HISTORY_PUBLISH_POLICY: String =
+      "composeai.daemon.gitRefHistoryPublishPolicy"
+    public const val HISTORY_MAX_ENTRIES_PER_PREVIEW: String =
+      "composeai.daemon.history.maxEntriesPerPreview"
+    public const val HISTORY_MAX_AGE_DAYS: String = "composeai.daemon.history.maxAgeDays"
+    public const val HISTORY_MAX_TOTAL_SIZE_BYTES: String =
+      "composeai.daemon.history.maxTotalSizeBytes"
+    public const val HISTORY_AUTO_PRUNE_INTERVAL_MS: String =
+      "composeai.daemon.history.autoPruneIntervalMs"
+
+    public const val SANDBOX_COUNT: String = "composeai.daemon.sandboxCount"
+    public const val WARM_SPARE: String = "composeai.daemon.warmSpare"
+    public const val BACKGROUND_SANDBOX_BOOT: String = "composeai.daemon.backgroundSandboxBoot"
+    public const val WARM_RENDER_ON_BOOT: String = "composeai.daemon.warmRenderOnBoot"
+    public const val USE_CONSUMER_APPLICATION: String = "composeai.daemon.useConsumerApplication"
+    public const val MAX_RENDERS_PER_SANDBOX: String = "composeai.daemon.maxRendersPerSandbox"
+    public const val MAX_HEAP_MB: String = "composeai.daemon.maxHeapMb"
+    public const val SANDBOX_WORKER_PORT: String = "composeai.daemon.sandboxWorker.port"
+    public const val SANDBOX_WORKER_SLOT: String = "composeai.daemon.sandboxWorker.slot"
+
+    public const val STARTUP_QUIET: String = "composeai.daemon.startupQuiet"
+    public const val ATRACE: String = "composeai.daemon.atrace"
+    public const val PERFETTO_TRACE: String = "composeai.daemon.perfettoTrace"
+    public const val COMPOSITION_TRACE: String = "composeai.daemon.compositionTrace"
+    public const val RECORDINGS_DIR: String = "composeai.daemon.recordingsDir"
+
+    public const val BUNDLE_MANIFEST_PATH: String = "composeai.daemon.bundleManifestPath"
+    public const val IR_DIR: String = "composeai.daemon.irDir"
+
+    public const val RES_DIRS: String = "composeai.daemon.resDirs"
+    public const val DEFAULT_LOCALE: String = "composeai.daemon.defaultLocale"
+
+    public const val PROTOCOL_VERSION: String = "composeai.daemon.protocolVersion"
+    public const val MODULE_PATH: String = "composeai.daemon.modulePath"
+    public const val MODULE_PROJECT_DIR: String = "composeai.daemon.moduleProjectDir"
+
+    public const val BTA_IMPL_CLASSPATH: String = "composeai.daemon.bta.implClasspath"
+    public const val BTA_COMPILE_CLASSPATH: String = "composeai.daemon.bta.compileClasspath"
+    public const val BTA_COMPILER_PLUGINS: String = "composeai.daemon.bta.compilerPlugins"
+    public const val BTA_MODULE_NAME: String = "composeai.daemon.bta.moduleName"
+    public const val BTA_OUTPUT_DIR: String = "composeai.daemon.bta.outputDir"
+    public const val BTA_IC_WORKING_DIR: String = "composeai.daemon.bta.icWorkingDir"
+    public const val BTA_INELIGIBILITY_REASON: String = "composeai.daemon.bta.ineligibilityReason"
+  }
+
+  // ---- Lifecycle and timeouts ---------------------------------------------------------------
+
+  public val idleTimeoutMs: LongProperty =
+    LongProperty(
+      Names.IDLE_TIMEOUT_MS,
+      5_000L,
+      "How long the daemon waits after its last client disconnects before exiting.",
+      G_LIFECYCLE,
+    )
+
+  public val renderTimeoutMs: LongProperty =
+    LongProperty(
+      Names.RENDER_TIMEOUT_MS,
+      5 * 60_000L,
+      "Initial per-render `host.submit` timeout, before `initialize.options.maxRenderMs` lands. " +
+        "Non-positive values keep the default.",
+      G_LIFECYCLE,
+    )
+
+  public val classpathDirtyGraceMs: LongProperty =
+    LongProperty(
+      Names.CLASSPATH_DIRTY_GRACE_MS,
+      2_000L,
+      "Grace window after a classpath-dirty signal before the daemon acts on it. " +
+        "See PROTOCOL.md § 6.",
+      G_LIFECYCLE,
+    )
+
+  public val dataFetchRerenderBudgetMs: LongProperty =
+    LongProperty(
+      Names.DATA_FETCH_RERENDER_BUDGET_MS,
+      30_000L,
+      "Budget for the re-render a `data/fetch` may trigger. See DATA-PRODUCTS.md § Re-render " +
+        "semantics.",
+      G_LIFECYCLE,
+    )
+
+  public val discoveryWatchdogMs: LongProperty =
+    LongProperty(
+      Names.DISCOVERY_WATCHDOG_MS,
+      1_500L,
+      "Window between `fileChanged({kind:source})` and the deferred discovery scan.",
+      G_LIFECYCLE,
+    )
+
+  public val interactiveIdleLeaseMs: LongProperty =
+    LongProperty(
+      Names.INTERACTIVE_IDLE_LEASE_MS,
+      60_000L,
+      "Idle lease before a held interactive session auto-closes.",
+      G_LIFECYCLE,
+    )
+
+  public val sandboxBootTimeoutMs: LongProperty =
+    LongProperty(
+      Names.SANDBOX_BOOT_TIMEOUT_MS,
+      10L * 60L * 1000L,
+      "Deadline for a Robolectric sandbox bootstrap. The default covers a cold " +
+        "`android-all-instrumented` download; warm boots are 5–15s.",
+      G_LIFECYCLE,
+    )
+
+  // ---- Classpath and discovery --------------------------------------------------------------
+
+  public val userClassDirs: PathListProperty =
+    PathListProperty(
+      Names.USER_CLASS_DIRS,
+      "`File.pathSeparator`-delimited user-class directories the child-first loader serves.",
+      G_CLASSPATH,
+    )
+
+  public val userClassPackages: PathListProperty =
+    PathListProperty(
+      Names.USER_CLASS_PACKAGES,
+      "Packages excluded from Robolectric instrumentation and served from the user classloader.",
+      G_CLASSPATH,
+    )
+
+  public val cheapSignalFiles: PathListProperty =
+    PathListProperty(
+      Names.CHEAP_SIGNAL_FILES,
+      "Files whose mtime/size form the cheap classpath-dirty signal.",
+      G_CLASSPATH,
+    )
+
+  public val previewsJsonPath: PathProperty =
+    PathProperty(
+      Names.PREVIEWS_JSON_PATH,
+      "Absolute path to the `previews.json` manifest. Unset boots with an empty preview index.",
+      G_CLASSPATH,
+    )
+
+  // ---- History ------------------------------------------------------------------------------
+
+  public val historyDir: PathProperty =
+    PathProperty(
+      Names.HISTORY_DIR,
+      "Render-history archive directory. Unset disables history entirely.",
+      G_HISTORY,
+    )
+
+  public val workspaceRoot: PathProperty =
+    PathProperty(
+      Names.WORKSPACE_ROOT,
+      "Repository root used for git provenance. Defaults to the daemon JVM's working directory.",
+      G_HISTORY,
+    )
+
+  public val moduleId: StringProperty =
+    StringProperty(
+      Names.MODULE_ID,
+      null,
+      "Gradle project path stamped into every history entry's `module` field.",
+      G_HISTORY,
+    )
+
+  public val gitRefHistory: CsvListProperty =
+    CsvListProperty(
+      Names.GIT_REF_HISTORY,
+      "Reporting refs wired as read-only history sources, e.g. `refs/heads/preview/main`.",
+      G_HISTORY,
+    )
+
+  public val gitRefHistorySyncMode: StringProperty =
+    StringProperty(
+      Names.GIT_REF_HISTORY_SYNC_MODE,
+      "READ_ONLY",
+      "Sync mode for the reporting refs: `READ_ONLY`, `WRITE_LOCAL` or `WRITE_PUSH`.",
+      G_HISTORY,
+    )
+
+  public val gitRefHistoryDebounceMs: LongProperty =
+    LongProperty(
+      Names.GIT_REF_HISTORY_DEBOUNCE_MS,
+      1_000L,
+      "Debounce window coalescing a render burst into one reporting-branch commit. `0` disables.",
+      G_HISTORY,
+      min = 0L,
+    )
+
+  public val gitRefHistoryPublishPolicy: StringProperty =
+    StringProperty(
+      Names.GIT_REF_HISTORY_PUBLISH_POLICY,
+      "cleanOnBranch",
+      "Which renders reach the reporting branch: `all`, or `cleanOnBranch` (the default).",
+      G_HISTORY,
+    )
+
+  public val historyMaxEntriesPerPreview: IntProperty =
+    IntProperty(
+      Names.HISTORY_MAX_ENTRIES_PER_PREVIEW,
+      50,
+      "Prune knob — entries retained per preview. `0` or negative disables this knob.",
+      G_HISTORY,
+    )
+
+  public val historyMaxAgeDays: IntProperty =
+    IntProperty(
+      Names.HISTORY_MAX_AGE_DAYS,
+      14,
+      "Prune knob — maximum entry age in days. `0` or negative disables this knob.",
+      G_HISTORY,
+    )
+
+  public val historyMaxTotalSizeBytes: LongProperty =
+    LongProperty(
+      Names.HISTORY_MAX_TOTAL_SIZE_BYTES,
+      500_000_000L,
+      "Prune knob — total archive size ceiling in bytes. `0` or negative disables this knob.",
+      G_HISTORY,
+    )
+
+  public val historyAutoPruneIntervalMs: LongProperty =
+    LongProperty(
+      Names.HISTORY_AUTO_PRUNE_INTERVAL_MS,
+      60L * 60L * 1000L,
+      "Prune knob — auto-prune scheduler period. `0` or negative disables the scheduler.",
+      G_HISTORY,
+    )
+
+  // ---- Sandbox pool -------------------------------------------------------------------------
+
+  public val sandboxCount: IntProperty =
+    IntProperty(
+      Names.SANDBOX_COUNT,
+      1,
+      "In-JVM Robolectric sandbox slots. Set by the supervisor to `1 + replicasPerDaemon`. The " +
+        "Android daemon main derives a larger default (5) when `warmSpare` is on; this default " +
+        "applies to every other reader.",
+      G_SANDBOX,
+      min = 1,
+    )
+
+  public val warmSpare: BooleanProperty =
+    BooleanProperty(
+      Names.WARM_SPARE,
+      true,
+      "Whether the pool keeps a warm spare sandbox so recycle is an atomic swap.",
+      G_SANDBOX,
+    )
+
+  public val backgroundSandboxBoot: BooleanProperty =
+    BooleanProperty(
+      Names.BACKGROUND_SANDBOX_BOOT,
+      false,
+      "Whether `initialize` may return once the first sandbox is ready, the rest booting behind " +
+        "it. The Gradle-plugin descriptor sets this `true`; the raw sysprop default is off.",
+      G_SANDBOX,
+    )
+
+  public val warmRenderOnBoot: BooleanProperty =
+    BooleanProperty(
+      Names.WARM_RENDER_ON_BOOT,
+      true,
+      "Whether each background-booted slot performs a boot-time warm render.",
+      G_SANDBOX,
+    )
+
+  public val useConsumerApplication: BooleanProperty =
+    BooleanProperty(
+      Names.USE_CONSUMER_APPLICATION,
+      false,
+      "Whether Robolectric instantiates the consumer manifest's `Application` instead of the " +
+        "pinned `android.app.Application` stub.",
+      G_SANDBOX,
+    )
+
+  public val maxRendersPerSandbox: IntProperty =
+    IntProperty(
+      Names.MAX_RENDERS_PER_SANDBOX,
+      1_000,
+      "Renders a sandbox handles before it is recycled regardless of drift signals.",
+      G_SANDBOX,
+      min = 1,
+    )
+
+  public val maxHeapMb: IntProperty =
+    IntProperty(
+      Names.MAX_HEAP_MB,
+      1_024,
+      "Post-GC heap ceiling for the daemon JVM, in MiB. Also becomes `-Xmx`.",
+      G_SANDBOX,
+    )
+
+  public val sandboxWorkerPort: IntProperty =
+    IntProperty(
+      Names.SANDBOX_WORKER_PORT,
+      0,
+      "Loopback port a spawned sandbox worker connects back on. Set by `SandboxProcessPool`; " +
+        "`SandboxWorkerMain` fails fast when unset.",
+      G_SANDBOX,
+    )
+
+  public val sandboxWorkerSlot: IntProperty =
+    IntProperty(
+      Names.SANDBOX_WORKER_SLOT,
+      0,
+      "Pool slot index a spawned sandbox worker owns. Set by `SandboxProcessPool`.",
+      G_SANDBOX,
+    )
+
+  // ---- Tracing and diagnostics --------------------------------------------------------------
+
+  public val startupQuiet: BooleanProperty =
+    BooleanProperty(
+      Names.STARTUP_QUIET,
+      false,
+      "Suppress startup-timing marks on stderr. Marks are still buffered for the summary.",
+      G_TRACING,
+    )
+
+  public val atrace: BooleanProperty =
+    BooleanProperty(
+      Names.ATRACE,
+      false,
+      "Mirror render trace sections into `android.os.Trace`.",
+      G_TRACING,
+    )
+
+  public val perfettoTrace: BooleanProperty =
+    BooleanProperty(
+      Names.PERFETTO_TRACE,
+      false,
+      "Emit a Perfetto trace for each render. Set from the Gradle plugin's daemon DSL.",
+      G_TRACING,
+    )
+
+  public val compositionTrace: BooleanProperty =
+    BooleanProperty(
+      Names.COMPOSITION_TRACE,
+      false,
+      "Enable Compose composition tracing in the render extension.",
+      G_TRACING,
+    )
+
+  public val recordingsDir: PathProperty =
+    PathProperty(
+      Names.RECORDINGS_DIR,
+      "Where interactive recordings are written. Unset falls back to a sibling of the render " +
+        "output directory.",
+      G_TRACING,
+    )
+
+  // ---- Bundle IR replay ---------------------------------------------------------------------
+
+  public val bundleManifestPath: PathProperty =
+    PathProperty(
+      Names.BUNDLE_MANIFEST_PATH,
+      "Portable-bundle manifest backing IR replay. Both this and `irDir` must be set.",
+      G_BUNDLE,
+    )
+
+  public val irDir: PathProperty =
+    PathProperty(Names.IR_DIR, "Directory holding the bundle's serialised preview IR.", G_BUNDLE)
+
+  // ---- Data products ------------------------------------------------------------------------
+
+  public val resDirs: PathListProperty =
+    PathListProperty(
+      Names.RES_DIRS,
+      "Android resource directories the resource / i18n data products read.",
+      G_DATA,
+    )
+
+  public val defaultLocale: StringProperty =
+    StringProperty(
+      Names.DEFAULT_LOCALE,
+      null,
+      "Locale treated as the source language by the i18n translations data product.",
+      G_DATA,
+    )
+
+  // ---- Launch descriptor --------------------------------------------------------------------
+
+  public val protocolVersion: StringProperty =
+    StringProperty(
+      Names.PROTOCOL_VERSION,
+      null,
+      "Daemon protocol version stamped by the Gradle plugin's launch descriptor.",
+      G_DESCRIPTOR,
+    )
+
+  public val modulePath: StringProperty =
+    StringProperty(
+      Names.MODULE_PATH,
+      null,
+      "Gradle project path of the module the daemon serves.",
+      G_DESCRIPTOR,
+    )
+
+  public val moduleProjectDir: PathProperty =
+    PathProperty(
+      Names.MODULE_PROJECT_DIR,
+      "Absolute project directory of the module the daemon serves.",
+      G_DESCRIPTOR,
+    )
+
+  // ---- In-process compile (BTA) -------------------------------------------------------------
+
+  public val btaImplClasspath: PathListProperty =
+    PathListProperty(
+      Names.BTA_IMPL_CLASSPATH,
+      "Build Tools API implementation JARs loaded into BTA's isolated classloader.",
+      G_BTA,
+    )
+
+  public val btaCompileClasspath: PathListProperty =
+    PathListProperty(Names.BTA_COMPILE_CLASSPATH, "Compile classpath for stage-2 compiles.", G_BTA)
+
+  public val btaCompilerPlugins: PathListProperty =
+    PathListProperty(
+      Names.BTA_COMPILER_PLUGINS,
+      "Compiler-plugin JARs (Compose, serialization, …) passed to the in-process compile.",
+      G_BTA,
+    )
+
+  public val btaModuleName: StringProperty =
+    StringProperty(Names.BTA_MODULE_NAME, null, "Kotlin module name for stage-2 compiles.", G_BTA)
+
+  public val btaOutputDir: PathProperty =
+    PathProperty(Names.BTA_OUTPUT_DIR, "Class output directory for stage-2 compiles.", G_BTA)
+
+  public val btaIcWorkingDir: PathProperty =
+    PathProperty(
+      Names.BTA_IC_WORKING_DIR,
+      "Incremental-compilation working directory for stage-2 compiles.",
+      G_BTA,
+    )
+
+  public val btaIneligibilityReason: StringProperty =
+    StringProperty(
+      Names.BTA_INELIGIBILITY_REASON,
+      null,
+      "Why the Gradle plugin ruled this module out of in-process compile; surfaced in diagnostics.",
+      G_BTA,
+    )
+
+  /**
+   * Every declared property, in the order the generated table renders them.
+   *
+   * `DaemonPropertyRegistryTest` asserts this is complete against the `composeai.daemon.*` literals
+   * in the tree, and that the names are unique.
+   */
+  public val ALL: List<DaemonProperty<*>> =
+    listOf(
+      idleTimeoutMs,
+      renderTimeoutMs,
+      classpathDirtyGraceMs,
+      dataFetchRerenderBudgetMs,
+      discoveryWatchdogMs,
+      interactiveIdleLeaseMs,
+      sandboxBootTimeoutMs,
+      userClassDirs,
+      userClassPackages,
+      cheapSignalFiles,
+      previewsJsonPath,
+      historyDir,
+      workspaceRoot,
+      moduleId,
+      gitRefHistory,
+      gitRefHistorySyncMode,
+      gitRefHistoryDebounceMs,
+      gitRefHistoryPublishPolicy,
+      historyMaxEntriesPerPreview,
+      historyMaxAgeDays,
+      historyMaxTotalSizeBytes,
+      historyAutoPruneIntervalMs,
+      sandboxCount,
+      warmSpare,
+      backgroundSandboxBoot,
+      warmRenderOnBoot,
+      useConsumerApplication,
+      maxRendersPerSandbox,
+      maxHeapMb,
+      sandboxWorkerPort,
+      sandboxWorkerSlot,
+      startupQuiet,
+      atrace,
+      perfettoTrace,
+      compositionTrace,
+      recordingsDir,
+      bundleManifestPath,
+      irDir,
+      resDirs,
+      defaultLocale,
+      protocolVersion,
+      modulePath,
+      moduleProjectDir,
+      btaImplClasspath,
+      btaCompileClasspath,
+      btaCompilerPlugins,
+      btaModuleName,
+      btaOutputDir,
+      btaIcWorkingDir,
+      btaIneligibilityReason,
+    )
+
+  /** [ALL] keyed by property name. */
+  public val BY_NAME: Map<String, DaemonProperty<*>> = ALL.associateBy { it.name }
+
+  /** Section order of the generated table. */
+  public val GROUPS: List<String> =
+    listOf(
+      G_LIFECYCLE,
+      G_CLASSPATH,
+      G_HISTORY,
+      G_SANDBOX,
+      G_TRACING,
+      G_BUNDLE,
+      G_DATA,
+      G_DESCRIPTOR,
+      G_BTA,
+    )
+
+  /**
+   * Renders the tunables table written to `docs/daemon/TUNABLES.md`. Kept next to the declarations
+   * so a new property shows up in the docs the moment it is declared — `DaemonPropertiesDocTest`
+   * fails the build when the checked-in file drifts.
+   */
+  public fun renderMarkdown(): String = buildString {
+    appendLine("<!--")
+    appendLine("  GENERATED FILE — do not edit by hand.")
+    appendLine()
+    appendLine("  Source of truth: DaemonProperties in")
+    appendLine(
+      "  daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/config/DaemonProperties.kt"
+    )
+    appendLine(
+      "  Regenerate:      ./gradlew :daemon:core:test --tests '*DaemonPropertiesDocTest*' " +
+        "-Pcomposeai.docs.regenerate=true"
+    )
+    appendLine("-->")
+    appendLine()
+    appendLine("# Preview daemon — tunables")
+    appendLine()
+    appendLine(
+      "Every `composeai.daemon.*` system property the daemon and its launch descriptor understand,"
+    )
+    appendLine(
+      "generated from the typed registry so the list cannot drift from the code that reads it."
+    )
+    appendLine()
+    appendLine(
+      "Pass one with `-D<name>=<value>` on the daemon JVM. The Gradle-facing knobs " +
+        "(`maxHeapMb`, `warmSpare`,"
+    )
+    appendLine(
+      "`maxRendersPerSandbox`, `backgroundSandboxBoot`) are normally set through the " +
+        "`composePreview.daemon { … }`"
+    )
+    appendLine("DSL rather than by hand — see [CONFIG.md](CONFIG.md).")
+    appendLine()
+    appendLine(
+      "\"Default\" is the value used when the property is unset **or** unparseable: a typo never " +
+        "silently"
+    )
+    appendLine("flips a knob.")
+    for (group in GROUPS) {
+      val entries = ALL.filter { it.group == group }
+      if (entries.isEmpty()) continue
+      appendLine()
+      appendLine("## $group")
+      appendLine()
+      appendLine("| Property | Type | Default | Effect |")
+      appendLine("| --- | --- | --- | --- |")
+      for (property in entries) {
+        appendLine(
+          "| `${property.name}` | ${property.typeLabel} | ${property.defaultLabel} | ${property.doc} |"
+        )
+      }
+    }
+  }
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon.history
 
+import ee.schimke.composeai.daemon.config.DaemonProperties
 import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload
 import ee.schimke.composeai.data.layoutinspector.SemanticsDiff
 import ee.schimke.composeai.io.LEGACY_HISTORY_DIRNAME
@@ -958,10 +959,10 @@ public class GitRefHistorySource(
      * Comma/semicolon-separated list of refs (e.g.
      * `refs/heads/preview/main,refs/heads/preview/agent/foo`).
      */
-    public const val GIT_REF_HISTORY_PROP: String = "composeai.daemon.gitRefHistory"
+    public const val GIT_REF_HISTORY_PROP: String = DaemonProperties.Names.GIT_REF_HISTORY
 
     /** Sync mode for the reporting refs: `READ_ONLY` (default) or `WRITE_LOCAL`. */
-    public const val SYNC_MODE_PROP: String = "composeai.daemon.gitRefHistorySyncMode"
+    public const val SYNC_MODE_PROP: String = DaemonProperties.Names.GIT_REF_HISTORY_SYNC_MODE
 
     // Synthetic identity for daemon-authored reporting-branch commits. These are machine-generated
     // history commits in the *consumer's* repo (not this project's git history), so they carry a
@@ -1003,7 +1004,7 @@ public class GitRefHistorySource(
     public const val MAX_PUSH_ATTEMPTS: Int = 5
 
     /** Sysprop for the reporting-branch commit debounce window in ms (#1882). */
-    public const val DEBOUNCE_PROP: String = "composeai.daemon.gitRefHistoryDebounceMs"
+    public const val DEBOUNCE_PROP: String = DaemonProperties.Names.GIT_REF_HISTORY_DEBOUNCE_MS
 
     /** Default debounce window (ms): coalesce a render burst into one commit. `0` disables it. */
     public const val DEFAULT_DEBOUNCE_MS: Long = 1_000
@@ -1015,7 +1016,8 @@ public class GitRefHistorySource(
     }
 
     /** Sysprop for the reporting-branch publish policy (#1872 curation). */
-    public const val PUBLISH_POLICY_PROP: String = "composeai.daemon.gitRefHistoryPublishPolicy"
+    public const val PUBLISH_POLICY_PROP: String =
+      DaemonProperties.Names.GIT_REF_HISTORY_PUBLISH_POLICY
 
     /**
      * Parses [PUBLISH_POLICY_PROP]; `all` → [PublishPolicy.ALL], else →

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryPruneConfig.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryPruneConfig.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.daemon.history
 
+import ee.schimke.composeai.daemon.config.DaemonProperties
+
 /**
  * H4 — pruning policy configuration. See HISTORY.md § "Pruning policy".
  *
@@ -39,29 +41,25 @@ public data class HistoryPruneConfig(
         autoPruneIntervalMs <= 0L
 
   public companion object {
-    public const val PROP_MAX_ENTRIES: String = "composeai.daemon.history.maxEntriesPerPreview"
-    public const val PROP_MAX_AGE_DAYS: String = "composeai.daemon.history.maxAgeDays"
+    public const val PROP_MAX_ENTRIES: String =
+      DaemonProperties.Names.HISTORY_MAX_ENTRIES_PER_PREVIEW
+    public const val PROP_MAX_AGE_DAYS: String = DaemonProperties.Names.HISTORY_MAX_AGE_DAYS
     public const val PROP_MAX_TOTAL_SIZE_BYTES: String =
-      "composeai.daemon.history.maxTotalSizeBytes"
+      DaemonProperties.Names.HISTORY_MAX_TOTAL_SIZE_BYTES
     public const val PROP_AUTO_PRUNE_INTERVAL_MS: String =
-      "composeai.daemon.history.autoPruneIntervalMs"
+      DaemonProperties.Names.HISTORY_AUTO_PRUNE_INTERVAL_MS
 
     /**
      * Builds a config from system properties, falling back to defaults for any unset / unparseable
      * value. Production daemon mains call this; tests construct [HistoryPruneConfig] directly.
      */
-    public fun fromSysprops(props: (String) -> String? = System::getProperty): HistoryPruneConfig {
-      val defaults = HistoryPruneConfig()
-      return HistoryPruneConfig(
-        maxEntriesPerPreview =
-          props(PROP_MAX_ENTRIES)?.toIntOrNull() ?: defaults.maxEntriesPerPreview,
-        maxAgeDays = props(PROP_MAX_AGE_DAYS)?.toIntOrNull() ?: defaults.maxAgeDays,
-        maxTotalSizeBytes =
-          props(PROP_MAX_TOTAL_SIZE_BYTES)?.toLongOrNull() ?: defaults.maxTotalSizeBytes,
-        autoPruneIntervalMs =
-          props(PROP_AUTO_PRUNE_INTERVAL_MS)?.toLongOrNull() ?: defaults.autoPruneIntervalMs,
+    public fun fromSysprops(props: (String) -> String? = System::getProperty): HistoryPruneConfig =
+      HistoryPruneConfig(
+        maxEntriesPerPreview = DaemonProperties.historyMaxEntriesPerPreview.read(props),
+        maxAgeDays = DaemonProperties.historyMaxAgeDays.read(props),
+        maxTotalSizeBytes = DaemonProperties.historyMaxTotalSizeBytes.read(props),
+        autoPruneIntervalMs = DaemonProperties.historyAutoPruneIntervalMs.read(props),
       )
-    }
   }
 }
 

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/config/DaemonPropertiesDocTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/config/DaemonPropertiesDocTest.kt
@@ -1,0 +1,46 @@
+package ee.schimke.composeai.daemon.config
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * `docs/daemon/TUNABLES.md` is generated from [DaemonProperties.renderMarkdown]; this test is the
+ * gate that keeps the checked-in copy honest.
+ *
+ * Regenerate with:
+ * ```
+ * ./gradlew :daemon:core:test --tests '*DaemonPropertiesDocTest*' -Pcomposeai.docs.regenerate=true
+ * ```
+ */
+class DaemonPropertiesDocTest {
+
+  @Test
+  fun generatedTableMatchesCheckedInDoc() {
+    val expected = DaemonProperties.renderMarkdown()
+    val doc = File(repoRoot(), "docs/daemon/TUNABLES.md")
+
+    if (System.getProperty("composeai.docs.regenerate") == "true") {
+      doc.parentFile.mkdirs()
+      doc.writeText(expected)
+      return
+    }
+
+    assertEquals(
+      "docs/daemon/TUNABLES.md is generated from DaemonProperties and is out of date. " +
+        "Regenerate with: ./gradlew :daemon:core:test --tests '*DaemonPropertiesDocTest*' " +
+        "-Pcomposeai.docs.regenerate=true",
+      expected,
+      if (doc.isFile) doc.readText() else "",
+    )
+  }
+
+  private fun repoRoot(): File {
+    var dir: File? = File("").absoluteFile
+    while (dir != null) {
+      if (File(dir, "settings.gradle.kts").isFile) return dir
+      dir = dir.parentFile
+    }
+    error("could not locate the repository root from ${File("").absolutePath}")
+  }
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/config/DaemonPropertyRegistryTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/config/DaemonPropertyRegistryTest.kt
@@ -1,0 +1,108 @@
+package ee.schimke.composeai.daemon.config
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * Pins the two invariants that make [DaemonProperties] a registry rather than a list that drifts:
+ * it is **complete** (every `composeai.daemon.*` literal in the tree is declared) and it is the
+ * **only** place those names are spelled inside `daemon/`.
+ *
+ * Both checks read the source tree, so a stray literal fails on the pull request that introduces it
+ * rather than months later, when a rename silently stops honouring somebody's `-D` flag.
+ */
+class DaemonPropertyRegistryTest {
+
+  @Test
+  fun namesAreUnique() {
+    val duplicates =
+      DaemonProperties.ALL.groupBy { it.name }.filterValues { it.size > 1 }.keys.sorted()
+    assertEquals("duplicate names in DaemonProperties.ALL", emptyList<String>(), duplicates)
+    assertEquals(DaemonProperties.ALL.size, DaemonProperties.BY_NAME.size)
+  }
+
+  @Test
+  fun everyNameIsUnderTheDaemonPrefix() {
+    assertEquals(
+      "DaemonProperties declares $PREFIX* knobs only",
+      emptyList<String>(),
+      DaemonProperties.ALL.map { it.name }.filterNot { it.startsWith(PREFIX) },
+    )
+  }
+
+  @Test
+  fun everyGroupIsRendered() {
+    assertEquals(
+      "group missing from DaemonProperties.GROUPS — the generated table would drop it",
+      emptySet<String>(),
+      DaemonProperties.ALL.map { it.group }.toSet() - DaemonProperties.GROUPS.toSet(),
+    )
+  }
+
+  @Test
+  fun theSourceScanSeesTheDaemonModules() {
+    // Guards the two scanning tests below against being vacuously green.
+    assertTrue(kotlinSources(File(repoRoot(), "daemon")).size > 100)
+  }
+
+  @Test
+  fun registryDeclaresEveryLiteralInTheTree() {
+    val undeclared =
+      kotlinSources(repoRoot())
+        .flatMap { file -> literalsIn(file).map { it to file.relativeTo(repoRoot()) } }
+        .filterNot { (name, _) -> name in DaemonProperties.BY_NAME }
+        .sortedBy { it.first }
+    if (undeclared.isNotEmpty()) {
+      fail(
+        "these $PREFIX* names are used in the tree but not declared in DaemonProperties:\n" +
+          undeclared.joinToString("\n") { (name, file) -> "  $name  ($file)" }
+      )
+    }
+  }
+
+  @Test
+  fun daemonModulesSpellNoDaemonPropertyLiteral() {
+    val offenders =
+      kotlinSources(File(repoRoot(), "daemon"))
+        .filterNot { it.path.endsWith(REGISTRY_FILE) }
+        .flatMap { file -> literalsIn(file).map { "  $it  (${file.relativeTo(repoRoot())})" } }
+        .sorted()
+    if (offenders.isNotEmpty()) {
+      fail(
+        "daemon/ must reach $PREFIX* knobs through DaemonProperties — a typed entry, or " +
+          "DaemonProperties.Names.* in a const context — never a string literal:\n" +
+          offenders.joinToString("\n")
+      )
+    }
+  }
+
+  private companion object {
+    const val PREFIX = "composeai.daemon."
+    const val REGISTRY_FILE = "config/DaemonProperties.kt"
+
+    /** Matches a *string literal* only, so KDoc prose like `-Dcomposeai.daemon.foo=1` is fine. */
+    val LITERAL = Regex("\"(composeai\\.daemon\\.[A-Za-z.]+)\"")
+
+    fun literalsIn(file: File): List<String> =
+      LITERAL.findAll(file.readText()).map { it.groupValues[1] }.distinct().toList()
+
+    fun kotlinSources(root: File): List<File> =
+      root
+        .walkTopDown()
+        .onEnter { it.name != "build" && it.name != ".git" }
+        .filter { it.isFile && it.extension == "kt" }
+        .toList()
+
+    fun repoRoot(): File {
+      var dir: File? = File("").absoluteFile
+      while (dir != null) {
+        if (File(dir, "settings.gradle.kts").isFile) return dir
+        dir = dir.parentFile
+      }
+      error("could not locate the repository root from ${File("").absolutePath}")
+    }
+  }
+}

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -2,6 +2,7 @@
 
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.config.DaemonProperties
 import ee.schimke.composeai.daemon.devices.frameDpOverriddenBy
 import ee.schimke.composeai.daemon.history.GitProvenance
 import ee.schimke.composeai.daemon.history.GitRefHistorySource
@@ -443,13 +444,13 @@ fun runDaemon(
  * property, default 5s).
  */
 /** HISTORY.md § "What this PR lands § H1" — null disables history. */
-private const val HISTORY_DIR_PROP = "composeai.daemon.historyDir"
+private const val HISTORY_DIR_PROP = DaemonProperties.Names.HISTORY_DIR
 
 /** Optional override for git-provenance resolution; defaults to JVM CWD. */
-private const val WORKSPACE_ROOT_PROP = "composeai.daemon.workspaceRoot"
+private const val WORKSPACE_ROOT_PROP = DaemonProperties.Names.WORKSPACE_ROOT
 
 /** Module project path stamped into every history entry's `module` field. */
-private const val MODULE_ID_PROP = "composeai.daemon.moduleId"
+private const val MODULE_ID_PROP = DaemonProperties.Names.MODULE_ID
 
 /**
  * Adapts a [PreviewIndex] into the `(previewId) -> RenderSpec?` lambda [DesktopHost] consumes for

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.config.DaemonProperties
 import ee.schimke.composeai.daemon.protocol.DataExtensionDescriptor
 import ee.schimke.composeai.daemon.protocol.FigmaSvgBackgroundMode
 import ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions
@@ -976,6 +977,6 @@ open class DesktopHost(
      * plugin's daemon launch descriptor in production; left unset in tests, in which case
      * [recordingsRootDir] falls back to a sibling of [RenderEngine.OUTPUT_DIR_PROP].
      */
-    const val RECORDINGS_DIR_PROP: String = "composeai.daemon.recordingsDir"
+    const val RECORDINGS_DIR_PROP: String = DaemonProperties.Names.RECORDINGS_DIR
   }
 }

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/FakeDaemonMain.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/FakeDaemonMain.kt
@@ -6,6 +6,7 @@ import ee.schimke.composeai.daemon.IncrementalDiscovery
 import ee.schimke.composeai.daemon.JsonRpcServer
 import ee.schimke.composeai.daemon.PreviewIndex
 import ee.schimke.composeai.daemon.PreviewInfoDto
+import ee.schimke.composeai.daemon.config.DaemonProperties
 import ee.schimke.composeai.daemon.history.GitProvenance
 import ee.schimke.composeai.daemon.history.GitRefHistorySource
 import ee.schimke.composeai.daemon.history.HistoryManager
@@ -95,8 +96,8 @@ fun main(args: Array<String>) {
   // H1+H2 — wire the per-render history archive when the harness opted in via
   // `composeai.daemon.historyDir`. Mirrors the production daemon main wireup. Tests that don't set
   // the sysprop see the pre-H1 default (no history written, history/list returns empty).
-  val historyDirProp = System.getProperty("composeai.daemon.historyDir")
-  val workspaceRootProp = System.getProperty("composeai.daemon.workspaceRoot")
+  val historyDirProp = System.getProperty(DaemonProperties.Names.HISTORY_DIR)
+  val workspaceRootProp = System.getProperty(DaemonProperties.Names.WORKSPACE_ROOT)
   // H10-read — `composeai.daemon.gitRefHistory` (comma-separated full ref names) wires read-only
   // GitRefHistorySources alongside the writable LocalFsHistorySource. Tests that don't set the
   // sysprop see the pre-H10 single-source behaviour.
@@ -110,7 +111,7 @@ fun main(args: Array<String>) {
     )
     HistoryManager.forLocalFsAndGitRefs(
       historyDir = Path.of(dir),
-      module = System.getProperty("composeai.daemon.moduleId") ?: ":harness",
+      module = System.getProperty(DaemonProperties.Names.MODULE_ID) ?: ":harness",
       gitProvenance = GitProvenance(workspaceRoot = workspaceRootProp?.let(Path::of)),
       gitRefs = gitRefHistoryRefs,
       repoRoot = workspaceRootProp?.let(Path::of) ?: Path.of(dir).parent,

--- a/docs/daemon/CONFIG.md
+++ b/docs/daemon/CONFIG.md
@@ -19,6 +19,11 @@ composePreview {
 The block used to live under `experimental`; new builds should use the top-level
 `composePreview.daemon { ... }` block.
 
+The DSL covers the knobs a consumer normally sets. The daemon JVM understands a wider set of
+`composeai.daemon.*` system properties — timeouts, history pruning, sandbox-pool and tracing
+knobs — enumerated in **[TUNABLES.md](TUNABLES.md)**, which is generated from the typed
+`DaemonProperties` registry in `:daemon:core` rather than hand-maintained.
+
 ## Fields
 
 ### `enabled: Boolean`

--- a/docs/daemon/README.md
+++ b/docs/daemon/README.md
@@ -37,6 +37,9 @@ the CI-canonical render path.
 - **[PROTOCOL.md](PROTOCOL.md)** — locked v1 wire format between
   client (VS Code, harness, MCP shim) and daemon.
 - **[CONFIG.md](CONFIG.md)** — `composePreview.daemon { … }` DSL.
+- **[TUNABLES.md](TUNABLES.md)** — generated table of every
+  `composeai.daemon.*` system property, with its type and default.
+  Source of truth is `DaemonProperties` in `:daemon:core`.
 
 ### Subsystems
 

--- a/docs/daemon/TUNABLES.md
+++ b/docs/daemon/TUNABLES.md
@@ -1,0 +1,114 @@
+<!--
+  GENERATED FILE — do not edit by hand.
+
+  Source of truth: DaemonProperties in
+  daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/config/DaemonProperties.kt
+  Regenerate:      ./gradlew :daemon:core:test --tests '*DaemonPropertiesDocTest*' -Pcomposeai.docs.regenerate=true
+-->
+
+# Preview daemon — tunables
+
+Every `composeai.daemon.*` system property the daemon and its launch descriptor understand,
+generated from the typed registry so the list cannot drift from the code that reads it.
+
+Pass one with `-D<name>=<value>` on the daemon JVM. The Gradle-facing knobs (`maxHeapMb`, `warmSpare`,
+`maxRendersPerSandbox`, `backgroundSandboxBoot`) are normally set through the `composePreview.daemon { … }`
+DSL rather than by hand — see [CONFIG.md](CONFIG.md).
+
+"Default" is the value used when the property is unset **or** unparseable: a typo never silently
+flips a knob.
+
+## Lifecycle and timeouts
+
+| Property | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `composeai.daemon.idleTimeoutMs` | Long | `5000` | How long the daemon waits after its last client disconnects before exiting. |
+| `composeai.daemon.renderTimeoutMs` | Long | `300000` | Initial per-render `host.submit` timeout, before `initialize.options.maxRenderMs` lands. Non-positive values keep the default. |
+| `composeai.daemon.classpathDirtyGraceMs` | Long | `2000` | Grace window after a classpath-dirty signal before the daemon acts on it. See PROTOCOL.md § 6. |
+| `composeai.daemon.dataFetchRerenderBudgetMs` | Long | `30000` | Budget for the re-render a `data/fetch` may trigger. See DATA-PRODUCTS.md § Re-render semantics. |
+| `composeai.daemon.discoveryWatchdogMs` | Long | `1500` | Window between `fileChanged({kind:source})` and the deferred discovery scan. |
+| `composeai.daemon.interactive.idleLeaseMs` | Long | `60000` | Idle lease before a held interactive session auto-closes. |
+| `composeai.daemon.sandboxBootTimeoutMs` | Long | `600000` | Deadline for a Robolectric sandbox bootstrap. The default covers a cold `android-all-instrumented` download; warm boots are 5–15s. |
+
+## Classpath and discovery
+
+| Property | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `composeai.daemon.userClassDirs` | path list | empty | `File.pathSeparator`-delimited user-class directories the child-first loader serves. |
+| `composeai.daemon.userClassPackages` | path list | empty | Packages excluded from Robolectric instrumentation and served from the user classloader. |
+| `composeai.daemon.cheapSignalFiles` | path list | empty | Files whose mtime/size form the cheap classpath-dirty signal. |
+| `composeai.daemon.previewsJsonPath` | path | unset | Absolute path to the `previews.json` manifest. Unset boots with an empty preview index. |
+
+## History
+
+| Property | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `composeai.daemon.historyDir` | path | unset | Render-history archive directory. Unset disables history entirely. |
+| `composeai.daemon.workspaceRoot` | path | unset | Repository root used for git provenance. Defaults to the daemon JVM's working directory. |
+| `composeai.daemon.moduleId` | String | unset | Gradle project path stamped into every history entry's `module` field. |
+| `composeai.daemon.gitRefHistory` | list | empty | Reporting refs wired as read-only history sources, e.g. `refs/heads/preview/main`. |
+| `composeai.daemon.gitRefHistorySyncMode` | String | `READ_ONLY` | Sync mode for the reporting refs: `READ_ONLY`, `WRITE_LOCAL` or `WRITE_PUSH`. |
+| `composeai.daemon.gitRefHistoryDebounceMs` | Long | `1000` | Debounce window coalescing a render burst into one reporting-branch commit. `0` disables. |
+| `composeai.daemon.gitRefHistoryPublishPolicy` | String | `cleanOnBranch` | Which renders reach the reporting branch: `all`, or `cleanOnBranch` (the default). |
+| `composeai.daemon.history.maxEntriesPerPreview` | Int | `50` | Prune knob — entries retained per preview. `0` or negative disables this knob. |
+| `composeai.daemon.history.maxAgeDays` | Int | `14` | Prune knob — maximum entry age in days. `0` or negative disables this knob. |
+| `composeai.daemon.history.maxTotalSizeBytes` | Long | `500000000` | Prune knob — total archive size ceiling in bytes. `0` or negative disables this knob. |
+| `composeai.daemon.history.autoPruneIntervalMs` | Long | `3600000` | Prune knob — auto-prune scheduler period. `0` or negative disables the scheduler. |
+
+## Sandbox pool
+
+| Property | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `composeai.daemon.sandboxCount` | Int | `1` | In-JVM Robolectric sandbox slots. Set by the supervisor to `1 + replicasPerDaemon`. The Android daemon main derives a larger default (5) when `warmSpare` is on; this default applies to every other reader. |
+| `composeai.daemon.warmSpare` | Boolean | `true` | Whether the pool keeps a warm spare sandbox so recycle is an atomic swap. |
+| `composeai.daemon.backgroundSandboxBoot` | Boolean | `false` | Whether `initialize` may return once the first sandbox is ready, the rest booting behind it. The Gradle-plugin descriptor sets this `true`; the raw sysprop default is off. |
+| `composeai.daemon.warmRenderOnBoot` | Boolean | `true` | Whether each background-booted slot performs a boot-time warm render. |
+| `composeai.daemon.useConsumerApplication` | Boolean | `false` | Whether Robolectric instantiates the consumer manifest's `Application` instead of the pinned `android.app.Application` stub. |
+| `composeai.daemon.maxRendersPerSandbox` | Int | `1000` | Renders a sandbox handles before it is recycled regardless of drift signals. |
+| `composeai.daemon.maxHeapMb` | Int | `1024` | Post-GC heap ceiling for the daemon JVM, in MiB. Also becomes `-Xmx`. |
+| `composeai.daemon.sandboxWorker.port` | Int | `0` | Loopback port a spawned sandbox worker connects back on. Set by `SandboxProcessPool`; `SandboxWorkerMain` fails fast when unset. |
+| `composeai.daemon.sandboxWorker.slot` | Int | `0` | Pool slot index a spawned sandbox worker owns. Set by `SandboxProcessPool`. |
+
+## Tracing and diagnostics
+
+| Property | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `composeai.daemon.startupQuiet` | Boolean | `false` | Suppress startup-timing marks on stderr. Marks are still buffered for the summary. |
+| `composeai.daemon.atrace` | Boolean | `false` | Mirror render trace sections into `android.os.Trace`. |
+| `composeai.daemon.perfettoTrace` | Boolean | `false` | Emit a Perfetto trace for each render. Set from the Gradle plugin's daemon DSL. |
+| `composeai.daemon.compositionTrace` | Boolean | `false` | Enable Compose composition tracing in the render extension. |
+| `composeai.daemon.recordingsDir` | path | unset | Where interactive recordings are written. Unset falls back to a sibling of the render output directory. |
+
+## Bundle IR replay
+
+| Property | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `composeai.daemon.bundleManifestPath` | path | unset | Portable-bundle manifest backing IR replay. Both this and `irDir` must be set. |
+| `composeai.daemon.irDir` | path | unset | Directory holding the bundle's serialised preview IR. |
+
+## Data products
+
+| Property | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `composeai.daemon.resDirs` | path list | empty | Android resource directories the resource / i18n data products read. |
+| `composeai.daemon.defaultLocale` | String | unset | Locale treated as the source language by the i18n translations data product. |
+
+## Launch descriptor (set by the Gradle plugin)
+
+| Property | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `composeai.daemon.protocolVersion` | String | unset | Daemon protocol version stamped by the Gradle plugin's launch descriptor. |
+| `composeai.daemon.modulePath` | String | unset | Gradle project path of the module the daemon serves. |
+| `composeai.daemon.moduleProjectDir` | path | unset | Absolute project directory of the module the daemon serves. |
+
+## In-process compile (BTA)
+
+| Property | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `composeai.daemon.bta.implClasspath` | path list | empty | Build Tools API implementation JARs loaded into BTA's isolated classloader. |
+| `composeai.daemon.bta.compileClasspath` | path list | empty | Compile classpath for stage-2 compiles. |
+| `composeai.daemon.bta.compilerPlugins` | path list | empty | Compiler-plugin JARs (Compose, serialization, …) passed to the in-process compile. |
+| `composeai.daemon.bta.moduleName` | String | unset | Kotlin module name for stage-2 compiles. |
+| `composeai.daemon.bta.outputDir` | path | unset | Class output directory for stage-2 compiles. |
+| `composeai.daemon.bta.icWorkingDir` | path | unset | Incremental-compilation working directory for stage-2 compiles. |
+| `composeai.daemon.bta.ineligibilityReason` | String | unset | Why the Gradle plugin ruled this module out of in-process compile; surfaced in diagnostics. |


### PR DESCRIPTION
Closes #5167.

## What this does

Gives the `composeai.daemon.*` system properties a single typed registry — `DaemonProperties` in `:daemon:core` (`daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/config/DaemonProperties.kt`) — and removes every `"composeai.daemon.…"` string literal from `daemon/`.

Before, each knob was a bare `System.getProperty("composeai.daemon.…")` at its point of use with its default and its parsing inline. That made the set an unversioned public API surface nobody could enumerate: the names were string literals invisible to `checkKotlinAbi`, and a rename was a silent behaviour change rather than a compile error.

The registry declares all **50** `composeai.daemon.*` names in the tree — including the producer-only ones the Gradle plugin's launch descriptor writes (`bta.*`, `protocolVersion`, `resDirs`, …), because the point is that the *name space* is enumerable, not just the half `:daemon:core` happens to read.

- `DaemonProperty<T>` — `name`, `defaultValue`, `doc`, `group`, and a `parse` that turns a raw string into a value. Subtypes: `StringProperty`, `PathProperty`, `PathListProperty`, `CsvListProperty`, `BooleanProperty`, `IntProperty`, `LongProperty`.
- `DaemonProperties.Names` holds the names as `const val`, so the published `const val …_PROP` declarations (`JsonRpcServer.IDLE_TIMEOUT_PROP`, `PreviewIndex.PREVIEWS_JSON_PATH_PROP`, …) now delegate to the registry **without changing their ABI** — a `const val` initialised from another `const val` still compiles to a `ConstantValue` field, and the regenerated dump shows no change to those entries.
- Read sites whose parsing was a plain "parse or default" now call `DaemonProperties.<knob>.read()`. Sites with bespoke semantics (`GitRefHistorySource`'s sync-mode / publish-policy enums, the Android `DaemonMain`'s warm-spare-derived `sandboxCount` default) keep their parse but take the name from the registry.

## Generated docs

`docs/daemon/TUNABLES.md` is new and generated from `DaemonProperties.renderMarkdown()` — one table per group, with type, default and effect for all 50 knobs. `DaemonPropertiesDocTest` fails the build when the checked-in copy drifts; regenerate with:

```
./gradlew :daemon:core:test --tests '*DocTest*' -Pcomposeai.docs.regenerate=true
```

`docs/daemon/CONFIG.md` (the DSL doc) and `docs/daemon/README.md` link to it.

## The invariant is tested, not just asserted in a KDoc

`DaemonPropertyRegistryTest` scans the source tree and fails when:

- a `composeai.daemon.*` literal exists anywhere in the tree that the registry does not declare (completeness), or
- any file under `daemon/` other than `DaemonProperties.kt` spells one as a string literal — the issue's "done looks like".

It matches string literals only, so KDoc prose like `-Dcomposeai.daemon.sandboxBootTimeoutMs=<ms>` stays legal.

## Behaviour notes

- `BooleanProperty` parses `true` / `false` case-insensitively and falls back to the declared default for anything else. That matches what each site already did for its own default; the one visible change is that a knob spelled `FALSE` is now honoured instead of falling through to the default.
- `PathListProperty` trims and drops empty segments, matching the hand-rolled splits it replaced.
- Every other default and parse is unchanged; `renderTimeoutMs` keeps its "non-positive keeps the default" rule at the call site.

## One unrelated line in the ABI dump

`./gradlew :daemon:core:updateKotlinAbi` also picked up `PreviewKnobDto.options`, added by #5142 without regenerating `daemon/core/api/core.api`. It is not separable from this change — the dump is one file — so it rides along here.

## Out of scope

The Gradle plugin writes many of these names and does not depend on `:daemon-core`, so its literals (`AndroidPreviewSupport`, `ComposePreviewTasks`) stay as they are; the registry test still pins that every name they write is declared. The other 96 `composeai.*` properties outside the `daemon.` prefix are untouched — the issue calls the `daemon.*` cluster the sensible first slice.

## Test plan

All run locally, all green:

- `./gradlew :daemon:core:test` — 6 tests in `DaemonPropertyRegistryTest`, 1 in `DaemonPropertiesDocTest`, plus the existing suite.
- `./gradlew :daemon:core:updateKotlinAbi`
- `./gradlew :daemon:android:compileDebugUnitTestKotlin :daemon:desktop:compileTestKotlin :daemon:harness:compileKotlin`
- `./gradlew :daemon:core:ktfmtCheckScripts` and `ktfmtFormat` on every touched module.

Non-visual change — no render evidence applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012c76ymmM8aTTgJG7we43KL

---
_Generated by [Claude Code](https://claude.ai/code/session_012c76ymmM8aTTgJG7we43KL)_