### PR TITLE
fix(cli): carry non-ASCII preview ids through a file, not a process argument

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -631,9 +631,10 @@ abstract class Command(
   }
 
   /**
-   * The `-PcomposePreview.idFilter` narrowing for this invocation's `--id` / `--filter`, plus the
-   * stderr diagnostics that go with it. Shared by the [renderModules] pipeline (`show`, `a11y`,
-   * reports) and by `render`, which drives Gradle itself.
+   * The `-PcomposePreview.idFilter` (or `-PcomposePreview.idFilterFile`, see [PreviewRenderScope])
+   * narrowing for this invocation's `--id` / `--filter`, plus the stderr diagnostics that go with
+   * it. Shared by the [renderModules] pipeline (`show`, `a11y`, reports) and by `render`, which
+   * drives Gradle itself.
    *
    * Returns [PreviewRenderScope.FULL] — render everything, the pre-#3730 behaviour — whenever the
    * request can't be resolved to an exact id list: no filter, no modules, or a discovery pass that
@@ -674,7 +675,7 @@ abstract class Command(
     if (verbose && scope.narrowed) {
       System.err.println(
         "compose-preview: $flag narrowed the render to ${scope.renderedIds?.size ?: 0} preview(s) " +
-          "via -P${PreviewRenderScope.GRADLE_PROPERTY}"
+          "via ${scope.gradleArgs.first().substringBefore('=')}"
       )
     }
     return scope

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -144,6 +144,7 @@ class DoctorCommand(
     checkOs()
     checkJava()
     checkPathJava()
+    checkArgEncoding()
     checkClaudeCloud()
 
     val projectDir = resolveProjectDir()
@@ -307,6 +308,44 @@ class DoctorCommand(
    * `scripts/install.sh` is the intended bootstrap path. Suppressed when no Claude cloud env vars
    * are set.
    */
+  /**
+   * Whether this JVM can carry a non-ASCII preview id across a process boundary (issue #5172).
+   *
+   * `sun.jnu.encoding` is what the JVM encodes process arguments with, and it comes from the
+   * process locale, not from `file.encoding`: a container with no locale configured, a CI runner,
+   * and most cloud agent sandboxes all run at `ANSI_X3.4-1968`. There, every non-ASCII character in
+   * an argument is replaced by `?` in transit — so a preview named `Cadence — Sync ready` used to
+   * fail a narrowed render with an id it could never match. The CLI now routes such ids through a
+   * file, but the Gradle daemon inherits the same locale, so the warning is still worth a line: it
+   * turns the next encoding-shaped failure into a preflight note.
+   */
+  private fun checkArgEncoding() {
+    val encoding = System.getProperty("sun.jnu.encoding") ?: System.getProperty("file.encoding")
+    val utf8 = encoding != null && runCatching { charset(encoding) }.getOrNull() == Charsets.UTF_8
+    addCheck(
+      DoctorCheck(
+        id = "env.arg-encoding",
+        category = "env",
+        status = if (utf8) "ok" else "warning",
+        message = "process argument encoding: ${encoding ?: "unknown"}",
+        detail =
+          if (utf8) null
+          else
+            "sun.jnu.encoding is not UTF-8, so non-ASCII characters (an em dash in a @Preview " +
+              "name, say) are replaced by '?' when they cross a process boundary. Renders still " +
+              "work; a Gradle daemon started under this locale can mangle preview ids it is " +
+              "asked for by name.",
+        remediation =
+          if (utf8) null
+          else
+            DoctorRemediation(
+              summary = "run with a UTF-8 locale (any UTF-8 locale the image has will do)",
+              commands = listOf("export LC_ALL=C.UTF-8 LANG=C.UTF-8", "compose-preview doctor"),
+            ),
+      )
+    )
+  }
+
   private fun checkClaudeCloud() {
     if (!inClaudeCloud) return
     val sessionId = System.getenv("CLAUDE_CODE_SESSION_ID").orEmpty()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PreviewRenderScope.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PreviewRenderScope.kt
@@ -35,6 +35,14 @@ internal object PreviewRenderScope {
   const val GRADLE_PROPERTY: String = "composePreview.idFilter"
 
   /**
+   * The delimiter- and encoding-safe form of [GRADLE_PROPERTY]: a **path** to a newline-delimited
+   * UTF-8 list of the same patterns (issue #5172), the positive twin of
+   * `composePreview.idExcludeFile`. Used only when the comma-joined property cannot carry the
+   * selection — see [forRequest].
+   */
+  const val FILE_GRADLE_PROPERTY: String = "composePreview.idFilterFile"
+
+  /**
    * Mirror of `PreviewNameFilter.ANCHOR` — the prefix that makes a pattern an exact match rather
    * than a substring one. Load-bearing here: ids are hierarchical, so an unanchored `Button` would
    * also select `Button_Dark` and every `@PreviewParameter` row under it, quietly re-widening the
@@ -72,6 +80,9 @@ internal object PreviewRenderScope {
    * (`Foo`) because the render applies its id filter before expanding — see
    * `RenderPreviewsTask.render`.
    *
+   * [filesDir] is where the `$FILE_GRADLE_PROPERTY` fallback file is written when the comma-joined
+   * property can't carry the selection; `null` means the JVM temp dir. Tests pass their own.
+   *
    * Returns [FULL] when there is no request, when nothing matched (the caller renders no module at
    * all in that case), or when the request selects every discovered preview.
    */
@@ -82,6 +93,7 @@ internal object PreviewRenderScope {
     previewRef: String? = null,
     permutations: List<String> = emptyList(),
     rowAware: Boolean = true,
+    filesDir: java.io.File? = null,
   ): Scope {
     if (exactId == null && filter == null && previewRef == null) return FULL
     if (manifests.isEmpty()) return FULL
@@ -131,21 +143,77 @@ internal object PreviewRenderScope {
     if (selected.isEmpty()) return FULL
     if (selected.size == discovered) return FULL
 
+    val patterns = selected.filter(String::isNotBlank).map { ANCHOR + it }
+    if (patterns.isEmpty()) return FULL
+
     // `previewIdFilterProperty` splits the property on `,`, so an id carrying a comma would be torn
     // into two patterns that each match nothing — and a filter matching nothing *fails* the render.
     // No discovered id should contain one (ids derive from Kotlin identifiers and are
-    // path-sanitised), so this is a guard rather than a code path: decline the narrowing and render
-    // wide instead of breaking the run.
-    val unsafe = selected.filter { it.contains(',') || it.isBlank() }
-    if (unsafe.isNotEmpty()) {
-      return Scope(
-        note =
-          "could not narrow the Gradle render: ${unsafe.size} matching preview id(s) contain a " +
-            "comma, which $GRADLE_PROPERTY cannot express (e.g. '${unsafe.first()}')"
-      )
+    // path-sanitised), so this is a guard rather than a code path.
+    val joined = patterns.joinToString(",")
+    val commaSafe = patterns.none { it.contains(',') }
+    // Issue #5172 — process arguments are encoded with the JVM's `sun.jnu.encoding`, so on a
+    // C/POSIX-locale JVM (`ANSI_X3.4-1968`: containers, CI runners, cloud agent sandboxes) every
+    // non-ASCII character in this argument is replaced by `?` before Gradle ever sees it. A preview
+    // named `Cadence — Sync ready` then resolves to an id the render worker can never match, so the
+    // narrowed path failed for exactly the previews it was meant to speed up.
+    val argSafe = platformArgEncodable(joined)
+    if (commaSafe && argSafe) {
+      return Scope(gradleArgs = listOf("-P$GRADLE_PROPERTY=$joined"), renderedIds = renderedIds)
     }
 
-    val patterns = selected.joinToString(",") { ANCHOR + it }
-    return Scope(gradleArgs = listOf("-P$GRADLE_PROPERTY=$patterns"), renderedIds = renderedIds)
+    // Both problems are transport problems, and a UTF-8 file behind an ASCII path solves both: the
+    // path is what crosses the argument boundary, and newlines delimit ids a comma cannot. Mirrors
+    // `composePreview.idExcludeFile`, which exists for the comma half of the same story.
+    val file = writeIdFilterFile(patterns, filesDir)
+    if (file == null || !platformArgEncodable(file.path)) {
+      val why =
+        if (!commaSafe) "contain a comma, which $GRADLE_PROPERTY cannot express"
+        else "cannot be passed through this JVM's argument encoding ($PLATFORM_ARG_ENCODING)"
+      return Scope(
+        note =
+          "could not narrow the Gradle render: ${patterns.size} matching preview id(s) $why, and " +
+            "the $FILE_GRADLE_PROPERTY fallback was unusable (e.g. '${patterns.first()}')"
+      )
+    }
+    return Scope(
+      gradleArgs = listOf("-P$FILE_GRADLE_PROPERTY=${file.path}"),
+      renderedIds = renderedIds,
+    )
   }
+
+  /**
+   * The charset the JVM encodes process arguments (and environment) with — `sun.jnu.encoding`.
+   * Unrelated to `file.encoding`: it comes from the process locale, so a container with no locale
+   * configured runs at `ANSI_X3.4-1968` (US-ASCII) even on a JDK whose default charset is UTF-8.
+   */
+  internal val PLATFORM_ARG_ENCODING: String
+    get() = System.getProperty("sun.jnu.encoding") ?: System.getProperty("file.encoding") ?: "UTF-8"
+
+  /** Whether [value] survives the trip through [PLATFORM_ARG_ENCODING] unchanged. */
+  internal fun platformArgEncodable(value: String): Boolean =
+    runCatching { java.nio.charset.Charset.forName(PLATFORM_ARG_ENCODING) }
+      .getOrNull()
+      ?.newEncoder()
+      ?.canEncode(value) ?: true
+
+  /**
+   * Write [patterns] as a newline-delimited UTF-8 file for `-P$FILE_GRADLE_PROPERTY`, or `null`
+   * when the file can't be created (a read-only temp dir — the caller then renders wide rather than
+   * failing the run).
+   *
+   * Written under the JVM temp dir rather than the project's `build/`, because the project path is
+   * exactly as likely to be un-encodable as the ids are, and the path is what has to reach Gradle
+   * intact. Deleted on exit: the Gradle invocation reads it during configuration of the same run.
+   */
+  private fun writeIdFilterFile(patterns: List<String>, dir: java.io.File?): java.io.File? =
+    runCatching {
+      val file =
+        java.io.File.createTempFile("compose-preview-id-filter-", ".txt", dir).apply {
+          deleteOnExit()
+        }
+      file.writeText(patterns.joinToString("\n"), Charsets.UTF_8)
+      file
+    }
+    .getOrNull()
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewRenderScopeTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewRenderScopeTest.kt
@@ -42,6 +42,31 @@ class PreviewRenderScopeTest {
           },
       )
 
+  private fun createTempDir(): File =
+    java.nio.file.Files.createTempDirectory("preview-render-scope").toFile().apply {
+      deleteOnExit()
+    }
+
+  /** The single `-PcomposePreview.idFilterFile=<path>` argument [scope] carries. */
+  private fun onlyFileArg(scope: PreviewRenderScope.Scope): String {
+    val arg = scope.gradleArgs.singleOrNull() ?: error("expected one argument: ${scope.gradleArgs}")
+    val prefix = "-P${PreviewRenderScope.FILE_GRADLE_PROPERTY}="
+    assertTrue(arg.startsWith(prefix), "expected a file argument, was '$arg'")
+    return arg.removePrefix(prefix)
+  }
+
+  /** Runs [body] as if the JVM encoded process arguments with [encoding]. */
+  private fun <T> withArgEncoding(encoding: String, body: () -> T): T {
+    val previous = System.getProperty("sun.jnu.encoding")
+    System.setProperty("sun.jnu.encoding", encoding)
+    try {
+      return body()
+    } finally {
+      if (previous == null) System.clearProperty("sun.jnu.encoding")
+      else System.setProperty("sun.jnu.encoding", previous)
+    }
+  }
+
   @Test
   fun `no request renders everything`() {
     val app = module("app")
@@ -152,19 +177,86 @@ class PreviewRenderScopeTest {
   }
 
   @Test
-  fun `an id carrying a comma declines the narrowing rather than breaking the render`() {
+  fun `an id carrying a comma travels as a file rather than a comma-joined property`() {
+    val app = module("app")
+    val dir = createTempDir()
+    val scope =
+      PreviewRenderScope.forRequest(
+        manifests = listOf(manifest(app, "Home,Preview", "SettingsPreview")),
+        exactId = null,
+        filter = "Home",
+        filesDir = dir,
+      )
+
+    // `composePreview.idFilter` splits on `,`, so this id can only travel newline-delimited.
+    val path = onlyFileArg(scope)
+    assertEquals(listOf("=Home,Preview"), File(path).readLines())
+    assertEquals(setOf("Home,Preview"), scope.renderedIds)
+  }
+
+  @Test
+  fun `an unwritable file dir declines the narrowing rather than breaking the render`() {
     val app = module("app")
     val scope =
       PreviewRenderScope.forRequest(
         manifests = listOf(manifest(app, "Home,Preview", "SettingsPreview")),
         exactId = null,
         filter = "Home",
+        filesDir = File(createTempDir(), "does-not-exist"),
       )
 
     assertEquals(emptyList(), scope.gradleArgs)
     assertTrue(
       scope.note!!.contains("comma"),
       "the declined narrowing explains itself: ${scope.note}",
+    )
+  }
+
+  /**
+   * Issue #5172 — process arguments are encoded with `sun.jnu.encoding`, so on a C/POSIX-locale JVM
+   * an em dash in a preview name reaches the render as `?` and can never match the id discovered
+   * there. The ids then travel through a UTF-8 file behind an ASCII path instead.
+   */
+  @Test
+  fun `a non-ASCII id travels as a file when the argument encoding cannot carry it`() {
+    val app = module("app")
+    val dir = createTempDir()
+    val scope =
+      withArgEncoding("ANSI_X3.4-1968") {
+        PreviewRenderScope.forRequest(
+          manifests = listOf(manifest(app, "SyncPreview_Cadence — Sync ready", "HomePreview")),
+          exactId = null,
+          filter = "Sync ready",
+          filesDir = dir,
+        )
+      }
+
+    val path = onlyFileArg(scope)
+    assertTrue(path.all { it.code < 128 }, "the path itself has to survive the boundary: $path")
+    assertEquals(
+      listOf("=SyncPreview_Cadence — Sync ready"),
+      File(path).readLines(Charsets.UTF_8),
+    )
+  }
+
+  @Test
+  fun `a non-ASCII id still travels as a plain property under a UTF-8 encoding`() {
+    val app = module("app")
+    val scope =
+      withArgEncoding("UTF-8") {
+        PreviewRenderScope.forRequest(
+          manifests = listOf(manifest(app, "SyncPreview_Cadence — Sync ready", "HomePreview")),
+          exactId = null,
+          filter = "Sync ready",
+          filesDir = createTempDir(),
+        )
+      }
+
+    // No file, no behaviour change: the fallback is scoped to the boundary that actually loses
+    // characters, so a UTF-8 host keeps the one-argument form (and its older-plugin compatibility).
+    assertEquals(
+      listOf("-PcomposePreview.idFilter==SyncPreview_Cadence — Sync ready"),
+      scope.gradleArgs,
     )
   }
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -2493,6 +2493,7 @@ internal object AndroidPreviewSupport {
           PreviewFilterSystemPropsProvider(
             nameFilters = previewFilters,
             idFilters = previewIdFilters,
+            idFilterFile = ComposePreviewTasks.previewIdFilterFileProperty(project),
             idExcludes = previewIdExcludes,
             idExcludeFile = ComposePreviewTasks.previewIdExcludeFileProperty(project),
             rowExcludes = previewRowExcludes,
@@ -2979,6 +2980,7 @@ internal object AndroidPreviewSupport {
           PreviewFilterSystemPropsProvider(
             nameFilters = ComposePreviewTasks.previewFilterProperty(project),
             idFilters = ComposePreviewTasks.previewIdFilterProperty(project),
+            idFilterFile = ComposePreviewTasks.previewIdFilterFileProperty(project),
             idExcludes = ComposePreviewTasks.previewIdExcludeProperty(project),
             idExcludeFile = ComposePreviewTasks.previewIdExcludeFileProperty(project),
             // Forwarded for uniformity; the XR subspace render has no `@PreviewParameter` fan-out
@@ -3816,6 +3818,13 @@ internal object AndroidPreviewSupport {
   internal class PreviewFilterSystemPropsProvider(
     @get:org.gradle.api.tasks.Input val nameFilters: org.gradle.api.provider.Provider<List<String>>,
     @get:org.gradle.api.tasks.Input val idFilters: org.gradle.api.provider.Provider<List<String>>,
+    /**
+     * Path to the newline-delimited UTF-8 id-filter file, when the build was given one
+     * (issue #5172). `@Internal` for the same reason as [idExcludeFile]: [idFilters] already
+     * carries this file's RESOLVED lines, so the contents drive the up-to-date check and the path
+     * must not.
+     */
+    @get:org.gradle.api.tasks.Internal val idFilterFile: org.gradle.api.provider.Provider<String>,
     @get:org.gradle.api.tasks.Input val idExcludes: org.gradle.api.provider.Provider<List<String>>,
     /**
      * Path to the newline-delimited exclusion file, when the build was given one. `@Internal`
@@ -3830,7 +3839,29 @@ internal object AndroidPreviewSupport {
   ) : org.gradle.process.CommandLineArgumentProvider {
     override fun asArguments(): Iterable<String> = buildList {
       arg("composeai.preview.filter", nameFilters.getOrElse(emptyList()))
-      arg("composeai.preview.idFilter", idFilters.getOrElse(emptyList()))
+      // The id filter travels as a PATH when it came from `composePreview.idFilterFile`, for both
+      // reasons the exclude file below travels that way — an id may contain a comma — plus the one
+      // the file property was added for (issue #5172): this argument is encoded with the Gradle
+      // daemon's `sun.jnu.encoding`, so on a C/POSIX-locale daemon every non-ASCII character in an
+      // id would be replaced by `?` on the way to the render JVM and match nothing there. Same
+      // "only while the file is still what the list came FROM" test as the excludes: an explicit
+      // `--preview-id` on the task overrides the property convention, and must not lose to a stale
+      // `-PcomposePreview.idFilterFile`.
+      val filterFile = idFilterFile.orNull?.trim().orEmpty()
+      val resolvedFilters =
+        idFilters.getOrElse(emptyList()).map(String::trim).filter(String::isNotEmpty)
+      val filtersFromFile =
+        java.io
+          .File(filterFile)
+          .takeIf { filterFile.isNotEmpty() && it.isFile }
+          ?.readLines(Charsets.UTF_8)
+          ?.map(String::trim)
+          ?.filter(String::isNotEmpty)
+      if (filtersFromFile != null && filtersFromFile == resolvedFilters) {
+        add("-Dcomposeai.preview.idFilterFile=${java.io.File(filterFile).absolutePath}")
+      } else {
+        arg("composeai.preview.idFilter", resolvedFilters)
+      }
       // The FILE wins when there is one, and the comma-joined form is then not emitted at all.
       // Re-joining here is what the file exists to avoid: a preview id may contain a comma, so the
       // round trip shatters each id into fragments that — matching by substring — exclude the whole

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -1581,10 +1581,42 @@ internal object ComposePreviewTasks {
    * Android modules where several catalogs actually live.
    */
   internal fun previewIdFilterProperty(project: Project): Provider<List<String>> =
-    project.providers
-      .gradleProperty("composePreview.idFilter")
-      .map { v -> v.split(",").map(String::trim).filter(String::isNotEmpty) }
+    previewIdFilterFileProperty(project)
+      .map { path ->
+        val file = java.io.File(path)
+        check(file.isFile) {
+          "composePreview.idFilterFile names '$path', which is not a readable file. Refusing to " +
+            "fall back to an unfiltered render, which would render every preview and look like " +
+            "success."
+        }
+        file.readLines(Charsets.UTF_8).map(String::trim).filter(String::isNotEmpty)
+      }
+      .orElse(
+        project.providers.gradleProperty("composePreview.idFilter").map { v ->
+          v.split(",").map(String::trim).filter(String::isNotEmpty)
+        }
+      )
       .orElse(emptyList())
+
+  /**
+   * `Provider<String>` for the `composePreview.idFilterFile` Gradle property — a **path** to a
+   * newline-delimited UTF-8 pattern list, the delimiter- and encoding-safe form of
+   * [previewIdFilterProperty] and the positive twin of [previewIdExcludeFileProperty].
+   *
+   * Exists for issue #5172: a JVM whose `sun.jnu.encoding` is not UTF-8 (a C/POSIX-locale
+   * container, a CI runner, a cloud agent sandbox — `ANSI_X3.4-1968`) replaces every non-ASCII
+   * character of a process argument with `?`, so `-PcomposePreview.idFilter==…_Cadence — Sync
+   * ready` reached the render as `…_Cadence ? Sync ready` and matched nothing, failing the task for
+   * exactly the previews the narrowing exists to speed up. A path is ASCII in practice and the file
+   * is read as UTF-8 here, inside the build, so the ids arrive intact — and, like the exclude file,
+   * it can carry an id containing a comma. Set by `compose-preview show --filter/--id`, which falls
+   * back to it only when the comma-joined property cannot carry the selection. When present it
+   * REPLACES `composePreview.idFilter`.
+   */
+  internal fun previewIdFilterFileProperty(project: Project): Provider<String> =
+    project.providers.gradleProperty("composePreview.idFilterFile").map(String::trim).filter {
+      it.isNotEmpty()
+    }
 
   /**
    * `Provider<List<String>>` for the `composePreview.idExclude` Gradle property — the

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -1178,6 +1178,7 @@ internal fun selectNamedPreviews(
       append("composePreviewRender --preview matched no previews for ")
       append(cleaned.joinToString(", ") { "'$it'" })
       append(".")
+      appendEncodingHint(cleaned)
       appendManifestContext(previews, manifestPath)
       if (available.isEmpty()) {
         append(" This module has no discovered previews — run composePreviewDiscover to confirm.")
@@ -1230,6 +1231,7 @@ internal fun selectPreviewIds(
       append("composePreviewRender --preview-id matched no previews for ")
       append(cleaned.joinToString(", ") { "'$it'" })
       append(".")
+      appendEncodingHint(cleaned)
       appendManifestContext(manifestPreviews, manifestPath)
       if (available.isEmpty()) {
         append(" This module has no discovered previews — run composePreviewDiscover to confirm.")
@@ -1244,6 +1246,28 @@ internal fun selectPreviewIds(
         }
       }
     }
+  )
+}
+
+/**
+ * Names the likeliest cause when a filter that should have matched carries a `?` (issue #5172).
+ *
+ * Preview ids reach this task as process arguments, encoded with the JVM's `sun.jnu.encoding`. On a
+ * C/POSIX-locale JVM (`ANSI_X3.4-1968` — containers, CI runners, cloud agent sandboxes) every
+ * non-ASCII character is replaced by `?` in transit, so a preview named `Cadence — Sync ready` is
+ * asked for as `Cadence ? Sync ready` and can never match. Without this line the failure reads as a
+ * typo in a filter the caller never typed: `compose-preview --filter` resolves an ASCII request to
+ * full ids itself, and it is those ids that get mangled.
+ */
+private fun StringBuilder.appendEncodingHint(filters: List<String>) {
+  if (filters.none { it.contains('?') }) return
+  val encoding = System.getProperty("sun.jnu.encoding") ?: return
+  if (encoding.equals("UTF-8", ignoreCase = true)) return
+  append(
+    " A requested id contains '?' and this JVM encodes process arguments as $encoding, so a" +
+      " non-ASCII character in the id (an em dash, say) was replaced on the way in: re-run with a" +
+      " UTF-8 locale (LC_ALL=C.UTF-8) or pass the ids as -PcomposePreview.idFilterFile=<path to a" +
+      " newline-delimited UTF-8 list>."
   )
 }
 

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewFilterSystemPropsProviderTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewFilterSystemPropsProviderTest.kt
@@ -35,6 +35,7 @@ class PreviewFilterSystemPropsProviderTest {
       AndroidPreviewSupport.PreviewFilterSystemPropsProvider(
           nameFilters = list("Foo", "Bar"),
           idFilters = list("*_Light"),
+          idFilterFile = noFile,
           idExcludes = list("*_Dark"),
           idExcludeFile = noFile,
           rowExcludes = list("Dark", "ExtraDark"),
@@ -59,6 +60,7 @@ class PreviewFilterSystemPropsProviderTest {
       AndroidPreviewSupport.PreviewFilterSystemPropsProvider(
           nameFilters = list(),
           idFilters = list(),
+          idFilterFile = noFile,
           idExcludes = list(),
           idExcludeFile = noFile,
           rowExcludes = list(),
@@ -76,6 +78,7 @@ class PreviewFilterSystemPropsProviderTest {
       AndroidPreviewSupport.PreviewFilterSystemPropsProvider(
           nameFilters = list(" Foo ", "", "  "),
           idFilters = list(),
+          idFilterFile = noFile,
           idExcludes = list(),
           idExcludeFile = noFile,
           rowExcludes = list(),
@@ -96,6 +99,7 @@ class PreviewFilterSystemPropsProviderTest {
       AndroidPreviewSupport.PreviewFilterSystemPropsProvider(
           nameFilters = list(),
           idFilters = list(),
+          idFilterFile = noFile,
           idExcludes = list(),
           idExcludeFile = noFile,
           rowExcludes = list("Dark", " ExtraDark "),
@@ -113,6 +117,7 @@ class PreviewFilterSystemPropsProviderTest {
       AndroidPreviewSupport.PreviewFilterSystemPropsProvider(
           nameFilters = list(),
           idFilters = list(),
+          idFilterFile = noFile,
           idExcludes = list(),
           idExcludeFile = noFile,
           rowExcludes = list(),
@@ -137,6 +142,7 @@ class PreviewFilterSystemPropsProviderTest {
       AndroidPreviewSupport.PreviewFilterSystemPropsProvider(
           nameFilters = list(),
           idFilters = list(),
+          idFilterFile = noFile,
           idExcludes = list(*ids.toTypedArray()),
           idExcludeFile = path(f),
           rowExcludes = list(),
@@ -160,6 +166,7 @@ class PreviewFilterSystemPropsProviderTest {
       AndroidPreviewSupport.PreviewFilterSystemPropsProvider(
           nameFilters = list(),
           idFilters = list(),
+          idFilterFile = noFile,
           idExcludes = list("TypedOnTheCommandLine"),
           idExcludeFile = path(f),
           rowExcludes = list(),
@@ -169,5 +176,51 @@ class PreviewFilterSystemPropsProviderTest {
         .toList()
 
     assertThat(args).containsExactly("-Dcomposeai.preview.idExclude=TypedOnTheCommandLine")
+  }
+
+  /**
+   * Issue #5172 — the same path treatment for the positive filter, for one more reason: this
+   * argument is encoded with the Gradle daemon's `sun.jnu.encoding`, so a C/POSIX-locale daemon
+   * would replace the em dash with `?` and the render worker could never match the id it was asked
+   * for.
+   */
+  @Test
+  fun `a file-sourced id filter travels as a path, not a joined string`() {
+    val ids = listOf("=SyncPreview_Cadence — Sync ready")
+    val f = fileWith(ids)
+    val args =
+      AndroidPreviewSupport.PreviewFilterSystemPropsProvider(
+          nameFilters = list(),
+          idFilters = list(*ids.toTypedArray()),
+          idFilterFile = path(f),
+          idExcludes = list(),
+          idExcludeFile = noFile,
+          rowExcludes = list(),
+          permutations = list(),
+        )
+        .asArguments()
+        .toList()
+
+    assertThat(args).containsExactly("-Dcomposeai.preview.idFilterFile=${f.absolutePath}")
+  }
+
+  /** `--preview-id` on the task overrides the property convention; a stale file must not win. */
+  @Test
+  fun `an overridden id filter ignores the file and travels joined`() {
+    val f = fileWith(listOf("=FromFile"))
+    val args =
+      AndroidPreviewSupport.PreviewFilterSystemPropsProvider(
+          nameFilters = list(),
+          idFilters = list("TypedOnTheCommandLine"),
+          idFilterFile = path(f),
+          idExcludes = list(),
+          idExcludeFile = noFile,
+          rowExcludes = list(),
+          permutations = list(),
+        )
+        .asArguments()
+        .toList()
+
+    assertThat(args).containsExactly("-Dcomposeai.preview.idFilter=TypedOnTheCommandLine")
   }
 }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/SelectPreviewIdsTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/SelectPreviewIdsTest.kt
@@ -96,6 +96,44 @@ class SelectPreviewIdsTest {
     assertThat(message).contains("FilledButton_Light")
   }
 
+  /**
+   * Issue #5172: `compose-preview --filter` resolves an ASCII request to full preview ids itself,
+   * so a `?` in the requested id is not something the caller typed — it is a non-ASCII character
+   * the platform argument encoding replaced in transit. Say that, or the failure reads as a typo in
+   * a filter nobody wrote.
+   */
+  @Test
+  fun `a mangled non-ASCII id names the argument encoding`() {
+    val previous = System.getProperty("sun.jnu.encoding")
+    System.setProperty("sun.jnu.encoding", "ANSI_X3.4-1968")
+    val thrown =
+      try {
+        selectPreviewIds(all, listOf("=FilledButton_Cadence ? Sync ready"))
+        null
+      } catch (e: GradleException) {
+        e
+      } finally {
+        if (previous == null) System.clearProperty("sun.jnu.encoding")
+        else System.setProperty("sun.jnu.encoding", previous)
+      }
+    val message = thrown!!.message!!
+    assertThat(message).contains("ANSI_X3.4-1968")
+    assertThat(message).contains("LC_ALL=C.UTF-8")
+    assertThat(message).contains("composePreview.idFilterFile")
+  }
+
+  @Test
+  fun `an unmatched ASCII id says nothing about encodings`() {
+    val thrown =
+      try {
+        selectPreviewIds(all, listOf("=NoSuchPreview"))
+        null
+      } catch (e: GradleException) {
+        e
+      }
+    assertThat(thrown!!.message).doesNotContain("argument")
+  }
+
   @Test
   fun `no match with no discovered previews explains the empty module`() {
     val thrown =

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -319,6 +319,42 @@ object PreviewManifestLoader {
     }
   }
 
+  /**
+   * Wire contract with the plugin's `PreviewFilterSystemPropsProvider`: the path to a
+   * newline-delimited UTF-8 `--preview-id` pattern list (issue #5172). Named alongside the
+   * renderer-side `PreviewFilter.ID_FILTER_PROPERTY` constants it stands in for.
+   */
+  internal const val ID_FILTER_FILE_PROPERTY: String = "composeai.preview.idFilterFile"
+
+  /**
+   * The `--preview-id` patterns for this render: the newline-delimited UTF-8 file named by
+   * `composeai.preview.idFilterFile` when the build passed one, else the comma-joined
+   * `composeai.preview.idFilter` property.
+   *
+   * The file form exists for issue #5172. System properties reach this JVM as process arguments,
+   * which the Gradle daemon encodes with its own `sun.jnu.encoding`; under a C/POSIX locale
+   * (`ANSI_X3.4-1968` — containers, CI runners, cloud agent sandboxes) every non-ASCII character in
+   * a preview id is replaced by `?` in transit, so an id like `…_Cadence — Sync ready` could never
+   * equal the id discovered here and the narrowed render failed for exactly the previews it was
+   * meant to speed up. A path is ASCII, and the file is read as UTF-8, so the ids arrive intact.
+   */
+  internal fun idFilterPatterns(read: (String) -> String? = System::getProperty): List<String> {
+    val path = read(ID_FILTER_FILE_PROPERTY)?.trim().orEmpty()
+    if (path.isNotEmpty()) {
+      val file = File(path)
+      if (file.isFile) {
+        return file.readLines(Charsets.UTF_8).map(String::trim).filter(String::isNotEmpty)
+      }
+      // Falling through to an unfiltered render would look like success while rendering the whole
+      // module, which is the cost the filter exists to avoid; say why instead.
+      System.err.println(
+        "composePreviewRender: $ID_FILTER_FILE_PROPERTY names '$path', which is not a readable " +
+          "file; falling back to ${PreviewFilter.ID_FILTER_PROPERTY}."
+      )
+    }
+    return PreviewFilter.patternsFrom(PreviewFilter.ID_FILTER_PROPERTY)
+  }
+
   @JvmStatic
   @JvmOverloads
   fun loadShard(
@@ -346,7 +382,7 @@ object PreviewManifestLoader {
       PreviewFilter.select(
         items = manifest.previews,
         nameFilters = PreviewFilter.patternsFrom(PreviewFilter.NAME_FILTER_PROPERTY),
-        idFilters = PreviewFilter.patternsFrom(PreviewFilter.ID_FILTER_PROPERTY),
+        idFilters = idFilterPatterns(),
         idExcludes = PreviewFilter.idExcludesFrom(),
         functionName = { it.functionName },
         className = { it.className },

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewIdFilterFileTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewIdFilterFileTest.kt
@@ -1,0 +1,49 @@
+package ee.schimke.composeai.renderer
+
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Pins the file form of the `--preview-id` filter (issue #5172).
+ *
+ * System properties reach this render JVM as process arguments, which the Gradle daemon encodes
+ * with its own `sun.jnu.encoding`. Under a C/POSIX locale (`ANSI_X3.4-1968` — containers, CI
+ * runners, cloud agent sandboxes) every non-ASCII character in a preview id is replaced by `?` in
+ * transit, so `…_Cadence — Sync ready` could never equal the id discovered here and a narrowed
+ * render failed for exactly the previews it was meant to speed up. The plugin now passes an ASCII
+ * path to a UTF-8 list instead, which is what [PreviewManifestLoader.idFilterPatterns] reads.
+ */
+class PreviewIdFilterFileTest {
+
+  @get:Rule val tmp = TemporaryFolder()
+
+  @Test
+  fun `reads the file as UTF-8, one pattern per line`() {
+    val file = tmp.newFile("id-filter.txt")
+    file.writeText("=SyncPreview_Cadence — Sync ready\n\n  =HomePreview  \n", Charsets.UTF_8)
+
+    val patterns = PreviewManifestLoader.idFilterPatterns { key ->
+      if (key == PreviewManifestLoader.ID_FILTER_FILE_PROPERTY) file.path else null
+    }
+
+    assertEquals(listOf("=SyncPreview_Cadence — Sync ready", "=HomePreview"), patterns)
+  }
+
+  @Test
+  fun `an unset file property leaves the joined property in charge`() {
+    assertEquals(emptyList<String>(), PreviewManifestLoader.idFilterPatterns { null })
+  }
+
+  @Test
+  fun `a missing file falls back rather than silently rendering everything as a match`() {
+    val patterns = PreviewManifestLoader.idFilterPatterns { key ->
+      if (key == PreviewManifestLoader.ID_FILTER_FILE_PROPERTY) "/no/such/id-filter.txt" else null
+    }
+
+    // The fallback is the joined property, which is unset here — an unfiltered render, exactly as
+    // if no filter had been passed, with the reason on stderr.
+    assertEquals(emptyList<String>(), patterns)
+  }
+}


### PR DESCRIPTION
Fixes #5172.

## The bug

`compose-preview show --filter …` / `--id …` resolves the request to full preview ids and forwards them as `-PcomposePreview.idFilter=…`. Process arguments are encoded with the JVM's `sun.jnu.encoding`, which comes from the process **locale** — a container with no locale configured, a CI runner and most cloud agent sandboxes all land on `ANSI_X3.4-1968`. Every non-ASCII character in that argument was replaced by `?` in transit, so a preview named `Cadence — Sync ready` was asked for as `Cadence ? Sync ready` and could never equal the id the render worker discovered. The narrowed path — the fast loop the skill docs recommend — was unusable for exactly those previews, and failed loudly (exit 2, and on Android a `testClassesDirs` diagnosis that had nothing to do with it). The same preview rendered fine unfiltered, because that path never puts an id on a command line.

The daemon → render-JVM hop loses the same characters, for the same reason, so both boundaries are fixed.

## The fix

Ids travel as a newline-delimited **UTF-8 file behind an ASCII path** — the positive twin of the existing `composePreview.idExcludeFile`, which exists for the comma half of the same story (suggestion 1 in the issue; forcing the worker's encoding, suggestion 2, cannot work: the loss happens in the *parent* when it encodes argv).

* `PreviewRenderScope` (CLI) falls back to `-PcomposePreview.idFilterFile=<path>` only when the joined property cannot carry the selection: an id this JVM's argument encoding cannot represent, or an id containing a comma — which previously *declined* the narrowing and rendered the whole module. A UTF-8 host keeps the one-argument form, so nothing changes for it (and an older plugin still sees the property it knows).
* `ComposePreviewTasks.previewIdFilterFileProperty` resolves `composePreview.idFilterFile` to the same pattern list as `composePreview.idFilter`, replacing it when present. A path that names no readable file fails rather than silently rendering everything.
* The Android backend forwards the path as `-Dcomposeai.preview.idFilterFile` when the file is what the resolved list came *from* (same override test as the exclude file, so an explicit `--preview-id` still wins over a stale property), and `PreviewManifestLoader.idFilterPatterns` reads it as UTF-8.

## Self-diagnosing, independently of the transport (suggestion 4)

* A `--preview` / `--preview-id` filter that matches nothing, contains a `?`, and runs under a non-UTF-8 `sun.jnu.encoding` now names the encoding and points at `LC_ALL=C.UTF-8` and the file property, instead of reading as a typo in a filter nobody typed.
* `doctor` gained `env.arg-encoding`: a warning (never an error) reporting `sun.jnu.encoding` with the `LC_ALL=C.UTF-8` remediation — the preflight the issue comment asked for.

## Test plan

* `:cli:test --tests '*PreviewRenderScopeTest'` — new cases: a non-ASCII id under `ANSI_X3.4-1968` travels as a file with an ASCII path and intact UTF-8 contents; the same id under UTF-8 still travels as the plain property; a comma-carrying id now narrows through the file instead of declining; an unwritable file dir still declines with a note rather than breaking the run.
* `:gradle-plugin:test` — `PreviewFilterSystemPropsProviderTest` pins the new `-Dcomposeai.preview.idFilterFile` wire form and the override case; `SelectPreviewIdsTest` pins the encoding hint (and its absence for an ordinary ASCII miss).
* `:renderer-android:testDebugUnitTest --tests '*PreviewIdFilterFileTest'` — new: UTF-8 line reading, unset property, missing file.
* `ktfmtFormat` on the touched modules.

Not visual — no renders change; this is the argument transport around them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5FMqxJvfzP8oqAXDn33o4

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5FMqxJvfzP8oqAXDn33o4)_