### PR TITLE
refactor(mcp): lift the render-matrix helpers into :render-matrix

### DIFF
--- a/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/CheckHttpServerFloor.kt
+++ b/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/CheckHttpServerFloor.kt
@@ -1,0 +1,83 @@
+package ee.schimke.composeai.buildlogic
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Fails when an HTTP server engine reaches the runtime classpath of a project that is not one of the
+ * two named exemptions.
+ *
+ * This is layer 1's own test, mechanised. `docs/design/REPOSITORY_LAYERS.md` places a module by
+ * *does it need an HTTP server, a browser, or the UI builder to do its job?*, and compose-ai-tools
+ * had no gate asserting the "no HTTP server" half of it — `checkRenderHostIsServerFree` makes that
+ * claim for one module, and nothing made it for the rest.
+ *
+ * The exemptions are `:mcp` and the `:cli` that bundles it, and they are temporary: #5176 decided
+ * that `:mcp` is layer 2 by the letter of the rule and is moving to compose-preview-server, rather
+ * than the rule growing a carve-out for it. Until that move lands the two projects genuinely carry
+ * five `ktor-server-*` artifacts, so the honest gate is a two-entry allowlist that goes to empty
+ * when `:mcp` leaves — the same shape as [CheckLayerBoundary]'s allowlist, which emptied when the
+ * `serve` edge closed. A third entry is a diff someone has to justify.
+ *
+ * **Resolved identity, not declared dependencies**, for the reason `:cli` proves: it declares no
+ * `ktor-server-*` line at all — the five artifacts arrive through `:mcp` and the MCP Kotlin SDK.
+ * Reading `dependencies {}` blocks would have found nothing to check, which is how "the Ktor floor
+ * left with `serve`" survived as a claim until someone measured the built distribution.
+ *
+ * **Prefixes, not coordinates**, following `checkRenderHostIsServerFree`: the invariant is "no web
+ * server", and an exact list of today's Ktor artifacts would pass the first time someone swaps CIO
+ * for Netty or Jetty.
+ *
+ * Scope is [CheckLayerBoundary]'s: projects with a `runtimeClasspath`, so Android modules — which
+ * resolve per-variant — are not covered. None of them serves anything.
+ */
+abstract class CheckHttpServerFloor : DefaultTask() {
+
+  /** Every component on the resolved runtime classpath as `<group>:<name>`, transitives included. */
+  @get:Input abstract val resolvedModules: SetProperty<String>
+
+  /** Coordinate prefixes that identify an embeddable HTTP server engine. */
+  @get:Input abstract val serverPrefixes: ListProperty<String>
+
+  @TaskAction
+  fun checkFloor() {
+    val prefixes = serverPrefixes.get()
+    val offenders =
+      resolvedModules.get().filter { module -> prefixes.any { module.startsWith(it) } }.sorted()
+
+    check(offenders.isEmpty()) {
+      "An HTTP server engine reached ${path.substringBeforeLast(':')}'s runtime classpath: " +
+        offenders.joinToString(", ") +
+        ". compose-ai-tools is layer 1: a module that needs an HTTP server to do its job belongs " +
+        "in compose-preview-server — see docs/design/REPOSITORY_LAYERS.md. The only exemptions " +
+        "are ${httpServerProjects.joinToString(", ")}, and they are the MCP server on its way out " +
+        "of this repository (#5176), not a precedent."
+    }
+  }
+
+  companion object {
+    /**
+     * The projects allowed a server engine on their runtime classpath, and the measure of #5176's
+     * completion: when `:mcp` moves to compose-preview-server this list is empty.
+     *
+     * `:mcp` runs the Streamable HTTP endpoint the MCP SDK's protocol routes sit on, and `:cli`
+     * bundles `:mcp` so `compose-preview mcp serve` starts it in-process. Nothing else depends on
+     * `:mcp`; `:render-session-subprocess` used to, which is why `DaemonClient` was lifted into
+     * `:daemon-client` (#3824), and `:cli`'s offline `render-matrix` command did, which is why
+     * `MatrixAxes` and `ContactSheet` were lifted into `:render-matrix`.
+     */
+    val httpServerProjects: List<String> = listOf(":mcp", ":cli")
+
+    /**
+     * What counts as a server. Ktor is what is here today; Jetty and Undertow are named because the
+     * cheapest way for this floor to stop meaning anything is for the next embedded server to be a
+     * different one. An HTTP *client* is deliberately absent — `:render-host` resolves the Ktor
+     * client through `:bundle-coordinates` and opens no listening socket for it.
+     */
+    val serverPrefixes: List<String> =
+      listOf("io.ktor:ktor-server", "org.eclipse.jetty:", "io.undertow:")
+  }
+}

--- a/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiBaseConventionsPlugin.kt
+++ b/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiBaseConventionsPlugin.kt
@@ -64,7 +64,28 @@ class ComposeAiBaseConventionsPlugin : Plugin<Project> {
     }
 
     registerLayerBoundaryCheck(project)
+    registerHttpServerFloorCheck(project)
   }
+
+  /**
+   * Every component on this project's resolved runtime classpath as `<group>:<name>`.
+   *
+   * Resolved identity rather than declared dependencies: an artifact arriving through another POM
+   * is the case that matters and the case a build-file scan misses. Shared by both boundary checks
+   * so they cannot disagree about what is on the classpath.
+   */
+  private fun resolvedRuntimeModules(project: Project) =
+    project.configurations.named("runtimeClasspath").flatMap { configuration ->
+      configuration.incoming.artifacts.resolvedArtifacts.map { artifacts ->
+        artifacts
+          .mapNotNull { artifact ->
+            (artifact.id.componentIdentifier as? ModuleComponentIdentifier)?.let {
+              "${it.group}:${it.module}"
+            }
+          }
+          .toSet()
+      }
+    }
 
   /**
    * Wires [CheckLayerBoundary] onto every project that has a `runtimeClasspath`, and onto `check`
@@ -83,25 +104,39 @@ class ComposeAiBaseConventionsPlugin : Plugin<Project> {
             "Fails if a compose-preview-server artifact reaches this project's runtime classpath."
           group = "verification"
 
-          // Resolved identity rather than declared dependencies: a layer-2 artifact arriving
-          // through another POM is the case that matters and the case a build-file scan misses.
-          resolvedModules.set(
-            project.configurations.named("runtimeClasspath").flatMap { configuration ->
-              configuration.incoming.artifacts.resolvedArtifacts.map { artifacts ->
-                artifacts
-                  .mapNotNull { artifact ->
-                    (artifact.id.componentIdentifier as? ModuleComponentIdentifier)?.let {
-                      "${it.group}:${it.module}"
-                    }
-                  }
-                  .toSet()
-              }
-            }
-          )
+          resolvedModules.set(resolvedRuntimeModules(project))
 
           allowedPreviewModules.set(
             CheckLayerBoundary.ownPreviewModules + CheckLayerBoundary.knownLayerTwoEdges
           )
+        }
+
+      project.tasks.named("check") { dependsOn(task) }
+    }
+  }
+
+  /**
+   * Wires [CheckHttpServerFloor] onto every project that has a `runtimeClasspath`, skipping the two
+   * projects that are allowed to carry a server engine.
+   *
+   * The skip is a not-registered task rather than an empty check so that `:mcp` and `:cli` cannot
+   * quietly pass a floor they are exempt from; the exemption lives in one list
+   * ([CheckHttpServerFloor.httpServerProjects]) and `docs/design/REPOSITORY_LAYERS.md` explains why
+   * those two are on it.
+   */
+  private fun registerHttpServerFloorCheck(project: Project) {
+    if (project.path in CheckHttpServerFloor.httpServerProjects) return
+
+    project.plugins.withId("org.gradle.java") {
+      val task =
+        project.tasks.register<CheckHttpServerFloor>("checkHttpServerFloor") {
+          description =
+            "Fails if an HTTP server engine reaches this project's runtime classpath. " +
+              "Preview-serving behaviour is compose-preview-server's."
+          group = "verification"
+
+          resolvedModules.set(resolvedRuntimeModules(project))
+          serverPrefixes.set(CheckHttpServerFloor.serverPrefixes)
         }
 
       project.tasks.named("check") { dependsOn(task) }

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -361,6 +361,13 @@ dependencies {
   // WebSockets plugin: the `serve` streamed-frame lane (`/ws/{id}`) — tier-2 streaming spike.
   // HEAD answers GET across the whole site — the probe link unfurlers send before downloading.
 
+  // Axis expansion + contact-sheet stitching for the OFFLINE `render-matrix` command, shared with
+  // the MCP server's `render_matrix` tool so the two agree by construction (#1788). This used to be
+  // reached through `:mcp`, which meant an offline command compiled against an MCP server; the lift
+  // out is what lets `:mcp` move to compose-preview-server without taking `render-matrix` with it
+  // (#5176).
+  implementation(project(":render-matrix"))
+
   // Bundle the MCP server so `compose-preview mcp serve` can invoke it in-process —
   // the consumer install story stays a single tarball + a single launcher.
   implementation(project(":mcp"))

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/MatrixRenderFetcher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/MatrixRenderFetcher.kt
@@ -1,7 +1,7 @@
 package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.io.SystemFileSystem
-import ee.schimke.composeai.mcp.MatrixCell
+import ee.schimke.composeai.render.matrix.MatrixCell
 import ee.schimke.composeai.render.session.RenderSessionConfig
 import ee.schimke.composeai.render.session.RenderSessionException
 import ee.schimke.composeai.render.session.RenderSessionFactory

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/RenderMatrixCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/RenderMatrixCommand.kt
@@ -1,10 +1,10 @@
 package ee.schimke.composeai.cli
 
-import ee.schimke.composeai.mcp.ContactSheet
-import ee.schimke.composeai.mcp.MatrixAxes
-import ee.schimke.composeai.mcp.MatrixCell
 import ee.schimke.composeai.previewdata.PreviewInfo
 import ee.schimke.composeai.previewdata.PreviewModule
+import ee.schimke.composeai.render.matrix.ContactSheet
+import ee.schimke.composeai.render.matrix.MatrixAxes
+import ee.schimke.composeai.render.matrix.MatrixCell
 import java.io.File
 import java.security.MessageDigest
 import kotlin.system.exitProcess

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/MatrixRenderFetcherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/MatrixRenderFetcherTest.kt
@@ -24,7 +24,7 @@ import ee.schimke.composeai.daemon.protocol.RejectedRender
 import ee.schimke.composeai.daemon.protocol.RenderNowResult
 import ee.schimke.composeai.daemon.protocol.RenderTier
 import ee.schimke.composeai.daemon.protocol.ServerCapabilities
-import ee.schimke.composeai.mcp.MatrixCell
+import ee.schimke.composeai.render.matrix.MatrixCell
 import ee.schimke.composeai.render.session.NotificationListener
 import ee.schimke.composeai.render.session.RenderSession
 import ee.schimke.composeai.render.session.RenderSessionBackend

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/RenderMatrixCellNamesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/RenderMatrixCellNamesTest.kt
@@ -1,6 +1,6 @@
 package ee.schimke.composeai.cli
 
-import ee.schimke.composeai.mcp.MatrixCell
+import ee.schimke.composeai.render.matrix.MatrixCell
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import okio.Path.Companion.toPath

--- a/docs/design/REPOSITORY_LAYERS.md
+++ b/docs/design/REPOSITORY_LAYERS.md
@@ -45,9 +45,47 @@ The test is not "is it a library" — layer 2 publishes libraries too. It is: *d
 server, a browser, or the UI builder to do its job?* If not, it is layer 1, even when the only
 consumer today is the server.
 
+Applied literally, with no exception for a module that serves something other than previews — see
+*where MCP lands* below for the decision that settled that, and what it cost to keep the test
+mechanical.
+
 Under this rule `:render-host` is compose-ai-tools' module. It renders, it reads history, and
 `checkRenderHostIsServerFree` already asserts that it is free of a web server — which is the layer-1
 test, enforced from inside layer 2.
+
+### 1 — `compose-ai-tools` — where MCP lands
+
+**`:mcp` is layer 2 and is moving** (compose-ai-tools#5176). It runs a server, the layer-1 test says
+a module that needs an HTTP server to do its job is layer 2, and the test is applied literally. The
+alternative on the table was a written carve-out — *MCP is a transport for this CLI, not a
+preview-serving surface, so it stays with the thing it drives* — and it was rejected for the reason
+that carve-out could not answer: the next module gets to argue from the exception, and this
+repository has just spent several changes learning that a placement rule earns its keep by being
+mechanical. "Layer 1 opens no socket" is worth more as a sentence with no *unless* in it.
+
+What that costs, stated rather than discovered later: the agent entry point ends up in the
+repository that owns the web UI, and what `:mcp` uses from layer 1 — `:daemon:core`,
+`:render-session-api`, `:daemon-client` as `api`, plus `data-layoutinspector-core` — becomes
+published surface across the boundary instead of a project dependency. That is the same trade
+`serve` made, and `serve` is the precedent for the shape of the move: `compose-preview mcp` becomes
+a launcher over the published MCP binary, exactly as `serve` and `browse` became launchers over the
+published server binary.
+
+The move is staged, because `:mcp` is not only an MCP server:
+
+1. **Lift the layer-1 pieces out first.** `MatrixAxes`, `MatrixCell` and `ContactSheet` back the
+   CLI's offline `render-matrix` command as well as the `render_matrix` tool, so `:cli` compiled
+   against an MCP server for an offline command. They are `:render-matrix` now — the same lift, for
+   the same reason, as `:daemon-client` before them (#3824). Nothing that leaves for layer 2 may be
+   something layer 1 still calls.
+2. **Stand the module up in compose-preview-server** against the published layer-1 coordinates.
+3. **Turn `compose-preview mcp` into a launcher and delete `:mcp` here.** The five `ktor-server-*`
+   artifacts leave the CLI distribution with it — the ones the `serve` change was expected to take
+   and did not.
+
+Until step 3 lands, `:mcp` and the `:cli` that bundles it are the two named exemptions in
+`checkHttpServerFloor` (below). The list emptying is what "the move is done" means, and it is
+checkable rather than asserted.
 
 ### 2 — `compose-preview-server`
 
@@ -121,3 +159,21 @@ Two limits worth stating rather than discovering later. The task covers projects
 none of them consumes a server artifact, and covering them means resolving every variant on every
 `check`. And it has no unit test, because `build-logic` has no test lane that CI runs; what
 exercises it is every module's `check`.
+
+**`checkHttpServerFloor` is the layer-1 test itself, mechanised** (`build-logic`, registered by the
+same convention plugin as `checkLayerBoundary` and wired onto `check`). It fails when an HTTP server
+engine — `io.ktor:ktor-server*`, Jetty, Undertow — reaches a project's runtime classpath, and its
+allowlist is two project paths: `:mcp`, and the `:cli` that bundles it. Every other module in this
+repository is checked, including the ones that resolve a Ktor *client*: a client is not a server,
+and `:render-host`'s own `checkRenderHostIsServerFree` has drawn that line since the split.
+
+It reads resolved artifacts rather than build files because `:cli` is the case that proves it has
+to: `:cli` declares no `ktor-server-*` line at all — the five artifacts arrive through `:mcp` and
+the MCP Kotlin SDK, which is exactly what made the "the Ktor floor left with `serve`" claim wrong
+until someone measured the built distribution. Prefixes rather than coordinates, for the same reason
+`checkRenderHostIsServerFree` uses them: the invariant is "no web server", and an exact list of
+today's Ktor artifacts would pass the first time someone swaps CIO for Netty.
+
+The allowlist is temporary by construction. It exists only for the window between the decision on
+#5176 and step 3 of the move, and when `:mcp` leaves it goes to empty — the same shape, and the same
+proof, as `checkLayerBoundary`'s allowlist emptying when the `serve` edge closed.

--- a/mcp/build.gradle.kts
+++ b/mcp/build.gradle.kts
@@ -68,6 +68,11 @@ dependencies {
   api(project(":daemon-client"))
   // Semantics diff engine + payload model for the `diff_semantics` tool (issue #1785).
   implementation(libs.composeai.data.layoutinspector.core)
+  // `MatrixAxes`/`MatrixCell`/`ContactSheet` behind the `render_matrix` tool. They used to live in
+  // this module and `:cli` compiled against them for its offline `render-matrix` command; the lift
+  // is #5176 preparation, so that command stops depending on an MCP server. `implementation`
+  // rather than `api`: the tool consumes them, none of them appears on this module's own surface.
+  implementation(project(":render-matrix"))
 
   testImplementation(libs.junit)
   testImplementation(libs.truth)

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -39,6 +39,9 @@ import ee.schimke.composeai.mcp.protocol.ReadResourceResult
 import ee.schimke.composeai.mcp.protocol.ResourceContents
 import ee.schimke.composeai.mcp.protocol.ResourceDescriptor
 import ee.schimke.composeai.mcp.protocol.ToolDef
+import ee.schimke.composeai.render.matrix.ContactSheet
+import ee.schimke.composeai.render.matrix.MatrixAxes
+import ee.schimke.composeai.render.matrix.MatrixCell
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import java.io.File
 import java.security.MessageDigest

--- a/render-matrix/api/render-matrix.api
+++ b/render-matrix/api/render-matrix.api
@@ -1,0 +1,41 @@
+public final class ee/schimke/composeai/render/matrix/ContactSheet {
+	public static final field INSTANCE Lee/schimke/composeai/render/matrix/ContactSheet;
+	public final fun stitch (Ljava/util/List;Ljava/lang/Integer;)[B
+	public static synthetic fun stitch$default (Lee/schimke/composeai/render/matrix/ContactSheet;Ljava/util/List;Ljava/lang/Integer;ILjava/lang/Object;)[B
+}
+
+public final class ee/schimke/composeai/render/matrix/ContactSheet$Cell {
+	public fun <init> (Ljava/lang/String;[B)V
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getPng ()[B
+}
+
+public final class ee/schimke/composeai/render/matrix/MatrixAxes {
+	public static final field CELL_CAP I
+	public static final field INSTANCE Lee/schimke/composeai/render/matrix/MatrixAxes;
+	public final fun cellCount (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)I
+	public final fun expand (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Ljava/util/List;
+}
+
+public final class ee/schimke/composeai/render/matrix/MatrixCell {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Float;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;)Lee/schimke/composeai/render/matrix/MatrixCell;
+	public static synthetic fun copy$default (Lee/schimke/composeai/render/matrix/MatrixCell;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;ILjava/lang/Object;)Lee/schimke/composeai/render/matrix/MatrixCell;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDevice ()Ljava/lang/String;
+	public final fun getFontScale ()Ljava/lang/Float;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getLocale ()Ljava/lang/String;
+	public final fun getUiMode ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun overridesJson ()Lkotlinx/serialization/json/JsonObject;
+	public final fun toOverrides ()Lee/schimke/composeai/daemon/protocol/PreviewOverrides;
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/render-matrix/build.gradle.kts
+++ b/render-matrix/build.gradle.kts
@@ -1,0 +1,64 @@
+// Render-matrix axes and the contact sheet that stitches their cells into one PNG.
+//
+// `MatrixAxes` expands the device × locale × uiMode × fontScale cross-product and caps it;
+// `MatrixCell` maps one point of that product onto `PreviewOverrides` and its wire JSON;
+// `ContactSheet` lays the resulting PNGs out in a labelled grid. Pure functions over protocol
+// types and image bytes — nothing here spawns a daemon, reads a project or opens a socket.
+//
+// This module exists because these types used to live in `:mcp`, and both surfaces that use them
+// are the same code by design (issue #1788): the `render_matrix` MCP tool and the CLI's
+// `render-matrix` command. `:cli` therefore compiled against `:mcp` for an offline command,
+// which is the coupling that has to go before `:mcp` moves to compose-preview-server as layer 2
+// (#5176). Same lift, same reason, as `:daemon-client` before it (#3824 preparation item 3):
+// after the move, the MCP server consumes this as a published layer-1 coordinate rather than
+// owning it.
+//
+// The package is `ee.schimke.composeai.render.matrix`, deliberately not the old
+// `ee.schimke.composeai.mcp` — two published artifacts sharing one package is a split package,
+// which breaks JPMS and OSGi consumers. Per docs/API_STABILITY.md § 1 the published surface of
+// `:mcp` is its MCP tool names and input schemas, not its Kotlin types, so the rename needs no
+// compatibility shim.
+
+plugins {
+  id("composeai.base-conventions")
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+}
+
+kotlin {
+  // `explicitApi()` and the ABI dump gate, following `:daemon-client`. This is a published module
+  // that an out-of-repository MCP server will compile against once #5176's move lands, so an
+  // implicitly-public declaration is an API decision nobody made and a surface change nobody
+  // reviewed. Regenerate the dump with `./gradlew :render-matrix:updateKotlinAbi`.
+  explicitApi()
+
+  @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class) abiValidation()
+}
+
+// `checkKotlinAbi` is not wired into `check` by the Kotlin Gradle plugin, so an unrecorded surface
+// change would pass CI silently. Wire it explicitly — the gate is only worth having if it runs.
+tasks.named("check") { dependsOn("checkKotlinAbi") }
+
+dependencies {
+  // `PreviewOverrides` and `UiMode` are on `MatrixCell`'s public surface (`toOverrides()`), so
+  // `api` rather than `implementation`: a consumer resolving from POM metadata must see them.
+  api(project(":daemon:core"))
+  implementation(libs.kotlinx.serialization.json)
+
+  testImplementation(libs.junit)
+  testImplementation(libs.truth)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "render-matrix",
+    displayName = "Compose Preview — Render Matrix",
+    description =
+      "Render-matrix axis expansion and contact-sheet composition shared by the compose-preview " +
+        "CLI's render-matrix command and the MCP server's render_matrix tool: the device × " +
+        "locale × uiMode × fontScale cross-product, its cell cap and override mapping, and the " +
+        "labelled grid PNG the cells stitch into.",
+  )
+  inceptionYear.set("2025")
+}

--- a/render-matrix/src/main/kotlin/ee/schimke/composeai/render/matrix/ContactSheet.kt
+++ b/render-matrix/src/main/kotlin/ee/schimke/composeai/render/matrix/ContactSheet.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.mcp
+package ee.schimke.composeai.render.matrix
 
 import java.awt.Color
 import java.awt.Font
@@ -16,9 +16,9 @@ import kotlin.math.sqrt
  * eyeball "does this survive small screen + RTL + large font?" in one image instead of reading N
  * PNGs (issue #1788). Pure: PNG bytes + captions in, one stitched PNG out.
  */
-object ContactSheet {
+public object ContactSheet {
   /** One labelled tile: [png] is a rendered cell's PNG bytes, [label] is its caption-strip text. */
-  class Cell(val label: String, val png: ByteArray)
+  public class Cell(public val label: String, public val png: ByteArray)
 
   private const val PADDING = 12
   private const val CAPTION_HEIGHT = 22
@@ -30,7 +30,7 @@ object ContactSheet {
    * empty. A cell whose bytes don't decode renders as a captioned placeholder so the grid stays
    * aligned.
    */
-  fun stitch(cells: List<Cell>, columns: Int? = null): ByteArray? {
+  public fun stitch(cells: List<Cell>, columns: Int? = null): ByteArray? {
     if (cells.isEmpty()) return null
     val images = cells.map { runCatching { ImageIO.read(it.png.inputStream()) }.getOrNull() }
 

--- a/render-matrix/src/main/kotlin/ee/schimke/composeai/render/matrix/MatrixAxes.kt
+++ b/render-matrix/src/main/kotlin/ee/schimke/composeai/render/matrix/MatrixAxes.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.mcp
+package ee.schimke.composeai.render.matrix
 
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.UiMode
@@ -14,18 +14,18 @@ import kotlinx.serialization.json.put
  * identical across both surfaces. A null axis means "leave at the preview's default" for that
  * dimension.
  */
-data class MatrixCell(
-  val device: String? = null,
-  val locale: String? = null,
-  val uiMode: String? = null,
-  val fontScale: Float? = null,
+public data class MatrixCell(
+  public val device: String? = null,
+  public val locale: String? = null,
+  public val uiMode: String? = null,
+  public val fontScale: Float? = null,
 ) {
   /**
    * Typed [PreviewOverrides] for this cell, ready for `renderNow`. `uiMode` is parsed to [UiMode];
    * an unrecognised value throws so the caller surfaces "invalid axis values" rather than rendering
    * with a silent default.
    */
-  fun toOverrides(): PreviewOverrides =
+  public fun toOverrides(): PreviewOverrides =
     PreviewOverrides(
       device = device,
       localeTag = locale,
@@ -44,7 +44,7 @@ data class MatrixCell(
    * The cell's overrides echoed as the same wire JSON `render_preview.overrides` accepts, so an
    * agent can replay a single cell with `render_preview` to fetch its pixels.
    */
-  fun overridesJson(): JsonObject = buildJsonObject {
+  public fun overridesJson(): JsonObject = buildJsonObject {
     device?.let { put("device", it) }
     locale?.let { put("localeTag", it) }
     uiMode?.let { put("uiMode", it) }
@@ -55,7 +55,7 @@ data class MatrixCell(
    * Compact human caption for contact-sheet tiles / CLI rows, e.g. `id:pixel_5 · ar · dark · 2.0x`;
    * `default` when no axis is set (the lone cell of an all-default matrix).
    */
-  val label: String
+  public val label: String
     get() {
       val parts = listOfNotNull(device, locale, uiMode, fontScale?.let { "${it}x" })
       return if (parts.isEmpty()) "default" else parts.joinToString(" · ")
@@ -66,12 +66,12 @@ data class MatrixCell(
  * Cross-product expansion + bounds for a render matrix — the single source of truth for both the
  * MCP `render_matrix` tool and the CLI `render-matrix` command (issue #1788).
  */
-object MatrixAxes {
+public object MatrixAxes {
   /** Upper bound on matrix cells, so a careless cross-product can't fan out unboundedly. */
-  const val CELL_CAP = 24
+  public const val CELL_CAP: Int = 24
 
   /** Cells a cross-product of these axes would produce; an unset (null) axis contributes 1. */
-  fun cellCount(
+  public fun cellCount(
     devices: List<String>?,
     locales: List<String>?,
     uiModes: List<String>?,
@@ -84,7 +84,7 @@ object MatrixAxes {
    * order, so cell ordering is deterministic. An unset (null) axis contributes a single "leave at
    * default" value, so e.g. `uiModes=[light,dark]` with every other axis null yields two cells.
    */
-  fun expand(
+  public fun expand(
     devices: List<String>?,
     locales: List<String>?,
     uiModes: List<String>?,

--- a/render-matrix/src/test/kotlin/ee/schimke/composeai/render/matrix/ContactSheetTest.kt
+++ b/render-matrix/src/test/kotlin/ee/schimke/composeai/render/matrix/ContactSheetTest.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.mcp
+package ee.schimke.composeai.render.matrix
 
 import com.google.common.truth.Truth.assertThat
 import java.awt.Color

--- a/render-matrix/src/test/kotlin/ee/schimke/composeai/render/matrix/MatrixAxesTest.kt
+++ b/render-matrix/src/test/kotlin/ee/schimke/composeai/render/matrix/MatrixAxesTest.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.mcp
+package ee.schimke.composeai.render.matrix
 
 import com.google.common.truth.Truth.assertThat
 import ee.schimke.composeai.daemon.protocol.UiMode

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -627,6 +627,12 @@ project(":daemon-client").projectDir = file("daemon/client")
 
 include(":mcp")
 
+// Render-matrix axes (`MatrixAxes`/`MatrixCell`) and the contact-sheet stitcher, shared by the
+// CLI's offline `render-matrix` command and the MCP server's `render_matrix` tool. Lifted out of
+// `:mcp` so an offline CLI command stops compiling against the MCP server, which is what has to be
+// true before `:mcp` moves to compose-preview-server (#5176). Same shape as `:daemon-client`.
+include(":render-matrix")
+
 // The render host, the bundle daemon and the git-backed preview history — daemon-backed rendering,
 // packed-bundle materialisation and manifest reads, with no web server underneath. Moved here from
 // yschimke/compose-preview-server. docs/build-scripts/SETTINGS.md#render-host


### PR DESCRIPTION
Closes #5176 — and starts the move it asked about.

## The decision

By the letter of the rule: `:mcp` needs an HTTP server to do its job, so it is layer 2 and moves to compose-preview-server. The alternative on the table was a written carve-out (*MCP is a transport for this CLI, not a preview-serving surface*), and it loses on the objection it could not answer — the next module gets to argue from the exception, and "layer 1 opens no socket" is worth more as a sentence with no *unless* in it. `docs/design/REPOSITORY_LAYERS.md` now records the decision, what it costs (the agent entry point ends up in the repo that owns the web UI; what `:mcp` uses from layer 1 becomes published surface), and the three-step shape of the move, with `serve` as the precedent for step 3.

## What this PR is

**Step 1: nothing that leaves for layer 2 may be something layer 1 still calls.**

`MatrixAxes`, `MatrixCell` and `ContactSheet` back the CLI's **offline** `render-matrix` command as well as the `render_matrix` MCP tool (#1788), so `:cli` compiled against an MCP server for an offline command. They are `:render-matrix` now — the same lift, for the same reason, as `:daemon-client` before them (#3824). New package `ee.schimke.composeai.render.matrix` rather than the old `ee.schimke.composeai.mcp`, because two published artifacts sharing one package is a split package; per `docs/API_STABILITY.md` §1 the published surface of `:mcp` is its tool names and schemas, so no shim is owed. `explicitApi()` + a committed ABI dump, following `:daemon-client`, since an out-of-repo MCP server will compile against this once the move lands.

**Plus the gate that says when the move is done.**

`checkHttpServerFloor` mechanises layer 1's own test: no `io.ktor:ktor-server*`, Jetty or Undertow on any runtime classpath, registered by the same convention plugin as `checkLayerBoundary` and wired onto `check`. Resolved artifacts rather than build files, for the reason `:cli` proves — it declares no `ktor-server-*` line at all, the five artifacts arrive through `:mcp` and the MCP Kotlin SDK, which is how "the Ktor floor left with `serve`" survived as a claim until someone measured the distribution. Prefixes rather than coordinates, so swapping CIO for Netty does not silently pass.

Its allowlist is two project paths — `:mcp`, and the `:cli` that bundles it — and it goes to **empty** when step 3 lands, exactly as `checkLayerBoundary`'s allowlist did when the `serve` edge closed. That is the completion criterion for #5176, checkable rather than asserted.

## Not in this PR

Steps 2 and 3: standing `:mcp` up in compose-preview-server against the published layer-1 coordinates, then turning `compose-preview mcp` into a launcher and deleting `:mcp` here. Those are cross-repo and want their own review.

## Test plan

```
./gradlew :render-matrix:check :mcp:test :cli:test checkHttpServerFloor
```

Green. `checkHttpServerFloor` also ran across every project in the build before the new module existed, and passed — the two exemptions are the only server engines in the repository.

Non-visual change: build wiring, a module lift with no behaviour change, and a design doc. No renders to diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Uxgbygt7e2LEBDruCGeKY

---
_Generated by [Claude Code](https://claude.ai/code/session_016Uxgbygt7e2LEBDruCGeKY)_