### PR TITLE
feat(render-host): enable explicitApi() and check an ABI dump

### DIFF
--- a/render-host/api/render-host.api
+++ b/render-host/api/render-host.api
@@ -1,0 +1,4811 @@
+public abstract interface class ee/schimke/composeai/cli/serve/A11yOutcome {
+}
+
+public final class ee/schimke/composeai/cli/serve/A11yOutcome$Failed : ee/schimke/composeai/cli/serve/A11yOutcome {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/A11yOutcome$Failed;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/A11yOutcome$Failed;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/A11yOutcome$Failed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/A11yOutcome$NotFound : ee/schimke/composeai/cli/serve/A11yOutcome {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/A11yOutcome$NotFound;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/A11yOutcome$Ok : ee/schimke/composeai/cli/serve/A11yOutcome {
+	public fun <init> ([B)V
+	public final fun component1 ()[B
+	public final fun copy ([B)Lee/schimke/composeai/cli/serve/A11yOutcome$Ok;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/A11yOutcome$Ok;[BILjava/lang/Object;)Lee/schimke/composeai/cli/serve/A11yOutcome$Ok;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getJson ()[B
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/AnnotationBounds {
+	public static final field Companion Lee/schimke/composeai/cli/serve/AnnotationBounds$Companion;
+	public fun <init> (IIII)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun copy (IIII)Lee/schimke/composeai/cli/serve/AnnotationBounds;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/AnnotationBounds;IIIIILjava/lang/Object;)Lee/schimke/composeai/cli/serve/AnnotationBounds;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeight ()I
+	public final fun getWidth ()I
+	public final fun getX ()I
+	public final fun getY ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/AnnotationBounds$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/AnnotationBounds$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/AnnotationBounds;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/AnnotationBounds;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/AnnotationBounds$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/AnnotationKind {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/AnnotationKind;
+	public static final field LAYOUT Ljava/lang/String;
+	public static final field THEME Ljava/lang/String;
+	public static final field TYPOGRAPHY Ljava/lang/String;
+	public final fun getKNOWN ()Ljava/util/Set;
+	public final fun getPUBLISHABLE ()Ljava/util/Set;
+	public final fun parseLayers (Ljava/lang/String;)Ljava/util/Set;
+	public final fun publishedLayersSuffice (Ljava/util/Set;)Z
+}
+
+public final class ee/schimke/composeai/cli/serve/AnnotationManifest {
+	public static final field Companion Lee/schimke/composeai/cli/serve/AnnotationManifest$Companion;
+	public static final field SCHEMA Ljava/lang/String;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)Lee/schimke/composeai/cli/serve/AnnotationManifest;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/AnnotationManifest;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/AnnotationManifest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPreviews ()Ljava/util/Map;
+	public final fun getReferences ()Ljava/util/Map;
+	public final fun getSchema ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/AnnotationManifest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/AnnotationManifest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/AnnotationManifest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/AnnotationManifest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/AnnotationManifest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/AnnotationPayload {
+	public static final field Companion Lee/schimke/composeai/cli/serve/AnnotationPayload$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;)Lee/schimke/composeai/cli/serve/AnnotationPayload;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/AnnotationPayload;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/AnnotationPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActual ()Ljava/util/List;
+	public final fun getReference ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/AnnotationPayload$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/AnnotationPayload$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/AnnotationPayload;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/AnnotationPayload;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/AnnotationPayload$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class ee/schimke/composeai/cli/serve/AnnotationsOutcome {
+}
+
+public final class ee/schimke/composeai/cli/serve/AnnotationsOutcome$Failed : ee/schimke/composeai/cli/serve/AnnotationsOutcome {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/AnnotationsOutcome$Failed;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/AnnotationsOutcome$Failed;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/AnnotationsOutcome$Failed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/AnnotationsOutcome$NotFound : ee/schimke/composeai/cli/serve/AnnotationsOutcome {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/AnnotationsOutcome$NotFound;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/AnnotationsOutcome$Ok : ee/schimke/composeai/cli/serve/AnnotationsOutcome {
+	public fun <init> ([B)V
+	public final fun component1 ()[B
+	public final fun copy ([B)Lee/schimke/composeai/cli/serve/AnnotationsOutcome$Ok;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/AnnotationsOutcome$Ok;[BILjava/lang/Object;)Lee/schimke/composeai/cli/serve/AnnotationsOutcome$Ok;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getJson ()[B
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/ApiDocLink {
+	public static final field Companion Lee/schimke/composeai/cli/serve/ApiDocLink$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Z
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)Lee/schimke/composeai/cli/serve/ApiDocLink;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ApiDocLink;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ApiDocLink;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComposable ()Z
+	public final fun getFqn ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/ApiDocLink$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ApiDocLink$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/ApiDocLink;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/ApiDocLink;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ApiDocLink$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class ee/schimke/composeai/cli/serve/BranchFetch {
+	public static final field BASE_BACKOFF_MILLIS J
+	public static final field Companion Lee/schimke/composeai/cli/serve/BranchFetch$Companion;
+	public static final field MAX_RETRIES I
+	public static final field MAX_RETRY_AFTER_SECONDS J
+	public fun getBytesOrNull ()[B
+	public fun getSummary ()Ljava/lang/String;
+	public fun isTransient ()Z
+}
+
+public final class ee/schimke/composeai/cli/serve/BranchFetch$Companion {
+	public static final field BASE_BACKOFF_MILLIS J
+	public static final field MAX_RETRIES I
+	public static final field MAX_RETRY_AFTER_SECONDS J
+	public final fun ofStatus (ILjava/lang/Long;)Lee/schimke/composeai/cli/serve/BranchFetch;
+	public static synthetic fun ofStatus$default (Lee/schimke/composeai/cli/serve/BranchFetch$Companion;ILjava/lang/Long;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/BranchFetch;
+	public final fun parseRetryAfter (Ljava/lang/String;)Ljava/lang/Long;
+	public final fun retryDelayMillis (Lee/schimke/composeai/cli/serve/BranchFetch;I)Ljava/lang/Long;
+}
+
+public final class ee/schimke/composeai/cli/serve/BranchFetch$DefaultImpls {
+	public static fun getBytesOrNull (Lee/schimke/composeai/cli/serve/BranchFetch;)[B
+	public static fun getSummary (Lee/schimke/composeai/cli/serve/BranchFetch;)Ljava/lang/String;
+	public static fun isTransient (Lee/schimke/composeai/cli/serve/BranchFetch;)Z
+}
+
+public final class ee/schimke/composeai/cli/serve/BranchFetch$NotFound : ee/schimke/composeai/cli/serve/BranchFetch {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/BranchFetch$NotFound;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBytesOrNull ()[B
+	public fun getSummary ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun isTransient ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/BranchFetch$Ok : ee/schimke/composeai/cli/serve/BranchFetch {
+	public fun <init> ([B)V
+	public final fun getBytes ()[B
+	public fun getBytesOrNull ()[B
+	public fun getSummary ()Ljava/lang/String;
+	public fun isTransient ()Z
+}
+
+public final class ee/schimke/composeai/cli/serve/BranchFetch$Throttled : ee/schimke/composeai/cli/serve/BranchFetch {
+	public fun <init> (Ljava/lang/Long;)V
+	public final fun component1 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/Long;)Lee/schimke/composeai/cli/serve/BranchFetch$Throttled;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/BranchFetch$Throttled;Ljava/lang/Long;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/BranchFetch$Throttled;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBytesOrNull ()[B
+	public final fun getRetryAfterSeconds ()Ljava/lang/Long;
+	public fun getSummary ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun isTransient ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/BranchFetch$TooLarge : ee/schimke/composeai/cli/serve/BranchFetch {
+	public fun <init> (J)V
+	public final fun component1 ()J
+	public final fun copy (J)Lee/schimke/composeai/cli/serve/BranchFetch$TooLarge;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/BranchFetch$TooLarge;JILjava/lang/Object;)Lee/schimke/composeai/cli/serve/BranchFetch$TooLarge;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBytesOrNull ()[B
+	public final fun getLimitBytes ()J
+	public fun getSummary ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun isTransient ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/BranchFetch$Transport : ee/schimke/composeai/cli/serve/BranchFetch {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/BranchFetch$Transport;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/BranchFetch$Transport;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/BranchFetch$Transport;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBytesOrNull ()[B
+	public final fun getDetail ()Ljava/lang/String;
+	public fun getSummary ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun isTransient ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/BranchFetch$Unavailable : ee/schimke/composeai/cli/serve/BranchFetch {
+	public fun <init> (ILjava/lang/Long;)V
+	public synthetic fun <init> (ILjava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun copy (ILjava/lang/Long;)Lee/schimke/composeai/cli/serve/BranchFetch$Unavailable;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/BranchFetch$Unavailable;ILjava/lang/Long;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/BranchFetch$Unavailable;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBytesOrNull ()[B
+	public final fun getRetryAfterSeconds ()Ljava/lang/Long;
+	public final fun getStatus ()I
+	public fun getSummary ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun isTransient ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/CatalogImagePaths {
+	public static final field IMAGES_DIR Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/CatalogImagePaths;
+	public final fun previewIdFor (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/CatalogRenderCacheSnapshot {
+	public static final field Companion Lee/schimke/composeai/cli/serve/CatalogRenderCacheSnapshot$Companion;
+	public fun <init> (IJJJJJJJLjava/lang/Double;Lee/schimke/composeai/cli/serve/ThemeCacheGenerationSnapshot;Ljava/lang/String;)V
+	public synthetic fun <init> (IJJJJJJJLjava/lang/Double;Lee/schimke/composeai/cli/serve/ThemeCacheGenerationSnapshot;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component10 ()Lee/schimke/composeai/cli/serve/ThemeCacheGenerationSnapshot;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component2 ()J
+	public final fun component3 ()J
+	public final fun component4 ()J
+	public final fun component5 ()J
+	public final fun component6 ()J
+	public final fun component7 ()J
+	public final fun component8 ()J
+	public final fun component9 ()Ljava/lang/Double;
+	public final fun copy (IJJJJJJJLjava/lang/Double;Lee/schimke/composeai/cli/serve/ThemeCacheGenerationSnapshot;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/CatalogRenderCacheSnapshot;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/CatalogRenderCacheSnapshot;IJJJJJJJLjava/lang/Double;Lee/schimke/composeai/cli/serve/ThemeCacheGenerationSnapshot;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/CatalogRenderCacheSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBytes ()J
+	public final fun getDiskHits ()J
+	public final fun getEntries ()I
+	public final fun getEvictions ()J
+	public final fun getHitRate ()Ljava/lang/Double;
+	public final fun getMaxBytes ()J
+	public final fun getMemoryHits ()J
+	public final fun getMisses ()J
+	public final fun getPersisted ()Lee/schimke/composeai/cli/serve/ThemeCacheGenerationSnapshot;
+	public final fun getPersistenceOff ()Ljava/lang/String;
+	public final fun getWithheld ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/CatalogRenderCacheSnapshot$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/CatalogRenderCacheSnapshot$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/CatalogRenderCacheSnapshot;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/CatalogRenderCacheSnapshot;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/CatalogRenderCacheSnapshot$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/CatalogRenderFailure {
+	public static final field Companion Lee/schimke/composeai/cli/serve/CatalogRenderFailure$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/RenderFailureFrame;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/RenderFailureFrame;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Lee/schimke/composeai/cli/serve/RenderFailureFrame;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/RenderFailureFrame;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/CatalogRenderFailure;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/CatalogRenderFailure;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/RenderFailureFrame;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/CatalogRenderFailure;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComponentId ()Ljava/lang/String;
+	public final fun getErrorClass ()Ljava/lang/String;
+	public final fun getGroup ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getMode ()Ljava/lang/String;
+	public final fun getPhase ()Ljava/lang/String;
+	public final fun getPreview ()Ljava/lang/String;
+	public final fun getProps ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getSection ()Ljava/lang/String;
+	public final fun getSourceFile ()Ljava/lang/String;
+	public final fun getStackTrace ()Ljava/lang/String;
+	public final fun getState ()Ljava/lang/String;
+	public final fun getTopAppFrame ()Lee/schimke/composeai/cli/serve/RenderFailureFrame;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/CatalogRenderFailure$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/CatalogRenderFailure$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/CatalogRenderFailure;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/CatalogRenderFailure;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/CatalogRenderFailure$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/CatalogThemeCache {
+	public static final field BUSY_LATCH I
+	public static final field Companion Lee/schimke/composeai/cli/serve/CatalogThemeCache$Companion;
+	public static final field DEFAULT_MAX_BYTES J
+	public static final field FAILURE_LATCH I
+	public static final field VERIFY_SAMPLE I
+	public fun <init> ()V
+	public fun <init> (JLee/schimke/composeai/cli/serve/ThemeCacheStore$Generation;Ljava/lang/String;)V
+	public synthetic fun <init> (JLee/schimke/composeai/cli/serve/ThemeCacheStore$Generation;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun configurePersistable (Ljava/util/Collection;)V
+	public final fun configureTargets (Ljava/util/Collection;)V
+	public final fun contains (Ljava/lang/String;)Z
+	public final fun dirtyTargets ()Ljava/util/List;
+	public final fun dropPersisted ()Z
+	public final fun failureReason (Ljava/lang/String;)Ljava/lang/String;
+	public final fun get (Ljava/lang/String;)[B
+	public final fun getHasOptimizationTargets ()Z
+	public final fun getMaxBytes ()J
+	public final fun markFailed (Ljava/lang/String;Ljava/lang/String;)V
+	public static synthetic fun markFailed$default (Lee/schimke/composeai/cli/serve/CatalogThemeCache;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public final fun markPassFinished (J)V
+	public final fun markPaused ()V
+	public final fun markPersistedDirty ()I
+	public final fun markRunning (J)V
+	public final fun put (Ljava/lang/String;[B)V
+	public final fun recordBackgroundBusy (Ljava/lang/String;)Z
+	public final fun recordBatch (IJ)V
+	public final fun recordGateWait (J)V
+	public final fun recordPermitWait (J)V
+	public final fun recordProduced (I)V
+	public final fun recordRenderFailure (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun recordTurnForced ()V
+	public final fun recordTurnGranted ()V
+	public final fun recordTurnYielded ()V
+	public final fun recordWarm (J)V
+	public final fun renderCacheSnapshot ()Lee/schimke/composeai/cli/serve/CatalogRenderCacheSnapshot;
+	public final fun snapshot ()Lee/schimke/composeai/cli/serve/ThemeOptimizationSnapshot;
+	public final fun verifySample (ILkotlin/jvm/functions/Function1;)Lee/schimke/composeai/cli/serve/CatalogThemeCache$VerifyOutcome;
+	public static synthetic fun verifySample$default (Lee/schimke/composeai/cli/serve/CatalogThemeCache;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/CatalogThemeCache$VerifyOutcome;
+}
+
+public final class ee/schimke/composeai/cli/serve/CatalogThemeCache$Companion {
+}
+
+public final class ee/schimke/composeai/cli/serve/CatalogThemeCache$VerifyOutcome : java/lang/Enum {
+	public static final field MISMATCH Lee/schimke/composeai/cli/serve/CatalogThemeCache$VerifyOutcome;
+	public static final field MISMATCH_UNDISCARDED Lee/schimke/composeai/cli/serve/CatalogThemeCache$VerifyOutcome;
+	public static final field NOTHING_TO_VERIFY Lee/schimke/composeai/cli/serve/CatalogThemeCache$VerifyOutcome;
+	public static final field NO_EVIDENCE Lee/schimke/composeai/cli/serve/CatalogThemeCache$VerifyOutcome;
+	public static final field VERIFIED Lee/schimke/composeai/cli/serve/CatalogThemeCache$VerifyOutcome;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getSettled ()Z
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/CatalogThemeCache$VerifyOutcome;
+	public static fun values ()[Lee/schimke/composeai/cli/serve/CatalogThemeCache$VerifyOutcome;
+}
+
+public final class ee/schimke/composeai/cli/serve/CodeEvent {
+	public static final field Companion Lee/schimke/composeai/cli/serve/CodeEvent$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lee/schimke/composeai/cli/serve/CodeEvent;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/CodeEvent;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/CodeEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAt ()Ljava/lang/String;
+	public final fun getAuthor ()Ljava/lang/String;
+	public final fun getComponents ()Ljava/util/List;
+	public final fun getPreviewIds ()Ljava/util/List;
+	public final fun getSha ()Ljava/lang/String;
+	public final fun getSubject ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/CodeEvent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/CodeEvent$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/CodeEvent;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/CodeEvent;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/CodeEvent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/CodeLane {
+	public static final field Companion Lee/schimke/composeai/cli/serve/CodeLane$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lee/schimke/composeai/cli/serve/CodeLane;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/CodeLane;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/CodeLane;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEvents ()Ljava/util/List;
+	public final fun getRef ()Ljava/lang/String;
+	public final fun getRepo ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/CodeLane$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/CodeLane$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/CodeLane;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/CodeLane;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/CodeLane$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/DaemonPoolSnapshot {
+	public static final field Companion Lee/schimke/composeai/cli/serve/DaemonPoolSnapshot$Companion;
+	public fun <init> (Ljava/lang/String;III)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun copy (Ljava/lang/String;III)Lee/schimke/composeai/cli/serve/DaemonPoolSnapshot;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/DaemonPoolSnapshot;Ljava/lang/String;IIIILjava/lang/Object;)Lee/schimke/composeai/cli/serve/DaemonPoolSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActiveStreams ()I
+	public final fun getMaxOpen ()I
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOpen ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/DaemonPoolSnapshot$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/DaemonPoolSnapshot$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/DaemonPoolSnapshot;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/DaemonPoolSnapshot;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/DaemonPoolSnapshot$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/DesignAnnotation {
+	public static final field Companion Lee/schimke/composeai/cli/serve/DesignAnnotation$Companion;
+	public fun <init> (Ljava/lang/String;Lee/schimke/composeai/cli/serve/AnnotationBounds;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Lee/schimke/composeai/cli/serve/AnnotationBounds;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lee/schimke/composeai/cli/serve/AnnotationBounds;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Lee/schimke/composeai/cli/serve/AnnotationBounds;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lee/schimke/composeai/cli/serve/DesignAnnotation;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/DesignAnnotation;Ljava/lang/String;Lee/schimke/composeai/cli/serve/AnnotationBounds;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/DesignAnnotation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBounds ()Lee/schimke/composeai/cli/serve/AnnotationBounds;
+	public final fun getDetail ()Ljava/util/Map;
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getRole ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/DesignAnnotation$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/DesignAnnotation$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/DesignAnnotation;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/DesignAnnotation;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/DesignAnnotation$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/DesignReference {
+	public static final field Companion Lee/schimke/composeai/cli/serve/DesignReference$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/DesignReferenceRaster;Lee/schimke/composeai/cli/serve/DesignReferenceSource;Lee/schimke/composeai/cli/serve/DesignReferenceArtifact;Lee/schimke/composeai/cli/serve/DesignReferenceMatch;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/DesignReferenceRaster;Lee/schimke/composeai/cli/serve/DesignReferenceSource;Lee/schimke/composeai/cli/serve/DesignReferenceArtifact;Lee/schimke/composeai/cli/serve/DesignReferenceMatch;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lee/schimke/composeai/cli/serve/DesignReferenceRaster;
+	public final fun component5 ()Lee/schimke/composeai/cli/serve/DesignReferenceSource;
+	public final fun component6 ()Lee/schimke/composeai/cli/serve/DesignReferenceArtifact;
+	public final fun component7 ()Lee/schimke/composeai/cli/serve/DesignReferenceMatch;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/DesignReferenceRaster;Lee/schimke/composeai/cli/serve/DesignReferenceSource;Lee/schimke/composeai/cli/serve/DesignReferenceArtifact;Lee/schimke/composeai/cli/serve/DesignReferenceMatch;)Lee/schimke/composeai/cli/serve/DesignReference;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/DesignReference;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/DesignReferenceRaster;Lee/schimke/composeai/cli/serve/DesignReferenceSource;Lee/schimke/composeai/cli/serve/DesignReferenceArtifact;Lee/schimke/composeai/cli/serve/DesignReferenceMatch;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/DesignReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArtifact ()Lee/schimke/composeai/cli/serve/DesignReferenceArtifact;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getMatch ()Lee/schimke/composeai/cli/serve/DesignReferenceMatch;
+	public final fun getPreviewId ()Ljava/lang/String;
+	public final fun getRaster ()Lee/schimke/composeai/cli/serve/DesignReferenceRaster;
+	public final fun getSource ()Lee/schimke/composeai/cli/serve/DesignReferenceSource;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/DesignReference$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/DesignReference$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/DesignReference;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/DesignReference;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/DesignReference$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/DesignReferenceArtifact {
+	public static final field Companion Lee/schimke/composeai/cli/serve/DesignReferenceArtifact$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/DesignReferenceArtifact;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/DesignReferenceArtifact;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/DesignReferenceArtifact;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/DesignReferenceArtifact$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/DesignReferenceArtifact$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/DesignReferenceArtifact;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/DesignReferenceArtifact;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/DesignReferenceArtifact$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/DesignReferenceManifest {
+	public static final field Companion Lee/schimke/composeai/cli/serve/DesignReferenceManifest$Companion;
+	public static final field SCHEMA Ljava/lang/String;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lee/schimke/composeai/cli/serve/DesignReferenceManifest;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/DesignReferenceManifest;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/DesignReferenceManifest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReferences ()Ljava/util/List;
+	public final fun getSchema ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/DesignReferenceManifest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/DesignReferenceManifest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/DesignReferenceManifest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/DesignReferenceManifest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/DesignReferenceManifest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/DesignReferenceMatch {
+	public static final field Companion Lee/schimke/composeai/cli/serve/DesignReferenceMatch$Companion;
+	public fun <init> (DLjava/lang/Double;Ljava/lang/Double;Ljava/lang/Integer;)V
+	public synthetic fun <init> (DLjava/lang/Double;Ljava/lang/Double;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()D
+	public final fun component2 ()Ljava/lang/Double;
+	public final fun component3 ()Ljava/lang/Double;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun copy (DLjava/lang/Double;Ljava/lang/Double;Ljava/lang/Integer;)Lee/schimke/composeai/cli/serve/DesignReferenceMatch;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/DesignReferenceMatch;DLjava/lang/Double;Ljava/lang/Double;Ljava/lang/Integer;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/DesignReferenceMatch;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChangedPercent ()Ljava/lang/Double;
+	public final fun getGeometry ()Ljava/lang/Double;
+	public final fun getPercent ()D
+	public final fun getScoreVersion ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/DesignReferenceMatch$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/DesignReferenceMatch$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/DesignReferenceMatch;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/DesignReferenceMatch;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/DesignReferenceMatch$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/DesignReferenceRaster {
+	public static final field Companion Lee/schimke/composeai/cli/serve/DesignReferenceRaster$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/DesignReferenceRaster;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/DesignReferenceRaster;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/DesignReferenceRaster;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeight ()Ljava/lang/Integer;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getSha256 ()Ljava/lang/String;
+	public final fun getWidth ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/DesignReferenceRaster$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/DesignReferenceRaster$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/DesignReferenceRaster;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/DesignReferenceRaster;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/DesignReferenceRaster$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/DesignReferenceSource {
+	public static final field Companion Lee/schimke/composeai/cli/serve/DesignReferenceSource$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lee/schimke/composeai/cli/serve/DesignReferenceSource;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/DesignReferenceSource;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/DesignReferenceSource;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttributes ()Ljava/util/Map;
+	public final fun getProvider ()Ljava/lang/String;
+	public final fun getRevision ()Ljava/lang/String;
+	public final fun getUri ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/DesignReferenceSource$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/DesignReferenceSource$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/DesignReferenceSource;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/DesignReferenceSource;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/DesignReferenceSource$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/FigmaCommentEvent {
+	public static final field Companion Lee/schimke/composeai/cli/serve/FigmaCommentEvent$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Z
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/util/List;Ljava/util/List;)Lee/schimke/composeai/cli/serve/FigmaCommentEvent;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/FigmaCommentEvent;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/FigmaCommentEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAt ()Ljava/lang/String;
+	public final fun getAuthor ()Ljava/lang/String;
+	public final fun getComponents ()Ljava/util/List;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getNodeId ()Ljava/lang/String;
+	public final fun getPreviewIds ()Ljava/util/List;
+	public final fun getResolved ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/FigmaCommentEvent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/FigmaCommentEvent$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/FigmaCommentEvent;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/FigmaCommentEvent;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/FigmaCommentEvent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/FigmaLane {
+	public static final field Companion Lee/schimke/composeai/cli/serve/FigmaLane$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lee/schimke/composeai/cli/serve/FigmaLane;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/FigmaLane;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/FigmaLane;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComments ()Ljava/util/List;
+	public final fun getFileKey ()Ljava/lang/String;
+	public final fun getFileName ()Ljava/lang/String;
+	public final fun getVersions ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/FigmaLane$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/FigmaLane$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/FigmaLane;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/FigmaLane;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/FigmaLane$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/FigmaVersionEvent {
+	public static final field Companion Lee/schimke/composeai/cli/serve/FigmaVersionEvent$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/FigmaVersionEvent;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/FigmaVersionEvent;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/FigmaVersionEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAt ()Ljava/lang/String;
+	public final fun getAuthor ()Ljava/lang/String;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/FigmaVersionEvent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/FigmaVersionEvent$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/FigmaVersionEvent;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/FigmaVersionEvent;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/FigmaVersionEvent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/FileOptimizerHostCoordinator : ee/schimke/composeai/cli/serve/OptimizerHostCoordinator, java/lang/AutoCloseable {
+	public fun <init> (Ljava/io/File;I)V
+	public fun close ()V
+	public fun tryAcquire (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/OptimizerHostLease;
+}
+
+public final class ee/schimke/composeai/cli/serve/GenerationInputs {
+	public static final field Companion Lee/schimke/composeai/cli/serve/GenerationInputs$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JJ)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()J
+	public final fun component7 ()J
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JJ)Lee/schimke/composeai/cli/serve/GenerationInputs;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/GenerationInputs;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JJILjava/lang/Object;)Lee/schimke/composeai/cli/serve/GenerationInputs;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAtEpochMillis ()J
+	public final fun getDirtyBeforeEpochMillis ()J
+	public final fun getFingerprint ()Ljava/lang/String;
+	public final fun getRenderConfig ()Ljava/lang/String;
+	public final fun getSystem ()Ljava/lang/String;
+	public final fun getToolVersion ()Ljava/lang/String;
+	public final fun getVariant ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/GenerationInputs$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/GenerationInputs$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/GenerationInputs;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/GenerationInputs;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/GenerationInputs$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/GitResult {
+	public fun <init> (ILjava/lang/String;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (ILjava/lang/String;)Lee/schimke/composeai/cli/serve/GitResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/GitResult;ILjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/GitResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExitCode ()I
+	public final fun getOk ()Z
+	public final fun getStdout ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class ee/schimke/composeai/cli/serve/GitRunner {
+	public abstract fun run (Ljava/io/File;Ljava/util/List;)Lee/schimke/composeai/cli/serve/GitResult;
+}
+
+public final class ee/schimke/composeai/cli/serve/GitWorktrees : java/lang/AutoCloseable {
+	public fun <init> (Ljava/io/File;Ljava/io/File;Ljava/util/List;Lee/schimke/composeai/cli/serve/GitRunner;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/io/File;Ljava/io/File;Ljava/util/List;Lee/schimke/composeai/cli/serve/GitRunner;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun close ()V
+	public final fun prepare (Ljava/lang/String;)Ljava/io/File;
+	public final fun remove (Ljava/io/File;)V
+}
+
+public final class ee/schimke/composeai/cli/serve/GitWorktrees$RealGitRunner : ee/schimke/composeai/cli/serve/GitRunner {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/GitWorktrees$RealGitRunner;
+	public fun run (Ljava/io/File;Ljava/util/List;)Lee/schimke/composeai/cli/serve/GitResult;
+}
+
+public final class ee/schimke/composeai/cli/serve/HostResourceSample {
+	public fun <init> (Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;)V
+	public synthetic fun <init> (Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Double;
+	public final fun component2 ()Ljava/lang/Double;
+	public final fun component3 ()Ljava/lang/Double;
+	public final fun component4 ()Ljava/lang/Double;
+	public final fun component5 ()Ljava/lang/Double;
+	public final fun copy (Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;)Lee/schimke/composeai/cli/serve/HostResourceSample;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/HostResourceSample;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/HostResourceSample;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCpuUtilization ()Ljava/lang/Double;
+	public final fun getLoadPerCpu ()Ljava/lang/Double;
+	public final fun getMemoryAvailableFraction ()Ljava/lang/Double;
+	public final fun getMemoryCgroup ()Ljava/lang/Double;
+	public final fun getMemoryHost ()Ljava/lang/Double;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/KnownDifferenceAuditContext {
+	public static final field Companion Lee/schimke/composeai/cli/serve/KnownDifferenceAuditContext$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lee/schimke/composeai/cli/serve/KnownDifferenceAuditContext;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/KnownDifferenceAuditContext;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/KnownDifferenceAuditContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArtifactBase ()Ljava/lang/String;
+	public final fun getArtifactQuery ()Ljava/lang/String;
+	public final fun getDocumentUrl ()Ljava/lang/String;
+	public final fun getIssues ()Ljava/util/List;
+	public final fun getPreviews ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/KnownDifferenceAuditContext$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/KnownDifferenceAuditContext$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/KnownDifferenceAuditContext;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/KnownDifferenceAuditContext;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/KnownDifferenceAuditContext$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/KnownDifferenceCatalogPreview {
+	public static final field Companion Lee/schimke/composeai/cli/serve/KnownDifferenceCatalogPreview$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lee/schimke/composeai/cli/serve/KnownDifferenceCatalogPreview;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/KnownDifferenceCatalogPreview;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/KnownDifferenceCatalogPreview;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComponent ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getReferenceIds ()Ljava/util/List;
+	public final fun getSystem ()Ljava/lang/String;
+	public final fun getVariant ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/KnownDifferenceCatalogPreview$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/KnownDifferenceCatalogPreview$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/KnownDifferenceCatalogPreview;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/KnownDifferenceCatalogPreview;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/KnownDifferenceCatalogPreview$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/KnownDifferenceContext {
+	public static final field Companion Lee/schimke/composeai/cli/serve/KnownDifferenceContext$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/KnownDifferenceScope;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/KnownDifferenceScope;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lee/schimke/composeai/cli/serve/KnownDifferenceScope;
+	public final fun component7 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/KnownDifferenceScope;Ljava/util/List;)Lee/schimke/composeai/cli/serve/KnownDifferenceContext;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/KnownDifferenceContext;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/KnownDifferenceScope;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/KnownDifferenceContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArtifactBase ()Ljava/lang/String;
+	public final fun getArtifactQuery ()Ljava/lang/String;
+	public final fun getCandidateUrl ()Ljava/lang/String;
+	public final fun getDocumentUrl ()Ljava/lang/String;
+	public final fun getIssues ()Ljava/util/List;
+	public final fun getReferenceUrl ()Ljava/lang/String;
+	public final fun getScope ()Lee/schimke/composeai/cli/serve/KnownDifferenceScope;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/KnownDifferenceContext$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/KnownDifferenceContext$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/KnownDifferenceContext;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/KnownDifferenceContext;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/KnownDifferenceContext$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/KnownDifferenceIssue {
+	public static final field Companion Lee/schimke/composeai/cli/serve/KnownDifferenceIssue$Companion;
+	public fun <init> (Ljava/lang/String;ILjava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;ILjava/lang/String;)Lee/schimke/composeai/cli/serve/KnownDifferenceIssue;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/KnownDifferenceIssue;Ljava/lang/String;ILjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/KnownDifferenceIssue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNumber ()I
+	public final fun getRepository ()Ljava/lang/String;
+	public final fun getState ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/KnownDifferenceIssue$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/KnownDifferenceIssue$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/KnownDifferenceIssue;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/KnownDifferenceIssue;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/KnownDifferenceIssue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/KnownDifferenceScope {
+	public static final field Companion Lee/schimke/composeai/cli/serve/KnownDifferenceScope$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/util/Map;)Lee/schimke/composeai/cli/serve/KnownDifferenceScope;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/KnownDifferenceScope;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/KnownDifferenceScope;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComponent ()Ljava/lang/String;
+	public final fun getOverrides ()Ljava/util/Map;
+	public final fun getPreviewId ()Ljava/lang/String;
+	public final fun getReferenceId ()Ljava/lang/String;
+	public final fun getReferenceSha256 ()Ljava/lang/String;
+	public final fun getSystem ()Ljava/lang/String;
+	public final fun getTagIndex ()Ljava/util/Map;
+	public final fun getVariant ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/KnownDifferenceScope$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/KnownDifferenceScope$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/KnownDifferenceScope;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/KnownDifferenceScope;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/KnownDifferenceScope$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/LinuxHostResourceSampler {
+	public fun <init> ()V
+	public fun <init> (Ljava/io/File;Ljava/io/File;)V
+	public synthetic fun <init> (Ljava/io/File;Ljava/io/File;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun sample ()Lee/schimke/composeai/cli/serve/HostResourceSample;
+}
+
+public final class ee/schimke/composeai/cli/serve/LiveSeatLimiter {
+	public static final field Companion Lee/schimke/composeai/cli/serve/LiveSeatLimiter$Companion;
+	public static final field DEFAULT_PER_PREVIEW_RESERVE I
+	public static final field STREAM_RESERVE I
+	public fun <init> (II)V
+	public synthetic fun <init> (IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun acquire (IZZ)Lee/schimke/composeai/cli/serve/LiveSeatLimiter$Ticket;
+	public static synthetic fun acquire$default (Lee/schimke/composeai/cli/serve/LiveSeatLimiter;IZZILjava/lang/Object;)Lee/schimke/composeai/cli/serve/LiveSeatLimiter$Ticket;
+	public final fun acquireBackground (IIZ)Lee/schimke/composeai/cli/serve/LiveSeatLimiter$Ticket;
+	public static synthetic fun acquireBackground$default (Lee/schimke/composeai/cli/serve/LiveSeatLimiter;IIZILjava/lang/Object;)Lee/schimke/composeai/cli/serve/LiveSeatLimiter$Ticket;
+	public final fun availablePermits ()I
+	public final fun getPerPreviewPermits ()I
+	public final fun getPerPreviewReserve ()I
+	public final fun getTotalPermits ()I
+	public final fun getUnbounded ()Z
+	public final fun perPreviewPermitsAvailable ()I
+	public final fun refusalCount ()J
+	public final fun unverifiedRefusalCount ()J
+}
+
+public final class ee/schimke/composeai/cli/serve/LiveSeatLimiter$Companion {
+}
+
+public final class ee/schimke/composeai/cli/serve/LiveSeatLimiter$Ticket : java/lang/AutoCloseable {
+	public fun close ()V
+	public final fun getPermits ()I
+}
+
+public final class ee/schimke/composeai/cli/serve/MappingGap {
+	public static final field Companion Lee/schimke/composeai/cli/serve/MappingGap$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/MappingGap;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/MappingGap;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/MappingGap;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCode ()Ljava/lang/String;
+	public final fun getComponent ()Ljava/lang/String;
+	public final fun getDetail ()Ljava/lang/String;
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getPreviewId ()Ljava/lang/String;
+	public final fun getRef ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/MappingGap$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/MappingGap$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/MappingGap;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/MappingGap;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/MappingGap$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/MappingGap$Kind {
+	public static final field DANGLING_MAPPING Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/MappingGap$Kind;
+	public static final field UNMAPPED_DESIGN_NODE Ljava/lang/String;
+	public static final field UNRENDERED_REFERENCE Ljava/lang/String;
+	public final fun getALL ()Ljava/util/Set;
+}
+
+public abstract interface class ee/schimke/composeai/cli/serve/OptimizerHostCoordinator {
+	public static final field Companion Lee/schimke/composeai/cli/serve/OptimizerHostCoordinator$Companion;
+	public abstract fun tryAcquire (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/OptimizerHostLease;
+}
+
+public final class ee/schimke/composeai/cli/serve/OptimizerHostCoordinator$Companion {
+	public final fun getNONE ()Lee/schimke/composeai/cli/serve/OptimizerHostCoordinator;
+}
+
+public abstract interface class ee/schimke/composeai/cli/serve/OptimizerHostLease : java/lang/AutoCloseable {
+}
+
+public final class ee/schimke/composeai/cli/serve/OptimizerPressureGate {
+	public fun <init> (Lkotlin/jvm/functions/Function0;Lee/schimke/composeai/cli/serve/OptimizerPressureThresholds;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lee/schimke/composeai/cli/serve/OptimizerPressureThresholds;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun snapshot ()Lee/schimke/composeai/cli/serve/OptimizerPressureSnapshot;
+}
+
+public final class ee/schimke/composeai/cli/serve/OptimizerPressureSnapshot {
+	public static final field Companion Lee/schimke/composeai/cli/serve/OptimizerPressureSnapshot$Companion;
+	public fun <init> (ZLjava/lang/String;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;ILee/schimke/composeai/cli/serve/OptimizerPressureThresholds;Ljava/lang/Double;Ljava/lang/Double;)V
+	public synthetic fun <init> (ZLjava/lang/String;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;ILee/schimke/composeai/cli/serve/OptimizerPressureThresholds;Ljava/lang/Double;Ljava/lang/Double;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component10 ()Lee/schimke/composeai/cli/serve/OptimizerPressureThresholds;
+	public final fun component11 ()Ljava/lang/Double;
+	public final fun component12 ()Ljava/lang/Double;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Double;
+	public final fun component4 ()Ljava/lang/Double;
+	public final fun component5 ()Ljava/lang/Double;
+	public final fun component6 ()Ljava/lang/Long;
+	public final fun component7 ()Ljava/lang/Long;
+	public final fun component8 ()Ljava/lang/Long;
+	public final fun component9 ()I
+	public final fun copy (ZLjava/lang/String;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;ILee/schimke/composeai/cli/serve/OptimizerPressureThresholds;Ljava/lang/Double;Ljava/lang/Double;)Lee/schimke/composeai/cli/serve/OptimizerPressureSnapshot;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/OptimizerPressureSnapshot;ZLjava/lang/String;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;ILee/schimke/composeai/cli/serve/OptimizerPressureThresholds;Ljava/lang/Double;Ljava/lang/Double;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/OptimizerPressureSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConstrained ()Z
+	public final fun getCpuUtilization ()Ljava/lang/Double;
+	public final fun getDutyCycleUntilEpochMillis ()Ljava/lang/Long;
+	public final fun getDutyCycles ()I
+	public final fun getHeldMillis ()Ljava/lang/Long;
+	public final fun getLoadPerCpu ()Ljava/lang/Double;
+	public final fun getMemoryAvailableFraction ()Ljava/lang/Double;
+	public final fun getMemoryCgroupAvailableFraction ()Ljava/lang/Double;
+	public final fun getMemoryHostAvailableFraction ()Ljava/lang/Double;
+	public final fun getReason ()Ljava/lang/String;
+	public final fun getSampledAtEpochMillis ()Ljava/lang/Long;
+	public final fun getThresholds ()Lee/schimke/composeai/cli/serve/OptimizerPressureThresholds;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/OptimizerPressureSnapshot$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/OptimizerPressureSnapshot$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/OptimizerPressureSnapshot;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/OptimizerPressureSnapshot;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/OptimizerPressureSnapshot$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/OptimizerPressureThresholds {
+	public static final field Companion Lee/schimke/composeai/cli/serve/OptimizerPressureThresholds$Companion;
+	public fun <init> ()V
+	public fun <init> (DDDDDDJJJJJD)V
+	public synthetic fun <init> (DDDDDDJJJJJDILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()D
+	public final fun component10 ()J
+	public final fun component11 ()J
+	public final fun component12 ()D
+	public final fun component2 ()D
+	public final fun component3 ()D
+	public final fun component4 ()D
+	public final fun component5 ()D
+	public final fun component6 ()D
+	public final fun component7 ()J
+	public final fun component8 ()J
+	public final fun component9 ()J
+	public final fun copy (DDDDDDJJJJJD)Lee/schimke/composeai/cli/serve/OptimizerPressureThresholds;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/OptimizerPressureThresholds;DDDDDDJJJJJDILjava/lang/Object;)Lee/schimke/composeai/cli/serve/OptimizerPressureThresholds;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDutyCycleFloorMemoryAvailableFraction ()D
+	public final fun getDutyCycleMillis ()J
+	public final fun getMaxRecoveryMillis ()J
+	public final fun getResumeCpuUtilization ()D
+	public final fun getResumeLoadPerCpu ()D
+	public final fun getResumeMemoryAvailableFraction ()D
+	public final fun getResumeQuietMillis ()J
+	public final fun getSampleIntervalMillis ()J
+	public final fun getStarvationCapMillis ()J
+	public final fun getStopCpuUtilization ()D
+	public final fun getStopLoadPerCpu ()D
+	public final fun getStopMemoryAvailableFraction ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/OptimizerPressureThresholds$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/OptimizerPressureThresholds$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/OptimizerPressureThresholds;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/OptimizerPressureThresholds;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/OptimizerPressureThresholds$Companion {
+	public final fun fromSystemProperties ()Lee/schimke/composeai/cli/serve/OptimizerPressureThresholds;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class ee/schimke/composeai/cli/serve/OverrideParse {
+}
+
+public final class ee/schimke/composeai/cli/serve/OverrideParse$Invalid : ee/schimke/composeai/cli/serve/OverrideParse {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/OverrideParse$Invalid;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/OverrideParse$Invalid;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/OverrideParse$Invalid;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/OverrideParse$Ok : ee/schimke/composeai/cli/serve/OverrideParse {
+	public fun <init> (Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)V
+	public final fun component1 ()Lee/schimke/composeai/daemon/protocol/PreviewOverrides;
+	public final fun copy (Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/OverrideParse$Ok;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/OverrideParse$Ok;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/OverrideParse$Ok;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOverrides ()Lee/schimke/composeai/daemon/protocol/PreviewOverrides;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/ParityActivity {
+	public static final field Companion Lee/schimke/composeai/cli/serve/ParityActivity$Companion;
+	public static final field DIRECTORY Ljava/lang/String;
+	public static final field FILE Ljava/lang/String;
+	public static final field SCHEMA Ljava/lang/String;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lee/schimke/composeai/cli/serve/CodeLane;Lee/schimke/composeai/cli/serve/FigmaLane;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lee/schimke/composeai/cli/serve/CodeLane;Lee/schimke/composeai/cli/serve/FigmaLane;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Lee/schimke/composeai/cli/serve/CodeLane;
+	public final fun component5 ()Lee/schimke/composeai/cli/serve/FigmaLane;
+	public final fun component6 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lee/schimke/composeai/cli/serve/CodeLane;Lee/schimke/composeai/cli/serve/FigmaLane;Ljava/util/List;)Lee/schimke/composeai/cli/serve/ParityActivity;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ParityActivity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lee/schimke/composeai/cli/serve/CodeLane;Lee/schimke/composeai/cli/serve/FigmaLane;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ParityActivity;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCode ()Lee/schimke/composeai/cli/serve/CodeLane;
+	public final fun getFigma ()Lee/schimke/composeai/cli/serve/FigmaLane;
+	public final fun getGaps ()Ljava/util/List;
+	public final fun getGeneratedAt ()Ljava/lang/String;
+	public final fun getSchema ()Ljava/lang/String;
+	public final fun getWindowDays ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/ParityActivity$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ParityActivity$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/ParityActivity;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/ParityActivity;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ParityActivity$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ParityAnchor {
+	public static final field Companion Lee/schimke/composeai/cli/serve/ParityAnchor$Companion;
+	public fun <init> (Ljava/lang/String;Lee/schimke/composeai/cli/serve/AnnotationBounds;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lee/schimke/composeai/cli/serve/AnnotationBounds;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lee/schimke/composeai/cli/serve/AnnotationBounds;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lee/schimke/composeai/cli/serve/AnnotationBounds;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/ParityAnchor;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ParityAnchor;Ljava/lang/String;Lee/schimke/composeai/cli/serve/AnnotationBounds;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ParityAnchor;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBounds ()Lee/schimke/composeai/cli/serve/AnnotationBounds;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getSide ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/ParityAnchor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ParityAnchor$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/ParityAnchor;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/ParityAnchor;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ParityAnchor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ParityAnchorPayload {
+	public static final field Companion Lee/schimke/composeai/cli/serve/ParityAnchorPayload$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/Map;)Lee/schimke/composeai/cli/serve/ParityAnchorPayload;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ParityAnchorPayload;Ljava/util/Map;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ParityAnchorPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFindings ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/ParityAnchorPayload$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ParityAnchorPayload$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/ParityAnchorPayload;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/ParityAnchorPayload;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ParityAnchorPayload$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ParityFinding {
+	public static final field Companion Lee/schimke/composeai/cli/serve/ParityFinding$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;)Lee/schimke/composeai/cli/serve/ParityFinding;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ParityFinding;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ParityFinding;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnchors ()Ljava/util/List;
+	public final fun getDetail ()Ljava/util/Map;
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getSeverity ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/ParityFinding$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ParityFinding$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/ParityFinding;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/ParityFinding;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ParityFinding$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ParityFindingGroup : java/lang/Enum {
+	public static final field ACCESSIBILITY Lee/schimke/composeai/cli/serve/ParityFindingGroup;
+	public static final field Companion Lee/schimke/composeai/cli/serve/ParityFindingGroup$Companion;
+	public static final field LAYOUT Lee/schimke/composeai/cli/serve/ParityFindingGroup;
+	public static final field PAIRING Lee/schimke/composeai/cli/serve/ParityFindingGroup;
+	public static final field TOKENS Lee/schimke/composeai/cli/serve/ParityFindingGroup;
+	public static final field VISUAL Lee/schimke/composeai/cli/serve/ParityFindingGroup;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getKinds ()Ljava/util/Set;
+	public final fun getTitle ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/ParityFindingGroup;
+	public static fun values ()[Lee/schimke/composeai/cli/serve/ParityFindingGroup;
+}
+
+public final class ee/schimke/composeai/cli/serve/ParityFindingGroup$Companion {
+	public final fun of (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/ParityFindingGroup;
+}
+
+public final class ee/schimke/composeai/cli/serve/ParityFindingKind {
+	public static final field A11Y Ljava/lang/String;
+	public static final field CONTRAST Ljava/lang/String;
+	public static final field I18N Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ParityFindingKind;
+	public static final field LAYOUT Ljava/lang/String;
+	public static final field PAIRING Ljava/lang/String;
+	public static final field SEMANTIC Ljava/lang/String;
+	public static final field TOKEN Ljava/lang/String;
+	public static final field VISUAL Ljava/lang/String;
+	public final fun getKNOWN ()Ljava/util/Set;
+}
+
+public final class ee/schimke/composeai/cli/serve/ParityFindingSet {
+	public static final field Companion Lee/schimke/composeai/cli/serve/ParityFindingSet$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lee/schimke/composeai/cli/serve/ParityFindingSet;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ParityFindingSet;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ParityFindingSet;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFindings ()Ljava/util/List;
+	public final fun getReferenceId ()Ljava/lang/String;
+	public final fun getReportUrl ()Ljava/lang/String;
+	public final fun getStatus ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/ParityFindingSet$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ParityFindingSet$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/ParityFindingSet;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/ParityFindingSet;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ParityFindingSet$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ParityFindingSeverity {
+	public static final field ERROR Ljava/lang/String;
+	public static final field INFO Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ParityFindingSeverity;
+	public static final field WARN Ljava/lang/String;
+	public final fun getKNOWN ()Ljava/util/Set;
+	public final fun rank (Ljava/lang/String;)I
+}
+
+public final class ee/schimke/composeai/cli/serve/ParityFindings {
+	public static final field Companion Lee/schimke/composeai/cli/serve/ParityFindings$Companion;
+	public static final field DIRECTORY Ljava/lang/String;
+	public static final field FILE Ljava/lang/String;
+	public static final field SCHEMA Ljava/lang/String;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lee/schimke/composeai/cli/serve/ParityFindings;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ParityFindings;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ParityFindings;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGeneratedAt ()Ljava/lang/String;
+	public final fun getPreviews ()Ljava/util/Map;
+	public final fun getSchema ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/ParityFindings$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ParityFindings$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/ParityFindings;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/ParityFindings;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ParityFindings$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundCatalogInfo {
+	public static final field Companion Lee/schimke/composeai/cli/serve/PlaygroundCatalogInfo$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Z
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/PlaygroundCatalogInfo;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/PlaygroundCatalogInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PlaygroundCatalogInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBackend ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getModes ()Ljava/util/List;
+	public final fun getModule ()Ljava/lang/String;
+	public final fun getResolved ()Z
+	public final fun getSystem ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/PlaygroundCatalogInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/PlaygroundCatalogInfo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/PlaygroundCatalogInfo;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/PlaygroundCatalogInfo;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundCatalogInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundCatalogsResponse {
+	public static final field Companion Lee/schimke/composeai/cli/serve/PlaygroundCatalogsResponse$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lee/schimke/composeai/cli/serve/PlaygroundCatalogsResponse;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/PlaygroundCatalogsResponse;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PlaygroundCatalogsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCatalogs ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/PlaygroundCatalogsResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/PlaygroundCatalogsResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/PlaygroundCatalogsResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/PlaygroundCatalogsResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundCatalogsResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundDiagnostic {
+	public static final field Companion Lee/schimke/composeai/cli/serve/PlaygroundDiagnostic$Companion;
+	public fun <init> (Lee/schimke/composeai/cli/serve/PlaygroundSeverity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Lee/schimke/composeai/cli/serve/PlaygroundSeverity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/cli/serve/PlaygroundSeverity;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun copy (Lee/schimke/composeai/cli/serve/PlaygroundSeverity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)Lee/schimke/composeai/cli/serve/PlaygroundDiagnostic;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/PlaygroundDiagnostic;Lee/schimke/composeai/cli/serve/PlaygroundSeverity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PlaygroundDiagnostic;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCh ()Ljava/lang/Integer;
+	public final fun getEndCh ()Ljava/lang/Integer;
+	public final fun getEndLine ()Ljava/lang/Integer;
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getLine ()Ljava/lang/Integer;
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getSeverity ()Lee/schimke/composeai/cli/serve/PlaygroundSeverity;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/PlaygroundDiagnostic$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/PlaygroundDiagnostic$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/PlaygroundDiagnostic;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/PlaygroundDiagnostic;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundDiagnostic$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundEditLeaseAcquireRequest {
+	public static final field Companion Lee/schimke/composeai/cli/serve/PlaygroundEditLeaseAcquireRequest$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/PlaygroundEditLeaseAcquireRequest;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/PlaygroundEditLeaseAcquireRequest;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PlaygroundEditLeaseAcquireRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClient ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/PlaygroundEditLeaseAcquireRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/PlaygroundEditLeaseAcquireRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/PlaygroundEditLeaseAcquireRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/PlaygroundEditLeaseAcquireRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundEditLeaseAcquireRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundEditLeaseReleaseRequest {
+	public static final field Companion Lee/schimke/composeai/cli/serve/PlaygroundEditLeaseReleaseRequest$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/PlaygroundEditLeaseReleaseRequest;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/PlaygroundEditLeaseReleaseRequest;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PlaygroundEditLeaseReleaseRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClient ()Ljava/lang/String;
+	public final fun getLease ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/PlaygroundEditLeaseReleaseRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/PlaygroundEditLeaseReleaseRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/PlaygroundEditLeaseReleaseRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/PlaygroundEditLeaseReleaseRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundEditLeaseReleaseRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundEditLeaseResponse {
+	public static final field Companion Lee/schimke/composeai/cli/serve/PlaygroundEditLeaseResponse$Companion;
+	public fun <init> (ZLjava/lang/String;Ljava/lang/Long;JLjava/lang/String;)V
+	public synthetic fun <init> (ZLjava/lang/String;Ljava/lang/Long;JLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun component4 ()J
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (ZLjava/lang/String;Ljava/lang/Long;JLjava/lang/String;)Lee/schimke/composeai/cli/serve/PlaygroundEditLeaseResponse;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/PlaygroundEditLeaseResponse;ZLjava/lang/String;Ljava/lang/Long;JLjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PlaygroundEditLeaseResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAcquired ()Z
+	public final fun getExpiresAtEpochMs ()Ljava/lang/Long;
+	public final fun getLease ()Ljava/lang/String;
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getRevision ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/PlaygroundEditLeaseResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/PlaygroundEditLeaseResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/PlaygroundEditLeaseResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/PlaygroundEditLeaseResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundEditLeaseResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundFile {
+	public static final field Companion Lee/schimke/composeai/cli/serve/PlaygroundFile$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/PlaygroundFile;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/PlaygroundFile;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PlaygroundFile;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPublicId ()Ljava/lang/String;
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/PlaygroundFile$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/PlaygroundFile$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/PlaygroundFile;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/PlaygroundFile;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundFile$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundInterval {
+	public static final field Companion Lee/schimke/composeai/cli/serve/PlaygroundInterval$Companion;
+	public fun <init> (Lee/schimke/composeai/cli/serve/PlaygroundPosition;Lee/schimke/composeai/cli/serve/PlaygroundPosition;)V
+	public final fun component1 ()Lee/schimke/composeai/cli/serve/PlaygroundPosition;
+	public final fun component2 ()Lee/schimke/composeai/cli/serve/PlaygroundPosition;
+	public final fun copy (Lee/schimke/composeai/cli/serve/PlaygroundPosition;Lee/schimke/composeai/cli/serve/PlaygroundPosition;)Lee/schimke/composeai/cli/serve/PlaygroundInterval;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/PlaygroundInterval;Lee/schimke/composeai/cli/serve/PlaygroundPosition;Lee/schimke/composeai/cli/serve/PlaygroundPosition;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PlaygroundInterval;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnd ()Lee/schimke/composeai/cli/serve/PlaygroundPosition;
+	public final fun getStart ()Lee/schimke/composeai/cli/serve/PlaygroundPosition;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/PlaygroundInterval$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/PlaygroundInterval$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/PlaygroundInterval;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/PlaygroundInterval;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundInterval$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundMode : java/lang/Enum {
+	public static final field ANDROID Lee/schimke/composeai/cli/serve/PlaygroundMode;
+	public static final field CMP Lee/schimke/composeai/cli/serve/PlaygroundMode;
+	public static final field Companion Lee/schimke/composeai/cli/serve/PlaygroundMode$Companion;
+	public static final field REMOTE_COMPOSE Lee/schimke/composeai/cli/serve/PlaygroundMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/PlaygroundMode;
+	public static fun values ()[Lee/schimke/composeai/cli/serve/PlaygroundMode;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundMode$Companion {
+	public final fun fromConfType (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/PlaygroundMode;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundPosition {
+	public static final field Companion Lee/schimke/composeai/cli/serve/PlaygroundPosition$Companion;
+	public fun <init> (II)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun copy (II)Lee/schimke/composeai/cli/serve/PlaygroundPosition;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/PlaygroundPosition;IIILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PlaygroundPosition;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCh ()I
+	public final fun getLine ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/PlaygroundPosition$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/PlaygroundPosition$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/PlaygroundPosition;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/PlaygroundPosition;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundPosition$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundPreviews {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/PlaygroundPreviews;
+	public final fun previewManifestJson (Lee/schimke/composeai/cli/serve/PlaygroundTokenStore$PlaygroundSnippet;)Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundPublicGate {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/PlaygroundPublicGate;
+	public final fun decide (ZZLee/schimke/composeai/cli/serve/PlaygroundSandbox;Lee/schimke/composeai/cli/serve/PlaygroundSandboxProbe$Report;)Lee/schimke/composeai/cli/serve/PlaygroundPublicGate$Decision;
+}
+
+public abstract interface class ee/schimke/composeai/cli/serve/PlaygroundPublicGate$Decision {
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundPublicGate$Decision$Allow : ee/schimke/composeai/cli/serve/PlaygroundPublicGate$Decision {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/PlaygroundPublicGate$Decision$Allow;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/PlaygroundPublicGate$Decision$Allow;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PlaygroundPublicGate$Decision$Allow;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDetail ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundPublicGate$Decision$Refuse : ee/schimke/composeai/cli/serve/PlaygroundPublicGate$Decision {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/PlaygroundPublicGate$Decision$Refuse;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/PlaygroundPublicGate$Decision$Refuse;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PlaygroundPublicGate$Decision$Refuse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundRunRequest {
+	public static final field Companion Lee/schimke/composeai/cli/serve/PlaygroundRunRequest$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;J)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()J
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;J)Lee/schimke/composeai/cli/serve/PlaygroundRunRequest;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/PlaygroundRunRequest;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PlaygroundRunRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArgs ()Ljava/lang/String;
+	public final fun getCatalog ()Ljava/lang/String;
+	public final fun getConfType ()Ljava/lang/String;
+	public final fun getEditLease ()Ljava/lang/String;
+	public final fun getFiles ()Ljava/util/List;
+	public final fun getRevision ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/PlaygroundRunRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/PlaygroundRunRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/PlaygroundRunRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/PlaygroundRunRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundRunRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundRunResponse {
+	public static final field Companion Lee/schimke/composeai/cli/serve/PlaygroundRunResponse$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/Long;Z)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/Long;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component10 ()Ljava/util/List;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/Long;
+	public final fun component13 ()Z
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/Long;Z)Lee/schimke/composeai/cli/serve/PlaygroundRunResponse;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/PlaygroundRunResponse;Ljava/util/List;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/Long;ZILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PlaygroundRunResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDiagnostics ()Ljava/util/List;
+	public final fun getDocumentUrl ()Ljava/lang/String;
+	public final fun getEditLease ()Ljava/lang/String;
+	public final fun getErrors ()Ljava/util/Map;
+	public final fun getException ()Ljava/lang/String;
+	public final fun getImage ()Ljava/lang/String;
+	public final fun getIncremental ()Z
+	public final fun getPreviewId ()Ljava/lang/String;
+	public final fun getPreviewToken ()Ljava/lang/String;
+	public final fun getPreviewUrl ()Ljava/lang/String;
+	public final fun getPreviews ()Ljava/util/List;
+	public final fun getRevision ()Ljava/lang/Long;
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/PlaygroundRunResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/PlaygroundRunResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/PlaygroundRunResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/PlaygroundRunResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundRunResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundSandbox {
+	public static final field Companion Lee/schimke/composeai/cli/serve/PlaygroundSandbox$Companion;
+	public static final field DEFAULT_CPUS D
+	public static final field DEFAULT_MEMORY_MB I
+	public static final field DEFAULT_PIDS I
+	public static final field DEFAULT_TTL_SECONDS J
+	public static final field MIN_HEAP_MB I
+	public fun <init> (Lee/schimke/composeai/cli/serve/PlaygroundSandbox$Profile;IDIJLjava/util/List;Ljava/util/List;Z)V
+	public synthetic fun <init> (Lee/schimke/composeai/cli/serve/PlaygroundSandbox$Profile;IDIJLjava/util/List;Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun command (Lee/schimke/composeai/cli/serve/PlaygroundSandbox$Paths;)Ljava/util/List;
+	public final fun component1 ()Lee/schimke/composeai/cli/serve/PlaygroundSandbox$Profile;
+	public final fun component2 ()I
+	public final fun component3 ()D
+	public final fun component4 ()I
+	public final fun component5 ()J
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Z
+	public final fun copy (Lee/schimke/composeai/cli/serve/PlaygroundSandbox$Profile;IDIJLjava/util/List;Ljava/util/List;Z)Lee/schimke/composeai/cli/serve/PlaygroundSandbox;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/PlaygroundSandbox;Lee/schimke/composeai/cli/serve/PlaygroundSandbox$Profile;IDIJLjava/util/List;Ljava/util/List;ZILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PlaygroundSandbox;
+	public final fun describe ()Ljava/lang/String;
+	public final fun droppingJail ()Lee/schimke/composeai/cli/serve/PlaygroundSandbox;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCpus ()D
+	public final fun getCustomCommand ()Ljava/util/List;
+	public final fun getExtraReadOnlyPaths ()Ljava/util/List;
+	public final fun getJailDropped ()Z
+	public final fun getMemoryMb ()I
+	public final fun getPids ()I
+	public final fun getProfile ()Lee/schimke/composeai/cli/serve/PlaygroundSandbox$Profile;
+	public final fun getTtlSeconds ()J
+	public fun hashCode ()I
+	public final fun isActive ()Z
+	public final fun jvmArgs (Ljava/io/File;)Ljava/util/List;
+	public final fun robolectricSystemProperties (Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;)Ljava/util/Map;
+	public static synthetic fun robolectricSystemProperties$default (Lee/schimke/composeai/cli/serve/PlaygroundSandbox;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundSandbox$Companion {
+	public final fun getNONE ()Lee/schimke/composeai/cli/serve/PlaygroundSandbox;
+	public final fun parseProfile-IoAF18A (Ljava/lang/String;)Ljava/lang/Object;
+	public final fun validate-IoAF18A (Lee/schimke/composeai/cli/serve/PlaygroundSandbox;)Ljava/lang/Object;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundSandbox$Paths {
+	public fun <init> (Ljava/io/File;Ljava/util/List;Ljava/io/File;)V
+	public final fun component1 ()Ljava/io/File;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/io/File;
+	public final fun copy (Ljava/io/File;Ljava/util/List;Ljava/io/File;)Lee/schimke/composeai/cli/serve/PlaygroundSandbox$Paths;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/PlaygroundSandbox$Paths;Ljava/io/File;Ljava/util/List;Ljava/io/File;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PlaygroundSandbox$Paths;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getJavaHome ()Ljava/io/File;
+	public final fun getReadOnly ()Ljava/util/List;
+	public final fun getWorkDir ()Ljava/io/File;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundSandbox$Profile : java/lang/Enum {
+	public static final field BWRAP Lee/schimke/composeai/cli/serve/PlaygroundSandbox$Profile;
+	public static final field CUSTOM Lee/schimke/composeai/cli/serve/PlaygroundSandbox$Profile;
+	public static final field NONE Lee/schimke/composeai/cli/serve/PlaygroundSandbox$Profile;
+	public static final field STRICT Lee/schimke/composeai/cli/serve/PlaygroundSandbox$Profile;
+	public static final field SYSTEMD Lee/schimke/composeai/cli/serve/PlaygroundSandbox$Profile;
+	public static final field UNSHARE Lee/schimke/composeai/cli/serve/PlaygroundSandbox$Profile;
+	public final fun getDeclaresEgressBlocked ()Z
+	public final fun getDeclaresFilesystemContained ()Z
+	public final fun getDeclaresResourceCaps ()Z
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getId ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/PlaygroundSandbox$Profile;
+	public static fun values ()[Lee/schimke/composeai/cli/serve/PlaygroundSandbox$Profile;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundSandboxProbe {
+	public static final field DEFAULT_TIMEOUT_SECONDS J
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/PlaygroundSandboxProbe;
+	public static final field PROBE_MAIN_CLASS Ljava/lang/String;
+	public static final field REPORT_PREFIX Ljava/lang/String;
+	public final fun run (Lee/schimke/composeai/cli/serve/PlaygroundSandbox;Ljava/io/File;Ljava/util/List;Ljava/io/File;JLkotlin/jvm/functions/Function2;)Lee/schimke/composeai/cli/serve/PlaygroundSandboxProbe$Report;
+	public static synthetic fun run$default (Lee/schimke/composeai/cli/serve/PlaygroundSandboxProbe;Lee/schimke/composeai/cli/serve/PlaygroundSandbox;Ljava/io/File;Ljava/util/List;Ljava/io/File;JLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PlaygroundSandboxProbe$Report;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundSandboxProbe$Launch {
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (ILjava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/PlaygroundSandboxProbe$Launch;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/PlaygroundSandboxProbe$Launch;ILjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PlaygroundSandboxProbe$Launch;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExitCode ()I
+	public final fun getStderr ()Ljava/lang/String;
+	public final fun getStdout ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundSandboxProbe$Report {
+	public static final field Companion Lee/schimke/composeai/cli/serve/PlaygroundSandboxProbe$Report$Companion;
+	public fun <init> ()V
+	public fun <init> (ZLjava/lang/String;ZZZZ)V
+	public synthetic fun <init> (ZLjava/lang/String;ZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Z
+	public final fun component4 ()Z
+	public final fun component5 ()Z
+	public final fun component6 ()Z
+	public final fun copy (ZLjava/lang/String;ZZZZ)Lee/schimke/composeai/cli/serve/PlaygroundSandboxProbe$Report;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/PlaygroundSandboxProbe$Report;ZLjava/lang/String;ZZZZILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PlaygroundSandboxProbe$Report;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun failedChecks ()Ljava/util/List;
+	public final fun getDetail ()Ljava/lang/String;
+	public final fun getEgressBlocked ()Z
+	public final fun getFilesystemContained ()Z
+	public final fun getProcessIsolated ()Z
+	public final fun getRan ()Z
+	public final fun getWorkDirWritable ()Z
+	public fun hashCode ()I
+	public final fun summary ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/PlaygroundSandboxProbe$Report$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/PlaygroundSandboxProbe$Report$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/PlaygroundSandboxProbe$Report;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/PlaygroundSandboxProbe$Report;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundSandboxProbe$Report$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundSandboxProbeMain {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/PlaygroundSandboxProbeMain;
+	public static final fun main ([Ljava/lang/String;)V
+	public final fun probe (Ljava/io/File;Ljava/io/File;Ljava/lang/Long;)Lee/schimke/composeai/cli/serve/PlaygroundSandboxProbe$Report;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundSeverity : java/lang/Enum {
+	public static final field Companion Lee/schimke/composeai/cli/serve/PlaygroundSeverity$Companion;
+	public static final field ERROR Lee/schimke/composeai/cli/serve/PlaygroundSeverity;
+	public static final field INFO Lee/schimke/composeai/cli/serve/PlaygroundSeverity;
+	public static final field WARNING Lee/schimke/composeai/cli/serve/PlaygroundSeverity;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/PlaygroundSeverity;
+	public static fun values ()[Lee/schimke/composeai/cli/serve/PlaygroundSeverity;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundSeverity$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundStockError {
+	public static final field Companion Lee/schimke/composeai/cli/serve/PlaygroundStockError$Companion;
+	public fun <init> (Lee/schimke/composeai/cli/serve/PlaygroundInterval;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Lee/schimke/composeai/cli/serve/PlaygroundInterval;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Lee/schimke/composeai/cli/serve/PlaygroundInterval;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/PlaygroundStockError;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/PlaygroundStockError;Lee/schimke/composeai/cli/serve/PlaygroundInterval;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PlaygroundStockError;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClassName ()Ljava/lang/String;
+	public final fun getInterval ()Lee/schimke/composeai/cli/serve/PlaygroundInterval;
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getSeverity ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/PlaygroundStockError$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/PlaygroundStockError$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/PlaygroundStockError;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/PlaygroundStockError;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundStockError$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundTokenStore {
+	public static final field Companion Lee/schimke/composeai/cli/serve/PlaygroundTokenStore$Companion;
+	public static final field DEFAULT_MAX_TOKENS I
+	public static final field DEFAULT_TTL_SECONDS J
+	public fun <init> ()V
+	public fun <init> (JILokio/FileSystem;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (JILokio/FileSystem;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun add (Lee/schimke/composeai/cli/serve/PlaygroundTokenStore$PlaygroundSnippet;Z)Lee/schimke/composeai/cli/serve/PlaygroundTokenStore$Token;
+	public final fun clear ()V
+	public final fun get (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/PlaygroundTokenStore$Token;
+	public final fun getTtlSeconds ()J
+	public final fun purgeExpired (J)I
+	public static synthetic fun purgeExpired$default (Lee/schimke/composeai/cli/serve/PlaygroundTokenStore;JILjava/lang/Object;)I
+	public final fun remainingSeconds (Lee/schimke/composeai/cli/serve/PlaygroundTokenStore$Token;)J
+	public final fun remove (Ljava/lang/String;)Z
+	public final fun snapshot ()Ljava/util/List;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundTokenStore$Companion {
+	public final fun isWellFormedId (Ljava/lang/String;)Z
+	public final fun randomId ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundTokenStore$PlaygroundSnippet {
+	public fun <init> (Lee/schimke/composeai/cli/serve/PlaygroundMode;Lokio/Path;Lokio/Path;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Lee/schimke/composeai/cli/serve/PlaygroundMode;Lokio/Path;Lokio/Path;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/cli/serve/PlaygroundMode;
+	public final fun component2 ()Lokio/Path;
+	public final fun component3 ()Lokio/Path;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/List;
+	public final fun copy (Lee/schimke/composeai/cli/serve/PlaygroundMode;Lokio/Path;Lokio/Path;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lee/schimke/composeai/cli/serve/PlaygroundTokenStore$PlaygroundSnippet;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/PlaygroundTokenStore$PlaygroundSnippet;Lee/schimke/composeai/cli/serve/PlaygroundMode;Lokio/Path;Lokio/Path;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PlaygroundTokenStore$PlaygroundSnippet;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClassesDir ()Lokio/Path;
+	public final fun getClasspath ()Ljava/util/List;
+	public final fun getMode ()Lee/schimke/composeai/cli/serve/PlaygroundMode;
+	public final fun getModuleName ()Ljava/lang/String;
+	public final fun getPreviewId ()Ljava/lang/String;
+	public final fun getPreviewIds ()Ljava/util/List;
+	public final fun getWorkDir ()Lokio/Path;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/PlaygroundTokenStore$Token {
+	public fun <init> (Ljava/lang/String;Lee/schimke/composeai/cli/serve/PlaygroundTokenStore$PlaygroundSnippet;JJ)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lee/schimke/composeai/cli/serve/PlaygroundTokenStore$PlaygroundSnippet;
+	public final fun component3 ()J
+	public final fun component4 ()J
+	public final fun copy (Ljava/lang/String;Lee/schimke/composeai/cli/serve/PlaygroundTokenStore$PlaygroundSnippet;JJ)Lee/schimke/composeai/cli/serve/PlaygroundTokenStore$Token;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/PlaygroundTokenStore$Token;Ljava/lang/String;Lee/schimke/composeai/cli/serve/PlaygroundTokenStore$PlaygroundSnippet;JJILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PlaygroundTokenStore$Token;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAtMillis ()J
+	public final fun getExpiresAtMillis ()J
+	public final fun getId ()Ljava/lang/String;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getSnippet ()Lee/schimke/composeai/cli/serve/PlaygroundTokenStore$PlaygroundSnippet;
+	public fun hashCode ()I
+	public final fun secondsUntilExpiry (J)J
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/PreviewHistory {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/PreviewHistory;
+	public static final field UNSTABLE_FLAP_THRESHOLD I
+	public final fun collapse (Ljava/util/Map;)Ljava/util/Map;
+	public final fun logArgs (Ljava/lang/String;Ljava/lang/String;)Ljava/util/List;
+	public final fun parseGitLog (Ljava/lang/String;)Ljava/util/Map;
+	public final fun read (Ljava/io/File;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/GitRunner;)Ljava/util/Map;
+	public static synthetic fun read$default (Lee/schimke/composeai/cli/serve/PreviewHistory;Ljava/io/File;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/GitRunner;ILjava/lang/Object;)Ljava/util/Map;
+}
+
+public final class ee/schimke/composeai/cli/serve/PreviewHistory$Observation {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)Lee/schimke/composeai/cli/serve/PreviewHistory$Observation;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/PreviewHistory$Observation;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PreviewHistory$Observation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlob ()Ljava/lang/String;
+	public final fun getCommit ()Ljava/lang/String;
+	public final fun getDate ()Ljava/lang/String;
+	public final fun getDeleted ()Z
+	public final fun getSourceSha ()Ljava/lang/String;
+	public final fun getSubject ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/PreviewHistory$Timeline {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;I)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()I
+	public final fun copy (Ljava/lang/String;Ljava/util/List;I)Lee/schimke/composeai/cli/serve/PreviewHistory$Timeline;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/PreviewHistory$Timeline;Ljava/lang/String;Ljava/util/List;IILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PreviewHistory$Timeline;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDisplayVersions ()Ljava/util/List;
+	public final fun getDistinctBlobs ()I
+	public final fun getFlapCount ()I
+	public final fun getObservations ()I
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getRecurringBlobs ()Ljava/util/Set;
+	public final fun getUnstable ()Z
+	public final fun getVersions ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/PreviewHistory$Version {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/PreviewHistory$Observation;Lee/schimke/composeai/cli/serve/PreviewHistory$Observation;II)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/PreviewHistory$Observation;Lee/schimke/composeai/cli/serve/PreviewHistory$Observation;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lee/schimke/composeai/cli/serve/PreviewHistory$Observation;
+	public final fun component4 ()Lee/schimke/composeai/cli/serve/PreviewHistory$Observation;
+	public final fun component5 ()I
+	public final fun component6 ()I
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/PreviewHistory$Observation;Lee/schimke/composeai/cli/serve/PreviewHistory$Observation;II)Lee/schimke/composeai/cli/serve/PreviewHistory$Version;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/PreviewHistory$Version;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/PreviewHistory$Observation;Lee/schimke/composeai/cli/serve/PreviewHistory$Observation;IIILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PreviewHistory$Version;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlob ()Ljava/lang/String;
+	public final fun getCommits ()I
+	public final fun getOccurrences ()I
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getRecurring ()Z
+	public final fun getSince ()Lee/schimke/composeai/cli/serve/PreviewHistory$Observation;
+	public final fun getUntil ()Lee/schimke/composeai/cli/serve/PreviewHistory$Observation;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/PreviewHistoryManifest {
+	public static final field BASELINES_FILE_NAME Ljava/lang/String;
+	public static final field FILE_NAME Ljava/lang/String;
+	public static final field FORMAT_VERSION Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/PreviewHistoryManifest;
+	public final fun build (Ljava/util/Map;Ljava/util/Map;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$Manifest;
+	public final fun decode (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$Manifest;
+	public final fun encode (Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$Manifest;)Ljava/lang/String;
+	public final fun imagePathsToPreviewIds (Ljava/lang/Iterable;)Ljava/util/Map;
+	public final fun renderPathsToPreviewIds (Ljava/lang/String;)Ljava/util/Map;
+}
+
+public final class ee/schimke/composeai/cli/serve/PreviewHistoryManifest$Layout : java/lang/Enum {
+	public static final field Companion Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$Layout$Companion;
+	public static final field IMAGES Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$Layout;
+	public static final field RENDERS Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$Layout;
+	public final fun getDir ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$Layout;
+	public static fun values ()[Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$Layout;
+}
+
+public final class ee/schimke/composeai/cli/serve/PreviewHistoryManifest$Layout$Companion {
+	public final fun of (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$Layout;
+}
+
+public final class ee/schimke/composeai/cli/serve/PreviewHistoryManifest$Manifest {
+	public static final field Companion Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$Manifest$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$Manifest;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$Manifest;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$Manifest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFormatVersion ()Ljava/lang/String;
+	public final fun getGeneratedFrom ()Ljava/lang/String;
+	public final fun getPreviews ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/PreviewHistoryManifest$Manifest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$Manifest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$Manifest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$Manifest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PreviewHistoryManifest$Manifest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PreviewHistoryManifest$ManifestVersion {
+	public static final field Companion Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$ManifestVersion$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()I
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Integer;)Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$ManifestVersion;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$ManifestVersion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Integer;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$ManifestVersion;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlob ()Ljava/lang/String;
+	public final fun getCommit ()Ljava/lang/String;
+	public final fun getCommits ()I
+	public final fun getDate ()Ljava/lang/String;
+	public final fun getIntroducedBy ()Ljava/lang/String;
+	public final fun getOccurrences ()Ljava/lang/Integer;
+	public final fun getSinceCommit ()Ljava/lang/String;
+	public final fun getSourceSha ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/PreviewHistoryManifest$ManifestVersion$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$ManifestVersion$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$ManifestVersion;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$ManifestVersion;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PreviewHistoryManifest$ManifestVersion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PreviewHistoryManifest$PreviewTimeline {
+	public static final field Companion Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$PreviewTimeline$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;IZI)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()I
+	public final fun component4 ()Z
+	public final fun component5 ()I
+	public final fun copy (Ljava/lang/String;Ljava/util/List;IZI)Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$PreviewTimeline;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$PreviewTimeline;Ljava/lang/String;Ljava/util/List;IZIILjava/lang/Object;)Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$PreviewTimeline;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFlapCount ()I
+	public final fun getObservations ()I
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getUnstable ()Z
+	public final fun getVersions ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/PreviewHistoryManifest$PreviewTimeline$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$PreviewTimeline$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$PreviewTimeline;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/PreviewHistoryManifest$PreviewTimeline;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PreviewHistoryManifest$PreviewTimeline$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/PreviewMode : java/lang/Enum {
+	public static final field Companion Lee/schimke/composeai/cli/serve/PreviewMode$Companion;
+	public static final field LIVE Lee/schimke/composeai/cli/serve/PreviewMode;
+	public static final field SNAPSHOT Lee/schimke/composeai/cli/serve/PreviewMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getWire ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/PreviewMode;
+	public static fun values ()[Lee/schimke/composeai/cli/serve/PreviewMode;
+}
+
+public final class ee/schimke/composeai/cli/serve/PreviewMode$Companion {
+	public final fun parse (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/PreviewMode;
+}
+
+public final class ee/schimke/composeai/cli/serve/RcCompareCell {
+	public static final field Companion Lee/schimke/composeai/cli/serve/RcCompareCell$Companion;
+	public fun <init> ()V
+	public fun <init> (ZLjava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/String;)V
+	public synthetic fun <init> (ZLjava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Double;
+	public final fun component5 ()Ljava/lang/Long;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (ZLjava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/RcCompareCell;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/RcCompareCell;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/RcCompareCell;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDiff ()Ljava/lang/String;
+	public final fun getMismatchPct ()Ljava/lang/Double;
+	public final fun getMismatchPx ()Ljava/lang/Long;
+	public final fun getNote ()Ljava/lang/String;
+	public final fun getRender ()Ljava/lang/String;
+	public final fun getRendered ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/RcCompareCell$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/RcCompareCell$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/RcCompareCell;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/RcCompareCell;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/RcCompareCell$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/RcCompareLane {
+	public static final field Companion Lee/schimke/composeai/cli/serve/RcCompareLane$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/RcCompareLane;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/RcCompareLane;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/RcCompareLane;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getShort ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/RcCompareLane$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/RcCompareLane$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/RcCompareLane;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/RcCompareLane;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/RcCompareLane$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/RcCompareManifest {
+	public static final field Companion Lee/schimke/composeai/cli/serve/RcCompareManifest$Companion;
+	public static final field DEFAULT_THRESHOLD D
+	public static final field SCHEMA Ljava/lang/String;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;DLjava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;DLjava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()D
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;DLjava/util/List;Ljava/util/List;)Lee/schimke/composeai/cli/serve/RcCompareManifest;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/RcCompareManifest;Ljava/lang/String;DLjava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/RcCompareManifest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLanes ()Ljava/util/List;
+	public final fun getRows ()Ljava/util/List;
+	public final fun getSchema ()Ljava/lang/String;
+	public final fun getThreshold ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/RcCompareManifest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/RcCompareManifest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/RcCompareManifest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/RcCompareManifest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/RcCompareManifest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/RcComparePlan {
+	public fun <init> (Lee/schimke/composeai/cli/serve/RcCompareManifest;Ljava/util/Map;)V
+	public final fun component1 ()Lee/schimke/composeai/cli/serve/RcCompareManifest;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Lee/schimke/composeai/cli/serve/RcCompareManifest;Ljava/util/Map;)Lee/schimke/composeai/cli/serve/RcComparePlan;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/RcComparePlan;Lee/schimke/composeai/cli/serve/RcCompareManifest;Ljava/util/Map;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/RcComparePlan;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssets ()Ljava/util/Map;
+	public final fun getManifest ()Lee/schimke/composeai/cli/serve/RcCompareManifest;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/RcCompareRow {
+	public static final field Companion Lee/schimke/composeai/cli/serve/RcCompareRow$Companion;
+	public fun <init> (Ljava/lang/String;IIZLjava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;IIZLjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()Z
+	public final fun component5 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;IIZLjava/util/Map;)Lee/schimke/composeai/cli/serve/RcCompareRow;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/RcCompareRow;Ljava/lang/String;IIZLjava/util/Map;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/RcCompareRow;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeight ()I
+	public final fun getLanes ()Ljava/util/Map;
+	public final fun getPreviewId ()Ljava/lang/String;
+	public final fun getReferenceBlank ()Z
+	public final fun getWidth ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/RcCompareRow$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/RcCompareRow$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/RcCompareRow;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/RcCompareRow;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/RcCompareRow$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/RcJvmRenderSpec {
+	public fun <init> (IIF)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()F
+	public final fun copy (IIF)Lee/schimke/composeai/cli/serve/RcJvmRenderSpec;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/RcJvmRenderSpec;IIFILjava/lang/Object;)Lee/schimke/composeai/cli/serve/RcJvmRenderSpec;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDensity ()F
+	public final fun getHeightPx ()I
+	public final fun getWidthPx ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/RcJvmServerRenderer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/RcJvmServerRenderer;
+	public final fun isAvailable ()Z
+	public final fun rcColorToArgb (Ljava/lang/String;)Ljava/lang/Integer;
+	public final fun render ([BLee/schimke/composeai/cli/serve/RcJvmRenderSpec;Ljava/util/Map;Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$Format;Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderTheme;)Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderResult;
+	public static synthetic fun render$default (Lee/schimke/composeai/cli/serve/RcJvmServerRenderer;[BLee/schimke/composeai/cli/serve/RcJvmRenderSpec;Ljava/util/Map;Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$Format;Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderTheme;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderResult;
+	public final fun shutdownPool ()V
+	public final fun unavailableReason ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/RcJvmServerRenderer$Format : java/lang/Enum {
+	public static final field PNG Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$Format;
+	public static final field SVG Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$Format;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getWire ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$Format;
+	public static fun values ()[Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$Format;
+}
+
+public abstract interface class ee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderResult {
+}
+
+public final class ee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderResult$Failed : ee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderResult {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderResult$Failed;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderResult$Failed;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderResult$Failed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderResult$Ok : ee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderResult {
+	public fun <init> ([B)V
+	public final fun component1 ()[B
+	public final fun copy ([B)Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderResult$Ok;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderResult$Ok;[BILjava/lang/Object;)Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderResult$Ok;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBytes ()[B
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderResult$Unavailable : ee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderResult {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderResult$Unavailable;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderResult$Unavailable;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderResult$Unavailable;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderTheme : java/lang/Enum {
+	public static final field DARK Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderTheme;
+	public static final field LIGHT Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderTheme;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getFrame ()I
+	public final fun getWire ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderTheme;
+	public static fun values ()[Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderTheme;
+}
+
+public final class ee/schimke/composeai/cli/serve/RcJvmWorkerPool : java/lang/AutoCloseable {
+	public static final field Companion Lee/schimke/composeai/cli/serve/RcJvmWorkerPool$Companion;
+	public static final field HANDSHAKE_TIMEOUT_SECONDS J
+	public static final field MAGIC_HELLO I
+	public static final field MAGIC_REQUEST I
+	public static final field MAGIC_RESPONSE I
+	public static final field MAX_START_FAILURES I
+	public static final field PROTOCOL_VERSION I
+	public static final field STATUS_FAILED I
+	public static final field STATUS_OK I
+	public static final field STDERR_TAIL_LINES I
+	public static final field SYS_PROP_ENABLED Ljava/lang/String;
+	public static final field SYS_PROP_MAX_AGE_MINUTES Ljava/lang/String;
+	public static final field SYS_PROP_MAX_RENDERS Ljava/lang/String;
+	public static final field SYS_PROP_WORKERS Ljava/lang/String;
+	public static final field WIRE_FORMAT_PNG I
+	public static final field WIRE_FORMAT_SVG I
+	public static final field WIRE_THEME_DARK I
+	public static final field WIRE_THEME_LIGHT I
+	public static final field WORKER_MAIN_CLASS Ljava/lang/String;
+	public fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/util/List;IIJJLkotlin/jvm/functions/Function0;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/util/List;IIJJLkotlin/jvm/functions/Function0;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun close ()V
+	public final fun render ([BLee/schimke/composeai/cli/serve/RcJvmRenderSpec;Ljava/lang/String;Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$Format;Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderTheme;J)Lee/schimke/composeai/cli/serve/RcJvmWorkerPool$PoolResult;
+	public static synthetic fun render$default (Lee/schimke/composeai/cli/serve/RcJvmWorkerPool;[BLee/schimke/composeai/cli/serve/RcJvmRenderSpec;Ljava/lang/String;Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$Format;Lee/schimke/composeai/cli/serve/RcJvmServerRenderer$RenderTheme;JILjava/lang/Object;)Lee/schimke/composeai/cli/serve/RcJvmWorkerPool$PoolResult;
+}
+
+public final class ee/schimke/composeai/cli/serve/RcJvmWorkerPool$Companion {
+	public final fun configuredMaxAgeMillis ()J
+	public final fun configuredMaxRenders ()I
+	public final fun configuredWorkers ()I
+	public final fun defaultWorkers ()I
+	public final fun isEnabled ()Z
+}
+
+public abstract interface class ee/schimke/composeai/cli/serve/RcJvmWorkerPool$PoolResult {
+}
+
+public final class ee/schimke/composeai/cli/serve/RcJvmWorkerPool$PoolResult$Failed : ee/schimke/composeai/cli/serve/RcJvmWorkerPool$PoolResult {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/RcJvmWorkerPool$PoolResult$Failed;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/RcJvmWorkerPool$PoolResult$Failed;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/RcJvmWorkerPool$PoolResult$Failed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/RcJvmWorkerPool$PoolResult$Ok : ee/schimke/composeai/cli/serve/RcJvmWorkerPool$PoolResult {
+	public fun <init> ([B)V
+	public final fun component1 ()[B
+	public final fun copy ([B)Lee/schimke/composeai/cli/serve/RcJvmWorkerPool$PoolResult$Ok;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/RcJvmWorkerPool$PoolResult$Ok;[BILjava/lang/Object;)Lee/schimke/composeai/cli/serve/RcJvmWorkerPool$PoolResult$Ok;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBytes ()[B
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/RcJvmWorkerPool$PoolResult$Unusable : ee/schimke/composeai/cli/serve/RcJvmWorkerPool$PoolResult {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/RcJvmWorkerPool$PoolResult$Unusable;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/RcJvmWorkerPool$PoolResult$Unusable;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/RcJvmWorkerPool$PoolResult$Unusable;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/RcLaneSource {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lkotlin/jvm/functions/Function1;
+	public final fun component7 ()Lkotlin/jvm/functions/Function1;
+	public final fun component8 ()Lkotlin/jvm/functions/Function1;
+	public final fun component9 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lee/schimke/composeai/cli/serve/RcLaneSource;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/RcLaneSource;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/RcLaneSource;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDiffDir ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getMismatchPct ()Lkotlin/jvm/functions/Function1;
+	public final fun getMismatchPx ()Lkotlin/jvm/functions/Function1;
+	public final fun getNote ()Lkotlin/jvm/functions/Function1;
+	public final fun getRenderDir ()Ljava/lang/String;
+	public final fun getRendered ()Lkotlin/jvm/functions/Function1;
+	public final fun getShort ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/RcPlayerBackend : java/lang/Enum {
+	public static final field CMP_ANDROID Lee/schimke/composeai/cli/serve/RcPlayerBackend;
+	public static final field CMP_JVM Lee/schimke/composeai/cli/serve/RcPlayerBackend;
+	public static final field CMP_WASM Lee/schimke/composeai/cli/serve/RcPlayerBackend;
+	public static final field Companion Lee/schimke/composeai/cli/serve/RcPlayerBackend$Companion;
+	public static final field JAVA Lee/schimke/composeai/cli/serve/RcPlayerBackend;
+	public static final field JS Lee/schimke/composeai/cli/serve/RcPlayerBackend;
+	public final fun getClientSide ()Z
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getPlayerKind ()Lee/schimke/composeai/daemon/protocol/RemoteComposePlayerKind;
+	public final fun getRcCompareLane ()Ljava/lang/String;
+	public final fun getWire ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/RcPlayerBackend;
+	public static fun values ()[Lee/schimke/composeai/cli/serve/RcPlayerBackend;
+}
+
+public final class ee/schimke/composeai/cli/serve/RcPlayerBackend$Companion {
+	public final fun fromWire (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/RcPlayerBackend;
+	public final fun getUNIVERSE ()Ljava/util/List;
+	public final fun serverSideFromParam (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/RcPlayerBackend;
+}
+
+public final class ee/schimke/composeai/cli/serve/RcSummary {
+	public static final field Companion Lee/schimke/composeai/cli/serve/RcSummary$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Double;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/Double;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Double;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/Double;Ljava/util/List;)Lee/schimke/composeai/cli/serve/RcSummary;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/RcSummary;Ljava/lang/Double;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/RcSummary;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRows ()Ljava/util/List;
+	public final fun getThreshold ()Ljava/lang/Double;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/RcSummary$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/RcSummary$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/RcSummary;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/RcSummary;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/RcSummary$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/RcSummaryRow {
+	public static final field Companion Lee/schimke/composeai/cli/serve/RcSummaryRow$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;ZLjava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;ZLjava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/Double;
+	public final fun component11 ()Ljava/lang/Long;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/Boolean;
+	public final fun component14 ()Ljava/lang/Double;
+	public final fun component15 ()Ljava/lang/Long;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Ljava/lang/Boolean;
+	public final fun component18 ()Ljava/lang/Double;
+	public final fun component19 ()Ljava/lang/Long;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component20 ()Ljava/lang/String;
+	public final fun component21 ()Ljava/lang/Boolean;
+	public final fun component22 ()Ljava/lang/Double;
+	public final fun component23 ()Ljava/lang/Long;
+	public final fun component24 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Z
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/lang/Double;
+	public final fun component7 ()Ljava/lang/Long;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;ZLjava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/RcSummaryRow;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/RcSummaryRow;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;ZLjava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/RcSummaryRow;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAndroidxEmbeddedMismatchPct ()Ljava/lang/Double;
+	public final fun getAndroidxEmbeddedMismatchPx ()Ljava/lang/Long;
+	public final fun getAndroidxEmbeddedNote ()Ljava/lang/String;
+	public final fun getAndroidxEmbeddedRendered ()Ljava/lang/Boolean;
+	public final fun getCmpWasmMismatchPct ()Ljava/lang/Double;
+	public final fun getCmpWasmMismatchPx ()Ljava/lang/Long;
+	public final fun getCmpWasmNote ()Ljava/lang/String;
+	public final fun getCmpWasmRendered ()Ljava/lang/Boolean;
+	public final fun getEmbeddedJvmMismatchPct ()Ljava/lang/Double;
+	public final fun getEmbeddedJvmMismatchPx ()Ljava/lang/Long;
+	public final fun getEmbeddedJvmNote ()Ljava/lang/String;
+	public final fun getEmbeddedJvmRendered ()Ljava/lang/Boolean;
+	public final fun getEmbeddedMismatchPct ()Ljava/lang/Double;
+	public final fun getEmbeddedMismatchPx ()Ljava/lang/Long;
+	public final fun getEmbeddedNote ()Ljava/lang/String;
+	public final fun getEmbeddedRendered ()Ljava/lang/Boolean;
+	public final fun getHeight ()Ljava/lang/Integer;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getMismatchPct ()Ljava/lang/Double;
+	public final fun getMismatchPx ()Ljava/lang/Long;
+	public final fun getNote ()Ljava/lang/String;
+	public final fun getReferenceBlank ()Z
+	public final fun getRendered ()Ljava/lang/Boolean;
+	public final fun getWidth ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/RcSummaryRow$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/RcSummaryRow$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/RcSummaryRow;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/RcSummaryRow;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/RcSummaryRow$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/RenderBreakerSnapshot {
+	public static final field Companion Lee/schimke/composeai/cli/serve/RenderBreakerSnapshot$Companion;
+	public fun <init> (ZZLjava/lang/String;Ljava/lang/Long;Ljava/lang/Double;IJ)V
+	public synthetic fun <init> (ZZLjava/lang/String;Ljava/lang/Long;Ljava/lang/Double;IJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Z
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Long;
+	public final fun component5 ()Ljava/lang/Double;
+	public final fun component6 ()I
+	public final fun component7 ()J
+	public final fun copy (ZZLjava/lang/String;Ljava/lang/Long;Ljava/lang/Double;IJ)Lee/schimke/composeai/cli/serve/RenderBreakerSnapshot;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/RenderBreakerSnapshot;ZZLjava/lang/String;Ljava/lang/Long;Ljava/lang/Double;IJILjava/lang/Object;)Lee/schimke/composeai/cli/serve/RenderBreakerSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFailureRate ()Ljava/lang/Double;
+	public final fun getFatal ()Z
+	public final fun getOpen ()Z
+	public final fun getOpenedAtEpochMillis ()Ljava/lang/Long;
+	public final fun getReason ()Ljava/lang/String;
+	public final fun getSampleCount ()I
+	public final fun getShortCircuitedRenders ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/RenderBreakerSnapshot$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/RenderBreakerSnapshot$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/RenderBreakerSnapshot;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/RenderBreakerSnapshot;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/RenderBreakerSnapshot$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/RenderCircuitBreaker {
+	public static final field Companion Lee/schimke/composeai/cli/serve/RenderCircuitBreaker$Companion;
+	public static final field FAILURE_RATE_THRESHOLD D
+	public static final field MIN_SAMPLES I
+	public static final field PROBE_COOLDOWN_MILLIS J
+	public static final field WINDOW_SIZE I
+	public fun <init> ()V
+	public fun <init> (IDIJLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (IDIJLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun blockedReason ()Ljava/lang/String;
+	public final fun peekReason ()Ljava/lang/String;
+	public final fun recordFailure (Ljava/lang/String;)V
+	public final fun recordOk ()V
+	public final fun snapshot ()Lee/schimke/composeai/cli/serve/RenderBreakerSnapshot;
+}
+
+public final class ee/schimke/composeai/cli/serve/RenderCircuitBreaker$Companion {
+}
+
+public final class ee/schimke/composeai/cli/serve/RenderFailureClassifier {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/RenderFailureClassifier;
+	public final fun fatalMarker (Ljava/lang/String;)Ljava/lang/String;
+	public final fun isFatal (Ljava/lang/String;)Z
+}
+
+public final class ee/schimke/composeai/cli/serve/RenderFailureFrame {
+	public static final field Companion Lee/schimke/composeai/cli/serve/RenderFailureFrame$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;ILjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;ILjava/lang/String;)Lee/schimke/composeai/cli/serve/RenderFailureFrame;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/RenderFailureFrame;Ljava/lang/String;ILjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/RenderFailureFrame;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getFunction ()Ljava/lang/String;
+	public final fun getLine ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/RenderFailureFrame$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/RenderFailureFrame$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/RenderFailureFrame;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/RenderFailureFrame;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/RenderFailureFrame$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/RenderFailureSample {
+	public static final field Companion Lee/schimke/composeai/cli/serve/RenderFailureSample$Companion;
+	public fun <init> (JJZLjava/lang/String;)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun component3 ()Z
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (JJZLjava/lang/String;)Lee/schimke/composeai/cli/serve/RenderFailureSample;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/RenderFailureSample;JJZLjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/RenderFailureSample;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAtEpochMillis ()J
+	public final fun getDurationMs ()J
+	public final fun getReason ()Ljava/lang/String;
+	public final fun getTimedOut ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/RenderFailureSample$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/RenderFailureSample$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/RenderFailureSample;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/RenderFailureSample;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/RenderFailureSample$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class ee/schimke/composeai/cli/serve/RenderOutcome {
+}
+
+public final class ee/schimke/composeai/cli/serve/RenderOutcome$Busy : ee/schimke/composeai/cli/serve/RenderOutcome {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/RenderOutcome$Busy;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/RenderOutcome$Failed : ee/schimke/composeai/cli/serve/RenderOutcome {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/RenderOutcome$Failed;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/RenderOutcome$Failed;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/RenderOutcome$Failed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/RenderOutcome$Generation : java/lang/Enum {
+	public static final field BAKED Lee/schimke/composeai/cli/serve/RenderOutcome$Generation;
+	public static final field CATALOG_CACHE Lee/schimke/composeai/cli/serve/RenderOutcome$Generation;
+	public static final field DAEMON Lee/schimke/composeai/cli/serve/RenderOutcome$Generation;
+	public static final field DAEMON_CACHE Lee/schimke/composeai/cli/serve/RenderOutcome$Generation;
+	public static final field RC_PUBLISHED Lee/schimke/composeai/cli/serve/RenderOutcome$Generation;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getWire ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/RenderOutcome$Generation;
+	public static fun values ()[Lee/schimke/composeai/cli/serve/RenderOutcome$Generation;
+}
+
+public final class ee/schimke/composeai/cli/serve/RenderOutcome$NotFound : ee/schimke/composeai/cli/serve/RenderOutcome {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/RenderOutcome$NotFound;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/RenderOutcome$Ok : ee/schimke/composeai/cli/serve/RenderOutcome {
+	public fun <init> ([BLee/schimke/composeai/cli/serve/RenderOutcome$Generation;)V
+	public synthetic fun <init> ([BLee/schimke/composeai/cli/serve/RenderOutcome$Generation;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()[B
+	public final fun component2 ()Lee/schimke/composeai/cli/serve/RenderOutcome$Generation;
+	public final fun copy ([BLee/schimke/composeai/cli/serve/RenderOutcome$Generation;)Lee/schimke/composeai/cli/serve/RenderOutcome$Ok;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/RenderOutcome$Ok;[BLee/schimke/composeai/cli/serve/RenderOutcome$Generation;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/RenderOutcome$Ok;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGeneration ()Lee/schimke/composeai/cli/serve/RenderOutcome$Generation;
+	public final fun getPng ()[B
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/RenderPerfSnapshot {
+	public static final field Companion Lee/schimke/composeai/cli/serve/RenderPerfSnapshot$Companion;
+	public fun <init> (JJJJJJJJLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;IZLjava/lang/String;Ljava/lang/Long;Ljava/util/List;Lee/schimke/composeai/cli/serve/RenderBreakerSnapshot;)V
+	public synthetic fun <init> (JJJJJJJJLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;IZLjava/lang/String;Ljava/lang/Long;Ljava/util/List;Lee/schimke/composeai/cli/serve/RenderBreakerSnapshot;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component10 ()Ljava/lang/Long;
+	public final fun component11 ()Ljava/lang/Long;
+	public final fun component12 ()Ljava/lang/Long;
+	public final fun component13 ()Ljava/lang/Long;
+	public final fun component14 ()Ljava/lang/Long;
+	public final fun component15 ()Ljava/lang/Long;
+	public final fun component16 ()Ljava/lang/Long;
+	public final fun component17 ()I
+	public final fun component18 ()Z
+	public final fun component19 ()Ljava/lang/String;
+	public final fun component2 ()J
+	public final fun component20 ()Ljava/lang/Long;
+	public final fun component21 ()Ljava/util/List;
+	public final fun component22 ()Lee/schimke/composeai/cli/serve/RenderBreakerSnapshot;
+	public final fun component3 ()J
+	public final fun component4 ()J
+	public final fun component5 ()J
+	public final fun component6 ()J
+	public final fun component7 ()J
+	public final fun component8 ()J
+	public final fun component9 ()Ljava/lang/Long;
+	public final fun copy (JJJJJJJJLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;IZLjava/lang/String;Ljava/lang/Long;Ljava/util/List;Lee/schimke/composeai/cli/serve/RenderBreakerSnapshot;)Lee/schimke/composeai/cli/serve/RenderPerfSnapshot;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/RenderPerfSnapshot;JJJJJJJJLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;IZLjava/lang/String;Ljava/lang/Long;Ljava/util/List;Lee/schimke/composeai/cli/serve/RenderBreakerSnapshot;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/RenderPerfSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAvgMs ()Ljava/lang/Long;
+	public final fun getBreaker ()Lee/schimke/composeai/cli/serve/RenderBreakerSnapshot;
+	public final fun getBusy ()J
+	public final fun getCacheHits ()J
+	public final fun getColdMaxMs ()Ljava/lang/Long;
+	public final fun getColdRenders ()J
+	public final fun getFailed ()J
+	public final fun getFirstRenderMs ()Ljava/lang/Long;
+	public final fun getLastFailureAtEpochMillis ()Ljava/lang/Long;
+	public final fun getLastFailureReason ()Ljava/lang/String;
+	public final fun getLastMs ()Ljava/lang/Long;
+	public final fun getLastRenderFailed ()Z
+	public final fun getMaxMs ()Ljava/lang/Long;
+	public final fun getMinMs ()Ljava/lang/Long;
+	public final fun getOk ()J
+	public final fun getP50Ms ()Ljava/lang/Long;
+	public final fun getP95Ms ()Ljava/lang/Long;
+	public final fun getRecentFailures ()Ljava/util/List;
+	public final fun getRenders ()J
+	public final fun getShortCircuited ()J
+	public final fun getTimedOut ()J
+	public final fun getWindowSize ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/RenderPerfSnapshot$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/RenderPerfSnapshot$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/RenderPerfSnapshot;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/RenderPerfSnapshot;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/RenderPerfSnapshot$Companion {
+	public final fun aggregate (Ljava/util/List;)Lee/schimke/composeai/cli/serve/RenderPerfSnapshot;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/RenderPerfStats {
+	public static final field Companion Lee/schimke/composeai/cli/serve/RenderPerfStats$Companion;
+	public static final field FAILURE_WINDOW_SIZE I
+	public static final field MAX_FAILURE_REASON_LENGTH I
+	public static final field WINDOW_SIZE I
+	public fun <init> ()V
+	public final fun recordBusy ()V
+	public final fun recordCacheHit ()V
+	public final fun recordFailed (JZLjava/lang/String;)V
+	public static synthetic fun recordFailed$default (Lee/schimke/composeai/cli/serve/RenderPerfStats;JZLjava/lang/String;ILjava/lang/Object;)V
+	public final fun recordOk (JZ)V
+	public final fun recordShortCircuit ()V
+	public final fun snapshot ()Lee/schimke/composeai/cli/serve/RenderPerfSnapshot;
+}
+
+public final class ee/schimke/composeai/cli/serve/RenderPerfStats$Companion {
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeAnnotationStore {
+	public static final field Companion Lee/schimke/composeai/cli/serve/ServeAnnotationStore$Companion;
+	public static final field DIRECTORY Ljava/lang/String;
+	public static final field INDEX_FILE Ljava/lang/String;
+	public final fun forPreview (Ljava/lang/String;)Ljava/util/List;
+	public final fun forReference (Ljava/lang/String;)Ljava/util/List;
+	public final fun isEmpty ()Z
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeAnnotationStore$Companion {
+	public final fun getEMPTY ()Lee/schimke/composeai/cli/serve/ServeAnnotationStore;
+	public final fun load (Ljava/io/File;Lokio/FileSystem;)Lee/schimke/composeai/cli/serve/ServeAnnotationStore;
+	public final fun load (Lokio/Path;Lokio/FileSystem;)Lee/schimke/composeai/cli/serve/ServeAnnotationStore;
+	public static synthetic fun load$default (Lee/schimke/composeai/cli/serve/ServeAnnotationStore$Companion;Ljava/io/File;Lokio/FileSystem;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServeAnnotationStore;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeAnnotationsKt {
+	public static final fun encodeAnnotationPayload (Lee/schimke/composeai/cli/serve/AnnotationPayload;)Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeAnnotationsPayload {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ServeAnnotationsPayload;
+	public final fun encode (Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)[B
+	public final fun encodeTags (Ljava/lang/String;Ljava/util/Map;)[B
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeBackgroundWork {
+	public static final field CONSERVATIVE_MAX_CONCURRENT_RENDERS I
+	public static final field Companion Lee/schimke/composeai/cli/serve/ServeBackgroundWork$Companion;
+	public static final field DEFAULT_MAX_CONCURRENT_OPTIMIZERS I
+	public static final field HOST_COORDINATION_RETRY_MILLIS J
+	public static final field IDLE_BLOCKED_BY_CATALOG_LOAD Ljava/lang/String;
+	public static final field IDLE_BLOCKED_BY_SESSION_LEASE Ljava/lang/String;
+	public static final field MAX_DERIVED_CONCURRENT_RENDERS I
+	public static final field MAX_PAUSE_REASON_CHARS I
+	public static final field PLUS_ONE_CHALLENGER I
+	public fun <init> ()V
+	public fun <init> (ILkotlin/jvm/functions/Function0;ILee/schimke/composeai/cli/serve/OptimizerHostCoordinator;Lee/schimke/composeai/cli/serve/OptimizerPressureGate;)V
+	public synthetic fun <init> (ILkotlin/jvm/functions/Function0;ILee/schimke/composeai/cli/serve/OptimizerHostCoordinator;Lee/schimke/composeai/cli/serve/OptimizerPressureGate;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun expectInitialCatalogLoad ()V
+	public final fun getCatalogsLoading ()Z
+	public final fun idleClock (Lkotlin/jvm/functions/Function0;)Lkotlin/jvm/functions/Function0;
+	public final fun initialCatalogLoadFinished ()V
+	public final fun optimizerAdmissionSnapshot ()Lee/schimke/composeai/cli/serve/ThemeOptimizerAdmissionSnapshot;
+	public final fun optimizerResumeSlots ()I
+	public final fun optimizersPaused ()Z
+	public final fun pauseOptimizers (JLjava/lang/String;)J
+	public final fun recordOptimizerHostResumed ()V
+	public final fun recordOptimizerHostSuspended ()V
+	public final fun resumeOptimizers ()V
+	public final fun whileLoadingCatalog (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public final fun withOptimizerSlot (Ljava/lang/String;JLkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public final fun withRenderPermit (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeBackgroundWork$Companion {
+	public final fun renderLaneFor (Lee/schimke/composeai/cli/serve/LiveSeatLimiter;)I
+	public final fun themeOptimizationIdleMillisDefault ()J
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeBakedTheme {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ServeBakedTheme;
+	public final fun resolve (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lee/schimke/composeai/daemon/protocol/UiMode;
+	public static synthetic fun resolve$default (Lee/schimke/composeai/cli/serve/ServeBakedTheme;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/UiMode;
+	public final fun token (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/UiMode;
+	public final fun twinIn (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/UiMode;Lkotlin/jvm/functions/Function1;)Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeBroadcastHub {
+	public fun <init> (Lee/schimke/composeai/cli/serve/StreamOpener;)V
+	public final fun activeStreamCount ()I
+	public final fun subscribe (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;Lee/schimke/composeai/daemon/protocol/StreamCodec;Ljava/lang/Integer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lee/schimke/composeai/cli/serve/StreamHandle;
+	public static synthetic fun subscribe$default (Lee/schimke/composeai/cli/serve/ServeBroadcastHub;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;Lee/schimke/composeai/daemon/protocol/StreamCodec;Ljava/lang/Integer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/StreamHandle;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeBundleDaemon {
+	public static final field ANDROID_LIVE_SEAT_WEIGHT I
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ServeBundleDaemon;
+	public final fun bundleDaemonClasspaths (Ljava/io/File;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Z)Lee/schimke/composeai/cli/serve/ServeBundleDaemon$BundleDaemonClasspaths;
+	public final fun extractKnobSidecars ([BLjava/io/File;Lokio/FileSystem;)V
+	public final fun jarPrecedesDaemonSidecar (Ljava/io/File;)Z
+	public final fun liveSeatWeightForDescriptor (Ljava/io/File;)I
+	public final fun materialize (Ljava/io/File;Ljava/io/File;Ljava/lang/String;ZLjava/util/List;Ljava/util/List;Lokio/FileSystem;Lkotlin/jvm/functions/Function1;)Lee/schimke/composeai/cli/serve/ServeSessionState;
+	public static synthetic fun materialize$default (Lee/schimke/composeai/cli/serve/ServeBundleDaemon;Ljava/io/File;Ljava/io/File;Ljava/lang/String;ZLjava/util/List;Ljava/util/List;Lokio/FileSystem;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServeSessionState;
+	public final fun materializePlaygroundSnippet (Lee/schimke/composeai/cli/serve/PlaygroundTokenStore$PlaygroundSnippet;Lee/schimke/composeai/cli/serve/PlaygroundSandbox;Lokio/FileSystem;Lkotlin/jvm/functions/Function1;)Lee/schimke/composeai/cli/serve/ServeSessionState;
+	public static synthetic fun materializePlaygroundSnippet$default (Lee/schimke/composeai/cli/serve/ServeBundleDaemon;Lee/schimke/composeai/cli/serve/PlaygroundTokenStore$PlaygroundSnippet;Lee/schimke/composeai/cli/serve/PlaygroundSandbox;Lokio/FileSystem;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServeSessionState;
+	public final fun readLaunchDescriptor (Ljava/io/File;)Lee/schimke/composeai/daemon/protocol/DaemonLaunchDescriptor;
+	public final fun readPreviews (Ljava/io/File;Ljava/io/File;Lokio/FileSystem;)Ljava/util/List;
+	public final fun shouldPrecedeDaemonSidecar (Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Maven;)Z
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeBundleDaemon$BundleDaemonClasspaths {
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/ServeBundleDaemon$BundleDaemonClasspaths;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ServeBundleDaemon$BundleDaemonClasspaths;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServeBundleDaemon$BundleDaemonClasspaths;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDaemonClasspath ()Ljava/util/List;
+	public final fun getUserClassPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeComponentParameter {
+	public static final field Companion Lee/schimke/composeai/cli/serve/ServeComponentParameter$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZZ)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Z
+	public final fun component4 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;ZZ)Lee/schimke/composeai/cli/serve/ServeComponentParameter;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ServeComponentParameter;Ljava/lang/String;Ljava/lang/String;ZZILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServeComponentParameter;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComposableSlot ()Z
+	public final fun getHasDefault ()Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/ServeComponentParameter$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ServeComponentParameter$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/ServeComponentParameter;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/ServeComponentParameter;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeComponentParameter$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeDegradation {
+	public static final field CATALOG_BAKED_ONLY Ljava/lang/String;
+	public static final field Companion Lee/schimke/composeai/cli/serve/ServeDegradation$Companion;
+	public static final field DEFERRED_NOT_SERVED Ljava/lang/String;
+	public static final field LIVEBUNDLE_UNAVAILABLE Ljava/lang/String;
+	public static final field RENDER_LANE_BROKEN Ljava/lang/String;
+	public static final field UNVERIFIED_NO_RERENDER Ljava/lang/String;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/ServeDegradation;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ServeDegradation;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServeDegradation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCode ()Ljava/lang/String;
+	public final fun getDetail ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeDegradation$Companion {
+	public final fun catalogBakedOnly ()Lee/schimke/composeai/cli/serve/ServeDegradation;
+	public final fun deferredNotServed (I)Lee/schimke/composeai/cli/serve/ServeDegradation;
+	public final fun liveBundleUnavailable (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/ServeDegradation;
+	public final fun renderLaneBroken (Ljava/lang/String;Z)Lee/schimke/composeai/cli/serve/ServeDegradation;
+	public final fun unverifiedNoRerender ()Lee/schimke/composeai/cli/serve/ServeDegradation;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeDesignAnnotations {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ServeDesignAnnotations;
+	public final fun annotations (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload;Lee/schimke/composeai/data/theme/ThemePayload;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPayload;)Ljava/util/List;
+	public static synthetic fun annotations$default (Lee/schimke/composeai/cli/serve/ServeDesignAnnotations;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload;Lee/schimke/composeai/data/theme/ThemePayload;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPayload;ILjava/lang/Object;)Ljava/util/List;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeDesignPageStore {
+	public static final field Companion Lee/schimke/composeai/cli/serve/ServeDesignPageStore$Companion;
+	public static final field DIRECTORY Ljava/lang/String;
+	public static final field INDEX_FILE Ljava/lang/String;
+	public static final field MAX_NODES_PER_PAGE I
+	public final fun getFileKey ()Ljava/lang/String;
+	public final fun getPages ()Ljava/util/List;
+	public final fun page (Ljava/lang/String;)Lee/schimke/composeai/designpages/DesignPage;
+	public final fun refFor (Lee/schimke/composeai/designpages/PageNode;)Ljava/lang/String;
+	public final fun svg (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeDesignPageStore$Companion {
+	public final fun drawablePages (Lee/schimke/composeai/designpages/DesignPagesManifest;)Ljava/util/List;
+	public final fun empty ()Lee/schimke/composeai/cli/serve/ServeDesignPageStore;
+	public final fun isSafeFileKey (Ljava/lang/String;)Z
+	public final fun load (Ljava/io/File;Lokio/FileSystem;)Lee/schimke/composeai/cli/serve/ServeDesignPageStore;
+	public static synthetic fun load$default (Lee/schimke/composeai/cli/serve/ServeDesignPageStore$Companion;Ljava/io/File;Lokio/FileSystem;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServeDesignPageStore;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeDesignPagesKt {
+	public static final fun getWire (Lee/schimke/composeai/designpages/PageNodeLink;)Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeDesignReferenceStore {
+	public static final field Companion Lee/schimke/composeai/cli/serve/ServeDesignReferenceStore$Companion;
+	public static final field DIRECTORY Ljava/lang/String;
+	public static final field INDEX_FILE Ljava/lang/String;
+	public static final field SCORE_VERSION I
+	public final fun forPreview (Ljava/lang/String;)Ljava/util/List;
+	public final fun getAll ()Ljava/util/List;
+	public final fun raster (Ljava/lang/String;)[B
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeDesignReferenceStore$Companion {
+	public final fun isSafeRelativePath (Ljava/lang/String;)Z
+	public final fun isValid (Lee/schimke/composeai/cli/serve/DesignReference;[B)Z
+	public final fun load (Ljava/io/File;Lokio/FileSystem;)Lee/schimke/composeai/cli/serve/ServeDesignReferenceStore;
+	public static synthetic fun load$default (Lee/schimke/composeai/cli/serve/ServeDesignReferenceStore$Companion;Ljava/io/File;Lokio/FileSystem;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServeDesignReferenceStore;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeDeviceFrame {
+	public static final field Companion Lee/schimke/composeai/cli/serve/ServeDeviceFrame$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Double;Ljava/lang/Double;Z)V
+	public synthetic fun <init> (Ljava/lang/Double;Ljava/lang/Double;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Double;
+	public final fun component2 ()Ljava/lang/Double;
+	public final fun component3 ()Z
+	public final fun copy (Ljava/lang/Double;Ljava/lang/Double;Z)Lee/schimke/composeai/cli/serve/ServeDeviceFrame;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ServeDeviceFrame;Ljava/lang/Double;Ljava/lang/Double;ZILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServeDeviceFrame;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeightDp ()Ljava/lang/Double;
+	public final fun getWidthDp ()Ljava/lang/Double;
+	public fun hashCode ()I
+	public final fun isRound ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/ServeDeviceFrame$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ServeDeviceFrame$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/ServeDeviceFrame;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/ServeDeviceFrame;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeDeviceFrame$Companion {
+	public final fun from (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;)Lee/schimke/composeai/cli/serve/ServeDeviceFrame;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeFigmaSvgKt {
+	public static final fun figmaRasterHrefs (Ljava/lang/String;)Ljava/util/List;
+	public static final fun inlineFigmaRasters (Lokio/FileSystem;Lokio/Path;Ljava/lang/String;I)Ljava/lang/String;
+	public static synthetic fun inlineFigmaRasters$default (Lokio/FileSystem;Lokio/Path;Ljava/lang/String;IILjava/lang/Object;)Ljava/lang/String;
+	public static final fun linkFigmaRasters (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public static final fun webModeSvg (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public abstract interface class ee/schimke/composeai/cli/serve/ServeHost : java/lang/AutoCloseable {
+	public abstract fun activeStreamCount ()I
+	public fun annotationsForPreview (Ljava/lang/String;)Ljava/util/List;
+	public fun annotationsForReference (Ljava/lang/String;)Ljava/util/List;
+	public fun bakedRcPlayer (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/RemoteComposePlayerKind;
+	public fun bakedRcPlayerBackend (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/RcPlayerBackend;
+	public fun bakedRender (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/RenderOutcome$Ok;
+	public fun bakedRenderSize (Ljava/lang/String;)Lkotlin/Pair;
+	public fun bakedTheme (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/UiMode;
+	public fun cachedRender (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/RenderOutcome$Ok;
+	public fun canDownloadExecutableBundle (Ljava/lang/String;)Z
+	public fun canRenderOverridesFor (Ljava/lang/String;)Z
+	public fun catalogRenderCacheSnapshot ()Lee/schimke/composeai/cli/serve/CatalogRenderCacheSnapshot;
+	public fun daemonPoolStats ()Ljava/util/List;
+	public fun designPageSvg (Ljava/lang/String;)Ljava/lang/String;
+	public fun designPages ()Lee/schimke/composeai/cli/serve/ServeDesignPageStore;
+	public fun designReferenceRaster (Ljava/lang/String;)[B
+	public fun designReferencesFor (Ljava/lang/String;)Ljava/util/List;
+	public fun enabledRcPlayersFor (Ljava/lang/String;)Ljava/util/List;
+	public fun executableBundle (Ljava/lang/String;)[B
+	public fun getAnnotationsFollowBakedFrame ()Z
+	public fun getBackgroundWorkActive ()Z
+	public fun getCanApplyOverrides ()Z
+	public fun getCanRenderOverrides ()Z
+	public fun getDaemonProcessCount ()I
+	public fun getDaemonStarted ()Z
+	public fun getDeclaredThemes ()Ljava/util/List;
+	public fun getDegradations ()Ljava/util/List;
+	public fun getGesturesRenderable ()Z
+	public fun getHasA11yOverlay ()Z
+	public fun getHasDesignAnnotations ()Z
+	public fun getHasLiveStream ()Z
+	public fun getHasScrollExport ()Z
+	public fun getHasSvgExport ()Z
+	public abstract fun getLabel ()Ljava/lang/String;
+	public fun getLiveOnlyPreviewIds ()Ljava/util/Set;
+	public abstract fun getPreviews ()Ljava/util/List;
+	public fun getRemoteComposePlayerSelectable ()Z
+	public fun getThemeRenderBurstCapacity ()I
+	public fun hasA11yOverlayFor (Ljava/lang/String;)Z
+	public fun hasDesignAnnotationsFor (Ljava/lang/String;)Z
+	public fun hasPublishedTypographyFor (Ljava/lang/String;)Z
+	public fun hasRemoteComposeDoc (Ljava/lang/String;)Z
+	public fun hasScrollExportFor (Ljava/lang/String;)Z
+	public fun hasSvgExportFor (Ljava/lang/String;)Z
+	public fun keepLiveWarm ()V
+	public fun knownDifferenceArtifact (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/ServeKnownDifferences$Artifact;
+	public fun knownDifferences ()Lee/schimke/composeai/cli/serve/ServeKnownDifferences$Document;
+	public fun motionRead (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/BranchFetch;
+	public fun parityActivity ()Lee/schimke/composeai/cli/serve/ParityActivity;
+	public fun parityFindingsFor (Ljava/lang/String;Ljava/lang/String;)Ljava/util/List;
+	public fun parityIssues ()Lee/schimke/composeai/parityissues/protocol/ParityIssues;
+	public fun publishedRcPlayerRender (Ljava/lang/String;Lee/schimke/composeai/cli/serve/RcPlayerBackend;)[B
+	public fun rcCompare ()Lee/schimke/composeai/cli/serve/RcCompareManifest;
+	public fun rcCompareImage (Ljava/lang/String;)[B
+	public fun rcComparePending ()Z
+	public fun releaseIdleDaemons (J)I
+	public fun remoteComposeDoc (Ljava/lang/String;)[B
+	public fun remoteComposeRenderSpec (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/RcJvmRenderSpec;
+	public abstract fun render (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/RenderOutcome;
+	public fun renderA11y (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/A11yOutcome;
+	public fun renderAnnotations (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;Ljava/util/Set;)Lee/schimke/composeai/cli/serve/AnnotationsOutcome;
+	public static synthetic fun renderAnnotations$default (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;Ljava/util/Set;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/AnnotationsOutcome;
+	public fun renderBreaker ()Lee/schimke/composeai/cli/serve/RenderBreakerSnapshot;
+	public fun renderFailureLatch (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Ljava/lang/String;
+	public fun renderLeased (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/RenderOutcome;
+	public fun renderPerfStats ()Lee/schimke/composeai/cli/serve/RenderPerfSnapshot;
+	public fun renderScrollPng (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/RenderOutcome;
+	public fun renderScrollSvg (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/SvgOutcome;
+	public fun renderSlots (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/SlotsOutcome;
+	public fun renderSvg (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/SvgOutcome;
+	public fun renderSvgForWeb (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/SvgOutcome;
+	public fun replayableThemes ()Ljava/util/List;
+	public fun spatialAsset (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/ServeSpatialAsset;
+	public fun stagedRcPlayers (Ljava/lang/String;)Ljava/util/List;
+	public abstract fun subscribeStream (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;Lee/schimke/composeai/daemon/protocol/StreamCodec;Ljava/lang/Integer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lee/schimke/composeai/cli/serve/StreamHandle;
+	public static synthetic fun subscribeStream$default (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;Lee/schimke/composeai/daemon/protocol/StreamCodec;Ljava/lang/Integer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/StreamHandle;
+	public fun supportsCmpJvm (Ljava/lang/String;)Z
+	public fun tagIndexForPreview (Ljava/lang/String;)Ljava/util/Map;
+	public fun themeOptimizationSnapshot ()Lee/schimke/composeai/cli/serve/ThemeOptimizationSnapshot;
+	public fun themeReplayColors (Ljava/lang/String;)Ljava/util/Map;
+	public fun warmBakedRender (Ljava/lang/String;)V
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeHost$DefaultImpls {
+	public static fun annotationsForPreview (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)Ljava/util/List;
+	public static fun annotationsForReference (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)Ljava/util/List;
+	public static fun bakedRcPlayer (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/RemoteComposePlayerKind;
+	public static fun bakedRcPlayerBackend (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/RcPlayerBackend;
+	public static fun bakedRender (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/RenderOutcome$Ok;
+	public static fun bakedRenderSize (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)Lkotlin/Pair;
+	public static fun bakedTheme (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/UiMode;
+	public static fun cachedRender (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/RenderOutcome$Ok;
+	public static fun canDownloadExecutableBundle (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)Z
+	public static fun canRenderOverridesFor (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)Z
+	public static fun catalogRenderCacheSnapshot (Lee/schimke/composeai/cli/serve/ServeHost;)Lee/schimke/composeai/cli/serve/CatalogRenderCacheSnapshot;
+	public static fun daemonPoolStats (Lee/schimke/composeai/cli/serve/ServeHost;)Ljava/util/List;
+	public static fun designPageSvg (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)Ljava/lang/String;
+	public static fun designPages (Lee/schimke/composeai/cli/serve/ServeHost;)Lee/schimke/composeai/cli/serve/ServeDesignPageStore;
+	public static fun designReferenceRaster (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)[B
+	public static fun designReferencesFor (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)Ljava/util/List;
+	public static fun enabledRcPlayersFor (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)Ljava/util/List;
+	public static fun executableBundle (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)[B
+	public static fun getAnnotationsFollowBakedFrame (Lee/schimke/composeai/cli/serve/ServeHost;)Z
+	public static fun getBackgroundWorkActive (Lee/schimke/composeai/cli/serve/ServeHost;)Z
+	public static fun getCanApplyOverrides (Lee/schimke/composeai/cli/serve/ServeHost;)Z
+	public static fun getCanRenderOverrides (Lee/schimke/composeai/cli/serve/ServeHost;)Z
+	public static fun getDaemonProcessCount (Lee/schimke/composeai/cli/serve/ServeHost;)I
+	public static fun getDaemonStarted (Lee/schimke/composeai/cli/serve/ServeHost;)Z
+	public static fun getDeclaredThemes (Lee/schimke/composeai/cli/serve/ServeHost;)Ljava/util/List;
+	public static fun getDegradations (Lee/schimke/composeai/cli/serve/ServeHost;)Ljava/util/List;
+	public static fun getGesturesRenderable (Lee/schimke/composeai/cli/serve/ServeHost;)Z
+	public static fun getHasA11yOverlay (Lee/schimke/composeai/cli/serve/ServeHost;)Z
+	public static fun getHasDesignAnnotations (Lee/schimke/composeai/cli/serve/ServeHost;)Z
+	public static fun getHasLiveStream (Lee/schimke/composeai/cli/serve/ServeHost;)Z
+	public static fun getHasScrollExport (Lee/schimke/composeai/cli/serve/ServeHost;)Z
+	public static fun getHasSvgExport (Lee/schimke/composeai/cli/serve/ServeHost;)Z
+	public static fun getLiveOnlyPreviewIds (Lee/schimke/composeai/cli/serve/ServeHost;)Ljava/util/Set;
+	public static fun getRemoteComposePlayerSelectable (Lee/schimke/composeai/cli/serve/ServeHost;)Z
+	public static fun getThemeRenderBurstCapacity (Lee/schimke/composeai/cli/serve/ServeHost;)I
+	public static fun hasA11yOverlayFor (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)Z
+	public static fun hasDesignAnnotationsFor (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)Z
+	public static fun hasPublishedTypographyFor (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)Z
+	public static fun hasRemoteComposeDoc (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)Z
+	public static fun hasScrollExportFor (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)Z
+	public static fun hasSvgExportFor (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)Z
+	public static fun keepLiveWarm (Lee/schimke/composeai/cli/serve/ServeHost;)V
+	public static fun knownDifferenceArtifact (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/ServeKnownDifferences$Artifact;
+	public static fun knownDifferences (Lee/schimke/composeai/cli/serve/ServeHost;)Lee/schimke/composeai/cli/serve/ServeKnownDifferences$Document;
+	public static fun motionRead (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/BranchFetch;
+	public static fun parityActivity (Lee/schimke/composeai/cli/serve/ServeHost;)Lee/schimke/composeai/cli/serve/ParityActivity;
+	public static fun parityFindingsFor (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;Ljava/lang/String;)Ljava/util/List;
+	public static fun parityIssues (Lee/schimke/composeai/cli/serve/ServeHost;)Lee/schimke/composeai/parityissues/protocol/ParityIssues;
+	public static fun publishedRcPlayerRender (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;Lee/schimke/composeai/cli/serve/RcPlayerBackend;)[B
+	public static fun rcCompare (Lee/schimke/composeai/cli/serve/ServeHost;)Lee/schimke/composeai/cli/serve/RcCompareManifest;
+	public static fun rcCompareImage (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)[B
+	public static fun rcComparePending (Lee/schimke/composeai/cli/serve/ServeHost;)Z
+	public static fun releaseIdleDaemons (Lee/schimke/composeai/cli/serve/ServeHost;J)I
+	public static fun remoteComposeDoc (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)[B
+	public static fun remoteComposeRenderSpec (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/RcJvmRenderSpec;
+	public static fun renderA11y (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/A11yOutcome;
+	public static fun renderAnnotations (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;Ljava/util/Set;)Lee/schimke/composeai/cli/serve/AnnotationsOutcome;
+	public static synthetic fun renderAnnotations$default (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;Ljava/util/Set;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/AnnotationsOutcome;
+	public static fun renderBreaker (Lee/schimke/composeai/cli/serve/ServeHost;)Lee/schimke/composeai/cli/serve/RenderBreakerSnapshot;
+	public static fun renderFailureLatch (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Ljava/lang/String;
+	public static fun renderLeased (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/RenderOutcome;
+	public static fun renderPerfStats (Lee/schimke/composeai/cli/serve/ServeHost;)Lee/schimke/composeai/cli/serve/RenderPerfSnapshot;
+	public static fun renderScrollPng (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/RenderOutcome;
+	public static fun renderScrollSvg (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/SvgOutcome;
+	public static fun renderSlots (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/SlotsOutcome;
+	public static fun renderSvg (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/SvgOutcome;
+	public static fun renderSvgForWeb (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/SvgOutcome;
+	public static fun replayableThemes (Lee/schimke/composeai/cli/serve/ServeHost;)Ljava/util/List;
+	public static fun spatialAsset (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/ServeSpatialAsset;
+	public static fun stagedRcPlayers (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)Ljava/util/List;
+	public static synthetic fun subscribeStream$default (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;Lee/schimke/composeai/daemon/protocol/StreamCodec;Ljava/lang/Integer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/StreamHandle;
+	public static fun supportsCmpJvm (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)Z
+	public static fun tagIndexForPreview (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)Ljava/util/Map;
+	public static fun themeOptimizationSnapshot (Lee/schimke/composeai/cli/serve/ServeHost;)Lee/schimke/composeai/cli/serve/ThemeOptimizationSnapshot;
+	public static fun themeReplayColors (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)Ljava/util/Map;
+	public static fun warmBakedRender (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;)V
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeHostKt {
+	public static final fun motionBytes (Lee/schimke/composeai/cli/serve/ServeHost;Ljava/lang/String;Ljava/lang/String;)[B
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeKnownDifferences {
+	public static final field ARTIFACT_DIRECTORY Ljava/lang/String;
+	public static final field ARTIFACT_INDEX_FILE Ljava/lang/String;
+	public static final field ARTIFACT_INDEX_SCHEMA Ljava/lang/String;
+	public static final field DIRECTORY Ljava/lang/String;
+	public static final field DOCUMENT_FILE Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ServeKnownDifferences;
+	public static final field MAX_ACCEPTANCES I
+	public static final field MAX_ARTIFACT_BYTES I
+	public static final field MAX_DOCUMENT_BYTES I
+	public static final field SCHEMA Ljava/lang/String;
+	public final fun artifact (Ljava/io/File;Ljava/lang/String;Lokio/FileSystem;)Lee/schimke/composeai/cli/serve/ServeKnownDifferences$Artifact;
+	public final fun artifact (Lokio/Path;Ljava/lang/String;Lokio/FileSystem;)Lee/schimke/composeai/cli/serve/ServeKnownDifferences$Artifact;
+	public static synthetic fun artifact$default (Lee/schimke/composeai/cli/serve/ServeKnownDifferences;Ljava/io/File;Ljava/lang/String;Lokio/FileSystem;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServeKnownDifferences$Artifact;
+	public final fun document (Ljava/io/File;Lokio/FileSystem;)Lee/schimke/composeai/cli/serve/ServeKnownDifferences$Document;
+	public final fun document (Lokio/Path;Lokio/FileSystem;)Lee/schimke/composeai/cli/serve/ServeKnownDifferences$Document;
+	public static synthetic fun document$default (Lee/schimke/composeai/cli/serve/ServeKnownDifferences;Ljava/io/File;Lokio/FileSystem;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServeKnownDifferences$Document;
+	public final fun isLookupPath (Ljava/lang/String;)Z
+}
+
+public abstract interface class ee/schimke/composeai/cli/serve/ServeKnownDifferences$Artifact {
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeKnownDifferences$Artifact$Bytes : ee/schimke/composeai/cli/serve/ServeKnownDifferences$Artifact {
+	public fun <init> ([B)V
+	public final fun getBytes ()[B
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeKnownDifferences$Artifact$NotContained : ee/schimke/composeai/cli/serve/ServeKnownDifferences$Artifact {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ServeKnownDifferences$Artifact$NotContained;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeKnownDifferences$Artifact$TooLarge : ee/schimke/composeai/cli/serve/ServeKnownDifferences$Artifact {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ServeKnownDifferences$Artifact$TooLarge;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeKnownDifferences$Artifact$Unreadable : ee/schimke/composeai/cli/serve/ServeKnownDifferences$Artifact {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ServeKnownDifferences$Artifact$Unreadable;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class ee/schimke/composeai/cli/serve/ServeKnownDifferences$Document {
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeKnownDifferences$Document$Text : ee/schimke/composeai/cli/serve/ServeKnownDifferences$Document {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/ServeKnownDifferences$Document$Text;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ServeKnownDifferences$Document$Text;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServeKnownDifferences$Document$Text;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeKnownDifferences$Document$TooLarge : ee/schimke/composeai/cli/serve/ServeKnownDifferences$Document {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ServeKnownDifferences$Document$TooLarge;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeKnownDifferencesKt {
+	public static final fun encodeKnownDifferenceAuditContext (Lee/schimke/composeai/cli/serve/KnownDifferenceAuditContext;)Ljava/lang/String;
+	public static final fun encodeKnownDifferenceContext (Lee/schimke/composeai/cli/serve/KnownDifferenceContext;)Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeMotion {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/ServeMotion;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ServeMotion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServeMotion;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCaption ()Ljava/lang/String;
+	public final fun getExtension ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getKind ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeOverrides {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ServeOverrides;
+	public static final field KNOB_PREFIX Ljava/lang/String;
+	public static final field RC_NAMED_PREFIX Ljava/lang/String;
+	public final fun cacheKey (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Ljava/lang/String;
+	public final fun declaredKnobKinds (Lee/schimke/composeai/cli/serve/ServePreview;)Ljava/util/Map;
+	public final fun getSUPPORTED_KEYS ()Ljava/util/Set;
+	public final fun isOverrideParam (Ljava/lang/String;)Z
+	public final fun knobControlValue (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public final fun knobKind (Ljava/lang/String;)Ljava/lang/String;
+	public final fun parse (Ljava/util/Map;Ljava/util/Map;Ljava/util/Set;)Lee/schimke/composeai/cli/serve/OverrideParse;
+	public static synthetic fun parse$default (Lee/schimke/composeai/cli/serve/ServeOverrides;Ljava/util/Map;Ljava/util/Map;Ljava/util/Set;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/OverrideParse;
+	public final fun rcControlValue (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public final fun rcNamedValueSeeds (Ljava/util/Map;)Ljava/util/Map;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeParameterRows {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ServeParameterRows;
+	public final fun claimedOutputs (Ljava/util/List;)Ljava/util/Set;
+	public final fun rowsFor (Lee/schimke/composeai/previewdata/PreviewInfo;Ljava/io/File;Ljava/util/Set;Lokio/FileSystem;)Ljava/util/List;
+	public final fun rowsFor (Lee/schimke/composeai/previewdata/PreviewInfo;Lokio/Path;Ljava/util/Set;Lokio/FileSystem;)Ljava/util/List;
+	public static synthetic fun rowsFor$default (Lee/schimke/composeai/cli/serve/ServeParameterRows;Lee/schimke/composeai/previewdata/PreviewInfo;Ljava/io/File;Ljava/util/Set;Lokio/FileSystem;ILjava/lang/Object;)Ljava/util/List;
+	public static synthetic fun rowsFor$default (Lee/schimke/composeai/cli/serve/ServeParameterRows;Lee/schimke/composeai/previewdata/PreviewInfo;Lokio/Path;Ljava/util/Set;Lokio/FileSystem;ILjava/lang/Object;)Ljava/util/List;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeParameterRows$Row {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/ServeParameterRows$Row;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ServeParameterRows$Row;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServeParameterRows$Row;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeParityActivityStore {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ServeParityActivityStore;
+	public final fun commitUrl (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public final fun fileUrl (Ljava/lang/String;)Ljava/lang/String;
+	public final fun load (Ljava/io/File;Lokio/FileSystem;)Lee/schimke/composeai/cli/serve/ParityActivity;
+	public static synthetic fun load$default (Lee/schimke/composeai/cli/serve/ServeParityActivityStore;Ljava/io/File;Lokio/FileSystem;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ParityActivity;
+	public final fun nodeUrl (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public final fun sanitize (Lee/schimke/composeai/cli/serve/ParityActivity;)Lee/schimke/composeai/cli/serve/ParityActivity;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeParityFindingStore {
+	public static final field Companion Lee/schimke/composeai/cli/serve/ServeParityFindingStore$Companion;
+	public static final field SIDE_ACTUAL Ljava/lang/String;
+	public static final field SIDE_REFERENCE Ljava/lang/String;
+	public final fun forComparison (Ljava/lang/String;Ljava/lang/String;)Ljava/util/List;
+	public final fun forPreview (Ljava/lang/String;)Ljava/util/List;
+	public final fun isEmpty ()Z
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeParityFindingStore$Companion {
+	public final fun getEMPTY ()Lee/schimke/composeai/cli/serve/ServeParityFindingStore;
+	public final fun load (Ljava/io/File;Lokio/FileSystem;)Lee/schimke/composeai/cli/serve/ServeParityFindingStore;
+	public static synthetic fun load$default (Lee/schimke/composeai/cli/serve/ServeParityFindingStore$Companion;Ljava/io/File;Lokio/FileSystem;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServeParityFindingStore;
+	public final fun sanitizeDocument (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/ParityFindings;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeParityFindingsKt {
+	public static final fun encodeParityAnchorPayload (Lee/schimke/composeai/cli/serve/ParityAnchorPayload;)Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeParityIssuesStore {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ServeParityIssuesStore;
+	public static final field MAX_ISSUES I
+	public final fun load (Ljava/io/File;Lokio/FileSystem;)Lee/schimke/composeai/parityissues/protocol/ParityIssues;
+	public static synthetic fun load$default (Lee/schimke/composeai/cli/serve/ServeParityIssuesStore;Ljava/io/File;Lokio/FileSystem;ILjava/lang/Object;)Lee/schimke/composeai/parityissues/protocol/ParityIssues;
+	public final fun sanitize (Lee/schimke/composeai/parityissues/protocol/ParityIssues;)Lee/schimke/composeai/parityissues/protocol/ParityIssues;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServePreview {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/util/List;Ljava/util/List;ZZZZLjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;IZJLjava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/CatalogRenderFailure;Ljava/util/List;Lee/schimke/composeai/cli/serve/ServeDeviceFrame;ZLjava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/util/List;Ljava/util/List;ZZZZLjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;IZJLjava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/CatalogRenderFailure;Ljava/util/List;Lee/schimke/composeai/cli/serve/ServeDeviceFrame;ZLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Z
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Ljava/lang/Integer;
+	public final fun component18 ()Ljava/lang/String;
+	public final fun component19 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component20 ()Ljava/lang/Integer;
+	public final fun component21 ()I
+	public final fun component22 ()Z
+	public final fun component23 ()J
+	public final fun component24 ()Ljava/lang/String;
+	public final fun component25 ()Ljava/lang/String;
+	public final fun component26 ()Lee/schimke/composeai/cli/serve/CatalogRenderFailure;
+	public final fun component27 ()Ljava/util/List;
+	public final fun component28 ()Lee/schimke/composeai/cli/serve/ServeDeviceFrame;
+	public final fun component29 ()Z
+	public final fun component3 ()Ljava/util/List;
+	public final fun component30 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/Set;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Z
+	public final fun component8 ()Z
+	public final fun component9 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/util/List;Ljava/util/List;ZZZZLjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;IZJLjava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/CatalogRenderFailure;Ljava/util/List;Lee/schimke/composeai/cli/serve/ServeDeviceFrame;ZLjava/util/List;)Lee/schimke/composeai/cli/serve/ServePreview;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ServePreview;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/util/List;Ljava/util/List;ZZZZLjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;IZJLjava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/CatalogRenderFailure;Ljava/util/List;Lee/schimke/composeai/cli/serve/ServeDeviceFrame;ZLjava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServePreview;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBackgroundColor ()J
+	public final fun getBodyLine ()Ljava/lang/Integer;
+	public final fun getCaption ()Ljava/lang/String;
+	public final fun getCatalogOrder ()Ljava/lang/Integer;
+	public final fun getComponentId ()Ljava/lang/String;
+	public final fun getComponentParameters ()Ljava/util/List;
+	public final fun getDataProductKinds ()Ljava/util/Set;
+	public final fun getDeviceFrame ()Lee/schimke/composeai/cli/serve/ServeDeviceFrame;
+	public final fun getFixedTheme ()Z
+	public final fun getGroup ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getModes ()Ljava/util/List;
+	public final fun getMotion ()Ljava/util/List;
+	public final fun getOverrides ()Ljava/util/List;
+	public final fun getProps ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getRemoteComposeKnobs ()Ljava/util/List;
+	public final fun getRenderFailure ()Lee/schimke/composeai/cli/serve/CatalogRenderFailure;
+	public final fun getSecondary ()Z
+	public final fun getSection ()Ljava/lang/String;
+	public final fun getShowBackground ()Z
+	public final fun getSize ()Ljava/lang/String;
+	public final fun getSourceFile ()Ljava/lang/String;
+	public final fun getSourceModule ()Ljava/lang/String;
+	public final fun getSpatial ()Z
+	public final fun getState ()Ljava/lang/String;
+	public final fun getSupportsFocus ()Z
+	public final fun getSupportsGestures ()Z
+	public final fun getTheme ()Ljava/lang/String;
+	public final fun getUiMode ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeRcCompare {
+	public static final field DIRECTORY Ljava/lang/String;
+	public static final field INDEX_FILE Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ServeRcCompare;
+	public static final field SUMMARY_FILE Ljava/lang/String;
+	public final fun encodeClientModel (Lee/schimke/composeai/cli/serve/ServeRcCompare$ClientModel;)Ljava/lang/String;
+	public final fun getLANES ()Ljava/util/List;
+	public final fun getNONE ()Lee/schimke/composeai/cli/serve/RcCompareManifest;
+	public final fun isStagedImageName (Ljava/lang/String;)Z
+	public final fun parseSummary ([B)Lee/schimke/composeai/cli/serve/RcSummary;
+	public final fun plan (Lee/schimke/composeai/cli/serve/RcSummary;Ljava/util/Map;)Lee/schimke/composeai/cli/serve/RcComparePlan;
+	public final fun retainStaged (Lee/schimke/composeai/cli/serve/RcCompareManifest;Ljava/util/Set;)Lee/schimke/composeai/cli/serve/RcCompareManifest;
+	public final fun stagesFor (Ljava/util/Map;)Z
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeRcCompare$ClientModel {
+	public static final field Companion Lee/schimke/composeai/cli/serve/ServeRcCompare$ClientModel$Companion;
+	public fun <init> (DLjava/util/List;Ljava/util/List;)V
+	public final fun component1 ()D
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (DLjava/util/List;Ljava/util/List;)Lee/schimke/composeai/cli/serve/ServeRcCompare$ClientModel;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ServeRcCompare$ClientModel;DLjava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServeRcCompare$ClientModel;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLanes ()Ljava/util/List;
+	public final fun getRows ()Ljava/util/List;
+	public final fun getThreshold ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/ServeRcCompare$ClientModel$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ServeRcCompare$ClientModel$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/ServeRcCompare$ClientModel;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/ServeRcCompare$ClientModel;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeRcCompare$ClientModel$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeRcCompare$ClientRow {
+	public static final field Companion Lee/schimke/composeai/cli/serve/ServeRcCompare$ClientRow$Companion;
+	public fun <init> (Ljava/lang/String;ZLjava/util/Map;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;ZLjava/util/Map;)Lee/schimke/composeai/cli/serve/ServeRcCompare$ClientRow;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ServeRcCompare$ClientRow;Ljava/lang/String;ZLjava/util/Map;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServeRcCompare$ClientRow;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getLanes ()Ljava/util/Map;
+	public final fun getReferenceBlank ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/ServeRcCompare$ClientRow$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ServeRcCompare$ClientRow$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/ServeRcCompare$ClientRow;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/ServeRcCompare$ClientRow;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeRcCompare$ClientRow$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeRcCompareStore {
+	public static final field Companion Lee/schimke/composeai/cli/serve/ServeRcCompareStore$Companion;
+	public final fun image (Ljava/lang/String;)[B
+	public final fun manifest ()Lee/schimke/composeai/cli/serve/RcCompareManifest;
+	public final fun pending ()Z
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeRcCompareStore$Companion {
+	public final fun load (Ljava/io/File;Lokio/FileSystem;)Lee/schimke/composeai/cli/serve/ServeRcCompareStore;
+	public static synthetic fun load$default (Lee/schimke/composeai/cli/serve/ServeRcCompareStore$Companion;Ljava/io/File;Lokio/FileSystem;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServeRcCompareStore;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeRenderHost : ee/schimke/composeai/cli/serve/ServeHost {
+	public static final field Companion Lee/schimke/composeai/cli/serve/ServeRenderHost$Companion;
+	public static final field SCROLL_LONG_KIND Ljava/lang/String;
+	public fun <init> (Lee/schimke/composeai/render/session/RenderSession;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Lokio/FileSystem;Lkotlin/jvm/functions/Function1;JJ)V
+	public synthetic fun <init> (Lee/schimke/composeai/render/session/RenderSession;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Lokio/FileSystem;Lkotlin/jvm/functions/Function1;JJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun activeStreamCount ()I
+	public fun annotationsForPreview (Ljava/lang/String;)Ljava/util/List;
+	public fun annotationsForReference (Ljava/lang/String;)Ljava/util/List;
+	public fun bakedRcPlayer (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/RemoteComposePlayerKind;
+	public fun bakedRcPlayerBackend (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/RcPlayerBackend;
+	public fun bakedRender (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/RenderOutcome$Ok;
+	public fun bakedRenderSize (Ljava/lang/String;)Lkotlin/Pair;
+	public fun bakedTheme (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/UiMode;
+	public fun cachedRender (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/RenderOutcome$Ok;
+	public fun canDownloadExecutableBundle (Ljava/lang/String;)Z
+	public fun canRenderOverridesFor (Ljava/lang/String;)Z
+	public fun catalogRenderCacheSnapshot ()Lee/schimke/composeai/cli/serve/CatalogRenderCacheSnapshot;
+	public fun close ()V
+	public fun daemonPoolStats ()Ljava/util/List;
+	public fun designPageSvg (Ljava/lang/String;)Ljava/lang/String;
+	public fun designPages ()Lee/schimke/composeai/cli/serve/ServeDesignPageStore;
+	public fun designReferenceRaster (Ljava/lang/String;)[B
+	public fun designReferencesFor (Ljava/lang/String;)Ljava/util/List;
+	public fun enabledRcPlayersFor (Ljava/lang/String;)Ljava/util/List;
+	public fun executableBundle (Ljava/lang/String;)[B
+	public fun getAnnotationsFollowBakedFrame ()Z
+	public fun getBackgroundWorkActive ()Z
+	public fun getCanApplyOverrides ()Z
+	public fun getCanRenderOverrides ()Z
+	public fun getDaemonProcessCount ()I
+	public fun getDaemonStarted ()Z
+	public fun getDeclaredThemes ()Ljava/util/List;
+	public fun getDegradations ()Ljava/util/List;
+	public fun getGesturesRenderable ()Z
+	public fun getHasA11yOverlay ()Z
+	public fun getHasDesignAnnotations ()Z
+	public fun getHasLiveStream ()Z
+	public fun getHasScrollExport ()Z
+	public fun getHasSvgExport ()Z
+	public fun getLabel ()Ljava/lang/String;
+	public fun getLiveOnlyPreviewIds ()Ljava/util/Set;
+	public fun getPreviews ()Ljava/util/List;
+	public fun getRemoteComposePlayerSelectable ()Z
+	public fun getThemeRenderBurstCapacity ()I
+	public fun hasA11yOverlayFor (Ljava/lang/String;)Z
+	public fun hasDesignAnnotationsFor (Ljava/lang/String;)Z
+	public fun hasPublishedTypographyFor (Ljava/lang/String;)Z
+	public fun hasRemoteComposeDoc (Ljava/lang/String;)Z
+	public fun hasScrollExportFor (Ljava/lang/String;)Z
+	public fun hasSvgExportFor (Ljava/lang/String;)Z
+	public fun keepLiveWarm ()V
+	public fun knownDifferenceArtifact (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/ServeKnownDifferences$Artifact;
+	public fun knownDifferences ()Lee/schimke/composeai/cli/serve/ServeKnownDifferences$Document;
+	public fun motionRead (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/BranchFetch;
+	public fun parityActivity ()Lee/schimke/composeai/cli/serve/ParityActivity;
+	public fun parityFindingsFor (Ljava/lang/String;Ljava/lang/String;)Ljava/util/List;
+	public fun parityIssues ()Lee/schimke/composeai/parityissues/protocol/ParityIssues;
+	public fun publishedRcPlayerRender (Ljava/lang/String;Lee/schimke/composeai/cli/serve/RcPlayerBackend;)[B
+	public fun rcCompare ()Lee/schimke/composeai/cli/serve/RcCompareManifest;
+	public fun rcCompareImage (Ljava/lang/String;)[B
+	public fun rcComparePending ()Z
+	public fun releaseIdleDaemons (J)I
+	public fun remoteComposeDoc (Ljava/lang/String;)[B
+	public fun remoteComposeRenderSpec (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/RcJvmRenderSpec;
+	public fun render (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/RenderOutcome;
+	public fun renderA11y (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/A11yOutcome;
+	public fun renderAnnotations (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;Ljava/util/Set;)Lee/schimke/composeai/cli/serve/AnnotationsOutcome;
+	public fun renderBreaker ()Lee/schimke/composeai/cli/serve/RenderBreakerSnapshot;
+	public fun renderFailureLatch (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Ljava/lang/String;
+	public fun renderLeased (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/RenderOutcome;
+	public fun renderPerfStats ()Lee/schimke/composeai/cli/serve/RenderPerfSnapshot;
+	public fun renderScrollPng (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/RenderOutcome;
+	public fun renderScrollSvg (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/SvgOutcome;
+	public fun renderSlots (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/SlotsOutcome;
+	public fun renderSvg (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/SvgOutcome;
+	public fun renderSvgForWeb (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/cli/serve/SvgOutcome;
+	public fun replayableThemes ()Ljava/util/List;
+	public fun spatialAsset (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/ServeSpatialAsset;
+	public fun stagedRcPlayers (Ljava/lang/String;)Ljava/util/List;
+	public final fun startStream (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;Lee/schimke/composeai/daemon/protocol/StreamCodec;Ljava/lang/Integer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lee/schimke/composeai/cli/serve/StreamHandle;
+	public static synthetic fun startStream$default (Lee/schimke/composeai/cli/serve/ServeRenderHost;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;Lee/schimke/composeai/daemon/protocol/StreamCodec;Ljava/lang/Integer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/StreamHandle;
+	public fun subscribeStream (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;Lee/schimke/composeai/daemon/protocol/StreamCodec;Ljava/lang/Integer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lee/schimke/composeai/cli/serve/StreamHandle;
+	public fun supportsCmpJvm (Ljava/lang/String;)Z
+	public fun tagIndexForPreview (Ljava/lang/String;)Ljava/util/Map;
+	public fun themeOptimizationSnapshot ()Lee/schimke/composeai/cli/serve/ThemeOptimizationSnapshot;
+	public fun themeReplayColors (Ljava/lang/String;)Ljava/util/Map;
+	public fun warmBakedRender (Ljava/lang/String;)V
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeRenderHost$Companion {
+	public final fun open (Ljava/io/File;Ljava/io/File;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lkotlin/jvm/functions/Function1;Lee/schimke/composeai/render/session/RenderSessionFactory;)Lee/schimke/composeai/cli/serve/ServeRenderHost;
+	public static synthetic fun open$default (Lee/schimke/composeai/cli/serve/ServeRenderHost$Companion;Ljava/io/File;Ljava/io/File;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lkotlin/jvm/functions/Function1;Lee/schimke/composeai/render/session/RenderSessionFactory;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServeRenderHost;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeRenderHostKt {
+	public static final fun declaredThemesFromPreviews (Ljava/util/List;)Ljava/util/List;
+	public static final fun detectedFeaturesOf (Lee/schimke/composeai/previewdata/PreviewInfo;)Lkotlin/Pair;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeSemanticsTags {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ServeSemanticsTags;
+	public static final field RENDER_PIXELS Ljava/lang/String;
+	public final fun index (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload;)Ljava/util/Map;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeSemanticsTags$TagEntry {
+	public static final field Companion Lee/schimke/composeai/cli/serve/ServeSemanticsTags$TagEntry$Companion;
+	public fun <init> (ILee/schimke/composeai/cli/serve/AnnotationBounds;Ljava/lang/String;)V
+	public synthetic fun <init> (ILee/schimke/composeai/cli/serve/AnnotationBounds;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Lee/schimke/composeai/cli/serve/AnnotationBounds;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (ILee/schimke/composeai/cli/serve/AnnotationBounds;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/ServeSemanticsTags$TagEntry;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ServeSemanticsTags$TagEntry;ILee/schimke/composeai/cli/serve/AnnotationBounds;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServeSemanticsTags$TagEntry;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBounds ()Lee/schimke/composeai/cli/serve/AnnotationBounds;
+	public final fun getCount ()I
+	public final fun getSpace ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/ServeSemanticsTags$TagEntry$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ServeSemanticsTags$TagEntry$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/ServeSemanticsTags$TagEntry;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/ServeSemanticsTags$TagEntry;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeSemanticsTags$TagEntry$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeSessionState {
+	public fun <init> (Ljava/io/File;Ljava/io/File;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lee/schimke/composeai/cli/serve/CatalogThemeCache;Lkotlin/jvm/functions/Function0;Lee/schimke/composeai/cli/serve/ServeBackgroundWork;Lkotlin/jvm/functions/Function0;I)V
+	public synthetic fun <init> (Ljava/io/File;Ljava/io/File;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lee/schimke/composeai/cli/serve/CatalogThemeCache;Lkotlin/jvm/functions/Function0;Lee/schimke/composeai/cli/serve/ServeBackgroundWork;Lkotlin/jvm/functions/Function0;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/io/File;
+	public final fun component10 ()Lkotlin/jvm/functions/Function1;
+	public final fun component11 ()Lkotlin/jvm/functions/Function1;
+	public final fun component12 ()Lkotlin/jvm/functions/Function0;
+	public final fun component13 ()Lkotlin/jvm/functions/Function0;
+	public final fun component14 ()Lkotlin/jvm/functions/Function0;
+	public final fun component15 ()Lkotlin/jvm/functions/Function1;
+	public final fun component16 ()Lee/schimke/composeai/cli/serve/CatalogThemeCache;
+	public final fun component17 ()Lkotlin/jvm/functions/Function0;
+	public final fun component18 ()Lee/schimke/composeai/cli/serve/ServeBackgroundWork;
+	public final fun component19 ()Lkotlin/jvm/functions/Function0;
+	public final fun component2 ()Ljava/io/File;
+	public final fun component20 ()I
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/Map;
+	public final fun component8 ()Lkotlin/jvm/functions/Function0;
+	public final fun component9 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/io/File;Ljava/io/File;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lee/schimke/composeai/cli/serve/CatalogThemeCache;Lkotlin/jvm/functions/Function0;Lee/schimke/composeai/cli/serve/ServeBackgroundWork;Lkotlin/jvm/functions/Function0;I)Lee/schimke/composeai/cli/serve/ServeSessionState;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ServeSessionState;Ljava/io/File;Ljava/io/File;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lee/schimke/composeai/cli/serve/CatalogThemeCache;Lkotlin/jvm/functions/Function0;Lee/schimke/composeai/cli/serve/ServeBackgroundWork;Lkotlin/jvm/functions/Function0;IILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServeSessionState;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBackgroundWork ()Lee/schimke/composeai/cli/serve/ServeBackgroundWork;
+	public final fun getBakedFallback ()Lkotlin/jvm/functions/Function0;
+	public final fun getCatalogThemeCache ()Lee/schimke/composeai/cli/serve/CatalogThemeCache;
+	public final fun getDeclaredThemes ()Ljava/util/List;
+	public final fun getDescriptor ()Ljava/io/File;
+	public final fun getExecutableBundleAvailable ()Lkotlin/jvm/functions/Function1;
+	public final fun getExecutableBundleProvider ()Lkotlin/jvm/functions/Function1;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getLiveSeatWeight ()I
+	public final fun getPerPreviewPoolStats ()Lkotlin/jvm/functions/Function0;
+	public final fun getPerPreviewReapIdle ()Lkotlin/jvm/functions/Function1;
+	public final fun getPerPreviewRenderStats ()Lkotlin/jvm/functions/Function0;
+	public final fun getPerPreviewResolve ()Lkotlin/jvm/functions/Function1;
+	public final fun getPerPreviewStreamCount ()Lkotlin/jvm/functions/Function0;
+	public final fun getPreviewAliases ()Ljava/util/Map;
+	public final fun getPreviews ()Ljava/util/List;
+	public final fun getReclaim ()Lkotlin/jvm/functions/Function0;
+	public final fun getServerIdleMillis ()Lkotlin/jvm/functions/Function0;
+	public final fun getWorkspaceName ()Ljava/lang/String;
+	public final fun getWorkspaceRoot ()Ljava/io/File;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeSpatialAsset {
+	public fun <init> ([BLjava/lang/String;)V
+	public final fun component1 ()[B
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy ([BLjava/lang/String;)Lee/schimke/composeai/cli/serve/ServeSpatialAsset;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ServeSpatialAsset;[BLjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServeSpatialAsset;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBytes ()[B
+	public final fun getContentType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeTagIndexStore {
+	public static final field Companion Lee/schimke/composeai/cli/serve/ServeTagIndexStore$Companion;
+	public static final field DIRECTORY Ljava/lang/String;
+	public static final field INDEX_FILE Ljava/lang/String;
+	public static final field MAX_PREVIEWS I
+	public final fun forPreview (Ljava/lang/String;)Ljava/util/Map;
+	public final fun getPreviewIds ()Ljava/util/Set;
+	public final fun isEmpty ()Z
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeTagIndexStore$Companion {
+	public final fun getEMPTY ()Lee/schimke/composeai/cli/serve/ServeTagIndexStore;
+	public final fun load (Ljava/io/File;Lokio/FileSystem;)Lee/schimke/composeai/cli/serve/ServeTagIndexStore;
+	public final fun load (Lokio/Path;Lokio/FileSystem;)Lee/schimke/composeai/cli/serve/ServeTagIndexStore;
+	public static synthetic fun load$default (Lee/schimke/composeai/cli/serve/ServeTagIndexStore$Companion;Ljava/io/File;Lokio/FileSystem;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServeTagIndexStore;
+}
+
+public final class ee/schimke/composeai/cli/serve/ServeTheme {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/ServeTheme;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ServeTheme;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServeTheme;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGroup ()Ljava/lang/String;
+	public final fun getMode ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getProviderFqn ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class ee/schimke/composeai/cli/serve/SlotsOutcome {
+}
+
+public final class ee/schimke/composeai/cli/serve/SlotsOutcome$Failed : ee/schimke/composeai/cli/serve/SlotsOutcome {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/SlotsOutcome$Failed;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/SlotsOutcome$Failed;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/SlotsOutcome$Failed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/SlotsOutcome$NotFound : ee/schimke/composeai/cli/serve/SlotsOutcome {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/SlotsOutcome$NotFound;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/SlotsOutcome$Ok : ee/schimke/composeai/cli/serve/SlotsOutcome {
+	public fun <init> ([B)V
+	public final fun component1 ()[B
+	public final fun copy ([B)Lee/schimke/composeai/cli/serve/SlotsOutcome$Ok;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/SlotsOutcome$Ok;[BILjava/lang/Object;)Lee/schimke/composeai/cli/serve/SlotsOutcome$Ok;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getJson ()[B
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class ee/schimke/composeai/cli/serve/StreamHandle : java/lang/AutoCloseable {
+	public abstract fun input (Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public static synthetic fun input$default (Lee/schimke/composeai/cli/serve/StreamHandle;Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public fun visibility (ZLjava/lang/Integer;)V
+	public static synthetic fun visibility$default (Lee/schimke/composeai/cli/serve/StreamHandle;ZLjava/lang/Integer;ILjava/lang/Object;)V
+}
+
+public final class ee/schimke/composeai/cli/serve/StreamHandle$DefaultImpls {
+	public static synthetic fun input$default (Lee/schimke/composeai/cli/serve/StreamHandle;Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public static fun visibility (Lee/schimke/composeai/cli/serve/StreamHandle;ZLjava/lang/Integer;)V
+	public static synthetic fun visibility$default (Lee/schimke/composeai/cli/serve/StreamHandle;ZLjava/lang/Integer;ILjava/lang/Object;)V
+}
+
+public abstract interface class ee/schimke/composeai/cli/serve/StreamOpener {
+	public abstract fun open (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;Lee/schimke/composeai/daemon/protocol/StreamCodec;Ljava/lang/Integer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lee/schimke/composeai/cli/serve/StreamHandle;
+}
+
+public abstract interface class ee/schimke/composeai/cli/serve/SvgOutcome {
+}
+
+public final class ee/schimke/composeai/cli/serve/SvgOutcome$Failed : ee/schimke/composeai/cli/serve/SvgOutcome {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/cli/serve/SvgOutcome$Failed;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/SvgOutcome$Failed;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/SvgOutcome$Failed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/SvgOutcome$NotFound : ee/schimke/composeai/cli/serve/SvgOutcome {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/SvgOutcome$NotFound;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/SvgOutcome$Ok : ee/schimke/composeai/cli/serve/SvgOutcome {
+	public fun <init> ([BLee/schimke/composeai/cli/serve/RenderOutcome$Generation;)V
+	public synthetic fun <init> ([BLee/schimke/composeai/cli/serve/RenderOutcome$Generation;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()[B
+	public final fun component2 ()Lee/schimke/composeai/cli/serve/RenderOutcome$Generation;
+	public final fun copy ([BLee/schimke/composeai/cli/serve/RenderOutcome$Generation;)Lee/schimke/composeai/cli/serve/SvgOutcome$Ok;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/SvgOutcome$Ok;[BLee/schimke/composeai/cli/serve/RenderOutcome$Generation;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/SvgOutcome$Ok;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGeneration ()Lee/schimke/composeai/cli/serve/RenderOutcome$Generation;
+	public final fun getSvg ()[B
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/SvgSanitizer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/SvgSanitizer;
+	public static final field MAX_BYTES I
+	public final fun sanitize (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/SweepResult {
+	public fun <init> (IJJZ)V
+	public final fun component1 ()I
+	public final fun component2 ()J
+	public final fun component3 ()J
+	public final fun component4 ()Z
+	public final fun copy (IJJZ)Lee/schimke/composeai/cli/serve/SweepResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/SweepResult;IJJZILjava/lang/Object;)Lee/schimke/composeai/cli/serve/SweepResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBytes ()J
+	public final fun getDeletedGenerations ()I
+	public final fun getOverCap ()Z
+	public final fun getReclaimedBytes ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/TagIndexManifest {
+	public static final field Companion Lee/schimke/composeai/cli/serve/TagIndexManifest$Companion;
+	public static final field SCHEMA Ljava/lang/String;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;)Lee/schimke/composeai/cli/serve/TagIndexManifest;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/TagIndexManifest;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/TagIndexManifest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPreviews ()Ljava/util/Map;
+	public final fun getSchema ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/TagIndexManifest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/TagIndexManifest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/TagIndexManifest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/TagIndexManifest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/TagIndexManifest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ThemeCacheGenerationSnapshot {
+	public static final field Companion Lee/schimke/composeai/cli/serve/ThemeCacheGenerationSnapshot$Companion;
+	public fun <init> (Ljava/lang/String;IIJJJ)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()J
+	public final fun component5 ()J
+	public final fun component6 ()J
+	public final fun copy (Ljava/lang/String;IIJJJ)Lee/schimke/composeai/cli/serve/ThemeCacheGenerationSnapshot;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ThemeCacheGenerationSnapshot;Ljava/lang/String;IIJJJILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ThemeCacheGenerationSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAdopted ()I
+	public final fun getEntries ()I
+	public final fun getFingerprint ()Ljava/lang/String;
+	public final fun getHits ()J
+	public final fun getMisses ()J
+	public final fun getWrites ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/ThemeCacheGenerationSnapshot$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ThemeCacheGenerationSnapshot$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/ThemeCacheGenerationSnapshot;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/ThemeCacheGenerationSnapshot;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ThemeCacheGenerationSnapshot$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ThemeCacheStore {
+	public static final field Companion Lee/schimke/composeai/cli/serve/ThemeCacheStore$Companion;
+	public static final field DEFAULT_MAX_BYTES J
+	public static final field DEFAULT_SWEEP_GRACE_MILLIS J
+	public static final field EVICTED_NAME Ljava/lang/String;
+	public static final field MANIFEST_NAME Ljava/lang/String;
+	public static final field MAX_REASON_CHARS I
+	public fun <init> (Ljava/io/File;JJLkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Ljava/io/File;JJLkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun evictAll ()I
+	public final fun open (Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/GenerationInputs;)Lee/schimke/composeai/cli/serve/ThemeCacheStore$Generation;
+	public final fun snapshot ()Lee/schimke/composeai/cli/serve/ThemeCacheStoreSnapshot;
+	public final fun sweep (Ljava/util/Set;Ljava/util/Set;)Lee/schimke/composeai/cli/serve/SweepResult;
+	public static synthetic fun sweep$default (Lee/schimke/composeai/cli/serve/ThemeCacheStore;Ljava/util/Set;Ljava/util/Set;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/SweepResult;
+	public final fun systems ()Ljava/util/Set;
+}
+
+public final class ee/schimke/composeai/cli/serve/ThemeCacheStore$Companion {
+}
+
+public final class ee/schimke/composeai/cli/serve/ThemeCacheStore$Generation {
+	public final fun contains (Ljava/lang/String;)Z
+	public final fun dirtyCount ()I
+	public final fun discard ()Z
+	public final fun discardAdopted ()I
+	public final fun discardDirty ()I
+	public final fun get (Ljava/lang/String;)[B
+	public final fun getFingerprint ()Ljava/lang/String;
+	public final fun getLoadedEntries ()I
+	public final fun isDirty (Ljava/lang/String;)Z
+	public final fun markAllDirty ()I
+	public final fun put (Ljava/lang/String;[BZ)V
+	public static synthetic fun put$default (Lee/schimke/composeai/cli/serve/ThemeCacheStore$Generation;Ljava/lang/String;[BZILjava/lang/Object;)V
+	public final fun stats ()Lee/schimke/composeai/cli/serve/ThemeCacheGenerationSnapshot;
+	public final fun wasAdopted (Ljava/lang/String;)Z
+}
+
+public final class ee/schimke/composeai/cli/serve/ThemeCacheStore$GenerationId {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/ThemeCacheStore$GenerationId;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ThemeCacheStore$GenerationId;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ThemeCacheStore$GenerationId;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFingerprint ()Ljava/lang/String;
+	public final fun getSystem ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/serve/ThemeCacheStoreSnapshot {
+	public static final field Companion Lee/schimke/composeai/cli/serve/ThemeCacheStoreSnapshot$Companion;
+	public fun <init> (Ljava/lang/String;ILjava/util/Map;JJJJJJLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILjava/util/Map;JJJJJJLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()J
+	public final fun component5 ()J
+	public final fun component6 ()J
+	public final fun component7 ()J
+	public final fun component8 ()J
+	public final fun component9 ()J
+	public final fun copy (Ljava/lang/String;ILjava/util/Map;JJJJJJLjava/lang/String;)Lee/schimke/composeai/cli/serve/ThemeCacheStoreSnapshot;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ThemeCacheStoreSnapshot;Ljava/lang/String;ILjava/util/Map;JJJJJJLjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ThemeCacheStoreSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBytes ()J
+	public final fun getGenerations ()I
+	public final fun getGenerationsBySystem ()Ljava/util/Map;
+	public final fun getHits ()J
+	public final fun getLastFailureReason ()Ljava/lang/String;
+	public final fun getMaxBytes ()J
+	public final fun getMisses ()J
+	public final fun getRoot ()Ljava/lang/String;
+	public final fun getWriteFailures ()J
+	public final fun getWrites ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/ThemeCacheStoreSnapshot$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ThemeCacheStoreSnapshot$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/ThemeCacheStoreSnapshot;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/ThemeCacheStoreSnapshot;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ThemeCacheStoreSnapshot$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ThemeOptimizationSnapshot {
+	public static final field Companion Lee/schimke/composeai/cli/serve/ThemeOptimizationSnapshot$Companion;
+	public fun <init> (Ljava/lang/String;IIIIJZLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;Ljava/lang/Long;JJJJJJIIIIII)V
+	public synthetic fun <init> (Ljava/lang/String;IIIIJZLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;Ljava/lang/Long;JJJJJJIIIIIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/Double;
+	public final fun component11 ()Ljava/lang/Long;
+	public final fun component12 ()J
+	public final fun component13 ()J
+	public final fun component14 ()J
+	public final fun component15 ()J
+	public final fun component16 ()J
+	public final fun component17 ()J
+	public final fun component18 ()I
+	public final fun component19 ()I
+	public final fun component2 ()I
+	public final fun component20 ()I
+	public final fun component21 ()I
+	public final fun component22 ()I
+	public final fun component23 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun component6 ()J
+	public final fun component7 ()Z
+	public final fun component8 ()Ljava/lang/Long;
+	public final fun component9 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/String;IIIIJZLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;Ljava/lang/Long;JJJJJJIIIIII)Lee/schimke/composeai/cli/serve/ThemeOptimizationSnapshot;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ThemeOptimizationSnapshot;Ljava/lang/String;IIIIJZLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;Ljava/lang/Long;JJJJJJIIIIIIILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ThemeOptimizationSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBatchMillis ()J
+	public final fun getCached ()I
+	public final fun getCachedBytes ()J
+	public final fun getCompletedAtEpochMillis ()Ljava/lang/Long;
+	public final fun getConverged ()Z
+	public final fun getDirty ()I
+	public final fun getEntriesPerMinute ()Ljava/lang/Double;
+	public final fun getEtaSeconds ()Ljava/lang/Long;
+	public final fun getFailed ()I
+	public final fun getFullyOptimized ()Z
+	public final fun getGateWaitMillis ()J
+	public final fun getLastBatchWidth ()I
+	public final fun getMaxBatchWidth ()I
+	public final fun getPermitWaitMillis ()J
+	public final fun getRemaining ()I
+	public final fun getRenderMillis ()J
+	public final fun getStartedAtEpochMillis ()Ljava/lang/Long;
+	public final fun getState ()Ljava/lang/String;
+	public final fun getTotal ()I
+	public final fun getTurnsForced ()I
+	public final fun getTurnsGranted ()I
+	public final fun getTurnsYielded ()I
+	public final fun getWaitingMillis ()J
+	public final fun getWarmMillis ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/ThemeOptimizationSnapshot$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ThemeOptimizationSnapshot$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/ThemeOptimizationSnapshot;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/ThemeOptimizationSnapshot;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ThemeOptimizationSnapshot$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ThemeOptimizerAdmissionSnapshot {
+	public static final field Companion Lee/schimke/composeai/cli/serve/ThemeOptimizerAdmissionSnapshot$Companion;
+	public fun <init> (IILjava/util/List;ILjava/util/List;JJJJJJZLjava/lang/Long;Ljava/lang/String;Lee/schimke/composeai/cli/serve/OptimizerPressureSnapshot;Ljava/lang/Long;Ljava/lang/String;J)V
+	public synthetic fun <init> (IILjava/util/List;ILjava/util/List;JJJJJJZLjava/lang/Long;Ljava/lang/String;Lee/schimke/composeai/cli/serve/OptimizerPressureSnapshot;Ljava/lang/Long;Ljava/lang/String;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component10 ()J
+	public final fun component11 ()J
+	public final fun component12 ()Z
+	public final fun component13 ()Ljava/lang/Long;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Lee/schimke/composeai/cli/serve/OptimizerPressureSnapshot;
+	public final fun component16 ()Ljava/lang/Long;
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()J
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()I
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()J
+	public final fun component7 ()J
+	public final fun component8 ()J
+	public final fun component9 ()J
+	public final fun copy (IILjava/util/List;ILjava/util/List;JJJJJJZLjava/lang/Long;Ljava/lang/String;Lee/schimke/composeai/cli/serve/OptimizerPressureSnapshot;Ljava/lang/Long;Ljava/lang/String;J)Lee/schimke/composeai/cli/serve/ThemeOptimizerAdmissionSnapshot;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ThemeOptimizerAdmissionSnapshot;IILjava/util/List;ILjava/util/List;JJJJJJZLjava/lang/Long;Ljava/lang/String;Lee/schimke/composeai/cli/serve/OptimizerPressureSnapshot;Ljava/lang/Long;Ljava/lang/String;JILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ThemeOptimizerAdmissionSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAdmissionWaitMillis ()J
+	public final fun getAdmissions ()J
+	public final fun getHostRefusals ()J
+	public final fun getHostResumes ()J
+	public final fun getHostSuspensions ()J
+	public final fun getIdleBlockedBy ()Ljava/lang/String;
+	public final fun getIdleThresholdMillis ()J
+	public final fun getLanes ()I
+	public final fun getPauseReason ()Ljava/lang/String;
+	public final fun getPaused ()Z
+	public final fun getPausedUntilEpochMillis ()Ljava/lang/Long;
+	public final fun getPressure ()Lee/schimke/composeai/cli/serve/OptimizerPressureSnapshot;
+	public final fun getRefusals ()J
+	public final fun getRunning ()I
+	public final fun getRunningSystems ()Ljava/util/List;
+	public final fun getServerIdleMillis ()Ljava/lang/Long;
+	public final fun getWaiting ()I
+	public final fun getWaitingSystems ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/ThemeOptimizerAdmissionSnapshot$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/ThemeOptimizerAdmissionSnapshot$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/ThemeOptimizerAdmissionSnapshot;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/ThemeOptimizerAdmissionSnapshot;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/ThemeOptimizerAdmissionSnapshot$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/UsageSnippetResponse {
+	public static final field Companion Lee/schimke/composeai/cli/serve/UsageSnippetResponse$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Z
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lee/schimke/composeai/cli/serve/UsageSnippetResponse;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/UsageSnippetResponse;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/UsageSnippetResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getApiDocs ()Ljava/util/List;
+	public final fun getBlobUrl ()Ljava/lang/String;
+	public final fun getEntryFunction ()Ljava/lang/String;
+	public final fun getPlaygroundHref ()Ljava/lang/String;
+	public final fun getResidue ()Ljava/util/List;
+	public final fun getScaffoldsDeclared ()Z
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/UsageSnippetResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/UsageSnippetResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/UsageSnippetResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/UsageSnippetResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/UsageSnippetResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/WireTagEntry {
+	public static final field Companion Lee/schimke/composeai/cli/serve/WireTagEntry$Companion;
+	public fun <init> ()V
+	public fun <init> (ILee/schimke/composeai/cli/serve/AnnotationBounds;Ljava/lang/String;)V
+	public synthetic fun <init> (ILee/schimke/composeai/cli/serve/AnnotationBounds;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Lee/schimke/composeai/cli/serve/AnnotationBounds;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (ILee/schimke/composeai/cli/serve/AnnotationBounds;Ljava/lang/String;)Lee/schimke/composeai/cli/serve/WireTagEntry;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/WireTagEntry;ILee/schimke/composeai/cli/serve/AnnotationBounds;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/WireTagEntry;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBounds ()Lee/schimke/composeai/cli/serve/AnnotationBounds;
+	public final fun getCount ()I
+	public final fun getSpace ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/serve/WireTagEntry$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/serve/WireTagEntry$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/serve/WireTagEntry;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/serve/WireTagEntry;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/serve/WireTagEntry$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+

--- a/render-host/build.gradle.kts
+++ b/render-host/build.gradle.kts
@@ -92,6 +92,18 @@ dependencies {
   testFixturesApi(project(":render-session-api"))
 }
 
+kotlin {
+  // Published across a repository boundary: compose-preview-server compiles against these
+  // coordinates on its own release cadence (yschimke/compose-preview-server#289), so every
+  // declaration states its visibility and every public one its return type.
+  explicitApi()
+
+  @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class) abiValidation()
+}
+
+// `checkKotlinAbi` is not wired into `check` by the Kotlin Gradle plugin.
+tasks.named("check") { dependsOn("checkKotlinAbi") }
+
 composeAiMavenPublishing {
   coordinates(
     artifactId = "render-host",

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogImagePaths.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogImagePaths.kt
@@ -13,9 +13,9 @@ package ee.schimke.composeai.cli.serve
  * Shape and a pure function, deliberately. Nothing here reads a file, so both sides of the module
  * boundary can agree on the convention without either owning the other's I/O.
  */
-object CatalogImagePaths {
+public object CatalogImagePaths {
   /** Directory, relative to the catalog root, holding the baked preview PNGs. */
-  const val IMAGES_DIR = "images"
+  public const val IMAGES_DIR: String = "images"
 
   /**
    * The single-path-segment preview id for a catalog image path. The serve routes (`/p/{name}`,
@@ -26,6 +26,6 @@ object CatalogImagePaths {
    * like `button-filled__ideal__default__dark`. The design-parity catalog exporter derives the
    * `livePreview` deep link the same way so the link resolves to this id.
    */
-  fun previewIdFor(imagePath: String): String =
+  public fun previewIdFor(imagePath: String): String =
     imagePath.removePrefix("$IMAGES_DIR/").removeSuffix(".png").replace("/", "__")
 }

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
 
 /** Progress for one catalog generation's server-side theme-cache optimization. */
 @Serializable
-data class ThemeOptimizationSnapshot(
+public data class ThemeOptimizationSnapshot(
   val state: String,
   val total: Int,
   val cached: Int,
@@ -126,7 +126,7 @@ data class ThemeOptimizationSnapshot(
  * the second one costs I/O on every render for nothing.
  */
 @Serializable
-data class CatalogRenderCacheSnapshot(
+public data class CatalogRenderCacheSnapshot(
   val entries: Int,
   val bytes: Long,
   val maxBytes: Long,
@@ -181,7 +181,7 @@ data class CatalogRenderCacheSnapshot(
  * builds a fresh session state and therefore a fresh cache, so entries accumulate for exactly as
  * long as the catalog content they were rendered from remains current.
  */
-class CatalogThemeCache(
+public class CatalogThemeCache(
   maxBytes: Long =
     System.getProperty("composeai.serve.catalogRenderCacheMaxBytes")?.toLongOrNull()
       ?: DEFAULT_MAX_BYTES,
@@ -202,7 +202,7 @@ class CatalogThemeCache(
    */
   private val persistenceOffReason: String? = null,
 ) {
-  val maxBytes: Long = maxBytes.coerceAtLeast(0)
+  public val maxBytes: Long = maxBytes.coerceAtLeast(0)
   private val renderLock = Any()
   // Access-order map: the byte cap evicts the least-recently-read render first.
   private val renders = LinkedHashMap<String, ByteArray>(16, 0.75f, true)
@@ -250,12 +250,12 @@ class CatalogThemeCache(
   private val optimizerProduced = java.util.concurrent.atomic.AtomicInteger(0)
 
   /** The idle gate handed the pass its turn. */
-  fun recordTurnGranted() {
+  public fun recordTurnGranted() {
     turnsGranted.incrementAndGet()
   }
 
   /** Traffic took the turn back. */
-  fun recordTurnYielded() {
+  public fun recordTurnYielded() {
     turnsYielded.incrementAndGet()
   }
 
@@ -263,18 +263,18 @@ class CatalogThemeCache(
    * The ceiling granted a turn the gate would not have. Counted in [recordTurnGranted] too, so
    * `turnsGranted` stays the total and this is the slice of it the box never actually offered.
    */
-  fun recordTurnForced() {
+  public fun recordTurnForced() {
     turnsForced.incrementAndGet()
     turnsGranted.incrementAndGet()
   }
 
   /** Wall-clock the idle gate withheld a turn because the box looked busy. */
-  fun recordGateWait(millis: Long) {
+  public fun recordGateWait(millis: Long) {
     if (millis > 0) gateWaitMillis.addAndGet(millis)
   }
 
   /** Wall-clock spent holding a turn but queued behind other catalogs for a render permit. */
-  fun recordPermitWait(millis: Long) {
+  public fun recordPermitWait(millis: Long) {
     if (millis > 0) permitWaitMillis.addAndGet(millis)
   }
 
@@ -282,14 +282,14 @@ class CatalogThemeCache(
    * One batch completed. [width] is the peak number of daemons that rendered **concurrently**, not
    * the job count — see [ThemeOptimizationSnapshot.lastBatchWidth] for why those differ.
    */
-  fun recordBatch(width: Int, millis: Long) {
+  public fun recordBatch(width: Int, millis: Long) {
     lastBatchWidth.set(width)
     maxBatchWidth.accumulateAndGet(width, ::maxOf)
     if (millis > 0) batchMillis.addAndGet(millis)
   }
 
   /** Entries this batch actually produced — the rate's numerator. */
-  fun recordProduced(count: Int) {
+  public fun recordProduced(count: Int) {
     if (count > 0) optimizerProduced.addAndGet(count)
   }
 
@@ -299,11 +299,11 @@ class CatalogThemeCache(
    * bucket made a cold catalog report a rate it was nowhere near. But it is kept apart from
    * [recordBatch] time because it produces no entries and does not recur per entry.
    */
-  fun recordWarm(millis: Long) {
+  public fun recordWarm(millis: Long) {
     if (millis > 0) warmMillis.addAndGet(millis)
   }
 
-  fun configureTargets(keys: Collection<String>) {
+  public fun configureTargets(keys: Collection<String>) {
     targetKeys += keys
     configurePersistable(keys)
     refreshCompletion()
@@ -323,7 +323,7 @@ class CatalogThemeCache(
    * Kept out of [targetKeys] so `/status` still reports no optimization row for a disabled pass,
    * rather than one parked at "waiting" forever.
    */
-  fun configurePersistable(keys: Collection<String>) {
+  public fun configurePersistable(keys: Collection<String>) {
     persistableKeys += keys
   }
 
@@ -333,7 +333,7 @@ class CatalogThemeCache(
    * The disk read is on the miss path only, so a warm working set costs exactly what it did before
    * persistence existed.
    */
-  fun get(key: String): ByteArray? {
+  public fun get(key: String): ByteArray? {
     synchronized(renderLock) { renders[key] }
       ?.let {
         memoryHits.incrementAndGet()
@@ -396,7 +396,7 @@ class CatalogThemeCache(
    * spec. This is the second queue, worked once the gaps are filled, so the store converges on
    * pixels this renderer actually produced instead of trusting a version boundary forever.
    */
-  fun dirtyTargets(): List<String> {
+  public fun dirtyTargets(): List<String> {
     val store = persistence ?: return emptyList()
     if (store.dirtyCount() == 0) return emptyList()
     // Walked from the TARGETS, not from the directory: the store holds hashed file names and the
@@ -415,7 +415,7 @@ class CatalogThemeCache(
    * queue to work, so a wake buys nothing and costs a resumed host, a possible Android daemon cold
    * start and a live seat.
    */
-  val hasOptimizationTargets: Boolean
+  public val hasOptimizationTargets: Boolean
     get() = targetKeys.isNotEmpty()
 
   /**
@@ -425,7 +425,7 @@ class CatalogThemeCache(
    * fingerprint sees. Deliberately not a delete: the entries keep serving while the background pass
    * replaces them.
    */
-  fun markPersistedDirty(): Int {
+  public fun markPersistedDirty(): Int {
     val store = persistence ?: return 0
     // A pass that was never given targets cannot regenerate anything. With
     // `-Dcomposeai.serve.themeOptimization=false` the startup configures `persistableKeys` and
@@ -446,7 +446,7 @@ class CatalogThemeCache(
    * The memory window is cleared with it. Leaving it would keep serving the very renders just
    * declared wrong, from the tier in front of the one that was emptied.
    */
-  fun dropPersisted(): Boolean {
+  public fun dropPersisted(): Boolean {
     // `true` when there is no disk tier: the memory window below is all this cache has, clearing it
     // is the whole of the drop, and it cannot fail. Reporting false would send the caller into a
     // retry loop against a generation write lock that does not exist — the route turns false into a
@@ -467,10 +467,10 @@ class CatalogThemeCache(
   }
 
   /** Whether [key] is warm in either tier, without paying to read the bytes. */
-  fun contains(key: String): Boolean =
+  public fun contains(key: String): Boolean =
     synchronized(renderLock) { renders.containsKey(key) } || persistence?.contains(key) == true
 
-  fun put(key: String, png: ByteArray) {
+  public fun put(key: String, png: ByteArray) {
     // Disk first, and NOT gated on the memory cap: the disk tier has its own budget and is the
     // authoritative store behind a deliberately smaller memory window, so a render too large for
     // that window must still be persisted rather than silently re-rendered after every restart.
@@ -558,7 +558,7 @@ class CatalogThemeCache(
    *
    * Returns true if the generation is trustworthy (verified, or nothing to verify).
    */
-  fun verifySample(
+  public fun verifySample(
     sampleSize: Int = VERIFY_SAMPLE,
     render: (String) -> ByteArray?,
   ): VerifyOutcome {
@@ -621,7 +621,7 @@ class CatalogThemeCache(
   }
 
   /** What [verifySample] managed to establish. */
-  enum class VerifyOutcome {
+  public enum class VerifyOutcome {
     /** At least one persisted render was re-rendered and matched. */
     VERIFIED,
     /** No disk tier, or nothing adopted from it — there is nothing that could be stale. */
@@ -645,16 +645,16 @@ class CatalogThemeCache(
     MISMATCH_UNDISCARDED;
 
     /** Whether the persisted renders may be trusted from here on. */
-    val settled: Boolean
+    public val settled: Boolean
       get() = this == VERIFIED || this == NOTHING_TO_VERIFY
   }
 
-  fun markRunning(nowMillis: Long) {
+  public fun markRunning(nowMillis: Long) {
     startedAt.compareAndSet(0, nowMillis)
     state.set("running")
   }
 
-  fun markPaused() {
+  public fun markPaused() {
     if (!snapshot().fullyOptimized) state.set("paused")
   }
 
@@ -667,7 +667,7 @@ class CatalogThemeCache(
    * terminal for [failureReason]. Without that distinction, three `Busy` outcomes during a warm
    * would tell the next visitor the preview can never render.
    */
-  fun markFailed(key: String, reason: String? = null) {
+  public fun markFailed(key: String, reason: String? = null) {
     failedKeys += key
     reason?.let { failureReasons[key] = it }
   }
@@ -685,7 +685,7 @@ class CatalogThemeCache(
    * [FAILURE_LATCH] rather than one strike because a first failure can be a cold-start timeout or a
    * daemon restart; a successful [put] clears the count, so only a run of failures latches.
    */
-  fun recordRenderFailure(key: String, reason: String): Boolean {
+  public fun recordRenderFailure(key: String, reason: String): Boolean {
     failureReasons[key] = reason
     val count = failureCounts.merge(key, 1, Int::plus) ?: 1
     if (count < FAILURE_LATCH) return false
@@ -709,7 +709,7 @@ class CatalogThemeCache(
    * how many previews are stuck. A successful [put] clears the count, so a genuinely contended key
    * that eventually renders is never penalised.
    */
-  fun recordBackgroundBusy(key: String): Boolean {
+  public fun recordBackgroundBusy(key: String): Boolean {
     val count = busyCounts.merge(key, 1, Int::plus) ?: 1
     if (count < BUSY_LATCH) return false
     failedKeys += key
@@ -728,9 +728,10 @@ class CatalogThemeCache(
    * contended during the optimization pass would be reported as permanently dead to every later
    * visitor.
    */
-  fun failureReason(key: String): String? = if (key in failedKeys) failureReasons[key] else null
+  public fun failureReason(key: String): String? =
+    if (key in failedKeys) failureReasons[key] else null
 
-  fun markPassFinished(nowMillis: Long) {
+  public fun markPassFinished(nowMillis: Long) {
     if (targetKeys.all(::contains)) {
       completedAt.compareAndSet(0, nowMillis)
       state.set("complete")
@@ -739,7 +740,7 @@ class CatalogThemeCache(
     }
   }
 
-  fun snapshot(): ThemeOptimizationSnapshot {
+  public fun snapshot(): ThemeOptimizationSnapshot {
     // Counted across BOTH tiers. Counting memory alone would report a fully warmed catalog as
     // partially cached the moment the 128 MB window started evicting, which is precisely the
     // condition persistence exists to create.
@@ -810,7 +811,7 @@ class CatalogThemeCache(
     )
   }
 
-  fun renderCacheSnapshot(): CatalogRenderCacheSnapshot {
+  public fun renderCacheSnapshot(): CatalogRenderCacheSnapshot {
     // Read once and derive, for the reason [snapshot] gives: a rate computed from counters read
     // separately can publish a hit rate that does not match the counts printed beside it.
     val memory = memoryHits.get()
@@ -847,8 +848,8 @@ class CatalogThemeCache(
     }
   }
 
-  companion object {
-    const val DEFAULT_MAX_BYTES: Long = 128L * 1024 * 1024
+  public companion object {
+    public const val DEFAULT_MAX_BYTES: Long = 128L * 1024 * 1024
 
     /**
      * Persisted renders re-rendered and compared when a generation is adopted.
@@ -858,12 +859,12 @@ class CatalogThemeCache(
      * question as well as a thousand would, at a cost (a few seconds) that a startup can absorb
      * against the 28 hours of rendering it is protecting.
      */
-    const val VERIFY_SAMPLE: Int = 5
+    public const val VERIFY_SAMPLE: Int = 5
 
     /**
      * Consecutive on-demand render failures before a key is treated as permanently unrenderable.
      */
-    const val FAILURE_LATCH = 3
+    public const val FAILURE_LATCH: Int = 3
 
     /**
      * Consecutive `Busy` outcomes on the BACKGROUND lane before a key is treated as one the
@@ -883,6 +884,6 @@ class CatalogThemeCache(
      * server could never honour, which the grid's three retries then burned before showing "Theme
      * preview unavailable".
      */
-    const val BUSY_LATCH = 12
+    public const val BUSY_LATCH: Int = 12
   }
 }

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/DaemonPoolSnapshot.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/DaemonPoolSnapshot.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 
 /** Resident child-daemon pool occupancy, additive on `/status.json`. */
 @Serializable
-data class DaemonPoolSnapshot(
+public data class DaemonPoolSnapshot(
   val name: String,
   val open: Int,
   val maxOpen: Int,

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/GitWorktrees.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/GitWorktrees.kt
@@ -8,11 +8,11 @@ import kotlin.concurrent.withLock
 /**
  * Runs a `git` subcommand in [workdir]. Injected so [GitWorktrees] is testable without a real repo.
  */
-fun interface GitRunner {
-  fun run(workdir: File, args: List<String>): GitResult
+public fun interface GitRunner {
+  public fun run(workdir: File, args: List<String>): GitResult
 }
 
-data class GitResult(val exitCode: Int, val stdout: String) {
+public data class GitResult(val exitCode: Int, val stdout: String) {
   val ok: Boolean
     get() = exitCode == 0
 }
@@ -27,7 +27,7 @@ data class GitResult(val exitCode: Int, val stdout: String) {
  * built from them (the registry evicts hosts, not checkouts) and are cleaned up on [close] / `git
  * worktree prune`.
  */
-class GitWorktrees(
+public class GitWorktrees(
   private val repoRoot: File,
   private val cacheRoot: File,
   /**
@@ -61,7 +61,7 @@ class GitWorktrees(
    * or `null` when the revision can't be resolved, isn't allowed by policy, or can't be created.
    * Registers a reference on the worktree — balance it with a [remove] (or a terminal [close]).
    */
-  fun prepare(rev: String): File? = lock.withLock {
+  public fun prepare(rev: String): File? = lock.withLock {
     val sha = resolve(rev) ?: return null
     if (!isAllowed(sha)) {
       onLog("serve: revision '$rev' ($sha) is not reachable from an allowed ref; refusing")
@@ -124,7 +124,7 @@ class GitWorktrees(
    * up any residue. A subsequent [prepare] of the same revision re-adds the worktree from the
    * shared object store.
    */
-  fun remove(dir: File) = lock.withLock {
+  public fun remove(dir: File): Unit = lock.withLock {
     val refs = prepared[dir] ?: return@withLock
     if (refs > 1) {
       prepared[dir] = refs - 1
@@ -145,7 +145,7 @@ class GitWorktrees(
   }
 
   /** Default [GitRunner] backed by the `git` CLI. */
-  object RealGitRunner : GitRunner {
+  public object RealGitRunner : GitRunner {
     override fun run(workdir: File, args: List<String>): GitResult {
       return try {
         val process =

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmission.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmission.kt
@@ -10,7 +10,7 @@ import java.util.concurrent.atomic.AtomicReference
 import kotlinx.serialization.Serializable
 
 /** One observation of the host resources background optimization must yield to. */
-data class HostResourceSample(
+public data class HostResourceSample(
   val loadPerCpu: Double?,
   val cpuUtilization: Double?,
   /** The governing headroom: the smaller of [memoryHost] and [memoryCgroup]. */
@@ -35,7 +35,7 @@ data class HostResourceSample(
  * override is a system property set outside the image, so the source cannot answer it either.
  */
 @Serializable
-data class OptimizerPressureThresholds(
+public data class OptimizerPressureThresholds(
   val stopLoadPerCpu: Double = 0.85,
   val resumeLoadPerCpu: Double = 0.60,
   val stopCpuUtilization: Double = 0.85,
@@ -95,7 +95,7 @@ data class OptimizerPressureThresholds(
    */
   val dutyCycleFloorMemoryAvailableFraction: Double = 0.05,
 ) {
-  companion object {
+  public companion object {
     /**
      * Thresholds overridden by `composeai.serve.optimizer*` system properties.
      *
@@ -104,7 +104,7 @@ data class OptimizerPressureThresholds(
      * baseline, so the gate is guaranteed to latch on the first transient dip. That is a property
      * of the host, not of the code, and it needs to be settable without a rebuild.
      */
-    fun fromSystemProperties(): OptimizerPressureThresholds {
+    public fun fromSystemProperties(): OptimizerPressureThresholds {
       val defaults = OptimizerPressureThresholds()
       return OptimizerPressureThresholds(
         // `ratio`, NOT `fraction`. Load average per CPU is not bounded by 1.0 — it is a queue
@@ -186,7 +186,7 @@ private enum class PressureSignal {
 
 /** Host-pressure state published on `/status.json` with the optimizer admission counters. */
 @Serializable
-data class OptimizerPressureSnapshot(
+public data class OptimizerPressureSnapshot(
   val constrained: Boolean,
   val reason: String? = null,
   val loadPerCpu: Double? = null,
@@ -237,7 +237,7 @@ data class OptimizerPressureSnapshot(
  * again. Only a host under [OptimizerPressureThresholds.dutyCycleFloorMemoryAvailableFraction]
  * keeps the latch.
  */
-class OptimizerPressureGate(
+public class OptimizerPressureGate(
   private val sample: () -> HostResourceSample?,
   private val thresholds: OptimizerPressureThresholds = OptimizerPressureThresholds(),
   private val clock: () -> Long = System::currentTimeMillis,
@@ -273,7 +273,7 @@ class OptimizerPressureGate(
   /** What was over a stop threshold on the previous sample — the [newlyTripped] baseline. */
   private var lastTripped = emptySet<PressureSignal>()
 
-  fun snapshot(): OptimizerPressureSnapshot =
+  public fun snapshot(): OptimizerPressureSnapshot =
     synchronized(lock) {
       val now = clock()
       if (now < nextSampleAt) return@synchronized cachedClosingExpiredDutyCycle(now)
@@ -515,13 +515,13 @@ class OptimizerPressureGate(
  * optimizer work in at precisely the moment it needed to stop. The reported fraction is the SMALLER
  * of the two headrooms, so whichever ceiling is nearer is the one that governs.
  */
-class LinuxHostResourceSampler(
+public class LinuxHostResourceSampler(
   private val procRoot: File = File("/proc"),
   private val cgroupRoot: File = File("/sys/fs/cgroup"),
 ) {
   private val previousCpu = AtomicReference<CpuTimes?>()
 
-  fun sample(): HostResourceSample? {
+  public fun sample(): HostResourceSample? {
     if (!procRoot.isDirectory) return null
     val statLines = runCatching { File(procRoot, "stat").readLines() }.getOrNull().orEmpty()
     val cpuCount =
@@ -647,14 +647,14 @@ class LinuxHostResourceSampler(
 }
 
 /** A host-wide optimizer lease. Closing it releases both the catalog and lane locks. */
-fun interface OptimizerHostLease : AutoCloseable
+public fun interface OptimizerHostLease : AutoCloseable
 
 /** Cross-process admission used by every preview replica sharing one coordination directory. */
-fun interface OptimizerHostCoordinator {
-  fun tryAcquire(system: String): OptimizerHostLease?
+public fun interface OptimizerHostCoordinator {
+  public fun tryAcquire(system: String): OptimizerHostLease?
 
-  companion object {
-    val NONE = OptimizerHostCoordinator { OptimizerHostLease {} }
+  public companion object {
+    public val NONE: OptimizerHostCoordinator = OptimizerHostCoordinator { OptimizerHostLease {} }
   }
 }
 
@@ -665,7 +665,7 @@ fun interface OptimizerHostCoordinator {
  * caps all optimizer passes on the physical host, rather than multiplying the configured lane count
  * by the number of replicas. Locks are released by the kernel if a replica exits or is OOM-killed.
  */
-class FileOptimizerHostCoordinator(
+public class FileOptimizerHostCoordinator(
   private val directory: File,
   private val lanes: Int,
 ) : OptimizerHostCoordinator, AutoCloseable {

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiter.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiter.kt
@@ -27,8 +27,8 @@ import java.util.concurrent.atomic.AtomicLong
  * Thread-safe: the backing [Semaphore] is fair-agnostic like the old flat gate, and each [Ticket]
  * releases its permits at most once.
  */
-class LiveSeatLimiter(
-  val totalPermits: Int,
+public class LiveSeatLimiter(
+  public val totalPermits: Int,
   /**
    * Permits carved out of [totalPermits] that **only** [acquireBackground] can draw on — the
    * per-preview lane's guaranteed slice.
@@ -47,7 +47,7 @@ class LiveSeatLimiter(
    * daemon simply does not carry the id) has no fallback that renders, unlike a burst replica which
    * can narrow onto the primary.
    */
-  val perPreviewReserve: Int = DEFAULT_PER_PREVIEW_RESERVE,
+  public val perPreviewReserve: Int = DEFAULT_PER_PREVIEW_RESERVE,
 ) {
   // The reserve is held in its own semaphore rather than subtracted from a single one, so no
   // amount of general-lane demand can consume it. `acquire` never sees it at all.
@@ -68,7 +68,7 @@ class LiveSeatLimiter(
   // and reporting that would state a slice the limiter may not actually hold — on a small box it is
   // clamped to nothing, and an oversized custom value would otherwise be reported as larger than
   // the whole budget. A diagnostic added to make starvation visible must not itself be able to lie.
-  val perPreviewPermits: Int =
+  public val perPreviewPermits: Int =
     if (totalPermits > 0)
       perPreviewReserve.coerceIn(0, (totalPermits - STREAM_RESERVE).coerceAtLeast(0))
     else 0
@@ -81,7 +81,7 @@ class LiveSeatLimiter(
     if (perPreviewPermits > 0) Semaphore(perPreviewPermits) else null
 
   /** True when this limiter imposes no bound (`totalPermits <= 0`). */
-  val unbounded: Boolean
+  public val unbounded: Boolean
     get() = semaphore == null
 
   /**
@@ -94,7 +94,7 @@ class LiveSeatLimiter(
    * coerced down to [totalPermits], so a backend heavier than the whole budget can still run alone
    * rather than being permanently refused.
    */
-  fun acquire(weight: Int, verified: Boolean = true, countRefusal: Boolean = true): Ticket? {
+  public fun acquire(weight: Int, verified: Boolean = true, countRefusal: Boolean = true): Ticket? {
     val sem = semaphore ?: return Ticket(0)
     if (weight <= 0) return Ticket(0)
     // Coerced to the GENERAL lane's capacity, not [totalPermits]: the reserve is not available
@@ -133,7 +133,7 @@ class LiveSeatLimiter(
    * can never over-admit under a race — the worst case is a background holder briefly seeing less
    * headroom than really exists and declining, which is the safe direction.
    */
-  fun acquireBackground(
+  public fun acquireBackground(
     weight: Int,
     reserve: Int = STREAM_RESERVE,
     /**
@@ -173,12 +173,12 @@ class LiveSeatLimiter(
    * [totalPermits]: a box with its slice free but its general lane full is not at capacity, and
    * reporting `0 free / 8` there would restate the very confusion this reserve fixes.
    */
-  fun availablePermits(): Int =
+  public fun availablePermits(): Int =
     semaphore?.let { it.availablePermits() + (perPreviewSemaphore?.availablePermits() ?: 0) }
       ?: Int.MAX_VALUE
 
   /** Permits free in the per-preview slice alone — lets `/status` show the lane isn't starved. */
-  fun perPreviewPermitsAvailable(): Int =
+  public fun perPreviewPermitsAvailable(): Int =
     perPreviewSemaphore?.availablePermits() ?: if (unbounded) Int.MAX_VALUE else 0
 
   /**
@@ -192,7 +192,7 @@ class LiveSeatLimiter(
    * the evidence any change to the budget (or to evicting an idle daemon in favour of an active
    * one) should be argued from.
    */
-  fun refusalCount(): Long = refusals.get()
+  public fun refusalCount(): Long = refusals.get()
 
   /**
    * Refusals for a session id the registry did not have at admission time, monotonic.
@@ -203,15 +203,15 @@ class LiveSeatLimiter(
    * `--revisions` produces on its first request. Read it alongside [refusalCount] rather than
    * instead of it.
    */
-  fun unverifiedRefusalCount(): Long = unverifiedRefusals.get()
+  public fun unverifiedRefusalCount(): Long = unverifiedRefusals.get()
 
-  companion object {
+  public companion object {
     /**
      * Permits [acquireBackground] must leave free for interactive streams. Sized at
      * [ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT] — the most expensive single stream — so one can
      * always start no matter how much render residency has built up.
      */
-    const val STREAM_RESERVE: Int = ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT
+    public const val STREAM_RESERVE: Int = ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT
 
     /**
      * Default [perPreviewReserve]: one desktop daemon's worth (weight 1).
@@ -222,7 +222,7 @@ class LiveSeatLimiter(
      * batch — gives up as little as possible; a second concurrent per-preview daemon still competes
      * for the general pool exactly as before.
      */
-    const val DEFAULT_PER_PREVIEW_RESERVE: Int = 1
+    public const val DEFAULT_PER_PREVIEW_RESERVE: Int = 1
   }
 
   private val refusals = AtomicLong()
@@ -236,7 +236,8 @@ class LiveSeatLimiter(
    * to the general one, and the starvation this class now prevents would reappear after the first
    * eviction.
    */
-  inner class Ticket internal constructor(val permits: Int, private val reserved: Boolean = false) :
+  public inner class Ticket
+  internal constructor(public val permits: Int, private val reserved: Boolean = false) :
     AutoCloseable {
     private val released = AtomicBoolean(false)
 

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundApi.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundApi.kt
@@ -21,7 +21,7 @@ import kotlinx.serialization.Serializable
 
 /** Which renderer + permalink target a snippet compiles for. See PLAYGROUND.md §3. */
 @Serializable
-enum class PlaygroundMode {
+public enum class PlaygroundMode {
   /** Compose Multiplatform, desktop (Skiko) daemon → live streaming session. */
   @SerialName("compose-cmp") CMP,
   /** Jetpack Compose, Robolectric daemon → live streaming session. */
@@ -29,7 +29,7 @@ enum class PlaygroundMode {
   /** Snippet emits a RemoteDocument → `/d/<id>` document permalink, played client-side. */
   @SerialName("remote-compose") REMOTE_COMPOSE;
 
-  companion object {
+  public companion object {
     /**
      * Resolve the request's `confType` to a mode. Accepts our own ids (the [SerialName]s above) and
      * tolerates the stock `kotlin-playground` target ids so an unmodified frontend still lands on a
@@ -37,7 +37,7 @@ enum class PlaygroundMode {
      * [CMP], everything else defaults to [CMP] as well — the one mode a from-source box can always
      * serve. An empty/absent `confType` is [CMP].
      */
-    fun fromConfType(confType: String?): PlaygroundMode =
+    public fun fromConfType(confType: String?): PlaygroundMode =
       when (confType?.trim()?.lowercase()) {
         "compose-android",
         "android" -> ANDROID
@@ -58,7 +58,7 @@ enum class PlaygroundMode {
  * compiler, since Kotlin does not require a file name to match its declarations.
  */
 @Serializable
-data class PlaygroundFile(val name: String, val text: String, val publicId: String = "")
+public data class PlaygroundFile(val name: String, val text: String, val publicId: String = "")
 
 /**
  * A Stage-1 run request. Mirrors the `kotlin-compiler-server` body so a stock frontend fits; [args]
@@ -69,7 +69,7 @@ data class PlaygroundFile(val name: String, val text: String, val publicId: Stri
  * `--playground-bundle` default exactly as before.
  */
 @Serializable
-data class PlaygroundRunRequest(
+public data class PlaygroundRunRequest(
   val args: String = "",
   val files: List<PlaygroundFile> = emptyList(),
   val confType: String = "",
@@ -92,7 +92,7 @@ data class PlaygroundRunRequest(
 
 /** Result of explicitly acquiring the host's one stateful Playground editing lease. */
 @Serializable
-data class PlaygroundEditLeaseResponse(
+public data class PlaygroundEditLeaseResponse(
   val acquired: Boolean,
   val lease: String? = null,
   val expiresAtEpochMs: Long? = null,
@@ -102,11 +102,11 @@ data class PlaygroundEditLeaseResponse(
 )
 
 /** Body for `POST /api/{version}/compiler/edit-lease`. [client] is unique to one browser tab. */
-@Serializable data class PlaygroundEditLeaseAcquireRequest(val client: String = "")
+@Serializable public data class PlaygroundEditLeaseAcquireRequest(val client: String = "")
 
 /** Body for `POST /api/{version}/compiler/edit-lease/release`. */
 @Serializable
-data class PlaygroundEditLeaseReleaseRequest(
+public data class PlaygroundEditLeaseReleaseRequest(
   val lease: String = "",
   /** Empty preserves the original whole-lease release contract for non-browser API callers. */
   val client: String = "",
@@ -121,7 +121,7 @@ data class PlaygroundEditLeaseReleaseRequest(
  * entry instead of offering modes the host would then refuse.
  */
 @Serializable
-data class PlaygroundCatalogInfo(
+public data class PlaygroundCatalogInfo(
   /** The `catalog` value to send back on a run. Empty for the host's pinned default entry. */
   val id: String,
   /** What the selector shows. */
@@ -141,11 +141,13 @@ data class PlaygroundCatalogInfo(
 
 /** `GET /api/{version}/compiler/catalogs`: what the editor's catalog selector may offer. */
 @Serializable
-data class PlaygroundCatalogsResponse(val catalogs: List<PlaygroundCatalogInfo> = emptyList())
+public data class PlaygroundCatalogsResponse(
+  val catalogs: List<PlaygroundCatalogInfo> = emptyList()
+)
 
 /** Severity of a compiler diagnostic, spelled the way the editor's highlight lane expects. */
 @Serializable
-enum class PlaygroundSeverity {
+public enum class PlaygroundSeverity {
   @SerialName("error") ERROR,
   @SerialName("warning") WARNING,
   @SerialName("info") INFO,
@@ -156,7 +158,7 @@ enum class PlaygroundSeverity {
  * `kotlin-playground` renders against); a null position is a file-level diagnostic with no anchor.
  */
 @Serializable
-data class PlaygroundDiagnostic(
+public data class PlaygroundDiagnostic(
   val severity: PlaygroundSeverity,
   val message: String,
   val file: String? = null,
@@ -167,11 +169,11 @@ data class PlaygroundDiagnostic(
 )
 
 /** A CodeMirror position in the stock `errors`-map shape (0-based line + char). */
-@Serializable data class PlaygroundPosition(val line: Int, val ch: Int)
+@Serializable public data class PlaygroundPosition(val line: Int, val ch: Int)
 
 /** A `[start, end)` span in the stock `errors`-map shape. */
 @Serializable
-data class PlaygroundInterval(val start: PlaygroundPosition, val end: PlaygroundPosition)
+public data class PlaygroundInterval(val start: PlaygroundPosition, val end: PlaygroundPosition)
 
 /**
  * One diagnostic in the **stock `kotlin-compiler-server`** `errors`-map shape — the wire form a
@@ -182,7 +184,7 @@ data class PlaygroundInterval(val start: PlaygroundPosition, val end: Playground
  * projects our diagnostics into this shape.
  */
 @Serializable
-data class PlaygroundStockError(
+public data class PlaygroundStockError(
   val interval: PlaygroundInterval,
   val message: String,
   val severity: String,
@@ -214,7 +216,7 @@ data class PlaygroundStockError(
  * richer [diagnostics] instead; both are populated, so neither client is second-class.
  */
 @Serializable
-data class PlaygroundRunResponse(
+public data class PlaygroundRunResponse(
   val diagnostics: List<PlaygroundDiagnostic> = emptyList(),
   val errors: Map<String, List<PlaygroundStockError>> = emptyMap(),
   val text: String = "",
@@ -242,7 +244,7 @@ data class PlaygroundRunResponse(
  * never open the panel — so a page load must not pay for it.
  */
 @Serializable
-data class UsageSnippetResponse(
+public data class UsageSnippetResponse(
   /** The cleaned Kotlin. */
   val text: String,
   /** The declaration the card's render comes from, for the panel's caption. */
@@ -279,7 +281,7 @@ data class UsageSnippetResponse(
  * stays free to carry things the viewer has no use for.
  */
 @Serializable
-data class ApiDocLink(
+public data class ApiDocLink(
   /** The name as the snippet writes it — an `as` alias where the code renamed one. */
   val name: String,
   /** The imported fully-qualified name, shown as the link's tooltip. */

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundPreviews.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundPreviews.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.json.Json
  */
 // Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
 // and the `:server` call sites are in a different module now. Not a widened API by intent.
-object PlaygroundPreviews {
+public object PlaygroundPreviews {
 
   private val json = Json {
     encodeDefaults = true
@@ -25,7 +25,7 @@ object PlaygroundPreviews {
    * `functionName` (the id is `"$className.$functionName"`, per [PlaygroundPreviewDiscoverer]),
    * ordered as the snippet declared them so entry 0 is the one the still frame drew.
    */
-  fun previewManifestJson(snippet: PlaygroundTokenStore.PlaygroundSnippet): String {
+  public fun previewManifestJson(snippet: PlaygroundTokenStore.PlaygroundSnippet): String {
     val manifest =
       PreviewManifest(
         module = snippet.moduleName,

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSandbox.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSandbox.kt
@@ -26,7 +26,7 @@ import kotlin.math.roundToInt
  * `--public` a passing probe is mandatory ([PlaygroundPublicGate]), because a profile's advertised
  * properties are a claim and the probe is the evidence.
  */
-data class PlaygroundSandbox(
+public data class PlaygroundSandbox(
   val profile: Profile,
   /** Heap + cgroup memory ceiling for one snippet JVM. */
   val memoryMb: Int = DEFAULT_MEMORY_MB,
@@ -58,11 +58,11 @@ data class PlaygroundSandbox(
    * containment at all" refusal. They are never a substitute for [PlaygroundSandboxProbe]; a
    * `--public` host must still prove the claim empirically.
    */
-  enum class Profile(
-    val id: String,
-    val declaresEgressBlocked: Boolean,
-    val declaresFilesystemContained: Boolean,
-    val declaresResourceCaps: Boolean,
+  public enum class Profile(
+    public val id: String,
+    public val declaresEgressBlocked: Boolean,
+    public val declaresFilesystemContained: Boolean,
+    public val declaresResourceCaps: Boolean,
   ) {
     /**
      * No jail — the pre-Phase-4 behaviour. Fine for a token-gated dev host; never for `--public`.
@@ -111,7 +111,7 @@ data class PlaygroundSandbox(
   }
 
   /** The host paths one snippet JVM needs: its writable work dir, its read-only inputs, the JDK. */
-  data class Paths(val workDir: File, val readOnly: List<File>, val javaHome: File)
+  public data class Paths(val workDir: File, val readOnly: List<File>, val javaHome: File)
 
   /** True when this sandbox does anything at all — [Profile.NONE] is the only no-op. */
   val isActive: Boolean
@@ -147,14 +147,14 @@ data class PlaygroundSandbox(
    * `--public` host whose probe never ran is refused outright by [PlaygroundPublicGate], so the
    * caller never gets far enough to call this.
    */
-  fun droppingJail(): PlaygroundSandbox = copy(jailDropped = true)
+  public fun droppingJail(): PlaygroundSandbox = copy(jailDropped = true)
 
   /**
    * The argv prefix the snippet JVM launches behind — empty for [Profile.NONE], and empty when
    * [jailDropped]. Paths are bound with the `-try` variants where a host may legitimately lack
    * them, so one missing `/lib64` can't turn a containment profile into a failed spawn.
    */
-  fun command(paths: Paths): List<String> =
+  public fun command(paths: Paths): List<String> =
     if (jailDropped) emptyList()
     else
       when (profile) {
@@ -173,7 +173,7 @@ data class PlaygroundSandbox(
    * thrashing JVM, and a temp dir inside the one writable path. Empty for [Profile.NONE], which
    * keeps the pre-Phase-4 launch byte-identical.
    */
-  fun jvmArgs(workDir: File): List<String> {
+  public fun jvmArgs(workDir: File): List<String> {
     if (!isActive) return emptyList()
     return listOf(
       "-Xmx${heapMb()}m",
@@ -195,7 +195,7 @@ data class PlaygroundSandbox(
    * Inactive sandboxes return [base] unchanged, preserving the pre-sandbox launch byte-for-byte.
    * Relative `maven.repo.local` overrides are made absolute before the jail changes directory.
    */
-  fun robolectricSystemProperties(
+  public fun robolectricSystemProperties(
     base: Map<String, String>,
     mavenRepoLocal: String? = System.getProperty("maven.repo.local"),
     userHome: String? = System.getProperty("user.home"),
@@ -218,7 +218,7 @@ data class PlaygroundSandbox(
   internal fun activeProcessorCount(): Int = ceil(cpus).toInt().coerceAtLeast(1)
 
   /** One-line summary for the startup log — what this host will do to a stranger's snippet. */
-  fun describe(): String =
+  public fun describe(): String =
     if (!isActive) "sandbox=none (playground refused under --public)"
     else
       "sandbox=${profile.id}${if (jailDropped) " (jail dropped — caps only)" else ""} " +
@@ -310,20 +310,20 @@ data class PlaygroundSandbox(
       // systemd 244+).
     )
 
-  companion object {
-    const val DEFAULT_MEMORY_MB = 1536
-    const val DEFAULT_CPUS = 1.0
-    const val DEFAULT_PIDS = 256
+  public companion object {
+    public const val DEFAULT_MEMORY_MB: Int = 1536
+    public const val DEFAULT_CPUS: Double = 1.0
+    public const val DEFAULT_PIDS: Int = 256
 
     /**
      * 15 minutes: comfortably longer than [PlaygroundTokenStore.DEFAULT_TTL_SECONDS] (so an
      * ordinary session ends by its token expiring, not by being shot), short enough that a wedged
      * JVM is reclaimed the same hour.
      */
-    const val DEFAULT_TTL_SECONDS = 900L
+    public const val DEFAULT_TTL_SECONDS: Long = 900L
 
     /** Below this a JVM can't even boot Skiko/Robolectric; refuse to configure a useless heap. */
-    const val MIN_HEAP_MB = 256
+    public const val MIN_HEAP_MB: Int = 256
 
     private const val MIN_MEMORY_MB = 384
 
@@ -348,14 +348,14 @@ data class PlaygroundSandbox(
         "/opt",
       )
 
-    val NONE = PlaygroundSandbox(profile = Profile.NONE)
+    public val NONE: PlaygroundSandbox = PlaygroundSandbox(profile = Profile.NONE)
 
     /**
      * Parse a `--playground-sandbox` value: a profile id (`none`, `unshare`, `bwrap`, `systemd`,
      * `strict`) or `custom:<argv>` where `<argv>` is a whitespace-separated command prefix. Null or
      * blank ⇒ [NONE], the pre-Phase-4 default.
      */
-    fun parseProfile(spec: String?): Result<PlaygroundSandbox> {
+    public fun parseProfile(spec: String?): Result<PlaygroundSandbox> {
       val raw = spec?.trim().orEmpty()
       if (raw.isEmpty()) return Result.success(NONE)
       if (raw.startsWith("custom:")) {
@@ -384,7 +384,7 @@ data class PlaygroundSandbox(
      * Validate the resource knobs, so a typo (`--playground-sandbox-memory-mb 15`) fails at startup
      * rather than as an unexplained daemon that never comes up.
      */
-    fun validate(sandbox: PlaygroundSandbox): Result<PlaygroundSandbox> {
+    public fun validate(sandbox: PlaygroundSandbox): Result<PlaygroundSandbox> {
       if (!sandbox.isActive) return Result.success(sandbox)
       if (sandbox.memoryMb < MIN_MEMORY_MB) {
         return Result.failure(
@@ -460,14 +460,14 @@ data class PlaygroundSandbox(
  * which posture admitted the lane, so an operator cannot mistake "admitted because collaborators
  * only" for "admitted because contained".
  */
-object PlaygroundPublicGate {
+public object PlaygroundPublicGate {
 
-  sealed interface Decision {
+  public sealed interface Decision {
     /** The lane may serve; [detail] is the startup log line. */
-    data class Allow(val detail: String) : Decision
+    public data class Allow(val detail: String) : Decision
 
     /** The lane stays disabled; [reason] is printed and is actionable. */
-    data class Refuse(val reason: String) : Decision
+    public data class Refuse(val reason: String) : Decision
   }
 
   /**
@@ -478,7 +478,7 @@ object PlaygroundPublicGate {
    * routes' `rejectMissingGithubRepoAccess` is a real check rather than a no-op. It admits the lane
    * on a public box without requiring containment — see the class KDoc.
    */
-  fun decide(
+  public fun decide(
     isPublic: Boolean,
     repoAccessGated: Boolean,
     sandbox: PlaygroundSandbox,

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSandboxProbe.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSandboxProbe.kt
@@ -25,15 +25,16 @@ import kotlinx.serialization.json.Json
  * - **process isolated** — the serve host's own pid must not be visible in the child's `/proc`.
  * - **work dir writable** — the containment must not be so total that a real render can't run.
  */
-object PlaygroundSandboxProbe {
+public object PlaygroundSandboxProbe {
 
   /**
    * The single line the in-jail probe prints, so ordinary JVM noise on stdout can't be mistaken.
    */
-  const val REPORT_PREFIX = "PLAYGROUND_SANDBOX_PROBE "
+  public const val REPORT_PREFIX: String = "PLAYGROUND_SANDBOX_PROBE "
 
   /** Main class of the in-jail probe; spawned as `java -cp <cli classpath> <this>`. */
-  const val PROBE_MAIN_CLASS = "ee.schimke.composeai.cli.serve.PlaygroundSandboxProbeMain"
+  public const val PROBE_MAIN_CLASS: String =
+    "ee.schimke.composeai.cli.serve.PlaygroundSandboxProbeMain"
 
   private val json = Json { ignoreUnknownKeys = true }
 
@@ -43,7 +44,7 @@ object PlaygroundSandboxProbe {
    * are then meaningless and left false.
    */
   @Serializable
-  data class Report(
+  public data class Report(
     val ran: Boolean = false,
     val detail: String = "",
     val egressBlocked: Boolean = false,
@@ -52,7 +53,7 @@ object PlaygroundSandboxProbe {
     val workDirWritable: Boolean = false,
   ) {
     /** Human-readable list of the properties this jail failed to provide; empty ⇒ clean. */
-    fun failedChecks(): List<String> = buildList {
+    public fun failedChecks(): List<String> = buildList {
       if (!ran) add("the probe JVM never reported")
       if (!egressBlocked) add("outbound network reachable from inside the sandbox")
       if (!filesystemContained) add("host files outside the session work dir are readable")
@@ -60,7 +61,7 @@ object PlaygroundSandboxProbe {
       if (!workDirWritable) add("the session work dir is not writable (a render could not run)")
     }
 
-    fun summary(): String =
+    public fun summary(): String =
       if (!ran) "sandbox preflight did not run: $detail"
       else
         "sandbox preflight: egressBlocked=$egressBlocked filesystemContained=$filesystemContained " +
@@ -68,7 +69,7 @@ object PlaygroundSandboxProbe {
   }
 
   /** One spawned probe's raw outcome; injected in tests instead of forking a JVM. */
-  data class Launch(val exitCode: Int, val stdout: String, val stderr: String)
+  public data class Launch(val exitCode: Int, val stdout: String, val stderr: String)
 
   /**
    * Run the preflight for [sandbox].
@@ -79,7 +80,7 @@ object PlaygroundSandboxProbe {
    * @param workRoot the playground work root; the probe gets a fresh writable dir under it.
    * @param launcher spawns argv and returns its outcome; defaults to a real subprocess.
    */
-  fun run(
+  public fun run(
     sandbox: PlaygroundSandbox,
     javaHome: File,
     classpath: List<String>,
@@ -198,7 +199,7 @@ object PlaygroundSandboxProbe {
       }
 
   /** A cold JVM inside a fresh namespace; generous, but the whole preflight is once per startup. */
-  const val DEFAULT_TIMEOUT_SECONDS = 60L
+  public const val DEFAULT_TIMEOUT_SECONDS: Long = 60L
 }
 
 /**
@@ -209,10 +210,10 @@ object PlaygroundSandboxProbe {
  *
  * `argv`: `<writable work dir> <canary path outside the jail> <serve host pid>`.
  */
-object PlaygroundSandboxProbeMain {
+public object PlaygroundSandboxProbeMain {
 
   @JvmStatic
-  fun main(args: Array<String>) {
+  public fun main(args: Array<String>) {
     val workDir = File(args.getOrElse(0) { "." })
     val canary = File(args.getOrElse(1) { "/nonexistent-canary" })
     val hostPid = args.getOrNull(2)?.toLongOrNull()
@@ -224,7 +225,7 @@ object PlaygroundSandboxProbeMain {
   }
 
   /** Exposed for tests: the same measurement, without the process/stdout wrapper. */
-  fun probe(workDir: File, canary: File, hostPid: Long?): PlaygroundSandboxProbe.Report =
+  public fun probe(workDir: File, canary: File, hostPid: Long?): PlaygroundSandboxProbe.Report =
     PlaygroundSandboxProbe.Report(
       ran = true,
       detail = "probed from pid ${ProcessHandle.current().pid()}",

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundTokenStore.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundTokenStore.kt
@@ -29,9 +29,9 @@ import okio.Path
  * explicit [remove], [clear]) routes through [disposeSnippet] to delete the work dir. The delete is
  * best-effort — a failure is swallowed so one undeletable directory can't wedge purging.
  */
-class PlaygroundTokenStore(
+public class PlaygroundTokenStore(
   /** How long a preview token stays redeemable. Short by design — minutes, not hours. */
-  val ttlSeconds: Long = DEFAULT_TTL_SECONDS,
+  public val ttlSeconds: Long = DEFAULT_TTL_SECONDS,
   private val maxTokens: Int = DEFAULT_MAX_TOKENS,
   /** Injected per the repo's Okio-everywhere rule; tests pass a `FakeFileSystem`. */
   private val fileSystem: FileSystem = FileSystem.SYSTEM,
@@ -51,7 +51,7 @@ class PlaygroundTokenStore(
    * A compiled snippet a token points at — everything Stage 2 needs to stand up (or, for Remote
    * Compose, replay) the preview without recompiling.
    */
-  data class PlaygroundSnippet(
+  public data class PlaygroundSnippet(
     val mode: PlaygroundMode,
     /** Temp root for this snippet; **deleted** when its token is dropped. */
     val workDir: Path,
@@ -79,7 +79,7 @@ class PlaygroundTokenStore(
   )
 
   /** One minted token and its lifetime. */
-  data class Token(
+  public data class Token(
     val id: String,
     val snippet: PlaygroundSnippet,
     val createdAtMillis: Long,
@@ -89,7 +89,7 @@ class PlaygroundTokenStore(
     val path: String
       get() = "/pg/$id"
 
-    fun secondsUntilExpiry(nowMillis: Long): Long =
+    public fun secondsUntilExpiry(nowMillis: Long): Long =
       ((expiresAtMillis - nowMillis) / 1000).coerceAtLeast(0)
 
     // Keyed by id, like ServeDocStore.Doc — array/path-reference equality would be surprising.
@@ -106,7 +106,7 @@ class PlaygroundTokenStore(
    * [ServeDocStore.add] uses (no runtime enforcement): the caller passes `true` only once the
    * request has cleared the playground route's gate.
    */
-  fun add(snippet: PlaygroundSnippet, isSecurityChecked: Boolean): Token {
+  public fun add(snippet: PlaygroundSnippet, isSecurityChecked: Boolean): Token {
     val now = clock()
     purgeExpired(now)
     val token =
@@ -122,7 +122,7 @@ class PlaygroundTokenStore(
   }
 
   /** The live token for [id], or null when it's unknown **or expired** (expired ⇒ dropped). */
-  fun get(id: String): Token? {
+  public fun get(id: String): Token? {
     val now = clock()
     purgeExpired(now)
     return tokens[id]?.takeIf { it.expiresAtMillis > now }
@@ -132,17 +132,17 @@ class PlaygroundTokenStore(
    * Seconds left on [token], measured on the **store's** clock — the one that decides expiry.
    * Callers must not read the wall clock themselves.
    */
-  fun remainingSeconds(token: Token): Long = token.secondsUntilExpiry(clock())
+  public fun remainingSeconds(token: Token): Long = token.secondsUntilExpiry(clock())
 
   /** Explicitly drop [id] (and delete its work dir); returns true if it was present. */
-  fun remove(id: String): Boolean {
+  public fun remove(id: String): Boolean {
     val removed = tokens.remove(id) ?: return false
     drop(removed)
     return true
   }
 
   /** Drop every token whose TTL has run out (deleting each work dir); returns how many went. */
-  fun purgeExpired(nowMillis: Long = clock()): Int {
+  public fun purgeExpired(nowMillis: Long = clock()): Int {
     var dropped = 0
     val it = tokens.entries.iterator()
     while (it.hasNext()) {
@@ -157,14 +157,14 @@ class PlaygroundTokenStore(
   }
 
   /** Live tokens, soonest expiry first — for the status page. */
-  fun snapshot(): List<Token> {
+  public fun snapshot(): List<Token> {
     val now = clock()
     purgeExpired(now)
     return tokens.values.sortedBy { it.expiresAtMillis }
   }
 
   /** Drop everything (deleting every work dir) — for host shutdown. */
-  fun clear() {
+  public fun clear() {
     val all = tokens.values.toList()
     tokens.clear()
     all.forEach { drop(it) }
@@ -198,22 +198,22 @@ class PlaygroundTokenStore(
     }
   }
 
-  companion object {
+  public companion object {
     /** Ten minutes: long enough to click through and refresh a tab, short enough to not linger. */
-    const val DEFAULT_TTL_SECONDS = 600L
+    public const val DEFAULT_TTL_SECONDS: Long = 600L
 
-    const val DEFAULT_MAX_TOKENS = 64
+    public const val DEFAULT_MAX_TOKENS: Int = 64
 
     /** 128 bits of [SecureRandom], base64url, `pg_`-prefixed — the id IS the capability. */
     private val random = SecureRandom()
 
-    fun randomId(): String {
+    public fun randomId(): String {
       val bytes = ByteArray(16)
       random.nextBytes(bytes)
       return "pg_" + Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
     }
 
     /** True when [id] could be one of ours — cheap shape check before a map lookup. */
-    fun isWellFormedId(id: String): Boolean = id.matches(Regex("pg_[A-Za-z0-9_-]{16,64}"))
+    public fun isWellFormedId(id: String): Boolean = id.matches(Regex("pg_[A-Za-z0-9_-]{16,64}"))
   }
 }

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PreviewHistory.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PreviewHistory.kt
@@ -28,7 +28,7 @@ import java.io.File
  * Everything here is pure — [parseGitLog] takes the text of one `git log` invocation and the git
  * call itself is isolated in [read] — so the collapse rules are unit-testable without a repo.
  */
-object PreviewHistory {
+public object PreviewHistory {
 
   /**
    * The `git log` arguments this parser expects, over [pathspec] on [ref].
@@ -49,7 +49,7 @@ object PreviewHistory {
    * belongs to. Turning quoting off is not sufficient on its own (see [unquotePath]), but it keeps
    * the common case exact rather than round-tripping every path through an unescaper.
    */
-  fun logArgs(ref: String, pathspec: String): List<String> =
+  public fun logArgs(ref: String, pathspec: String): List<String> =
     listOf(
       "-c",
       "core.quotePath=false",
@@ -117,7 +117,7 @@ object PreviewHistory {
   }
 
   /** One commit on the delivery branch in which a given render had particular bytes. */
-  data class Observation(
+  public data class Observation(
     /** Delivery-branch commit sha. */
     val commit: String,
     /** Author date, ISO-8601, as git emitted it. */
@@ -145,7 +145,7 @@ object PreviewHistory {
    * A maximal run of consecutive commits whose render bytes were identical — one *visible* version
    * of a preview, however many publishes it survived.
    */
-  data class Version(
+  public data class Version(
     /** Content sha of the render. */
     val blob: String,
     /** Path on the delivery branch, e.g. `renders/samples:wear/Foo.png`. */
@@ -169,7 +169,7 @@ object PreviewHistory {
   }
 
   /** The full history of one render path, newest version first. */
-  data class Timeline(
+  public data class Timeline(
     val path: String,
     /** Newest first. */
     val versions: List<Version>,
@@ -253,7 +253,7 @@ object PreviewHistory {
    * Deletions terminate a path's history rather than becoming a version: a preview that was removed
    * and later re-added should not read as having "returned" to its old bytes and so score a flap.
    */
-  fun collapse(observations: Map<String, List<Observation>>): Map<String, Timeline> =
+  public fun collapse(observations: Map<String, List<Observation>>): Map<String, Timeline> =
     observations.mapValues { (path, rows) ->
       collapseOne(path, rows)
     }
@@ -291,7 +291,7 @@ object PreviewHistory {
    * line arriving before any header (impossible from git, possible from a truncated capture) is
    * dropped for the same reason.
    */
-  fun parseGitLog(output: String): Map<String, List<Observation>> {
+  public fun parseGitLog(output: String): Map<String, List<Observation>> {
     val byPath = LinkedHashMap<String, MutableList<Observation>>()
     var commit: String? = null
     var date = ""
@@ -337,7 +337,7 @@ object PreviewHistory {
    * the ref is absent (a clone that never fetched the delivery branch) rather than throwing — the
    * history surface is additive, and a viewer without it should degrade to no timeline, not fail.
    */
-  fun read(
+  public fun read(
     repoRoot: File,
     ref: String,
     pathspec: String = "renders",
@@ -349,7 +349,7 @@ object PreviewHistory {
   }
 
   /** Two returns to previously-seen bytes before a preview is called unstable. See [Timeline]. */
-  const val UNSTABLE_FLAP_THRESHOLD: Int = 2
+  public const val UNSTABLE_FLAP_THRESHOLD: Int = 2
 
   private const val HEADER_MARK = "\u0001"
   private const val FIELD_SEP = "\u001F"

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PreviewHistoryManifest.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/PreviewHistoryManifest.kt
@@ -38,15 +38,15 @@ import kotlinx.serialization.json.jsonPrimitive
  * is the file to fold in.
  */
 @OptIn(ExperimentalSerializationApi::class)
-object PreviewHistoryManifest {
+public object PreviewHistoryManifest {
 
   /**
    * Bumped when the shape changes incompatibly, so a viewer can refuse a manifest it can't read.
    */
-  const val FORMAT_VERSION: String = "compose-preview-history/v1"
+  public const val FORMAT_VERSION: String = "compose-preview-history/v1"
 
   /** The file's name on the delivery branch, beside `baselines.json`. */
-  const val FILE_NAME: String = "history.json"
+  public const val FILE_NAME: String = "history.json"
 
   /**
    * Its neighbour, and the only source of the render-path → preview-id join
@@ -54,10 +54,10 @@ object PreviewHistoryManifest {
    * `HistoryManifestCommand`, `serve`'s project-mode [ServeProjectHistory] — doesn't restate the
    * filename per call site.
    */
-  const val BASELINES_FILE_NAME: String = "baselines.json"
+  public const val BASELINES_FILE_NAME: String = "baselines.json"
 
   @Serializable
-  data class Manifest(
+  public data class Manifest(
     /**
      * [EncodeDefault] is load-bearing, not decoration: [JSON] sets `encodeDefaults = false` so the
      * redundant fields below stay off the wire, and without this the version discriminator would be
@@ -84,7 +84,7 @@ object PreviewHistoryManifest {
   )
 
   @Serializable
-  data class PreviewTimeline(
+  public data class PreviewTimeline(
     /** Render path on the branch, so a viewer can fetch any version's bytes. */
     @SerialName("path") val path: String,
     /** Newest first. Trimmed when [unstable] — see [PreviewHistory.Timeline.displayVersions]. */
@@ -102,7 +102,7 @@ object PreviewHistoryManifest {
   )
 
   @Serializable
-  data class ManifestVersion(
+  public data class ManifestVersion(
     /** Content sha of the render — stable across commits, so a viewer can cache by it. */
     @SerialName("blob") val blob: String,
     /** Newest delivery-branch commit carrying these bytes. */
@@ -145,15 +145,15 @@ object PreviewHistoryManifest {
    * other than the id the routes use is a manifest the viewer silently finds nothing in, and a
    * second spelling of the derivation is how the two would drift apart without anyone noticing.
    */
-  enum class Layout(val dir: String) {
+  public enum class Layout(public val dir: String) {
     /** `renders/<module>/<basename>`, joined through `baselines.json`. */
     RENDERS("renders"),
     /** `images/<slug>/<variant>.png`, joined by flattening the path. */
     IMAGES(CatalogImagePaths.IMAGES_DIR);
 
-    companion object {
+    public companion object {
       /** Parse a `--layout` value, or null when it names neither layout. */
-      fun of(value: String?): Layout? = entries.firstOrNull { it.name.equals(value, true) }
+      public fun of(value: String?): Layout? = entries.firstOrNull { it.name.equals(value, true) }
     }
   }
 
@@ -167,7 +167,7 @@ object PreviewHistoryManifest {
    * pathspec, so one appearing here means something is wrong and inventing an id for it would put a
    * bogus key in the manifest.
    */
-  fun imagePathsToPreviewIds(paths: Iterable<String>): Map<String, String> {
+  public fun imagePathsToPreviewIds(paths: Iterable<String>): Map<String, String> {
     val byPath = LinkedHashMap<String, String>()
     for (path in paths) {
       if (!path.startsWith("${CatalogImagePaths.IMAGES_DIR}/") || !path.endsWith(".png")) continue
@@ -185,7 +185,7 @@ object PreviewHistoryManifest {
    * Entries missing either field are skipped rather than guessed at — a preview whose path can't be
    * reconstructed is better absent from the manifest than present under a wrong key.
    */
-  fun renderPathsToPreviewIds(baselinesJson: String): Map<String, String> {
+  public fun renderPathsToPreviewIds(baselinesJson: String): Map<String, String> {
     val root =
       runCatching { Json.parseToJsonElement(baselinesJson).jsonObject }.getOrNull()
         ?: return emptyMap()
@@ -210,7 +210,7 @@ object PreviewHistoryManifest {
    * Previews are emitted in sorted key order so regenerating an unchanged branch produces a
    * byte-identical file — otherwise every publish would show a spurious `history.json` diff.
    */
-  fun build(
+  public fun build(
     timelines: Map<String, PreviewHistory.Timeline>,
     pathToPreviewId: Map<String, String>,
     generatedFrom: String,
@@ -247,10 +247,10 @@ object PreviewHistoryManifest {
    * the diff bot read: a one-line JSON blob would make every regeneration an unreviewable diff,
    * whereas one field per line keeps a changed timeline legible in a PR.
    */
-  fun encode(manifest: Manifest): String = JSON.encodeToString(manifest) + "\n"
+  public fun encode(manifest: Manifest): String = JSON.encodeToString(manifest) + "\n"
 
   /** Lenient on read so a manifest written by a newer CLI (extra fields) still loads. */
-  fun decode(text: String): Manifest? = runCatching {
+  public fun decode(text: String): Manifest? = runCatching {
     JSON.decodeFromString<Manifest>(text)
   }
     .getOrNull()

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/RcJvmServerRenderer.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/RcJvmServerRenderer.kt
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit
  */
 // Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
 // and the `:server` call sites are in a different module now. Not a widened API by intent.
-object RcJvmServerRenderer {
+public object RcJvmServerRenderer {
 
   private const val MAIN_CLASS = "ee.schimke.composeai.rcembedded.jvm.RcJvmRenderMainKt"
   private const val RENDER_TIMEOUT_SECONDS = 120L
@@ -65,10 +65,10 @@ object RcJvmServerRenderer {
   }
 
   /** True when both sidecar classpaths are present, so a cmp-jvm render can actually be spawned. */
-  fun isAvailable(): Boolean = classpath().isNotEmpty()
+  public fun isAvailable(): Boolean = classpath().isNotEmpty()
 
   /** Human-readable description of where the sidecars were looked for, for error messages. */
-  fun unavailableReason(): String =
+  public fun unavailableReason(): String =
     "cmp-jvm render needs lib-rcjvm and lib-daemon-desktop on the CLI install " +
       "(${bundleSidecarSearchDescription("lib-rcjvm")}; " +
       "${bundleSidecarSearchDescription("lib-daemon-desktop")})"
@@ -78,7 +78,7 @@ object RcJvmServerRenderer {
    * serve `rc.<name>=…` knob edits) on top of the document's authored defaults. Reports whether the
    * subprocess is unavailable, timed out, or could not draw the document.
    */
-  fun render(
+  public fun render(
     docBytes: ByteArray,
     spec: RcJvmRenderSpec,
     seeds: Map<String, RemoteNamedValue> = emptyMap(),
@@ -286,7 +286,7 @@ object RcJvmServerRenderer {
   }
 
   /** Releases every pooled worker. Exposed for tests and for an explicit serve shutdown. */
-  fun shutdownPool() {
+  public fun shutdownPool() {
     synchronized(this) {
       poolInstance?.close()
       poolInstance = null
@@ -337,7 +337,7 @@ object RcJvmServerRenderer {
    */
   // Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
   // and the `:server` call sites are in a different module now. Not a widened API by intent.
-  fun rcColorToArgb(raw: String): Int? {
+  public fun rcColorToArgb(raw: String): Int? {
     val hex = raw.removePrefix("%23").removePrefix("#")
     val opaque = if (hex.length == 6) "FF$hex" else hex
     return opaque.takeIf { it.length == 8 }?.toLongOrNull(16)?.toInt()
@@ -349,15 +349,15 @@ object RcJvmServerRenderer {
     return if (candidate.canExecute()) candidate.absolutePath else "java"
   }
 
-  sealed interface RenderResult {
-    data class Ok(val bytes: ByteArray) : RenderResult
+  public sealed interface RenderResult {
+    public data class Ok(val bytes: ByteArray) : RenderResult
 
-    data class Failed(val reason: String) : RenderResult
+    public data class Failed(val reason: String) : RenderResult
 
-    data class Unavailable(val reason: String) : RenderResult
+    public data class Unavailable(val reason: String) : RenderResult
   }
 
-  enum class Format(val wire: String) {
+  public enum class Format(public val wire: String) {
     PNG("png"),
     SVG("svg"),
   }
@@ -371,7 +371,7 @@ object RcJvmServerRenderer {
    * — a `--theme` argument on the one-shot path, and an int in the pooled worker's request frame,
    * whose values `RcJvmRenderWorkerMain` mirrors.
    */
-  enum class RenderTheme(val wire: String, val frame: Int) {
+  public enum class RenderTheme(public val wire: String, public val frame: Int) {
     LIGHT("light", 0),
     DARK("dark", 1),
   }
@@ -380,4 +380,4 @@ object RcJvmServerRenderer {
 /**
  * The pixel size and density a cmp-jvm render should use — matched to the baked/View-player lane.
  */
-data class RcJvmRenderSpec(val widthPx: Int, val heightPx: Int, val density: Float)
+public data class RcJvmRenderSpec(val widthPx: Int, val heightPx: Int, val density: Float)

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/RcJvmWorkerPool.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/RcJvmWorkerPool.kt
@@ -66,7 +66,7 @@ import java.util.concurrent.atomic.AtomicInteger
  */
 // Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
 // and the `:server` call sites are in a different module now. Not a widened API by intent.
-class RcJvmWorkerPool(
+public class RcJvmWorkerPool(
   private val classpath: List<File>,
   private val javaBin: String,
   private val extraJvmArgs: List<String>,
@@ -83,14 +83,14 @@ class RcJvmWorkerPool(
   private val workerMainClass: String = WORKER_MAIN_CLASS,
 ) : AutoCloseable {
 
-  sealed interface PoolResult {
-    data class Ok(val bytes: ByteArray) : PoolResult
+  public sealed interface PoolResult {
+    public data class Ok(val bytes: ByteArray) : PoolResult
 
     /** The player answered, and the answer is "I cannot draw this". Do not fall back. */
-    data class Failed(val reason: String) : PoolResult
+    public data class Failed(val reason: String) : PoolResult
 
     /** The pool could not serve this at all. The caller should use the one-shot path. */
-    data class Unusable(val reason: String) : PoolResult
+    public data class Unusable(val reason: String) : PoolResult
   }
 
   private val permits = Semaphore(maxWorkers, /* fair= */ true)
@@ -116,7 +116,7 @@ class RcJvmWorkerPool(
     Thread(r, "rcjvm-pool-watchdog").apply { isDaemon = true }
   }
 
-  fun render(
+  public fun render(
     docBytes: ByteArray,
     spec: RcJvmRenderSpec,
     seedsText: String,
@@ -466,52 +466,54 @@ class RcJvmWorkerPool(
 
   // Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
   // and the `:server` call sites are in a different module now. Not a widened API by intent.
-  companion object {
-    const val WORKER_MAIN_CLASS = "ee.schimke.composeai.rcembedded.jvm.RcJvmRenderWorkerMainKt"
+  public companion object {
+    public const val WORKER_MAIN_CLASS: String =
+      "ee.schimke.composeai.rcembedded.jvm.RcJvmRenderWorkerMainKt"
 
     // Mirrors `RcJvmRenderWorkerMain.kt`. The cli cannot depend on the player module (its Skiko
     // natives are deliberately kept off the cli classpath — that is why the render is a subprocess
     // at all), so the wire constants are duplicated here on purpose. The version check in
     // [Worker.handshake] is what keeps the duplication honest: a sidecar that disagrees is refused
     // and the caller falls back, rather than the two sides silently misreading each other.
-    const val MAGIC_HELLO = 0x52435731
-    const val MAGIC_REQUEST = 0x52435131
-    const val MAGIC_RESPONSE = 0x52435231
+    public const val MAGIC_HELLO: Int = 0x52435731
+    public const val MAGIC_REQUEST: Int = 0x52435131
+    public const val MAGIC_RESPONSE: Int = 0x52435231
     // 2 adds the per-request `theme` field; see `RcJvmRenderWorkerMain`'s frame layout.
-    const val PROTOCOL_VERSION = 2
-    const val STATUS_OK = 0
-    const val STATUS_FAILED = 1
-    const val WIRE_THEME_LIGHT = 0
-    const val WIRE_THEME_DARK = 1
-    const val WIRE_FORMAT_PNG = 0
-    const val WIRE_FORMAT_SVG = 1
+    public const val PROTOCOL_VERSION: Int = 2
+    public const val STATUS_OK: Int = 0
+    public const val STATUS_FAILED: Int = 1
+    public const val WIRE_THEME_LIGHT: Int = 0
+    public const val WIRE_THEME_DARK: Int = 1
+    public const val WIRE_FORMAT_PNG: Int = 0
+    public const val WIRE_FORMAT_SVG: Int = 1
 
-    const val HANDSHAKE_TIMEOUT_SECONDS = 60L
-    const val MAX_START_FAILURES = 3
-    const val STDERR_TAIL_LINES = 40
+    public const val HANDSHAKE_TIMEOUT_SECONDS: Long = 60L
+    public const val MAX_START_FAILURES: Int = 3
+    public const val STDERR_TAIL_LINES: Int = 40
 
-    const val SYS_PROP_ENABLED = "composeai.rcjvm.pool"
-    const val SYS_PROP_WORKERS = "composeai.rcjvm.pool.workers"
-    const val SYS_PROP_MAX_RENDERS = "composeai.rcjvm.pool.maxRenders"
-    const val SYS_PROP_MAX_AGE_MINUTES = "composeai.rcjvm.pool.maxAgeMinutes"
+    public const val SYS_PROP_ENABLED: String = "composeai.rcjvm.pool"
+    public const val SYS_PROP_WORKERS: String = "composeai.rcjvm.pool.workers"
+    public const val SYS_PROP_MAX_RENDERS: String = "composeai.rcjvm.pool.maxRenders"
+    public const val SYS_PROP_MAX_AGE_MINUTES: String = "composeai.rcjvm.pool.maxAgeMinutes"
 
     /**
      * Default worker count. Each worker is a full Compose Desktop JVM, so this is deliberately
      * small and independent of core count past a point — serve's own render semaphore already
      * bounds concurrency, and more workers buy resident memory rather than throughput.
      */
-    fun defaultWorkers(): Int = (Runtime.getRuntime().availableProcessors() / 2).coerceIn(1, 3)
+    public fun defaultWorkers(): Int =
+      (Runtime.getRuntime().availableProcessors() / 2).coerceIn(1, 3)
 
-    fun isEnabled(): Boolean =
+    public fun isEnabled(): Boolean =
       !System.getProperty(SYS_PROP_ENABLED).equals("off", ignoreCase = true)
 
-    fun configuredWorkers(): Int =
+    public fun configuredWorkers(): Int =
       System.getProperty(SYS_PROP_WORKERS)?.toIntOrNull()?.coerceIn(1, 16) ?: defaultWorkers()
 
-    fun configuredMaxRenders(): Int =
+    public fun configuredMaxRenders(): Int =
       System.getProperty(SYS_PROP_MAX_RENDERS)?.toIntOrNull()?.coerceAtLeast(1) ?: 200
 
-    fun configuredMaxAgeMillis(): Long =
+    public fun configuredMaxAgeMillis(): Long =
       (System.getProperty(SYS_PROP_MAX_AGE_MINUTES)?.toLongOrNull()?.coerceAtLeast(1) ?: 30L) *
         60_000L
   }

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/RcPlayerBackend.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/RcPlayerBackend.kt
@@ -41,11 +41,11 @@ import ee.schimke.composeai.daemon.protocol.RemoteComposePlayerKind
  * [ServeHost.enabledRcPlayersFor]; the rest are shown disabled. [wire] is the stable id used both
  * in the `rcPlayer=` render query param and the `/api/previews` capability list.
  */
-enum class RcPlayerBackend(
+public enum class RcPlayerBackend(
   /** Stable wire id — the `rcPlayer=` query value and the `/api/previews` capability spelling. */
-  val wire: String,
+  public val wire: String,
   /** Short human label for the selector chip. */
-  val label: String,
+  public val label: String,
   /**
    * The daemon player kind a **server-side** backend renders through, or null for the lanes that
    * don't ride the daemon `remoteCompose.player` override: the client-side [JS] lane and the
@@ -53,11 +53,11 @@ enum class RcPlayerBackend(
    * Drives [ServeOverrides]'s mapping of the `rcPlayer=` param onto
    * [ee.schimke.composeai.daemon.protocol.RemoteComposeOverride.player].
    */
-  val playerKind: RemoteComposePlayerKind?,
+  public val playerKind: RemoteComposePlayerKind?,
   /**
    * True when the browser plays the `.rc` document itself (the [JS] lane); false for a PNG lane.
    */
-  val clientSide: Boolean,
+  public val clientSide: Boolean,
   /**
    * This backend's column id in the catalog's published `rc-compare` staging
    * ([RcCompareManifest.lanes]), or null when the offline pipeline has no column for it.
@@ -73,7 +73,7 @@ enum class RcPlayerBackend(
    * player's pixels under a confident `200`. The java lane therefore routes to the daemon, which
    * can still draw it on request.
    */
-  val rcCompareLane: String?,
+  public val rcCompareLane: String?,
 ) {
   JS("js", "JS", playerKind = null, clientSide = true, rcCompareLane = "js"),
   CMP_WASM(
@@ -99,12 +99,12 @@ enum class RcPlayerBackend(
   ),
   CMP_JVM("cmp-jvm", "CMP JVM", playerKind = null, clientSide = false, rcCompareLane = "cmp-jvm");
 
-  companion object {
+  public companion object {
     /** The fixed universe the viewer renders as chips, in display order. */
-    val UNIVERSE: List<RcPlayerBackend> = entries.toList()
+    public val UNIVERSE: List<RcPlayerBackend> = entries.toList()
 
     /** The backend for [wire], or null when it names none. Case-insensitive. */
-    fun fromWire(wire: String?): RcPlayerBackend? =
+    public fun fromWire(wire: String?): RcPlayerBackend? =
       wire?.lowercase()?.let { v -> entries.firstOrNull { it.wire == v } }
 
     /**
@@ -115,7 +115,7 @@ enum class RcPlayerBackend(
      * in its own subprocess lane ([ServeHttpServer] handles `rcPlayer=cmp-jvm` directly), so
      * neither rides the daemon override this maps.
      */
-    fun serverSideFromParam(raw: String): RcPlayerBackend? =
+    public fun serverSideFromParam(raw: String): RcPlayerBackend? =
       when (raw.lowercase()) {
         "java",
         "view" -> JAVA

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/RenderCircuitBreaker.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/RenderCircuitBreaker.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.Serializable
  * classpath/runtime level: the same call will fail identically for every preview, every override,
  * forever. Retrying is not merely useless, it is actively harmful — see [RenderCircuitBreaker].
  */
-object RenderFailureClassifier {
+public object RenderFailureClassifier {
   /**
    * Substrings of a failure reason that mean "linkage/classpath fault". Matched against the reason
    * text because that is all the serve host has: the daemon reports its render failure as a message
@@ -39,9 +39,9 @@ object RenderFailureClassifier {
     )
 
   /** The linkage fault named in [reason], or null when it is an ordinary (retryable) failure. */
-  fun fatalMarker(reason: String): String? = FATAL_MARKERS.firstOrNull { it in reason }
+  public fun fatalMarker(reason: String): String? = FATAL_MARKERS.firstOrNull { it in reason }
 
-  fun isFatal(reason: String): Boolean = fatalMarker(reason) != null
+  public fun isFatal(reason: String): Boolean = fatalMarker(reason) != null
 }
 
 /**
@@ -76,7 +76,7 @@ object RenderFailureClassifier {
  *
  * Thread-safe; every method takes one short critical section.
  */
-class RenderCircuitBreaker(
+public class RenderCircuitBreaker(
   /** Outcomes that must be in the window before the rate trip can fire at all. */
   private val minSamples: Int = MIN_SAMPLES,
   /** Failure fraction of the window at or above which the rate trip fires. */
@@ -120,7 +120,7 @@ class RenderCircuitBreaker(
    * cooldown, admitting exactly one probe render. Use [peekReason] for a read-only look (status
    * reporting, the HTTP failure latch) so a status poll can't spend the probe.
    */
-  fun blockedReason(): String? =
+  public fun blockedReason(): String? =
     synchronized(lock) {
       val reason = openReason ?: return null
       if (fatal) {
@@ -139,10 +139,10 @@ class RenderCircuitBreaker(
     }
 
   /** Read-only [blockedReason]: never admits a probe, never counts a short-circuit. */
-  fun peekReason(): String? = synchronized(lock) { openReason }
+  public fun peekReason(): String? = synchronized(lock) { openReason }
 
   /** A render succeeded. Closes a rate-tripped breaker; a fatal one stays open. */
-  fun recordOk(): Unit =
+  public fun recordOk(): Unit =
     synchronized(lock) {
       push(false)
       if (fatal) return
@@ -153,7 +153,7 @@ class RenderCircuitBreaker(
     }
 
   /** A render failed with [reason]; trips the breaker when fatal or when the rate says so. */
-  fun recordFailure(reason: String): Unit =
+  public fun recordFailure(reason: String): Unit =
     synchronized(lock) {
       push(true)
       if (fatal) return
@@ -183,7 +183,7 @@ class RenderCircuitBreaker(
     }
 
   /** Point-in-time state for `/status.json`, or null while the breaker has never tripped. */
-  fun snapshot(): RenderBreakerSnapshot? =
+  public fun snapshot(): RenderBreakerSnapshot? =
     synchronized(lock) {
       val reason = openReason ?: return null
       RenderBreakerSnapshot(
@@ -205,17 +205,17 @@ class RenderCircuitBreaker(
   private fun failureRate(): Double =
     if (window.isEmpty()) 0.0 else window.count { it }.toDouble() / window.size
 
-  companion object {
-    const val MIN_SAMPLES: Int = 20
-    const val FAILURE_RATE_THRESHOLD: Double = 0.9
-    const val WINDOW_SIZE: Int = 50
+  public companion object {
+    public const val MIN_SAMPLES: Int = 20
+    public const val FAILURE_RATE_THRESHOLD: Double = 0.9
+    public const val WINDOW_SIZE: Int = 50
 
     /**
      * Cooldown between probe renders on a rate-tripped breaker. Long enough that a wedged daemon
      * costs one render a minute instead of thousands (the #3448 behaviour), short enough that a
      * transient wave — a daemon restart, a burst of cold-start timeouts — heals within a browse.
      */
-    const val PROBE_COOLDOWN_MILLIS: Long = 60_000L
+    public const val PROBE_COOLDOWN_MILLIS: Long = 60_000L
   }
 }
 
@@ -225,7 +225,7 @@ class RenderCircuitBreaker(
  * Additive on `compose-preview-serve/status/v1`.
  */
 @Serializable
-data class RenderBreakerSnapshot(
+public data class RenderBreakerSnapshot(
   val open: Boolean,
   /** A linkage/classpath fault: terminal, never probed, needs a redeploy rather than a retry. */
   val fatal: Boolean,

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/RenderPerfStats.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/RenderPerfStats.kt
@@ -16,7 +16,7 @@ import kotlinx.serialization.Serializable
  * the most recent [WINDOW_SIZE] successful render durations, so a long-lived daemon reports recent
  * behaviour rather than an all-time blur (the all-time min/max/avg/first are kept separately).
  */
-class RenderPerfStats {
+public class RenderPerfStats {
   private val lock = Any()
 
   private var renders = 0L
@@ -42,10 +42,10 @@ class RenderPerfStats {
   private var windowIdx = 0
 
   /** A `/render` served straight from the PNG cache — no daemon round-trip. */
-  fun recordCacheHit(): Unit = synchronized(lock) { cacheHits++ }
+  public fun recordCacheHit(): Unit = synchronized(lock) { cacheHits++ }
 
   /** The bounded render-lock acquire backed off ([RenderOutcome.Busy] → caller serves baked). */
-  fun recordBusy(): Unit = synchronized(lock) { busy++ }
+  public fun recordBusy(): Unit = synchronized(lock) { busy++ }
 
   /**
    * A render refused without asking the daemon because this host's [RenderCircuitBreaker] is open.
@@ -53,7 +53,7 @@ class RenderPerfStats {
    * `failed` would inflate the very failure rate that tripped the breaker and hide how much work
    * the breaker is saving.
    */
-  fun recordShortCircuit(): Unit = synchronized(lock) { shortCircuited++ }
+  public fun recordShortCircuit(): Unit = synchronized(lock) { shortCircuited++ }
 
   /**
    * A render that ended in [RenderOutcome.Failed]; [timeout] when it blew its render budget.
@@ -62,7 +62,7 @@ class RenderPerfStats {
    * render fails otherwise shows only a climbing `failed` counter while the composite silently
    * serves baked fallback.
    */
-  fun recordFailed(durationMs: Long, timeout: Boolean, reason: String? = null): Unit =
+  public fun recordFailed(durationMs: Long, timeout: Boolean, reason: String? = null): Unit =
     synchronized(lock) {
       renders++
       failed++
@@ -89,7 +89,7 @@ class RenderPerfStats {
    * had not yet completed any successful render — the cold-start population the background-boot /
    * warm-render work targets — so `/status` can separate first-render latency from steady state.
    */
-  fun recordOk(durationMs: Long, cold: Boolean): Unit =
+  public fun recordOk(durationMs: Long, cold: Boolean): Unit =
     synchronized(lock) {
       renders++
       ok++
@@ -108,7 +108,7 @@ class RenderPerfStats {
       if (windowCount < window.size) windowCount++
     }
 
-  fun snapshot(): RenderPerfSnapshot =
+  public fun snapshot(): RenderPerfSnapshot =
     synchronized(lock) {
       val sorted = window.copyOf(windowCount).also { it.sort() }
       fun pct(p: Double): Long? =
@@ -138,21 +138,21 @@ class RenderPerfStats {
       )
     }
 
-  companion object {
+  public companion object {
     /** Ring size for the recent-durations percentile window. */
-    const val WINDOW_SIZE: Int = 128
+    public const val WINDOW_SIZE: Int = 128
 
     /** Cap on the carried failure-reason text — enough for a message, not a stack trace. */
-    const val MAX_FAILURE_REASON_LENGTH: Int = 300
+    public const val MAX_FAILURE_REASON_LENGTH: Int = 300
 
     /** Number of render errors retained for the human status page. */
-    const val FAILURE_WINDOW_SIZE: Int = 10
+    public const val FAILURE_WINDOW_SIZE: Int = 10
   }
 }
 
 /** One recent failed render, newest-first in [RenderPerfSnapshot.recentFailures]. */
 @Serializable
-data class RenderFailureSample(
+public data class RenderFailureSample(
   val atEpochMillis: Long,
   val durationMs: Long,
   val timedOut: Boolean,
@@ -166,7 +166,7 @@ data class RenderFailureSample(
  * Additive on `compose-preview-serve/status/v1`.
  */
 @Serializable
-data class RenderPerfSnapshot(
+public data class RenderPerfSnapshot(
   /** Renders attempted against the daemon (ok + failed; excludes cache hits and busy backoffs). */
   val renders: Long,
   val ok: Long,
@@ -214,13 +214,13 @@ data class RenderPerfSnapshot(
    */
   val breaker: RenderBreakerSnapshot? = null,
 ) {
-  companion object {
+  public companion object {
     /**
      * Server-wide roll-up across daemons for the `/status` summary. Counts sum; min/max span;
      * `avgMs` is ok-weighted; `firstRenderMs` reports the WORST first render (the number the
      * cold-start work drives down). Percentiles don't merge across windows, so they stay null.
      */
-    fun aggregate(snapshots: List<RenderPerfSnapshot>): RenderPerfSnapshot? {
+    public fun aggregate(snapshots: List<RenderPerfSnapshot>): RenderPerfSnapshot? {
       if (snapshots.isEmpty()) return null
       val ok = snapshots.sumOf { it.ok }
       return RenderPerfSnapshot(

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAnnotations.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAnnotations.kt
@@ -23,21 +23,21 @@ import okio.Path.Companion.toPath
  * never measures pixels or fetches design URLs itself.
  */
 @Serializable
-data class AnnotationManifest(
+public data class AnnotationManifest(
   val schema: String = SCHEMA,
   /** Annotations over a preview's *rendered* frame, keyed by exact serve/catalog preview id. */
   val previews: Map<String, List<DesignAnnotation>> = emptyMap(),
   /** Annotations over a *reference* raster, keyed by [DesignReference.id]. */
   val references: Map<String, List<DesignAnnotation>> = emptyMap(),
 ) {
-  companion object {
-    const val SCHEMA = "compose-preview-annotations/v1"
+  public companion object {
+    public const val SCHEMA: String = "compose-preview-annotations/v1"
   }
 }
 
 /** Which spec layer an annotation belongs to; the compare page toggles them independently. */
-object AnnotationKind {
-  const val TYPOGRAPHY = "typography"
+public object AnnotationKind {
+  public const val TYPOGRAPHY: String = "typography"
 
   /**
    * Box geometry and the tokens that shaped it — size, padding, arrangement gap, `defaultMinSize`.
@@ -45,7 +45,7 @@ object AnnotationKind {
    * derived live from a render's own semantics tree by [ServeDesignAnnotations], so the viewer's
    * inspection layers can show the code side of the same redline.
    */
-  const val LAYOUT = "layout"
+  public const val LAYOUT: String = "layout"
 
   /**
    * Resolved theme attributes of a container — fill / border colour, corner radius, shape. Produced
@@ -53,9 +53,9 @@ object AnnotationKind {
    * inspection layers, rather than authored in a bundle's `annotations/index.json` (the compare
    * page's producer-side layers are [TYPOGRAPHY] / [LAYOUT] only).
    */
-  const val THEME = "theme"
+  public const val THEME: String = "theme"
 
-  val KNOWN = setOf(TYPOGRAPHY, LAYOUT, THEME)
+  public val KNOWN: Set<String> = setOf(TYPOGRAPHY, LAYOUT, THEME)
 
   /**
    * The layers a **published bundle** can answer on its own, without a daemon.
@@ -71,7 +71,7 @@ object AnnotationKind {
    * [publishedLayersSuffice] is the predicate; this set is the reason it is not simply "whatever
    * the bundle happens to carry".
    */
-  val PUBLISHABLE = setOf(TYPOGRAPHY)
+  public val PUBLISHABLE: Set<String> = setOf(TYPOGRAPHY)
 
   /**
    * Whether a `.annotations` request naming exactly [layers] can be answered from a bundle's
@@ -81,14 +81,14 @@ object AnnotationKind {
    * which is what every client did before `layers=` existed, and what a hand-typed URL still does.
    * Answering those from published bytes is precisely the regression #224 reverted.
    */
-  fun publishedLayersSuffice(layers: Set<String>?): Boolean =
+  public fun publishedLayersSuffice(layers: Set<String>?): Boolean =
     layers != null && layers.isNotEmpty() && PUBLISHABLE.containsAll(layers)
 
   /**
    * The `layers=` query value parsed into a validated kind set, or null when the request named none
    * (or none that this build knows). Null means "every layer", the pre-`layers=` behaviour.
    */
-  fun parseLayers(raw: String?): Set<String>? =
+  public fun parseLayers(raw: String?): Set<String>? =
     raw?.split(',')?.map { it.trim() }?.filter { it in KNOWN }?.toSet()?.takeIf { it.isNotEmpty() }
 }
 
@@ -100,7 +100,7 @@ object AnnotationKind {
  * page scales each layer to its panel rather than assuming a shared coordinate space.
  */
 @Serializable
-data class DesignAnnotation(
+public data class DesignAnnotation(
   /** One of [AnnotationKind.KNOWN]. Unknown kinds are dropped on load. */
   val kind: String,
   val bounds: AnnotationBounds,
@@ -117,7 +117,7 @@ data class DesignAnnotation(
 
 /** Both panels' layers, as embedded in the compare page for the client to draw. */
 @Serializable
-data class AnnotationPayload(
+public data class AnnotationPayload(
   val reference: List<DesignAnnotation> = emptyList(),
   val actual: List<DesignAnnotation> = emptyList(),
 )
@@ -132,11 +132,12 @@ private val ANNOTATION_JSON = Json { encodeDefaults = false }
  * string value, which ends the block early; `<` is a valid JSON escape for `<` and closes that hole
  * without touching the parsed value.
  */
-fun encodeAnnotationPayload(payload: AnnotationPayload): String =
+public fun encodeAnnotationPayload(payload: AnnotationPayload): String =
   ANNOTATION_JSON.encodeToString(payload).replace("<", "\\u003c")
 
 /** A region in the annotated image's pixel space. */
-@Serializable data class AnnotationBounds(val x: Int, val y: Int, val width: Int, val height: Int)
+@Serializable
+public data class AnnotationBounds(val x: Int, val y: Int, val width: Int, val height: Int)
 
 /**
  * Validated, read-only view of a bundle/catalog's `annotations/index.json`.
@@ -145,29 +146,32 @@ fun encodeAnnotationPayload(payload: AnnotationPayload): String =
  * kind, or a nonsensical box is dropped while the rest of the session serves normally. An
  * annotation layer is a reading aid — losing one must never take the compare page down with it.
  */
-class ServeAnnotationStore
+public class ServeAnnotationStore
 private constructor(
   private val byPreview: Map<String, List<DesignAnnotation>>,
   private val byReference: Map<String, List<DesignAnnotation>>,
 ) {
-  fun forPreview(previewId: String): List<DesignAnnotation> = byPreview[previewId].orEmpty()
+  public fun forPreview(previewId: String): List<DesignAnnotation> = byPreview[previewId].orEmpty()
 
-  fun forReference(referenceId: String): List<DesignAnnotation> = byReference[referenceId].orEmpty()
+  public fun forReference(referenceId: String): List<DesignAnnotation> =
+    byReference[referenceId].orEmpty()
 
-  val isEmpty: Boolean = byPreview.isEmpty() && byReference.isEmpty()
+  public val isEmpty: Boolean = byPreview.isEmpty() && byReference.isEmpty()
 
-  companion object {
-    const val DIRECTORY = "annotations"
-    const val INDEX_FILE = "index.json"
+  public companion object {
+    public const val DIRECTORY: String = "annotations"
+    public const val INDEX_FILE: String = "index.json"
     private val JSON = Json { ignoreUnknownKeys = true }
 
     /** Empty store — a session that carries no annotations at all. */
-    val EMPTY = ServeAnnotationStore(emptyMap(), emptyMap())
+    public val EMPTY: ServeAnnotationStore = ServeAnnotationStore(emptyMap(), emptyMap())
 
-    fun load(bundleDir: File, fileSystem: FileSystem = FileSystem.SYSTEM): ServeAnnotationStore =
-      load(bundleDir.toOkioPath(), fileSystem)
+    public fun load(
+      bundleDir: File,
+      fileSystem: FileSystem = FileSystem.SYSTEM,
+    ): ServeAnnotationStore = load(bundleDir.toOkioPath(), fileSystem)
 
-    fun load(bundleRoot: Path, fileSystem: FileSystem): ServeAnnotationStore {
+    public fun load(bundleRoot: Path, fileSystem: FileSystem): ServeAnnotationStore {
       val index = bundleRoot / DIRECTORY.toPath() / INDEX_FILE.toPath()
       if (!fileSystem.exists(index)) return EMPTY
       val manifest =

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAnnotationsPayload.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAnnotationsPayload.kt
@@ -20,7 +20,7 @@ import kotlinx.serialization.json.encodeToJsonElement
  */
 // Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
 // and the `:server` call sites are in a different module now. Not a widened API by intent.
-object ServeAnnotationsPayload {
+public object ServeAnnotationsPayload {
 
   private val json = Json { ignoreUnknownKeys = true }
 
@@ -28,7 +28,7 @@ object ServeAnnotationsPayload {
    * `{"previewId":…, "annotations":[…], "tags":{…}}` — the annotations the viewer draws, plus
    * [ServeSemanticsTags]' tag index over the same frame (empty where the source carries none).
    */
-  fun encode(
+  public fun encode(
     previewId: String,
     annotations: List<DesignAnnotation>,
     tags: Map<String, ServeSemanticsTags.TagEntry>,
@@ -61,7 +61,10 @@ object ServeAnnotationsPayload {
    * catalog's published `tags/index.json` and performs no render, so it has no annotation layer to
    * describe and must not look as though it found none.
    */
-  fun encodeTags(previewId: String, tags: Map<String, ServeSemanticsTags.TagEntry>): ByteArray =
+  public fun encodeTags(
+    previewId: String,
+    tags: Map<String, ServeSemanticsTags.TagEntry>,
+  ): ByteArray =
     json
       .encodeToString(
         JsonObject.serializer(),

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWork.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWork.kt
@@ -33,7 +33,7 @@ import kotlinx.serialization.Serializable
  * Both knobs are process-wide: one instance is built per `serve` run and shared by every catalog
  * host it opens.
  */
-class ServeBackgroundWork(
+public class ServeBackgroundWork(
   /**
    * Background renders admitted at once, server-wide. Defaults to the conservative single lane; a
    * server that knows its seat budget passes [renderLaneFor] instead.
@@ -122,7 +122,7 @@ class ServeBackgroundWork(
    * admin registration is fetching one right now. Background work treats this as "busy" even though
    * no visitor is waiting, because a catalog that loads slowly enough loses its live lane.
    */
-  val catalogsLoading: Boolean
+  public val catalogsLoading: Boolean
     get() = initialLoadPending.get() || loadsInFlight.get() > 0
 
   /**
@@ -130,18 +130,18 @@ class ServeBackgroundWork(
    * built — not when it runs — so the window between "server up" and "first catalog load" is busy
    * too, rather than a gap the optimizer can start in.
    */
-  fun expectInitialCatalogLoad() {
+  public fun expectInitialCatalogLoad() {
     initialLoadPending.set(true)
   }
 
   /** The startup pass is done (however it ended — loaded, failed, or shut down mid-pass). */
-  fun initialCatalogLoadFinished() {
+  public fun initialCatalogLoadFinished() {
     initialLoadPending.set(false)
     lastCatalogLoadFinishedAt.set(clock())
   }
 
   /** Run one catalog load, counted so background work stays parked for its duration. */
-  fun <T> whileLoadingCatalog(block: () -> T): T {
+  public fun <T> whileLoadingCatalog(block: () -> T): T {
     loadsInFlight.incrementAndGet()
     try {
       return block()
@@ -156,7 +156,7 @@ class ServeBackgroundWork(
    * clock restarts at zero when startup, refresh, or admin registration finishes. The catalog host
    * applies its quiet-window threshold to the smaller of this and request/render idleness.
    */
-  fun idleClock(idleMillis: () -> Long?): () -> Long? =
+  public fun idleClock(idleMillis: () -> Long?): () -> Long? =
     composeIdleClock(idleMillis).also {
       // Every catalog host asks for one and they all wrap the same registry, so last-wins is the
       // same clock each time. Retained purely so status can read it; nothing here drives behaviour.
@@ -195,7 +195,7 @@ class ServeBackgroundWork(
    * a parked catalog re-checks the idle gate rather than sleeping through the quiet window it was
    * waiting for.
    */
-  fun <T : Any> withOptimizerSlot(system: String, waitMillis: Long, block: () -> T): T? {
+  public fun <T : Any> withOptimizerSlot(system: String, waitMillis: Long, block: () -> T): T? {
     if (!acquireOptimizerLane(system, waitMillis)) {
       optimizerRefusals.incrementAndGet()
       return null
@@ -325,7 +325,7 @@ class ServeBackgroundWork(
    * this read one too high and the resumed pass simply queues, which is what a challenger does
    * anyway.
    */
-  fun optimizerResumeSlots(): Int =
+  public fun optimizerResumeSlots(): Int =
     if (optimizersPaused()) 0
     else
       admissionLock.run {
@@ -339,12 +339,12 @@ class ServeBackgroundWork(
       }
 
   /** A catalog with optimization left to do had its host released to reclaim its daemon's RAM. */
-  fun recordOptimizerHostSuspended() {
+  public fun recordOptimizerHostSuspended() {
     optimizerHostSuspensions.incrementAndGet()
   }
 
   /** A parked catalog was made resident again so it could take a lane. */
-  fun recordOptimizerHostResumed() {
+  public fun recordOptimizerHostResumed() {
     optimizerHostResumes.incrementAndGet()
   }
 
@@ -381,7 +381,7 @@ class ServeBackgroundWork(
    *
    * Returns the epoch instant the pause lifts.
    */
-  fun pauseOptimizers(millis: Long, reason: String): Long {
+  public fun pauseOptimizers(millis: Long, reason: String): Long {
     val until = clock() + millis.coerceAtLeast(0)
     optimizerPausedUntil.set(until)
     optimizerPauseReason["reason"] = reason.take(MAX_PAUSE_REASON_CHARS)
@@ -397,17 +397,17 @@ class ServeBackgroundWork(
   }
 
   /** Lift a pause early. */
-  fun resumeOptimizers() {
+  public fun resumeOptimizers() {
     optimizerPausedUntil.set(Long.MIN_VALUE)
     optimizerPauseReason.clear()
   }
 
   /** Whether optimizer passes are currently stood down. Cheap enough for a per-batch check. */
-  fun optimizersPaused(): Boolean =
+  public fun optimizersPaused(): Boolean =
     clock() < optimizerPausedUntil.get() || pressureGate?.snapshot()?.constrained == true
 
   /** Counters for `/status.json`; see [ThemeOptimizerAdmissionSnapshot]. */
-  fun optimizerAdmissionSnapshot(): ThemeOptimizerAdmissionSnapshot {
+  public fun optimizerAdmissionSnapshot(): ThemeOptimizerAdmissionSnapshot {
     val until = optimizerPausedUntil.get()
     val manuallyPaused = clock() < until
     val pressure = pressureGate?.snapshot()
@@ -456,7 +456,7 @@ class ServeBackgroundWork(
     )
   }
 
-  fun <T : Any> withRenderPermit(block: () -> T): T? {
+  public fun <T : Any> withRenderPermit(block: () -> T): T? {
     try {
       renderPermits.acquire()
     } catch (_: InterruptedException) {
@@ -470,7 +470,7 @@ class ServeBackgroundWork(
     }
   }
 
-  companion object {
+  public companion object {
     /**
      * Whole-server quiet the idle theme-optimizer gate requires before a cold pass may start.
      *
@@ -483,14 +483,14 @@ class ServeBackgroundWork(
      * Public rather than `internal`: `ServeCatalogLiveHost` is in `:server` now, and `internal` is
      * module-scoped.
      */
-    fun themeOptimizationIdleMillisDefault(): Long =
+    public fun themeOptimizationIdleMillisDefault(): Long =
       System.getProperty("composeai.serve.themeOptimizationIdleMillis")?.toLongOrNull() ?: 60_000L
 
     /**
      * The historical lane: one background render server-wide. Still the right answer when nothing
      * else bounds daemon count — see [renderLaneFor].
      */
-    const val CONSERVATIVE_MAX_CONCURRENT_RENDERS: Int = 1
+    public const val CONSERVATIVE_MAX_CONCURRENT_RENDERS: Int = 1
 
     /**
      * Catalogs allowed inside an optimizer pass at once. Two, not one: a single lane would leave
@@ -498,27 +498,27 @@ class ServeBackgroundWork(
      * warming is where a pass spends most of its time. Two overlaps one catalog's warm with
      * another's renders without recreating the free-for-all.
      */
-    const val DEFAULT_MAX_CONCURRENT_OPTIMIZERS: Int = 2
+    public const val DEFAULT_MAX_CONCURRENT_OPTIMIZERS: Int = 2
 
     /**
      * The one queued challenger [optimizerResumeSlots] keeps beyond the lanes themselves, so a
      * parked catalog can actually win a turn instead of waiting for an incumbent to finish.
      */
-    const val PLUS_ONE_CHALLENGER: Int = 1
+    public const val PLUS_ONE_CHALLENGER: Int = 1
 
-    const val HOST_COORDINATION_RETRY_MILLIS: Long = 100L
+    public const val HOST_COORDINATION_RETRY_MILLIS: Long = 100L
 
     /** Pause reasons are bounded before they reach a status page. */
-    const val MAX_PAUSE_REASON_CHARS: Int = 200
+    public const val MAX_PAUSE_REASON_CHARS: Int = 200
 
     /** [ThemeOptimizerAdmissionSnapshot.idleBlockedBy]: a session holds an open lease. */
-    const val IDLE_BLOCKED_BY_SESSION_LEASE: String = "session-lease"
+    public const val IDLE_BLOCKED_BY_SESSION_LEASE: String = "session-lease"
 
     /** [ThemeOptimizerAdmissionSnapshot.idleBlockedBy]: catalogs are still loading. */
-    const val IDLE_BLOCKED_BY_CATALOG_LOAD: String = "catalog-load"
+    public const val IDLE_BLOCKED_BY_CATALOG_LOAD: String = "catalog-load"
 
     /** Widest lane [renderLaneFor] will derive on its own. Beyond this, ask for it explicitly. */
-    const val MAX_DERIVED_CONCURRENT_RENDERS: Int = 3
+    public const val MAX_DERIVED_CONCURRENT_RENDERS: Int = 3
 
     /**
      * How many background renders this server admits at once, given its live-seat budget.
@@ -546,7 +546,7 @@ class ServeBackgroundWork(
      * `-Dcomposeai.serve.backgroundRenders=<n>` overrides both, for a deployment that knows better
      * than either rule.
      */
-    fun renderLaneFor(seats: LiveSeatLimiter?): Int {
+    public fun renderLaneFor(seats: LiveSeatLimiter?): Int {
       System.getProperty("composeai.serve.backgroundRenders")?.toIntOrNull()?.let {
         return it.coerceAtLeast(1)
       }
@@ -576,7 +576,7 @@ class ServeBackgroundWork(
  * being turned away and nothing said the same system was being turned away every time.
  */
 @Serializable
-data class ThemeOptimizerAdmissionSnapshot(
+public data class ThemeOptimizerAdmissionSnapshot(
   val lanes: Int,
   val running: Int,
   val runningSystems: List<String>,

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBakedTheme.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBakedTheme.kt
@@ -36,7 +36,7 @@ import ee.schimke.composeai.daemon.protocol.UiMode
  * dark-first catalog that bakes a light pair still names its light renders with an explicit
  * `__light` token, which [token] reads.
  */
-object ServeBakedTheme {
+public object ServeBakedTheme {
 
   /**
    * The explicit `light` / `dark` token a flattened catalog id carries, or null when it carries
@@ -47,7 +47,7 @@ object ServeBakedTheme {
    * in an otherwise-light variant, wrongly treating `uiMode=dark` as a no-op and dropping the
    * override.
    */
-  fun token(previewId: String): UiMode? =
+  public fun token(previewId: String): UiMode? =
     when (previewId.split("__").drop(1).lastOrNull { it == "light" || it == "dark" }) {
       "dark" -> UiMode.DARK
       "light" -> UiMode.LIGHT
@@ -64,7 +64,7 @@ object ServeBakedTheme {
    * Null is the honest answer, not a default: it leaves a `uiMode` request routed to a real render,
    * which is what a session that cannot name the sticker's theme owes the caller.
    */
-  fun resolve(
+  public fun resolve(
     previewId: String,
     declaredTheme: String? = null,
     publishesId: (String) -> Boolean = { false },
@@ -96,7 +96,7 @@ object ServeBakedTheme {
    * `theme: "light"` explicitly, and 44 of `m3-catalog`'s do. Untagged is tried first — it is what
    * the default mode actually produces.
    */
-  fun twinIn(previewId: String, theme: UiMode, publishesId: (String) -> Boolean): String? {
+  public fun twinIn(previewId: String, theme: UiMode, publishesId: (String) -> Boolean): String? {
     val segments = previewId.split(THEME_SEPARATOR)
     // Everything but the theme axis: the identity the pair shares. Drops the token [token] found,
     // scanning from the same end so the two cannot disagree about which segment is the theme.

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBranchFetch.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBranchFetch.kt
@@ -23,10 +23,10 @@ package ee.schimke.composeai.cli.serve
  * Deliberately transport-agnostic and dependency-free so the classification and the backoff policy
  * unit-test without a socket.
  */
-sealed interface BranchFetch {
+public sealed interface BranchFetch {
 
   /** The bytes, read and size-capped. */
-  class Ok(val bytes: ByteArray) : BranchFetch
+  public class Ok(public val bytes: ByteArray) : BranchFetch
 
   /**
    * The branch answered, definitively, that there is no such file — `404`/`410`.
@@ -34,7 +34,7 @@ sealed interface BranchFetch {
    * The only outcome a caller may treat as permanent. Everything else below is a statement about
    * *now*.
    */
-  data object NotFound : BranchFetch
+  public data object NotFound : BranchFetch
 
   /**
    * Rate limited — `429`, or a `403` that carries no body we asked for. [retryAfterSeconds] is the
@@ -45,7 +45,7 @@ sealed interface BranchFetch {
    * rate-limit conditions, and the cost of guessing wrong in this direction is one wasted retry,
    * where guessing wrong in the other direction caches a throttle as a missing asset.
    */
-  data class Throttled(val retryAfterSeconds: Long?) : BranchFetch
+  public data class Throttled(val retryAfterSeconds: Long?) : BranchFetch
 
   /**
    * The branch host is unwell — any `5xx`, or a `4xx` that is neither missing nor throttled.
@@ -56,10 +56,10 @@ sealed interface BranchFetch {
    * asking for ten seconds got 250 ms and 500 ms instead, spending both retries inside the outage
    * and then reporting the asset as missing — the exact confusion this type exists to end.
    */
-  data class Unavailable(val status: Int, val retryAfterSeconds: Long? = null) : BranchFetch
+  public data class Unavailable(val status: Int, val retryAfterSeconds: Long? = null) : BranchFetch
 
   /** Never got an answer: connect/read timeout, DNS, TLS, reset. */
-  data class Transport(val detail: String) : BranchFetch
+  public data class Transport(val detail: String) : BranchFetch
 
   /**
    * The branch has the file and it is **past the envelope this read was given** — the body outgrew
@@ -77,21 +77,21 @@ sealed interface BranchFetch {
    * publish a smaller file tomorrow — but every caller that memoises does so on a pinned `(commit,
    * path)`, where the size is as immutable as the bytes.
    */
-  data class TooLarge(val limitBytes: Long) : BranchFetch
+  public data class TooLarge(val limitBytes: Long) : BranchFetch
 
   /** The bytes, or null for every failure — the shape the pre-existing call sites still want. */
-  val bytesOrNull: ByteArray?
+  public val bytesOrNull: ByteArray?
     get() = (this as? Ok)?.bytes
 
   /**
    * Whether asking again could plausibly answer differently. False for [Ok] (nothing to ask) and
    * for [NotFound] (the answer will not change), true for the three "right now" outcomes.
    */
-  val isTransient: Boolean
+  public val isTransient: Boolean
     get() = this is Throttled || this is Unavailable || this is Transport
 
   /** A short, log-safe reason. Never includes the URL — callers pair it with their own. */
-  val summary: String
+  public val summary: String
     get() =
       when (this) {
         is Ok -> "ok"
@@ -103,15 +103,15 @@ sealed interface BranchFetch {
         is TooLarge -> "too large (over $limitBytes bytes)"
       }
 
-  companion object {
+  public companion object {
     /** Longest we will ever honour a `Retry-After` for — beyond this, failing fast is kinder. */
-    const val MAX_RETRY_AFTER_SECONDS = 30L
+    public const val MAX_RETRY_AFTER_SECONDS: Long = 30L
 
     /** Attempts after the first. Small: a request is waiting behind this. */
-    const val MAX_RETRIES = 2
+    public const val MAX_RETRIES: Int = 2
 
     /** First backoff step; doubled per attempt. */
-    const val BASE_BACKOFF_MILLIS = 250L
+    public const val BASE_BACKOFF_MILLIS: Long = 250L
 
     /**
      * Classify one HTTP status.
@@ -119,7 +119,7 @@ sealed interface BranchFetch {
      * [retryAfterSeconds] is the parsed `Retry-After` header, or null. Only consulted for the
      * statuses that can carry one.
      */
-    fun ofStatus(status: Int, retryAfterSeconds: Long? = null): BranchFetch =
+    public fun ofStatus(status: Int, retryAfterSeconds: Long? = null): BranchFetch =
       when {
         status == 404 || status == 410 -> NotFound
         status == 429 || status == 403 -> Throttled(retryAfterSeconds?.coerceAtLeast(0))
@@ -135,7 +135,7 @@ sealed interface BranchFetch {
      * [MAX_RETRY_AFTER_SECONDS] so a hostile or confused header cannot park a request thread for
      * minutes.
      */
-    fun retryDelayMillis(outcome: BranchFetch, attempt: Int): Long? {
+    public fun retryDelayMillis(outcome: BranchFetch, attempt: Int): Long? {
       if (!outcome.isTransient) return null
       if (attempt < 1 || attempt > MAX_RETRIES) return null
       val backoff = BASE_BACKOFF_MILLIS shl (attempt - 1)
@@ -154,6 +154,7 @@ sealed interface BranchFetch {
      * needs a clock and a parse to answer the same question, and no branch host we read sends it.
      * An unparseable value is simply absent, which falls back to the exponential schedule.
      */
-    fun parseRetryAfter(header: String?): Long? = header?.trim()?.toLongOrNull()?.takeIf { it >= 0 }
+    public fun parseRetryAfter(header: String?): Long? =
+      header?.trim()?.toLongOrNull()?.takeIf { it >= 0 }
   }
 }

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBroadcastHub.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBroadcastHub.kt
@@ -10,8 +10,8 @@ import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
 /** Opens one upstream daemon stream. Matches [ServeRenderHost.startStream]. */
-fun interface StreamOpener {
-  fun open(
+public fun interface StreamOpener {
+  public fun open(
     previewId: String,
     overrides: PreviewOverrides,
     codec: StreamCodec?,
@@ -39,7 +39,7 @@ fun interface StreamOpener {
  * shared session and its [StreamHandle.close] drops just that watcher (closing the shared upstream
  * only when it was the last).
  */
-class ServeBroadcastHub(private val opener: StreamOpener) {
+public class ServeBroadcastHub(private val opener: StreamOpener) {
 
   private val lock = ReentrantLock()
   private val broadcasts = HashMap<String, Broadcast>()
@@ -49,7 +49,7 @@ class ServeBroadcastHub(private val opener: StreamOpener) {
    * this is the first watcher. Returns `null` (and opens nothing) when the backend can't stream, so
    * the caller falls back to the snapshot lane — same contract as [ServeRenderHost.startStream].
    */
-  fun subscribe(
+  public fun subscribe(
     previewId: String,
     overrides: PreviewOverrides,
     codec: StreamCodec? = null,
@@ -76,7 +76,7 @@ class ServeBroadcastHub(private val opener: StreamOpener) {
   }
 
   /** Live shared upstream streams (one per distinct key). For tests / diagnostics. */
-  fun activeStreamCount(): Int = lock.withLock { broadcasts.size }
+  public fun activeStreamCount(): Int = lock.withLock { broadcasts.size }
 
   private fun release(broadcast: Broadcast, watcher: Broadcast.Watcher) {
     lock.withLock {

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -57,7 +57,7 @@ public object ServeBundleDaemon {
    * takes one. Tuned for the reference 4 GB box's default budget; a bigger box's budget scales up
    * (see `deploy/image/entrypoint.sh`), letting more of these run at once.
    */
-  const val ANDROID_LIVE_SEAT_WEIGHT: Int = 2
+  public const val ANDROID_LIVE_SEAT_WEIGHT: Int = 2
 
   /**
    * Live-seat weight ([LiveSeatLimiter] permits) of an already-built daemon [descriptor] file — for
@@ -69,7 +69,7 @@ public object ServeBundleDaemon {
    * protection intact in from-source deployments. Defaults to `1` (desktop) when the descriptor is
    * missing or unreadable.
    */
-  fun liveSeatWeightForDescriptor(descriptor: File): Int {
+  public fun liveSeatWeightForDescriptor(descriptor: File): Int {
     val text = descriptor.takeIf { it.isFile }?.let { runCatching { it.readText() }.getOrNull() }
     val launch =
       text?.let {
@@ -90,7 +90,7 @@ public object ServeBundleDaemon {
    * `-Dcomposeai.bundle.offline`); default `false` still honours that sysprop /
    * `COMPOSE_PREVIEW_OFFLINE` via [CoordinateResolver]'s own default.
    */
-  fun materialize(
+  public fun materialize(
     bundleFile: File,
     destDir: File,
     system: String,
@@ -449,7 +449,7 @@ public object ServeBundleDaemon {
    * the snippet's daemon inside the jail and shoots it at the deadline. [PlaygroundSandbox.NONE]
    * leaves the descriptor identical to the pre-sandbox one.
    */
-  fun materializePlaygroundSnippet(
+  public fun materializePlaygroundSnippet(
     snippet: PlaygroundTokenStore.PlaygroundSnippet,
     sandbox: PlaygroundSandbox = PlaygroundSandbox.NONE,
     fileSystem: FileSystem = SystemFileSystem,
@@ -728,7 +728,7 @@ public object ServeBundleDaemon {
    * Null on anything unreadable, which the caller treats as "this generation has no durable
    * identity" and therefore as "do not persist".
    */
-  fun readLaunchDescriptor(descriptorFile: File): DaemonLaunchDescriptor? = runCatching {
+  public fun readLaunchDescriptor(descriptorFile: File): DaemonLaunchDescriptor? = runCatching {
     launchDescriptorJson.decodeFromString(
       DaemonLaunchDescriptor.serializer(),
       descriptorFile.readText(),

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeDegradation.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeDegradation.kt
@@ -11,28 +11,28 @@ package ee.schimke.composeai.cli.serve
  * [code] is a stable machine slug a programmatic client can switch on; [detail] is a one-sentence
  * explanation shown in the UI. Keep [code] values in lockstep with any downstream consumer.
  */
-data class ServeDegradation(val code: String, val detail: String) {
-  companion object {
+public data class ServeDegradation(val code: String, val detail: String) {
+  public companion object {
     /**
      * The catalog publishes baked PNGs only — its delivery branch carries no `liveBundle` (and no
      * source this server can build), so no device/theme/knob control can re-render. The common case
      * for an app catalog that hasn't opted into the live tier yet.
      */
-    const val CATALOG_BAKED_ONLY = "catalog-baked-only"
+    public const val CATALOG_BAKED_ONLY: String = "catalog-baked-only"
 
     /**
      * The catalog declared a `liveBundle` but the server couldn't stand a daemon up from it (the
      * bundle or one of its externalized resources failed to fetch/verify, or the daemon didn't
      * start), so it fell back to baked PNGs. [detail] carries the specific cause.
      */
-    const val LIVEBUNDLE_UNAVAILABLE = "livebundle-unavailable"
+    public const val LIVEBUNDLE_UNAVAILABLE: String = "livebundle-unavailable"
 
     /**
      * The catalog offers a live lane (a `liveBundle` or a buildable source) but verified as
      * `Unverified`, so the server refuses to re-render it (fail-closed) and serves baked PNGs. The
      * trust badge already shows the amber verdict; this states the consequence.
      */
-    const val UNVERIFIED_NO_RERENDER = "unverified-no-rerender"
+    public const val UNVERIFIED_NO_RERENDER: String = "unverified-no-rerender"
 
     /**
      * The catalog declares live-only (`deferred[]`) coverage this session can't produce: those
@@ -40,7 +40,7 @@ data class ServeDegradation(val code: String, val detail: String) {
      * them from — so they are omitted from the grid rather than shown as broken cards. The count
      * rides in [detail] so a visitor knows the sheet is thinner than the catalog claims.
      */
-    const val DEFERRED_NOT_SERVED = "deferred-not-served"
+    public const val DEFERRED_NOT_SERVED: String = "deferred-not-served"
 
     /**
      * The session HAD a working live lane and the server has since **switched it off**: its render
@@ -48,14 +48,14 @@ data class ServeDegradation(val code: String, val detail: String) {
      * sustained failure rate), so live renders are refused with the underlying reason rather than
      * retried. Distinct from [LIVEBUNDLE_UNAVAILABLE], which is a daemon that never came up.
      */
-    const val RENDER_LANE_BROKEN = "render-lane-broken"
+    public const val RENDER_LANE_BROKEN: String = "render-lane-broken"
 
     /**
      * The live render lane was disabled by its circuit breaker; [reason] is the breaker's text and
      * [fatal] marks a linkage fault (needs a fixed bundle, not a retry). See
      * [RenderCircuitBreaker].
      */
-    fun renderLaneBroken(reason: String, fatal: Boolean): ServeDegradation =
+    public fun renderLaneBroken(reason: String, fatal: Boolean): ServeDegradation =
       ServeDegradation(
         RENDER_LANE_BROKEN,
         if (fatal) {
@@ -73,7 +73,7 @@ data class ServeDegradation(val code: String, val detail: String) {
      * whichever reason explains the missing live lane (no live bundle / unverified / bundle
      * unavailable).
      */
-    fun deferredNotServed(count: Int): ServeDegradation =
+    public fun deferredNotServed(count: Int): ServeDegradation =
       ServeDegradation(
         DEFERRED_NOT_SERVED,
         "$count preview(s) in this catalog are published live-only (rendered on demand rather " +
@@ -82,7 +82,7 @@ data class ServeDegradation(val code: String, val detail: String) {
       )
 
     /** A baked-only catalog with no live bundle on its delivery branch. */
-    fun catalogBakedOnly(): ServeDegradation =
+    public fun catalogBakedOnly(): ServeDegradation =
       ServeDegradation(
         CATALOG_BAKED_ONLY,
         "This catalog serves baked PNG snapshots only — its delivery branch publishes no live " +
@@ -90,7 +90,7 @@ data class ServeDegradation(val code: String, val detail: String) {
       )
 
     /** A declared live bundle that couldn't be brought up; [cause] is the specific reason. */
-    fun liveBundleUnavailable(cause: String): ServeDegradation =
+    public fun liveBundleUnavailable(cause: String): ServeDegradation =
       ServeDegradation(
         LIVEBUNDLE_UNAVAILABLE,
         "This catalog publishes a live bundle, but the server couldn't render from it ($cause) — " +
@@ -98,7 +98,7 @@ data class ServeDegradation(val code: String, val detail: String) {
       )
 
     /** A live-capable catalog that verified as unverified, so re-render is refused. */
-    fun unverifiedNoRerender(): ServeDegradation =
+    public fun unverifiedNoRerender(): ServeDegradation =
       ServeDegradation(
         UNVERIFIED_NO_RERENDER,
         "This catalog is unverified, so the server won't re-render it (fail-closed) — showing " +

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeDesignAnnotations.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeDesignAnnotations.kt
@@ -48,7 +48,7 @@ import ee.schimke.composeai.data.theme.ThemePayload
  * may therefore contain multiple honest candidates when two roles resolve identically. A node that
  * resolved no typography (or no container tokens) simply contributes no annotation to that layer.
  */
-object ServeDesignAnnotations {
+public object ServeDesignAnnotations {
 
   /**
    * The typography, theme and layout annotations for one render, in depth-first order (the order
@@ -64,7 +64,7 @@ object ServeDesignAnnotations {
    * parent, so a chain of wrappers that all reproduce one box collapses to one rectangle instead of
    * comparing each node only against the one directly above it and emitting the whole stack.
    */
-  fun annotations(
+  public fun annotations(
     payload: ComposeSemanticsPayload,
     theme: ThemePayload? = null,
     layout: LayoutInspectorPayload? = null,

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeDesignPages.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeDesignPages.kt
@@ -45,9 +45,9 @@ import okio.Path.Companion.toPath
  * origin ([ServeFigmaSpec]) rather than taken from the file, so a manifest declaring `javascript:…`
  * yields no link instead of an attacker-chosen href.
  */
-class ServeDesignPageStore
+public class ServeDesignPageStore
 private constructor(
-  val pages: List<DesignPage>,
+  public val pages: List<DesignPage>,
   /** Sanitized markup per page id, ready to inline. Built at load; see the class comment. */
   private val markup: Map<String, String>,
   private val manifest: DesignPagesManifest? = null,
@@ -55,9 +55,9 @@ private constructor(
   private val byId: Map<String, DesignPage> = pages.associateBy { it.id }
 
   /** The Figma file the pages came from, or empty when the manifest named no well-formed one. */
-  val fileKey: String = manifest?.fileKey?.takeIf(::isSafeFileKey).orEmpty()
+  public val fileKey: String = manifest?.fileKey?.takeIf(::isSafeFileKey).orEmpty()
 
-  fun page(pageId: String): DesignPage? = byId[pageId]
+  public fun page(pageId: String): DesignPage? = byId[pageId]
 
   /**
    * Sanitized SVG for a previously advertised page, or null.
@@ -67,7 +67,7 @@ private constructor(
    * export from the catalog branch would get markup this server has already judged unsafe to
    * inline, and shipping two different answers for one URL is how a check gets bypassed.
    */
-  fun svg(pageId: String): String? = markup[pageId]
+  public fun svg(pageId: String): String? = markup[pageId]
 
   /**
    * The design ref for [node] — the producer's own, or the one it would have written.
@@ -76,20 +76,20 @@ private constructor(
    * node with no ref can still deep-link back into the design tool. That matters most for an
    * *unlinked* node, where the design-tool link is the only one there is.
    */
-  fun refFor(node: PageNode): String = manifest?.refFor(node) ?: node.ref.orEmpty()
+  public fun refFor(node: PageNode): String = manifest?.refFor(node) ?: node.ref.orEmpty()
 
-  companion object {
+  public companion object {
     /** Directory (bundle-relative) the manifest and its cached SVGs live in. */
-    const val DIRECTORY = "pages"
+    public const val DIRECTORY: String = "pages"
 
-    const val INDEX_FILE = "index.json"
+    public const val INDEX_FILE: String = "index.json"
 
     /**
      * How many nodes one page may carry. The kit's densest definition sheet — `Buttons` — holds a
      * few hundred component nodes; this is above that and far below anything that would turn one
      * page into an enormous response. Every node becomes a list row and a hotspot.
      */
-    const val MAX_NODES_PER_PAGE = 500
+    public const val MAX_NODES_PER_PAGE: Int = 500
 
     private val SAFE_ID = Regex("[A-Za-z0-9._-]{1,160}")
 
@@ -100,9 +100,12 @@ private constructor(
       Regex("""\A\s*(?:<\?xml[^>]*\?>\s*)?(?:<!--.*?-->\s*)*<svg\b""", RegexOption.DOT_MATCHES_ALL)
 
     /** An empty store — the state every host without a page manifest is in. */
-    fun empty(): ServeDesignPageStore = ServeDesignPageStore(emptyList(), emptyMap())
+    public fun empty(): ServeDesignPageStore = ServeDesignPageStore(emptyList(), emptyMap())
 
-    fun load(bundleDir: File, fileSystem: FileSystem = SystemFileSystem): ServeDesignPageStore {
+    public fun load(
+      bundleDir: File,
+      fileSystem: FileSystem = SystemFileSystem,
+    ): ServeDesignPageStore {
       val root = bundleDir.toOkioPath()
       val manifestPath = root / DIRECTORY / INDEX_FILE
       val manifest =
@@ -147,7 +150,7 @@ private constructor(
      * written into the staging tree, not only when it is read back — the same split
      * [ServeParityActivityStore.sanitize] uses.
      */
-    fun drawablePages(manifest: DesignPagesManifest): List<DesignPage> {
+    public fun drawablePages(manifest: DesignPagesManifest): List<DesignPage> {
       if (!manifest.isSupported) return emptyList()
       val seen = HashSet<String>()
       return manifest.pages
@@ -156,7 +159,7 @@ private constructor(
     }
 
     /** A Figma file key is URL-safe alphanumerics; anything else is not a key we will link to. */
-    fun isSafeFileKey(value: String): Boolean = Regex("[A-Za-z0-9_-]{1,64}").matches(value)
+    public fun isSafeFileKey(value: String): Boolean = Regex("[A-Za-z0-9_-]{1,64}").matches(value)
 
     /**
      * `.svg` and `.json` are **reserved**, because the export and the page's data come off the same
@@ -194,7 +197,7 @@ private constructor(
  */
 // Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
 // and the `:server` call sites are in a different module now. Not a widened API by intent.
-val PageNodeLink.wire: String
+public val PageNodeLink.wire: String
   get() =
     when (this) {
       PageNodeLink.CODE_CONNECT -> "code-connect"

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeDesignReferences.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeDesignReferences.kt
@@ -21,18 +21,18 @@ import okio.Path.Companion.toPath
  * design URLs.
  */
 @Serializable
-data class DesignReferenceManifest(
+public data class DesignReferenceManifest(
   val schema: String = SCHEMA,
   val references: List<DesignReference> = emptyList(),
 ) {
-  companion object {
-    const val SCHEMA = "compose-preview-references/v1"
+  public companion object {
+    public const val SCHEMA: String = "compose-preview-references/v1"
   }
 }
 
 /** One independently-authored design reference mapped to an exact [previewId]. */
 @Serializable
-data class DesignReference(
+public data class DesignReference(
   /** Route-safe identity, unique within one served session. */
   val id: String,
   /** Exact serve/catalog preview id; theme/state/props selection is never inferred. */
@@ -72,7 +72,7 @@ data class DesignReference(
  * and the lane's live ones come from one implementation and cannot disagree.
  */
 @Serializable
-data class DesignReferenceMatch(
+public data class DesignReferenceMatch(
   val percent: Double,
   val changedPercent: Double? = null,
   val geometry: Double? = null,
@@ -96,7 +96,7 @@ data class DesignReferenceMatch(
 )
 
 @Serializable
-data class DesignReferenceRaster(
+public data class DesignReferenceRaster(
   val path: String,
   val width: Int? = null,
   val height: Int? = null,
@@ -105,7 +105,7 @@ data class DesignReferenceRaster(
 )
 
 @Serializable
-data class DesignReferenceSource(
+public data class DesignReferenceSource(
   /** `figma`, `png`, `svg`, `html`, or another provider-defined token. */
   val provider: String = "file",
   /** Informational only. The serve host never fetches this URI. */
@@ -115,7 +115,7 @@ data class DesignReferenceSource(
   val attributes: Map<String, String> = emptyMap(),
 )
 
-@Serializable data class DesignReferenceArtifact(val kind: String, val path: String? = null)
+@Serializable public data class DesignReferenceArtifact(val kind: String, val path: String? = null)
 
 /**
  * Validated, read-only view of a bundle/catalog's `references/index.json`.
@@ -123,7 +123,7 @@ data class DesignReferenceSource(
  * All failures are fail-soft: malformed, missing, traversing, duplicate, or hash-mismatched records
  * are omitted while the rest of the preview bundle continues to serve normally.
  */
-class ServeDesignReferenceStore
+public class ServeDesignReferenceStore
 private constructor(
   private val root: Path,
   references: List<DesignReference>,
@@ -132,11 +132,11 @@ private constructor(
   private val byId: Map<String, DesignReference> = references.associateBy { it.id }
   private val byPreview: Map<String, List<DesignReference>> = references.groupBy { it.previewId }
 
-  val all: List<DesignReference> = references
+  public val all: List<DesignReference> = references
 
-  fun forPreview(previewId: String): List<DesignReference> = byPreview[previewId].orEmpty()
+  public fun forPreview(previewId: String): List<DesignReference> = byPreview[previewId].orEmpty()
 
-  fun raster(referenceId: String): ByteArray? {
+  public fun raster(referenceId: String): ByteArray? {
     val reference = byId[referenceId] ?: return null
     val path = containedPath(reference.raster.path) ?: return null
     return runCatching { fileSystem.read(path) { readByteArray() } }.getOrNull()
@@ -162,9 +162,9 @@ private constructor(
     val references: List<JsonElement> = emptyList(),
   )
 
-  companion object {
-    const val DIRECTORY = "references"
-    const val INDEX_FILE = "index.json"
+  public companion object {
+    public const val DIRECTORY: String = "references"
+    public const val INDEX_FILE: String = "index.json"
 
     /**
      * The pixel path this build's scorer implements — mirrored from `SCORE_VERSION` in
@@ -176,13 +176,13 @@ private constructor(
      * it, so a host reading the wrong version would either discard every current match or trust
      * every stale one.
      */
-    const val SCORE_VERSION = 3
+    public const val SCORE_VERSION: Int = 3
     private val SAFE_ID = Regex("[A-Za-z0-9._-]{1,160}")
     private val SHA256 = Regex("[a-f0-9]{64}")
     private val PNG_SIGNATURE = byteArrayOf(0x89.toByte(), 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a)
     private val JSON = Json { ignoreUnknownKeys = true }
 
-    fun load(
+    public fun load(
       bundleDir: File,
       fileSystem: FileSystem = SystemFileSystem,
     ): ServeDesignReferenceStore {
@@ -241,7 +241,7 @@ private constructor(
 
     // Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
     // and the `:server` call sites are in a different module now. Not a widened API by intent.
-    fun isSafeRelativePath(value: String): Boolean {
+    public fun isSafeRelativePath(value: String): Boolean {
       if (value.isBlank() || value.startsWith('/') || value.startsWith('\\')) return false
       if (Regex("^[A-Za-z]:").containsMatchIn(value)) return false
       return value.replace('\\', '/').split('/').none { it.isBlank() || it == "." || it == ".." }
@@ -249,7 +249,7 @@ private constructor(
 
     // Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
     // and the `:server` call sites are in a different module now. Not a widened API by intent.
-    fun isValid(reference: DesignReference, bytes: ByteArray): Boolean =
+    public fun isValid(reference: DesignReference, bytes: ByteArray): Boolean =
       hasValidMetadata(reference) && hasValidRaster(reference, bytes)
 
     private fun hasValidMetadata(reference: DesignReference): Boolean =

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvg.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvg.kt
@@ -27,7 +27,7 @@ private val FIGMA_RASTER_HREF = Regex("href=\"([^\"]*figma-raster/[^\"]+)\"")
  */
 // Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
 // and the `:server` call sites are in a different module now. Not a widened API by intent.
-fun figmaRasterHrefs(svg: String): List<String> =
+public fun figmaRasterHrefs(svg: String): List<String> =
   FIGMA_RASTER_HREF.findAll(svg).map { it.groupValues[1] }.toList()
 
 /**
@@ -53,7 +53,7 @@ internal const val MAX_INLINE_RASTER_EDGE_PX: Int = MAX_FIGMA_RASTER_EDGE_PX
  */
 // Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
 // and the `:server` call sites are in a different module now. Not a widened API by intent.
-fun inlineFigmaRasters(
+public fun inlineFigmaRasters(
   fileSystem: FileSystem,
   dir: Path,
   svg: String,
@@ -83,7 +83,7 @@ fun inlineFigmaRasters(
  */
 // Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
 // and the `:server` call sites are in a different module now. Not a widened API by intent.
-fun linkFigmaRasters(svg: String, baseUrl: String): String {
+public fun linkFigmaRasters(svg: String, baseUrl: String): String {
   if (!svg.contains("figma-raster/")) return svg
   val base = baseUrl.trimEnd('/')
   return FIGMA_RASTER_HREF.replace(svg) { match ->
@@ -123,7 +123,7 @@ private val FONT_FACE_BLOCK = Regex("@font-face\\{[^}]*\\}")
  */
 // Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
 // and the `:server` call sites are in a different module now. Not a widened API by intent.
-fun webModeSvg(svg: String): String {
+public fun webModeSvg(svg: String): String {
   val faces = FONT_FACE_BLOCK.findAll(svg).mapNotNull { parseWebFontFace(it.value) }.toList()
   if (faces.isEmpty()) return svg
   val importUrl = googleFontsImportUrl(faces) ?: return svg

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -15,42 +15,42 @@ import ee.schimke.composeai.daemon.protocol.UiMode
  * The HTTP routes and the registry only need this surface, so either kind can be served at
  * `?session=<id>` uniformly.
  */
-interface ServeHost : AutoCloseable {
+public interface ServeHost : AutoCloseable {
   /** The whole servable preview set for this session. */
-  val previews: List<ServePreview>
+  public val previews: List<ServePreview>
 
   /** One same-origin asset from a preview's portable spatial scene, or null when unavailable. */
-  fun spatialAsset(previewId: String, relativePath: String): ServeSpatialAsset? = null
+  public fun spatialAsset(previewId: String, relativePath: String): ServeSpatialAsset? = null
 
   /** Whether the server can return a self-contained executable bundle for this preview. */
-  fun canDownloadExecutableBundle(previewId: String): Boolean = false
+  public fun canDownloadExecutableBundle(previewId: String): Boolean = false
 
   /** A hydrated, self-contained PNG+ZIP preview bundle, or null when this host has no such lane. */
-  fun executableBundle(previewId: String): ByteArray? = null
+  public fun executableBundle(previewId: String): ByteArray? = null
 
   /** Independently-authored design references mapped to [previewId], if this host carries any. */
-  fun designReferencesFor(previewId: String): List<DesignReference> = emptyList()
+  public fun designReferencesFor(previewId: String): List<DesignReference> = emptyList()
 
   /** Canonical PNG bytes for a previously advertised design [referenceId]. */
-  fun designReferenceRaster(referenceId: String): ByteArray? = null
+  public fun designReferenceRaster(referenceId: String): ByteArray? = null
 
   /**
    * Design pages this session publishes (`pages/index.json`), or empty when it publishes none — the
    * common case, and the one every host defaults to. See [ServeDesignPages].
    */
-  fun designPages(): ServeDesignPageStore = ServeDesignPageStore.empty()
+  public fun designPages(): ServeDesignPageStore = ServeDesignPageStore.empty()
 
   /** Sanitized SVG markup for a previously advertised page. */
-  fun designPageSvg(pageId: String): String? = designPages().svg(pageId)
+  public fun designPageSvg(pageId: String): String? = designPages().svg(pageId)
 
   /**
    * Typography / layout annotations over this preview's *rendered* frame, if the session carries
    * any. Empty by default — a host with no annotation manifest serves the compare page unchanged.
    */
-  fun annotationsForPreview(previewId: String): List<DesignAnnotation> = emptyList()
+  public fun annotationsForPreview(previewId: String): List<DesignAnnotation> = emptyList()
 
   /** Typography / layout annotations over a design reference's raster. */
-  fun annotationsForReference(referenceId: String): List<DesignAnnotation> = emptyList()
+  public fun annotationsForReference(referenceId: String): List<DesignAnnotation> = emptyList()
 
   /**
    * The **published** tag index for [previewId] — `testTag → {count, bounds}`, the element identity
@@ -64,7 +64,8 @@ interface ServeHost : AutoCloseable {
    * from. Two producers, one projection, deliberately not one code path: only one of them has a
    * daemon.
    */
-  fun tagIndexForPreview(previewId: String): Map<String, ServeSemanticsTags.TagEntry> = emptyMap()
+  public fun tagIndexForPreview(previewId: String): Map<String, ServeSemanticsTags.TagEntry> =
+    emptyMap()
 
   /**
    * The design-parity activity feed this catalog published (`parity/activity.json`), or null when
@@ -72,10 +73,10 @@ interface ServeHost : AutoCloseable {
    * `/<system>/parity` view's code / Figma feeds; the coverage half of that page is derived from
    * [previews] + [designReferencesFor] and needs no feed at all.
    */
-  fun parityActivity(): ParityActivity? = null
+  public fun parityActivity(): ParityActivity? = null
 
   /** The validated GitHub issue snapshot this catalog published. */
-  fun parityIssues(): ParityIssues? = null
+  public fun parityIssues(): ParityIssues? = null
 
   /**
    * The parity **verdict** this catalog published for one comparison (`parity/findings.json`) — the
@@ -85,7 +86,7 @@ interface ServeHost : AutoCloseable {
    * Keyed by the PAIR rather than by the preview alone because that is what a finding describes;
    * see [ServeParityFindingStore.forComparison] for what an unscoped set means.
    */
-  fun parityFindingsFor(previewId: String, referenceId: String): List<ParityFindingSet> =
+  public fun parityFindingsFor(previewId: String, referenceId: String): List<ParityFindingSet> =
     emptyList()
 
   /**
@@ -98,7 +99,7 @@ interface ServeHost : AutoCloseable {
    * would be a third implementation of the same rules with no conformance suite behind it. See
    * [ServeKnownDifferences].
    */
-  fun knownDifferences(): ServeKnownDifferences.Document? = null
+  public fun knownDifferences(): ServeKnownDifferences.Document? = null
 
   /**
    * One of that document's artifacts, addressed as the document addresses it (`<id>/<path>`).
@@ -107,7 +108,7 @@ interface ServeHost : AutoCloseable {
    * with no artifact tree and a path that resolves to no file are the same answer to the consumer:
    * the record's bytes could not be read.
    */
-  fun knownDifferenceArtifact(relativePath: String): ServeKnownDifferences.Artifact =
+  public fun knownDifferenceArtifact(relativePath: String): ServeKnownDifferences.Artifact =
     ServeKnownDifferences.Artifact.Unreadable
 
   /**
@@ -117,7 +118,7 @@ interface ServeHost : AutoCloseable {
    * (`themeProvider` needs the daemon to load the provider off the app classpath), so it stays
    * empty and the selector shows only the built-in light/dark axis.
    */
-  val declaredThemes: List<ServeTheme>
+  public val declaredThemes: List<ServeTheme>
     get() = emptyList()
 
   /**
@@ -131,7 +132,7 @@ interface ServeHost : AutoCloseable {
    * [ServeBundleHost] (the baked host [ServeCatalogStore] terminally registers) carries a populated
    * list.
    */
-  val degradations: List<ServeDegradation>
+  public val degradations: List<ServeDegradation>
     get() = emptyList()
 
   /**
@@ -146,7 +147,7 @@ interface ServeHost : AutoCloseable {
    * browse (there is no baked PNG to replay — see [CatalogLiveRouting.daemonIdForRender]), and the
    * viewer can badge the card as live-only. Empty for every ordinary session.
    */
-  val liveOnlyPreviewIds: Set<String>
+  public val liveOnlyPreviewIds: Set<String>
     get() = emptySet()
 
   /**
@@ -160,7 +161,7 @@ interface ServeHost : AutoCloseable {
    * conservative one — an unnamed theme routes a `uiMode` request to a real render rather than
    * replaying a sticker whose mode nothing established.
    */
-  fun bakedTheme(previewId: String): UiMode? = ServeBakedTheme.token(previewId)
+  public fun bakedTheme(previewId: String): UiMode? = ServeBakedTheme.token(previewId)
 
   /**
    * The Remote Compose player [previewId]'s **baked** pixels were drawn with, or null when this
@@ -190,10 +191,10 @@ interface ServeHost : AutoCloseable {
    * exporter carries it). A catalog published before that field existed reads back null and keeps
    * naming its player, which is the behaviour that predates this seam.
    */
-  fun bakedRcPlayer(previewId: String): RemoteComposePlayerKind? = null
+  public fun bakedRcPlayer(previewId: String): RemoteComposePlayerKind? = null
 
   /** Human label for the tenant (module Gradle path, `module@rev`, or a bundle name). */
-  val label: String
+  public val label: String
 
   /**
    * Whether editing an override actually re-renders. `true` for a daemon-backed host
@@ -201,7 +202,7 @@ interface ServeHost : AutoCloseable {
    * replay the baked PNGs — the viewer then shows the preview's declared knobs as disabled,
    * informational controls.
    */
-  val canApplyOverrides: Boolean
+  public val canApplyOverrides: Boolean
     get() = false
 
   /**
@@ -214,7 +215,7 @@ interface ServeHost : AutoCloseable {
    * and instant) but `canRenderOverrides = true` — an override-bearing `/render` re-renders through
    * the carried daemon on demand, so a `?knob.<key>=…` (or display-axis) URL returns fresh pixels.
    */
-  val canRenderOverrides: Boolean
+  public val canRenderOverrides: Boolean
     get() = canApplyOverrides
 
   /**
@@ -226,7 +227,7 @@ interface ServeHost : AutoCloseable {
    * theme) as disabled/informational rather than enabled-but-dead (an override on such a preview
    * falls back to the baked PNG, which ignores it).
    */
-  fun canRenderOverridesFor(previewId: String): Boolean = canRenderOverrides
+  public fun canRenderOverridesFor(previewId: String): Boolean = canRenderOverrides
 
   /**
    * The **named-value overrides that apply a declared theme to an already-recorded document** —
@@ -248,7 +249,7 @@ interface ServeHost : AutoCloseable {
    * re-running the composable, which reaches everything a theme does — including the typeface,
    * which has no named value to carry it.
    */
-  fun themeReplayColors(providerFqn: String): Map<String, String> = emptyMap()
+  public fun themeReplayColors(providerFqn: String): Map<String, String> = emptyMap()
 
   /**
    * The declared themes a **replayed** preview can actually be rendered under — those this host
@@ -259,7 +260,7 @@ interface ServeHost : AutoCloseable {
    * whole declared set because *one* of them is mapped puts the unmapped ones back on the terminal
    * 409 the gate exists to prevent.
    */
-  fun replayableThemes(): List<ServeTheme> = declaredThemes.filter {
+  public fun replayableThemes(): List<ServeTheme> = declaredThemes.filter {
     themeReplayColors(it.providerFqn).isNotEmpty()
   }
 
@@ -269,7 +270,7 @@ interface ServeHost : AutoCloseable {
    * per-preview daemons may opt into a larger temporary burst; the HTTP server still clamps it to
    * its render slots and shares that burst across every active page for the same catalog.
    */
-  val themeRenderBurstCapacity: Int
+  public val themeRenderBurstCapacity: Int
     get() = 1
 
   /**
@@ -277,7 +278,7 @@ interface ServeHost : AutoCloseable {
    * no cache return null. [render] remains the authoritative path and must recheck its cache after
    * admission to close the lookup/render race.
    */
-  fun cachedRender(previewId: String, overrides: PreviewOverrides): RenderOutcome.Ok? = null
+  public fun cachedRender(previewId: String, overrides: PreviewOverrides): RenderOutcome.Ok? = null
 
   /**
    * Serve [previewId] from pixels **already on this box** — a baked PNG on disk — or null when
@@ -293,7 +294,7 @@ interface ServeHost : AutoCloseable {
    * Must be cheap and non-blocking: no daemon, no network, no waiting. Returning null is always
    * safe — the caller falls back to the admitted [render] path.
    */
-  fun bakedRender(previewId: String, overrides: PreviewOverrides): RenderOutcome.Ok? = null
+  public fun bakedRender(previewId: String, overrides: PreviewOverrides): RenderOutcome.Ok? = null
 
   /**
    * Make [previewId]'s published pixels local, if this host can fetch them and has not already.
@@ -313,7 +314,7 @@ interface ServeHost : AutoCloseable {
    * attempt retries. Default does nothing, which is right for every host with no published bytes
    * behind it.
    */
-  fun warmBakedRender(previewId: String) {}
+  public fun warmBakedRender(previewId: String) {}
 
   /**
    * [previewId]'s baked render size in pixels, read from the PNG header alone — no decode, no
@@ -325,7 +326,7 @@ interface ServeHost : AutoCloseable {
    * build to learn two integers. Null is always safe: the page then omits the dimensions and the
    * unfurler measures the image itself.
    */
-  fun bakedRenderSize(previewId: String): Pair<Int, Int>? = null
+  public fun bakedRenderSize(previewId: String): Pair<Int, Int>? = null
 
   /**
    * The bytes of one published animated capture, or null when this host has none to serve.
@@ -343,7 +344,7 @@ interface ServeHost : AutoCloseable {
    * say but 404, and the reader with "could not be loaded" for both. Defaults to
    * [BranchFetch.NotFound] — a host with no branch behind it publishes no captures.
    */
-  fun motionRead(motionId: String, extension: String): BranchFetch = BranchFetch.NotFound
+  public fun motionRead(motionId: String, extension: String): BranchFetch = BranchFetch.NotFound
 
   /**
    * A visitor is present on this session's pages right now (see `POST /api/presence`) — get its
@@ -359,7 +360,7 @@ interface ServeHost : AutoCloseable {
    * implementation must return immediately and do nothing at all once its lane is ready. Hosts with
    * no live lane (a static baked bundle) keep the default no-op.
    */
-  fun keepLiveWarm() {}
+  public fun keepLiveWarm() {}
 
   /**
    * Aggregate render-performance counters for this host's live render lane, surfaced on `/status`
@@ -368,7 +369,7 @@ interface ServeHost : AutoCloseable {
    *   record every serve-side render round-trip; composites ([ServeCatalogLiveHost]) forward their
    *   carried daemon's stats.
    */
-  fun renderPerfStats(): RenderPerfSnapshot? = null
+  public fun renderPerfStats(): RenderPerfSnapshot? = null
 
   /**
    * This lane's open render breaker, or null while it is rendering normally (the healthy case, and
@@ -378,23 +379,23 @@ interface ServeHost : AutoCloseable {
    * that schedule background render work must consult it and stand down: feeding a broken renderer
    * is what burned 275s of render gate and a ~7h ETA in issue #3448.
    */
-  fun renderBreaker(): RenderBreakerSnapshot? = null
+  public fun renderBreaker(): RenderBreakerSnapshot? = null
 
   /**
    * Bounded child-daemon pools owned by this host, surfaced on `/status.json` so production
    * monitors can distinguish "one catalog daemon is up" from "a catalog daemon plus N per-preview
    * daemons are resident". Empty for ordinary hosts.
    */
-  fun daemonPoolStats(): List<DaemonPoolSnapshot> = emptyList()
+  public fun daemonPoolStats(): List<DaemonPoolSnapshot> = emptyList()
 
   /** Server-side catalog theme optimization progress, or null for hosts without that cache. */
-  fun themeOptimizationSnapshot(): ThemeOptimizationSnapshot? = null
+  public fun themeOptimizationSnapshot(): ThemeOptimizationSnapshot? = null
 
   /** Memory occupancy of this catalog generation's durable rendered-preview cache. */
-  fun catalogRenderCacheSnapshot(): CatalogRenderCacheSnapshot? = null
+  public fun catalogRenderCacheSnapshot(): CatalogRenderCacheSnapshot? = null
 
   /** True while low-priority work still needs this host resident. */
-  val backgroundWorkActive: Boolean
+  public val backgroundWorkActive: Boolean
     get() = false
 
   /**
@@ -405,7 +406,7 @@ interface ServeHost : AutoCloseable {
    * `@GestureHintPreview` component doesn't show a toggle that would do nothing on a desktop-backed
    * session. Defaults false (a static bundle has no daemon; a desktop daemon doesn't support it).
    */
-  val gesturesRenderable: Boolean
+  public val gesturesRenderable: Boolean
     get() = false
 
   /**
@@ -414,7 +415,7 @@ interface ServeHost : AutoCloseable {
    * `figma/<slug>.svg` vectors (a design catalog). Drives whether the viewer offers a copyable SVG
    * download URL alongside the PNG one. Defaults to false (a plain bundle 404s the `.svg` lane).
    */
-  val hasSvgExport: Boolean
+  public val hasSvgExport: Boolean
     get() = false
 
   /**
@@ -425,14 +426,14 @@ interface ServeHost : AutoCloseable {
    * isn't offered on a preview that would then render "failed" (issue #2352). Defaults to the
    * session-wide [hasSvgExport] — a daemon-backed host exports any of its previews.
    */
-  fun hasSvgExportFor(previewId: String): Boolean = hasSvgExport
+  public fun hasSvgExportFor(previewId: String): Boolean = hasSvgExport
 
   /** Whether this host can produce the tall raster `render/scroll/long` export. */
-  val hasScrollExport: Boolean
+  public val hasScrollExport: Boolean
     get() = false
 
   /** Per-preview refinement of [hasScrollExport]. */
-  fun hasScrollExportFor(previewId: String): Boolean = hasScrollExport
+  public fun hasScrollExportFor(previewId: String): Boolean = hasScrollExport
 
   /**
    * Whether a **live daemon stream** ("Live (stream)") is available for this session — distinct
@@ -451,7 +452,7 @@ interface ServeHost : AutoCloseable {
    * all — a static baked bundle — must report 0 rather than inherit a truthy default, or the page
    * would tell a visitor a purely static catalog has a render server connected.
    */
-  val daemonProcessCount: Int
+  public val daemonProcessCount: Int
     get() = 0
 
   /**
@@ -463,14 +464,14 @@ interface ServeHost : AutoCloseable {
    * every host with nothing to defer (baked bundles, and daemon hosts handed an already-open
    * session), so their reporting is unchanged.
    */
-  val daemonStarted: Boolean
+  public val daemonStarted: Boolean
     get() = true
 
-  val hasLiveStream: Boolean
+  public val hasLiveStream: Boolean
     get() = canApplyOverrides
 
   /** Render [previewId] at [overrides] (cached where possible). */
-  fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome
+  public fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome
 
   /**
    * Why this host has permanently given up on rendering [previewId] at [overrides], or null while
@@ -480,7 +481,7 @@ interface ServeHost : AutoCloseable {
    * say) otherwise reads to the browser as "try again", forever. Hosts with no such memory report
    * null and behave exactly as before.
    */
-  fun renderFailureLatch(previewId: String, overrides: PreviewOverrides): String? = null
+  public fun renderFailureLatch(previewId: String, overrides: PreviewOverrides): String? = null
 
   /**
    * Close daemon subprocesses this host has held idle for [idleMillis] without closing the host
@@ -493,14 +494,14 @@ interface ServeHost : AutoCloseable {
    * replica and per-preview pools forever. This is the narrower action — shed the processes, keep
    * the host.
    */
-  fun releaseIdleDaemons(idleMillis: Long): Int = 0
+  public fun releaseIdleDaemons(idleMillis: Long): Int = 0
 
   /**
    * Render a request admitted by the server's short-lived catalog theme lease. Hosts that cannot
    * parallelise keep the ordinary [render] behaviour. A catalog backed by a replica pool overrides
    * this to borrow an independent shared daemon, so only explicitly leased batches grow the pool.
    */
-  fun renderLeased(previewId: String, overrides: PreviewOverrides): RenderOutcome =
+  public fun renderLeased(previewId: String, overrides: PreviewOverrides): RenderOutcome =
     render(previewId, overrides)
 
   /**
@@ -510,7 +511,7 @@ interface ServeHost : AutoCloseable {
    * daemon render). Defaults to null: only a bundle host that carries the `ir/` sidecars returns
    * bytes; a daemon-only host has none.
    */
-  fun remoteComposeDoc(previewId: String): ByteArray? = null
+  public fun remoteComposeDoc(previewId: String): ByteArray? = null
 
   /**
    * Whether [previewId] carries a captured Remote Compose document ([remoteComposeDoc]) the viewer
@@ -519,7 +520,7 @@ interface ServeHost : AutoCloseable {
    * [remoteComposeDoc]; a bundle host overrides it with a cheap existence check so the per-preview
    * page render doesn't read the whole doc just to know it's there.
    */
-  fun hasRemoteComposeDoc(previewId: String): Boolean = remoteComposeDoc(previewId) != null
+  public fun hasRemoteComposeDoc(previewId: String): Boolean = remoteComposeDoc(previewId) != null
 
   /**
    * The **published** Remote Compose player comparison this catalog carries — every player's render
@@ -531,14 +532,14 @@ interface ServeHost : AutoCloseable {
    * Null for every host but a catalog whose delivery branch published one — a plain uploaded
    * bundle, or a system that ships no `ir/<id>.rc`, keeps the client-rendered lane.
    */
-  fun rcCompare(): RcCompareManifest? = null
+  public fun rcCompare(): RcCompareManifest? = null
 
   /**
    * Bytes for one staged rc-compare lane image ([RcCompareCell.render] / [RcCompareCell.diff]),
    * served over `GET /<system>/rc-compare/<lane>/<slot>.png`. Null for anything the host didn't
    * stage — the name vocabulary is fixed, so this is never a general file read.
    */
-  fun rcCompareImage(name: String): ByteArray? = null
+  public fun rcCompareImage(name: String): ByteArray? = null
 
   /**
    * The **published** render of [previewId] by [backend], from this catalog's `rc-compare` staging
@@ -566,7 +567,7 @@ interface ServeHost : AutoCloseable {
    * Reads the manifest, not the images: this runs per preview while building a page, and whether a
    * lane was staged is a field on the row.
    */
-  fun stagedRcPlayers(previewId: String): List<RcPlayerBackend> {
+  public fun stagedRcPlayers(previewId: String): List<RcPlayerBackend> {
     val row = rcCompare()?.rows?.firstOrNull { it.previewId == previewId } ?: return emptyList()
     return RcPlayerBackend.UNIVERSE.filter { backend ->
       val cell = backend.rcCompareLane?.let { row.lanes[it] }
@@ -574,7 +575,7 @@ interface ServeHost : AutoCloseable {
     }
   }
 
-  fun publishedRcPlayerRender(previewId: String, backend: RcPlayerBackend): ByteArray? {
+  public fun publishedRcPlayerRender(previewId: String, backend: RcPlayerBackend): ByteArray? {
     val lane = backend.rcCompareLane ?: return null
     val cell = rcCompare()?.rows?.firstOrNull { it.previewId == previewId }?.lanes?.get(lane)
     val name = cell?.takeIf { it.rendered }?.render?.takeIf { it.isNotEmpty() } ?: return null
@@ -591,7 +592,7 @@ interface ServeHost : AutoCloseable {
    * the pre-manifest shape for minutes after the lanes had landed. False everywhere else: a host
    * with no staging lane is never provisional.
    */
-  fun rcComparePending(): Boolean = false
+  public fun rcComparePending(): Boolean = false
 
   /**
    * The pixel size and density a **cmp-jvm** render of [previewId] should use — matched to the
@@ -600,14 +601,14 @@ interface ServeHost : AutoCloseable {
    * missing), in which case the cmp-jvm chip stays disabled. Only a bundle/catalog host that
    * carries both the `ir/<id>.rc` sidecar and the baked `previews/<id>.png` returns a spec.
    */
-  fun remoteComposeRenderSpec(previewId: String): RcJvmRenderSpec? = null
+  public fun remoteComposeRenderSpec(previewId: String): RcJvmRenderSpec? = null
 
   /**
    * Whether the server-side **cmp-jvm** lane can render [previewId]: the host carries the captured
    * document and a render spec, and the isolated desktop-player subprocess is installed
    * ([RcJvmServerRenderer.isAvailable]). Hosts fold this into [enabledRcPlayersFor].
    */
-  fun supportsCmpJvm(previewId: String): Boolean =
+  public fun supportsCmpJvm(previewId: String): Boolean =
     hasRemoteComposeDoc(previewId) &&
       remoteComposeRenderSpec(previewId) != null &&
       RcJvmServerRenderer.isAvailable()
@@ -638,12 +639,12 @@ interface ServeHost : AutoCloseable {
    * Factored here rather than spelled out at each site, because three copies of one fact drifting
    * apart is the bug this whole seam exists to stop.
    */
-  fun bakedRcPlayerBackend(previewId: String): RcPlayerBackend? =
+  public fun bakedRcPlayerBackend(previewId: String): RcPlayerBackend? =
     bakedRcPlayer(previewId)?.let { kind ->
       RcPlayerBackend.entries.firstOrNull { it.playerKind == kind }
     }
 
-  fun enabledRcPlayersFor(previewId: String): List<RcPlayerBackend> =
+  public fun enabledRcPlayersFor(previewId: String): List<RcPlayerBackend> =
     if (hasRemoteComposeDoc(previewId)) {
       buildList {
         add(RcPlayerBackend.JS)
@@ -675,7 +676,7 @@ interface ServeHost : AutoCloseable {
    * whether [enabledRcPlayersFor] offers the server-side lanes, so the viewer never shows a backend
    * chip that would re-render to the same image. Defaults false.
    */
-  val remoteComposePlayerSelectable: Boolean
+  public val remoteComposePlayerSelectable: Boolean
     get() = false
 
   /**
@@ -683,7 +684,8 @@ interface ServeHost : AutoCloseable {
    * when this host can't produce SVG. Defaults to `NotFound`: only the daemon-backed
    * [ServeRenderHost] overrides this — a static [ServeBundleHost] has no daemon to export one.
    */
-  fun renderSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome = SvgOutcome.NotFound
+  public fun renderSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome =
+    SvgOutcome.NotFound
 
   /**
    * The figma-svg export tailored for **web/document** viewing (`?mode=web`): where possible the
@@ -694,7 +696,7 @@ interface ServeHost : AutoCloseable {
    * font-`@import` rewrite still applies on top either way. Only the catalog-backed
    * [ServeBundleHost] (which knows the `repo@branch` its crops were published to) overrides this.
    */
-  fun renderSvgForWeb(previewId: String, overrides: PreviewOverrides): SvgOutcome =
+  public fun renderSvgForWeb(previewId: String, overrides: PreviewOverrides): SvgOutcome =
     renderSvg(previewId, overrides)
 
   /**
@@ -705,14 +707,14 @@ interface ServeHost : AutoCloseable {
    * re-render needs a daemon; a static bundle has none). A non-scrolling preview yields its
    * ordinary viewport SVG. See [docs/design/SCROLLING_SVG.md].
    */
-  fun renderScrollSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome =
+  public fun renderScrollSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome =
     SvgOutcome.NotFound
 
   /**
    * Render [previewId]'s full-page raster scroll capture (`render/scroll/long`) at [overrides], or
    * [RenderOutcome.NotFound] when this host has no daemon-backed scroll producer.
    */
-  fun renderScrollPng(previewId: String, overrides: PreviewOverrides): RenderOutcome =
+  public fun renderScrollPng(previewId: String, overrides: PreviewOverrides): RenderOutcome =
     RenderOutcome.NotFound
 
   /**
@@ -721,7 +723,7 @@ interface ServeHost : AutoCloseable {
    * daemon-backed [ServeRenderHost] overrides this — a static [ServeBundleHost] has no daemon to
    * capture a semantics tree.
    */
-  fun renderSlots(previewId: String, overrides: PreviewOverrides): SlotsOutcome =
+  public fun renderSlots(previewId: String, overrides: PreviewOverrides): SlotsOutcome =
     SlotsOutcome.NotFound
 
   /**
@@ -730,25 +732,26 @@ interface ServeHost : AutoCloseable {
    * Defaults to false — only the daemon-backed [ServeRenderHost] carries an a11y producer, and a
    * static bundle has no daemon to walk a semantics tree.
    */
-  val hasA11yOverlay: Boolean
+  public val hasA11yOverlay: Boolean
     get() = false
 
   /** Per-preview accessibility availability; composite hosts may only map part of a catalog. */
-  fun hasA11yOverlayFor(previewId: String): Boolean = hasA11yOverlay
+  public fun hasA11yOverlayFor(previewId: String): Boolean = hasA11yOverlay
 
   /**
    * Fetch [previewId]'s merged accessibility products at [overrides] as JSON (`{previewId, nodes,
    * findings, touchTargets}`), or [A11yOutcome.NotFound] when this host can't produce them. See
    * [ServeRenderHost.renderA11y].
    */
-  fun renderA11y(previewId: String, overrides: PreviewOverrides): A11yOutcome = A11yOutcome.NotFound
+  public fun renderA11y(previewId: String, overrides: PreviewOverrides): A11yOutcome =
+    A11yOutcome.NotFound
 
   /**
    * Whether this host can derive the viewer's typography, theme and layout inspection layers from a
    * render's `compose/semantics` tree ([renderAnnotations]). Tracks [canApplyOverrides]: capturing
    * a semantics tree needs a daemon, exactly like [renderSlots].
    */
-  val hasDesignAnnotations: Boolean
+  public val hasDesignAnnotations: Boolean
     get() = canApplyOverrides
 
   /**
@@ -757,7 +760,7 @@ interface ServeHost : AutoCloseable {
    * offering the Typography / Theme / Layout layers on a preview whose fetch can only 404 is
    * exactly the dead control [hasDesignAnnotations] exists to avoid.
    */
-  fun hasDesignAnnotationsFor(previewId: String): Boolean = hasDesignAnnotations
+  public fun hasDesignAnnotationsFor(previewId: String): Boolean = hasDesignAnnotations
 
   /**
    * Whether this host can answer `.annotations` for [previewId] from the catalog's **published**
@@ -771,7 +774,7 @@ interface ServeHost : AutoCloseable {
    * Typography layer on a catalog that published it, or offer a Theme checkbox with nothing behind
    * it. Defaults to false — a host with no published annotation manifest has neither.
    */
-  fun hasPublishedTypographyFor(previewId: String): Boolean = false
+  public fun hasPublishedTypographyFor(previewId: String): Boolean = false
 
   /**
    * Render [previewId] at [overrides] and return its typography + theme inspection layers as JSON
@@ -792,7 +795,7 @@ interface ServeHost : AutoCloseable {
    * [AnnotationKind.publishedLayersSuffice] — a typography-only request can be answered off a
    * published bundle without a daemon, which is worth 16-22s on an idle catalog.
    */
-  fun renderAnnotations(
+  public fun renderAnnotations(
     previewId: String,
     overrides: PreviewOverrides,
     layers: Set<String>? = null,
@@ -814,7 +817,7 @@ interface ServeHost : AutoCloseable {
    * withholds annotation-box selection on them — the layers still draw, since being a render out of
    * date costs a reading aid nothing.
    */
-  val annotationsFollowBakedFrame: Boolean
+  public val annotationsFollowBakedFrame: Boolean
     get() = false
 
   /**
@@ -828,7 +831,7 @@ interface ServeHost : AutoCloseable {
    * re-rendered snapshots instead of the opaque "input requires a live stream". Not called on
    * success (a non-null return).
    */
-  fun subscribeStream(
+  public fun subscribeStream(
     previewId: String,
     overrides: PreviewOverrides,
     codec: StreamCodec?,
@@ -838,7 +841,7 @@ interface ServeHost : AutoCloseable {
   ): StreamHandle?
 
   /** Count of live upstream streams (0 for hosts without a live lane). */
-  fun activeStreamCount(): Int
+  public fun activeStreamCount(): Int
 }
 
 /**
@@ -851,5 +854,5 @@ interface ServeHost : AutoCloseable {
  * implemented a pair and missed a member of it. An extension cannot be overridden, so there is one
  * place to implement and no way to implement the wrong one.
  */
-fun ServeHost.motionBytes(motionId: String, extension: String): ByteArray? =
+public fun ServeHost.motionBytes(motionId: String, extension: String): ByteArray? =
   motionRead(motionId, extension).bytesOrNull

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeKnownDifferences.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeKnownDifferences.kt
@@ -61,10 +61,10 @@ import okio.Path.Companion.toPath
  * The source repo commits them under `.design-parity/`; `@design-parity/catalog-export` is what
  * carries them across.
  */
-object ServeKnownDifferences {
-  const val DIRECTORY = "parity"
-  const val DOCUMENT_FILE = "known-differences.json"
-  const val ARTIFACT_DIRECTORY = "known-differences"
+public object ServeKnownDifferences {
+  public const val DIRECTORY: String = "parity"
+  public const val DOCUMENT_FILE: String = "known-differences.json"
+  public const val ARTIFACT_DIRECTORY: String = "known-differences"
 
   /**
    * The producer's own list of the artifacts it published, beside the document.
@@ -81,10 +81,10 @@ object ServeKnownDifferences {
    * transport convenience between a producer and a host, which is why a catalog without it still
    * works.
    */
-  const val ARTIFACT_INDEX_FILE = "known-differences-index.json"
+  public const val ARTIFACT_INDEX_FILE: String = "known-differences-index.json"
 
   /** The index's schema token; a document declaring another is ignored rather than guessed at. */
-  const val ARTIFACT_INDEX_SCHEMA = "compose-preview-known-difference-artifacts/v1"
+  public const val ARTIFACT_INDEX_SCHEMA: String = "compose-preview-known-difference-artifacts/v1"
 
   /**
    * The document's schema token, mirrored for the same one job the record cap is: the staging path
@@ -94,7 +94,7 @@ object ServeKnownDifferences {
    * Not a licence to interpret the document — nothing here decides a record's verdict. Pinned to
    * the contract by [ServeKnownDifferencesTest] like the ceilings beside it.
    */
-  const val SCHEMA = "compose-preview-known-differences/v1"
+  public const val SCHEMA: String = "compose-preview-known-differences/v1"
 
   /**
    * The two ceilings, versioned with the schema and **not** per-catalog settings.
@@ -105,8 +105,8 @@ object ServeKnownDifferences {
    * same device the scorer's tuning mirror uses: two copies are fine while something fails when
    * they disagree.
    */
-  const val MAX_DOCUMENT_BYTES = 1024 * 1024
-  const val MAX_ARTIFACT_BYTES = 8 * 1024 * 1024
+  public const val MAX_DOCUMENT_BYTES: Int = 1024 * 1024
+  public const val MAX_ARTIFACT_BYTES: Int = 8 * 1024 * 1024
 
   /**
    * The record cap, mirrored for the one job the host has that needs it: the staging path
@@ -116,7 +116,7 @@ object ServeKnownDifferences {
    * It bounds a fetch list, never a verdict. Checked against `BUDGET.maxAcceptances` by the same
    * mirror test the two byte ceilings use.
    */
-  const val MAX_ACCEPTANCES = 256
+  public const val MAX_ACCEPTANCES: Int = 256
 
   /**
    * §4's portable path grammar, restated: the character class, the length, and the three shapes a
@@ -156,17 +156,17 @@ object ServeKnownDifferences {
    * them into the record's verdict, and inventing a fourth here would be a rule with no conformance
    * case behind it.
    */
-  sealed interface Artifact {
-    class Bytes(val bytes: ByteArray) : Artifact
+  public sealed interface Artifact {
+    public class Bytes(public val bytes: ByteArray) : Artifact
 
     /** The path resolves outside the acceptance's own directory. */
-    data object NotContained : Artifact
+    public data object NotContained : Artifact
 
     /** The file is past [MAX_ARTIFACT_BYTES], refused from its length rather than read. */
-    data object TooLarge : Artifact
+    public data object TooLarge : Artifact
 
     /** No file, a directory, or a spelling the filesystem resolved case-insensitively. */
-    data object Unreadable : Artifact
+    public data object Unreadable : Artifact
   }
 
   /**
@@ -178,10 +178,10 @@ object ServeKnownDifferences {
    * apart cannot report the second one. It is refused *here* rather than handed over, so nothing
    * allocates a hostile document to discover its size.
    */
-  fun document(bundleDir: File, fileSystem: FileSystem = FileSystem.SYSTEM): Document? =
+  public fun document(bundleDir: File, fileSystem: FileSystem = FileSystem.SYSTEM): Document? =
     document(bundleDir.toOkioPath(), fileSystem)
 
-  fun document(bundleRoot: Path, fileSystem: FileSystem): Document? {
+  public fun document(bundleRoot: Path, fileSystem: FileSystem): Document? {
     val path = bundleRoot / DIRECTORY.toPath() / DOCUMENT_FILE.toPath()
     val metadata = runCatching { fileSystem.metadataOrNull(path) }.getOrNull() ?: return null
     if (metadata.isDirectory) return null
@@ -195,10 +195,10 @@ object ServeKnownDifferences {
     return Document.Text(text)
   }
 
-  sealed interface Document {
-    data class Text(val text: String) : Document
+  public sealed interface Document {
+    public data class Text(val text: String) : Document
 
-    data object TooLarge : Document
+    public data object TooLarge : Document
   }
 
   /**
@@ -208,7 +208,7 @@ object ServeKnownDifferences {
    * The `<id>` is the first segment and is a path segment in its own right, which is why a record's
    * `id` is grammar-checked at all — it names a directory on every consumer's disk.
    */
-  fun artifact(
+  public fun artifact(
     bundleDir: File,
     relativePath: String,
     fileSystem: FileSystem = FileSystem.SYSTEM,
@@ -226,13 +226,13 @@ object ServeKnownDifferences {
    * The filesystem half — containment inside the record's own directory, exact case, the byte cap —
    * stays in [artifact], where there is a resolved path to ask about.
    */
-  fun isLookupPath(relativePath: String): Boolean {
+  public fun isLookupPath(relativePath: String): Boolean {
     val segments = relativePath.split('/')
     if (segments.size < 2) return false
     return segments.all { isPortableSegment(it) }
   }
 
-  fun artifact(bundleRoot: Path, relativePath: String, fileSystem: FileSystem): Artifact {
+  public fun artifact(bundleRoot: Path, relativePath: String, fileSystem: FileSystem): Artifact {
     val segments = relativePath.split('/')
     // Lexical first, and cheaply: an absolute path, a backslash, a `..`, an over-long segment or a
     // Windows-reserved name never reaches the filesystem. The engine refuses these too — this is
@@ -290,7 +290,7 @@ object ServeKnownDifferences {
  * miss the very comparison it was authored on.
  */
 @Serializable
-data class KnownDifferenceContext(
+public data class KnownDifferenceContext(
   val documentUrl: String,
   /**
    * Prefix and suffix an artifact URL is built from: `artifactBase + "<id>/<file>" +
@@ -310,7 +310,7 @@ data class KnownDifferenceContext(
 )
 
 @Serializable
-data class KnownDifferenceIssue(
+public data class KnownDifferenceIssue(
   val repository: String,
   val number: Int,
   val state: String,
@@ -326,7 +326,7 @@ data class KnownDifferenceIssue(
  * silently withheld itself from a catalog publishing a perfectly good index.
  */
 @Serializable
-data class KnownDifferenceScope(
+public data class KnownDifferenceScope(
   val system: String,
   val component: String,
   val previewId: String,
@@ -355,7 +355,7 @@ data class KnownDifferenceScope(
 private val CONTEXT_JSON = Json { encodeDefaults = true }
 
 /** As an inline `application/json` payload, with `<` escaped so it cannot close the script tag. */
-fun encodeKnownDifferenceContext(context: KnownDifferenceContext): String =
+public fun encodeKnownDifferenceContext(context: KnownDifferenceContext): String =
   CONTEXT_JSON.encodeToString(context).replace("<", "\\u003c")
 
 /**
@@ -373,7 +373,7 @@ fun encodeKnownDifferenceContext(context: KnownDifferenceContext): String =
  * `variant` here would report every acceptance in the catalog as an orphan.
  */
 @Serializable
-data class KnownDifferenceAuditContext(
+public data class KnownDifferenceAuditContext(
   val documentUrl: String,
   val artifactBase: String,
   val artifactQuery: String,
@@ -384,7 +384,7 @@ data class KnownDifferenceAuditContext(
 
 /** One served preview, as an acceptance's scope names it. */
 @Serializable
-data class KnownDifferenceCatalogPreview(
+public data class KnownDifferenceCatalogPreview(
   val system: String,
   val id: String,
   /** Null when the preview declares no component — it can then match no acceptance. */
@@ -394,5 +394,5 @@ data class KnownDifferenceCatalogPreview(
 )
 
 /** As an inline `application/json` payload, with `<` escaped so it cannot close the script tag. */
-fun encodeKnownDifferenceAuditContext(context: KnownDifferenceAuditContext): String =
+public fun encodeKnownDifferenceAuditContext(context: KnownDifferenceAuditContext): String =
   CONTEXT_JSON.encodeToString(context).replace("<", "\\u003c")

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
@@ -21,23 +21,23 @@ import java.security.MessageDigest
  * in-browser [LIVE] transport (CMP→JS) slots into the same `/p/{id}` surface instead of a parallel
  * one. See the plan's "design both now, build PNG first" decision.
  */
-enum class PreviewMode(val wire: String) {
+public enum class PreviewMode(public val wire: String) {
   /** Daemon renders server-side; the browser shows PNG bytes. Universal (Android + Desktop). */
   SNAPSHOT("snapshot"),
   /** Composable compiled to Kotlin/Wasm and run live in the browser. CMP-only; not yet built. */
   LIVE("live");
 
-  companion object {
-    fun parse(raw: String?): PreviewMode? =
+  public companion object {
+    public fun parse(raw: String?): PreviewMode? =
       raw?.lowercase()?.let { v -> entries.firstOrNull { it.wire == v } }
   }
 }
 
 /** Outcome of parsing query-string overrides — either a typed [PreviewOverrides] or a reason. */
-sealed interface OverrideParse {
-  data class Ok(val overrides: PreviewOverrides) : OverrideParse
+public sealed interface OverrideParse {
+  public data class Ok(val overrides: PreviewOverrides) : OverrideParse
 
-  data class Invalid(val message: String) : OverrideParse
+  public data class Invalid(val message: String) : OverrideParse
 }
 
 /**
@@ -46,10 +46,10 @@ sealed interface OverrideParse {
  * `render-matrix` axes ([ee.schimke.composeai.mcp.MatrixCell]) plus the extra display knobs the
  * daemon already honours, so behaviour matches the rest of the CLI.
  */
-object ServeOverrides {
+public object ServeOverrides {
 
   /** Query keys `/render` understands. Unknown keys are ignored (forward-compatible). */
-  val SUPPORTED_KEYS: Set<String> =
+  public val SUPPORTED_KEYS: Set<String> =
     setOf(
       "uiMode",
       "device",
@@ -132,7 +132,7 @@ object ServeOverrides {
    * it, so it is skipped rather than rejected — the viewer builds these URLs itself and a
    * half-typed number field must not 400 the page it came from.
    */
-  const val KNOB_PREFIX = "knob."
+  public const val KNOB_PREFIX: String = "knob."
 
   /**
    * Prefix for Remote Compose named-value seeds: `rc.<name>=<value>`, e.g. `rc.label=Tap me` or
@@ -145,7 +145,7 @@ object ServeOverrides {
    * tag ([RC_KNOWN_KINDS], default `string`). Daemon-only + Android-only — a desktop/static session
    * has no Remote Compose runtime and ignores it. Dynamic keys, so not listed in [SUPPORTED_KEYS].
    */
-  const val RC_NAMED_PREFIX = "rc."
+  public const val RC_NAMED_PREFIX: String = "rc."
 
   /**
    * True when [key] is a param [parse] consumes — a fixed [SUPPORTED_KEYS] axis, an author-declared
@@ -155,7 +155,7 @@ object ServeOverrides {
    * the WebSocket live/stream sessions send is already scoped, so it is passed to [parse]
    * wholesale.
    */
-  fun isOverrideParam(key: String): Boolean =
+  public fun isOverrideParam(key: String): Boolean =
     key in SUPPORTED_KEYS || key.startsWith(KNOB_PREFIX) || key.startsWith(RC_NAMED_PREFIX)
 
   /**
@@ -166,7 +166,7 @@ object ServeOverrides {
    * returns [OverrideParse.Invalid] for the daemon lanes. Both read the same `<kind>:` grammar
    * ([RC_KNOWN_KINDS], default `string`).
    */
-  fun rcNamedValueSeeds(params: Map<String, String>): Map<String, RemoteNamedValue> {
+  public fun rcNamedValueSeeds(params: Map<String, String>): Map<String, RemoteNamedValue> {
     val seeds = mutableMapOf<String, RemoteNamedValue>()
     for ((rawKey, raw) in params) {
       if (!rawKey.startsWith(RC_NAMED_PREFIX)) continue
@@ -213,7 +213,7 @@ object ServeOverrides {
    * so what may be stripped is exactly what [parse] treats as a type tag, and the two must agree
    * for the control and the pixels to.
    */
-  fun knobControlValue(raw: String, declaredKind: String?): String? {
+  public fun knobControlValue(raw: String, declaredKind: String?): String? {
     val sep = raw.indexOf(':')
     val prefix =
       if (sep > 0) {
@@ -247,7 +247,7 @@ object ServeOverrides {
    * explicit tag that agrees, or no tag at all on a `string` knob. Anything else — a bare value on
    * a typed knob, a `float:` on an `int` — leaves the control showing what the render used.
    */
-  fun rcControlValue(raw: String, declaredKind: String): String? {
+  public fun rcControlValue(raw: String, declaredKind: String): String? {
     // A blank `rc.<name>=` is skipped wholesale by [parse] — unlike a knob, not even a string RC
     // seed accepts one — so the declaration stands and the control has to keep showing it.
     if (raw.isBlank()) return null
@@ -269,7 +269,7 @@ object ServeOverrides {
    * Map a `compose/overrides` declaration `type` to the [PreviewOverrideValue] wire kind. Shared
    * with the viewer's control rendering so the inferred type always matches the widget shown.
    */
-  fun knobKind(type: String): String =
+  public fun knobKind(type: String): String =
     when (type.lowercase()) {
       "int" -> "int"
       "float",
@@ -286,7 +286,7 @@ object ServeOverrides {
    * [ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration.seedKey]). Empty when the
    * preview is unknown or declares no knobs — a bare value then falls back to string.
    */
-  fun declaredKnobKinds(preview: ServePreview?): Map<String, String> =
+  public fun declaredKnobKinds(preview: ServePreview?): Map<String, String> =
     preview?.overrides?.associate { it.seedKey to knobKind(it.type) } ?: emptyMap()
 
   /**
@@ -309,7 +309,7 @@ object ServeOverrides {
    * set** means the session declares none, so any `themeProvider` is rejected — nothing could apply
    * it.
    */
-  fun parse(
+  public fun parse(
     params: Map<String, String>,
     knobKinds: Map<String, String> = emptyMap(),
     declaredThemeFqns: Set<String>? = null,
@@ -754,7 +754,7 @@ object ServeOverrides {
    * coalesce to one render and the key is safe as a map key. Only the fields tier 1 supports
    * participate; adding a field here is the one place to keep in lockstep with [parse].
    */
-  fun cacheKey(previewId: String, o: PreviewOverrides): String {
+  public fun cacheKey(previewId: String, o: PreviewOverrides): String {
     val canonical = buildString {
       append(previewId).append(' ')
       append("w=").append(o.widthPx).append('|')

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParameterRows.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParameterRows.kt
@@ -30,10 +30,10 @@ import okio.Path.Companion.toPath
  * — a bundle-backed session, or a render that failed), expands to nothing and keeps its bare id, so
  * this only ever adds rows that genuinely exist.
  */
-object ServeParameterRows {
+public object ServeParameterRows {
 
   /** One row of a parameterized preview: the addressable id plus the token that names it. */
-  data class Row(val id: String, val label: String)
+  public data class Row(val id: String, val label: String)
 
   /**
    * The rows of [preview] found under [moduleDir]`/build/compose-previews/`, in the fan-out's own
@@ -43,7 +43,7 @@ object ServeParameterRows {
    * [siblingOutputs] must be every *other* preview's capture outputs, used to reject files this
    * preview doesn't own.
    */
-  fun rowsFor(
+  public fun rowsFor(
     preview: PreviewInfo,
     moduleDir: Path,
     siblingOutputs: Set<String>,
@@ -77,13 +77,13 @@ object ServeParameterRows {
    * Every capture output claimed by [previews], as `renderOutput`-relative paths — the exclusion
    * set [rowsFor] needs so one preview's render can't be read as another's row.
    */
-  fun claimedOutputs(previews: List<PreviewInfo>): Set<String> =
+  public fun claimedOutputs(previews: List<PreviewInfo>): Set<String> =
     previews.flatMapTo(mutableSetOf()) { p ->
       p.captures.map { it.renderOutput }.filter { it.isNotBlank() }
     }
 
   /** Convenience for callers holding a `java.io.File` project dir (the Tooling API's shape). */
-  fun rowsFor(
+  public fun rowsFor(
     preview: PreviewInfo,
     moduleDir: java.io.File,
     siblingOutputs: Set<String>,

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParityActivity.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParityActivity.kt
@@ -43,7 +43,7 @@ import okio.Path.Companion.toPath
  * file, so a catalog declaring `javascript:…` produces no link instead of an attacker-chosen href.
  */
 @Serializable
-data class ParityActivity(
+public data class ParityActivity(
   val schema: String = SCHEMA,
   /** ISO-8601 instant the feed was snapshotted. Shown as the feed's "as of". */
   val generatedAt: String? = null,
@@ -54,16 +54,16 @@ data class ParityActivity(
   /** Gaps only the producer can see — the server derives preview-side coverage itself. */
   val gaps: List<MappingGap> = emptyList(),
 ) {
-  companion object {
-    const val SCHEMA = "compose-preview-activity/v1"
-    const val DIRECTORY = "parity"
-    const val FILE = "activity.json"
+  public companion object {
+    public const val SCHEMA: String = "compose-preview-activity/v1"
+    public const val DIRECTORY: String = "parity"
+    public const val FILE: String = "activity.json"
   }
 }
 
 /** Recent commits to the code side of the parity pair. */
 @Serializable
-data class CodeLane(
+public data class CodeLane(
   /** `owner/name` of the source repo, used to rebuild commit URLs. */
   val repo: String? = null,
   /** Branch or ref the commits were read from. */
@@ -73,7 +73,7 @@ data class CodeLane(
 
 /** One commit that touched a file backing at least one catalog preview. */
 @Serializable
-data class CodeEvent(
+public data class CodeEvent(
   val sha: String,
   val subject: String,
   /** ISO-8601 author date. */
@@ -90,7 +90,7 @@ data class CodeEvent(
 
 /** Recent activity on the Figma file the catalog is specified by. */
 @Serializable
-data class FigmaLane(
+public data class FigmaLane(
   /** Figma file key. Validated before any deep link is built from it. */
   val fileKey: String? = null,
   val fileName: String? = null,
@@ -100,7 +100,7 @@ data class FigmaLane(
 
 /** One named version / autosave checkpoint in the Figma file's history. */
 @Serializable
-data class FigmaVersionEvent(
+public data class FigmaVersionEvent(
   val id: String,
   /** ISO-8601. */
   val at: String,
@@ -117,7 +117,7 @@ data class FigmaVersionEvent(
  * preview's reference-vs-render comparison.
  */
 @Serializable
-data class FigmaCommentEvent(
+public data class FigmaCommentEvent(
   val id: String,
   /** ISO-8601. */
   val at: String,
@@ -136,7 +136,7 @@ data class FigmaCommentEvent(
  * here — publishing it would let a stale `activity.json` contradict the live catalog.
  */
 @Serializable
-data class MappingGap(
+public data class MappingGap(
   /** One of [Kind]; an unknown token drops the record rather than rendering as a mystery row. */
   val kind: String,
   /** Human summary — what is missing, in the producer's own words. */
@@ -150,17 +150,18 @@ data class MappingGap(
   val component: String? = null,
 ) {
   /** The gap kinds the dashboard groups and explains. */
-  object Kind {
+  public object Kind {
     /** `design-map.json` names a preview id the published catalog does not contain. */
-    const val DANGLING_MAPPING = "dangling-mapping"
+    public const val DANGLING_MAPPING: String = "dangling-mapping"
 
     /** A mapped Figma node exists but its reference raster could not be published. */
-    const val UNRENDERED_REFERENCE = "unrendered-reference"
+    public const val UNRENDERED_REFERENCE: String = "unrendered-reference"
 
     /** A component published in the Figma file that no code entry maps to. */
-    const val UNMAPPED_DESIGN_NODE = "unmapped-design-node"
+    public const val UNMAPPED_DESIGN_NODE: String = "unmapped-design-node"
 
-    val ALL = setOf(DANGLING_MAPPING, UNRENDERED_REFERENCE, UNMAPPED_DESIGN_NODE)
+    public val ALL: Set<String> =
+      setOf(DANGLING_MAPPING, UNRENDERED_REFERENCE, UNMAPPED_DESIGN_NODE)
   }
 }
 
@@ -172,7 +173,7 @@ data class MappingGap(
  * go), an over-long free-text field is truncated rather than dropped (the text is display-only),
  * and a gap with an unknown [MappingGap.Kind] is dropped.
  */
-object ServeParityActivityStore {
+public object ServeParityActivityStore {
 
   /** Feed rows kept per lane. A catalog cannot make a page arbitrarily large. */
   private const val MAX_EVENTS = 100
@@ -201,7 +202,7 @@ object ServeParityActivityStore {
    * The catalog's activity feed, or null when it publishes none (the common case) or publishes one
    * that does not parse. Never throws.
    */
-  fun load(bundleDir: File, fileSystem: FileSystem = SystemFileSystem): ParityActivity? {
+  public fun load(bundleDir: File, fileSystem: FileSystem = SystemFileSystem): ParityActivity? {
     val path = bundleDir.toOkioPath() / ParityActivity.DIRECTORY.toPath() / ParityActivity.FILE
     val raw =
       runCatching {
@@ -217,7 +218,7 @@ object ServeParityActivityStore {
    * private to [load]) because it is the whole of the trust boundary and is what the unit tests
    * exercise — no filesystem needed.
    */
-  fun sanitize(raw: ParityActivity): ParityActivity? {
+  public fun sanitize(raw: ParityActivity): ParityActivity? {
     if (raw.schema != ParityActivity.SCHEMA) return null
     val code =
       raw.code?.let { lane ->
@@ -317,7 +318,7 @@ object ServeParityActivityStore {
    * The github.com commit URL for [sha] in [repo], or null when either is not the exact shape the
    * URL is built from. Assembled from a literal origin, never taken from the catalog.
    */
-  fun commitUrl(repo: String?, sha: String): String? {
+  public fun commitUrl(repo: String?, sha: String): String? {
     val owner = repo?.trim()?.takeIf { REPO.matches(it) } ?: return null
     val id = sha.trim().lowercase().takeIf { SHA.matches(it) } ?: return null
     return "https://github.com/$owner/commit/$id"
@@ -327,14 +328,14 @@ object ServeParityActivityStore {
    * The figma.com deep link for [nodeId] in [fileKey], or null when either is malformed. Figma's
    * URL form spells a node id `73-6` where the API and the design map use `73:6`.
    */
-  fun nodeUrl(fileKey: String?, nodeId: String?): String? {
+  public fun nodeUrl(fileKey: String?, nodeId: String?): String? {
     val key = fileKey?.trim()?.takeIf { FILE_KEY.matches(it) } ?: return null
     val node = nodeId?.trim()?.takeIf { NODE_ID.matches(it) } ?: return null
     return "https://www.figma.com/design/$key?node-id=${node.replace(':', '-')}"
   }
 
   /** The figma.com file URL for [fileKey], or null when it is not a key. */
-  fun fileUrl(fileKey: String?): String? {
+  public fun fileUrl(fileKey: String?): String? {
     val key = fileKey?.trim()?.takeIf { FILE_KEY.matches(it) } ?: return null
     return "https://www.figma.com/design/$key"
   }

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParityFindings.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParityFindings.kt
@@ -59,22 +59,22 @@ import okio.Path.Companion.toPath
  * cost the reader the panel it describes, never the comparison.
  */
 @Serializable
-data class ParityFindings(
+public data class ParityFindings(
   val schema: String = SCHEMA,
   val generatedAt: String? = null,
   /** Finding sets over a preview's rendered frame, keyed by exact serve/catalog preview id. */
   val previews: Map<String, List<ParityFindingSet>> = emptyMap(),
 ) {
-  companion object {
-    const val SCHEMA = "compose-preview-parity-findings/v1"
-    const val DIRECTORY = "parity"
-    const val FILE = "findings.json"
+  public companion object {
+    public const val SCHEMA: String = "compose-preview-parity-findings/v1"
+    public const val DIRECTORY: String = "parity"
+    public const val FILE: String = "findings.json"
   }
 }
 
 /** One run's conclusion about one (preview, reference) pair. */
 @Serializable
-data class ParityFindingSet(
+public data class ParityFindingSet(
   /** The [DesignReference.id] this verdict compared against; null ⇒ it applies to any of them. */
   val referenceId: String? = null,
   /** `pass` / `warn` / `fail`, as the run concluded. Unknown values are dropped, not defaulted. */
@@ -86,7 +86,7 @@ data class ParityFindingSet(
 
 /** One observation, in the diff engine's own vocabulary. */
 @Serializable
-data class ParityFinding(
+public data class ParityFinding(
   /**
    * One of [ParityFindingKind.KNOWN]. An unknown kind is dropped rather than shown uncategorised.
    */
@@ -107,7 +107,7 @@ data class ParityFinding(
 
 /** A region of one panel a finding points at, in that panel image's own pixel space. */
 @Serializable
-data class ParityAnchor(
+public data class ParityAnchor(
   /** `reference` or `actual`; anything else is dropped. */
   val side: String,
   val bounds: AnnotationBounds,
@@ -123,28 +123,29 @@ data class ParityAnchor(
  * whole record, and the point of the fail-soft posture is that a newer producer costs this reader
  * only the rows it cannot place.
  */
-object ParityFindingKind {
-  const val A11Y = "a11y"
-  const val I18N = "i18n"
-  const val CONTRAST = "contrast"
-  const val TOKEN = "token"
-  const val LAYOUT = "layout"
-  const val SEMANTIC = "semantic"
-  const val VISUAL = "visual"
-  const val PAIRING = "pairing"
+public object ParityFindingKind {
+  public const val A11Y: String = "a11y"
+  public const val I18N: String = "i18n"
+  public const val CONTRAST: String = "contrast"
+  public const val TOKEN: String = "token"
+  public const val LAYOUT: String = "layout"
+  public const val SEMANTIC: String = "semantic"
+  public const val VISUAL: String = "visual"
+  public const val PAIRING: String = "pairing"
 
-  val KNOWN = setOf(A11Y, I18N, CONTRAST, TOKEN, LAYOUT, SEMANTIC, VISUAL, PAIRING)
+  public val KNOWN: Set<String> =
+    setOf(A11Y, I18N, CONTRAST, TOKEN, LAYOUT, SEMANTIC, VISUAL, PAIRING)
 }
 
-object ParityFindingSeverity {
-  const val INFO = "info"
-  const val WARN = "warn"
-  const val ERROR = "error"
+public object ParityFindingSeverity {
+  public const val INFO: String = "info"
+  public const val WARN: String = "warn"
+  public const val ERROR: String = "error"
 
-  val KNOWN = setOf(INFO, WARN, ERROR)
+  public val KNOWN: Set<String> = setOf(INFO, WARN, ERROR)
 
   /** Worst-first, so a group leads with the row that decides its status. */
-  fun rank(value: String): Int =
+  public fun rank(value: String): Int =
     when (value) {
       ERROR -> 0
       WARN -> 1
@@ -160,7 +161,11 @@ object ParityFindingSeverity {
  * will truncate in German is a bug in the component, while an `error` on 35% of pixels differing is
  * usually the two frames being different sizes.
  */
-enum class ParityFindingGroup(val id: String, val title: String, val kinds: Set<String>) {
+public enum class ParityFindingGroup(
+  public val id: String,
+  public val title: String,
+  public val kinds: Set<String>,
+) {
   ACCESSIBILITY(
     "a11y",
     "Accessibility & i18n",
@@ -171,8 +176,8 @@ enum class ParityFindingGroup(val id: String, val title: String, val kinds: Set<
   PAIRING("pairing", "Pairing", setOf(ParityFindingKind.PAIRING)),
   VISUAL("visual", "Visual", setOf(ParityFindingKind.VISUAL));
 
-  companion object {
-    fun of(kind: String): ParityFindingGroup? = entries.firstOrNull { kind in it.kinds }
+  public companion object {
+    public fun of(kind: String): ParityFindingGroup? = entries.firstOrNull { kind in it.kinds }
   }
 }
 
@@ -187,7 +192,7 @@ enum class ParityFindingGroup(val id: String, val title: String, val kinds: Set<
  * that travels as data.
  */
 @Serializable
-data class ParityAnchorPayload(val findings: Map<String, List<ParityAnchor>> = emptyMap())
+public data class ParityAnchorPayload(val findings: Map<String, List<ParityAnchor>> = emptyMap())
 
 private val PARITY_FINDINGS_JSON = Json { encodeDefaults = false }
 
@@ -197,7 +202,7 @@ private val PARITY_FINDINGS_JSON = Json { encodeDefaults = false }
  * element, so HTML-escaping would reach `JSON.parse` verbatim and throw, while an unescaped
  * `</script>` inside a label would end the block early.
  */
-fun encodeParityAnchorPayload(payload: ParityAnchorPayload): String =
+public fun encodeParityAnchorPayload(payload: ParityAnchorPayload): String =
   PARITY_FINDINGS_JSON.encodeToString(payload).replace("<", "\\u003c")
 
 /**
@@ -216,13 +221,13 @@ fun encodeParityAnchorPayload(payload: ParityAnchorPayload): String =
  * multiply, so twenty sets of two hundred findings is four thousand rows and a browser that stops
  * responding while the anchors are placed.
  */
-class ServeParityFindingStore
+public class ServeParityFindingStore
 private constructor(private val byPreview: Map<String, List<ParityFindingSet>>) {
 
-  val isEmpty: Boolean = byPreview.isEmpty()
+  public val isEmpty: Boolean = byPreview.isEmpty()
 
   /** Every set published for [previewId], scoped and unscoped alike. */
-  fun forPreview(previewId: String): List<ParityFindingSet> = byPreview[previewId].orEmpty()
+  public fun forPreview(previewId: String): List<ParityFindingSet> = byPreview[previewId].orEmpty()
 
   /**
    * The sets that describe the comparison on screen: those naming [referenceId], plus the unscoped
@@ -234,12 +239,12 @@ private constructor(private val byPreview: Map<String, List<ParityFindingSet>>) 
    * two exhaust it and left the third comparison with no verdict at all, for a page that was never
    * going to render the other two.
    */
-  fun forComparison(previewId: String, referenceId: String): List<ParityFindingSet> =
+  public fun forComparison(previewId: String, referenceId: String): List<ParityFindingSet> =
     spendPageBudget(
       forPreview(previewId).filter { it.referenceId == null || it.referenceId == referenceId }
     )
 
-  companion object {
+  public companion object {
     private const val MAX_PREVIEWS = 5000
     private const val MAX_SETS_PER_PREVIEW = 20
     private const val MAX_FINDINGS_PER_SET = 200
@@ -293,7 +298,7 @@ private constructor(private val byPreview: Map<String, List<ParityFindingSet>>) 
     private val JSON = Json { ignoreUnknownKeys = true }
 
     /** Empty store — a catalog that publishes no parity verdict at all. */
-    val EMPTY = ServeParityFindingStore(emptyMap())
+    public val EMPTY: ServeParityFindingStore = ServeParityFindingStore(emptyMap())
 
     /**
      * The document as read from disk, with its records left as raw JSON.
@@ -335,7 +340,7 @@ private constructor(private val byPreview: Map<String, List<ParityFindingSet>>) 
       val anchors: List<JsonElement> = emptyList(),
     )
 
-    fun load(
+    public fun load(
       bundleDir: File,
       fileSystem: FileSystem = SystemFileSystem,
     ): ServeParityFindingStore {
@@ -358,7 +363,7 @@ private constructor(private val byPreview: Map<String, List<ParityFindingSet>>) 
      * very code that will later read it: staging writes what this returns, not what the branch
      * said, and a manifest that could not survive the reader never reaches the staged tree at all.
      */
-    fun sanitizeDocument(text: String): ParityFindings? {
+    public fun sanitizeDocument(text: String): ParityFindings? {
       val raw = runCatching { JSON.decodeFromString<RawManifest>(text) }.getOrNull() ?: return null
       if (raw.schema != ParityFindings.SCHEMA) return null
       val previews =
@@ -544,8 +549,8 @@ private constructor(private val byPreview: Map<String, List<ParityFindingSet>>) 
         anchor.bounds.x >= 0 &&
         anchor.bounds.y >= 0
 
-    const val SIDE_REFERENCE = "reference"
-    const val SIDE_ACTUAL = "actual"
+    public const val SIDE_REFERENCE: String = "reference"
+    public const val SIDE_ACTUAL: String = "actual"
 
     private fun clamp(value: String, max: Int): String =
       if (value.length <= max) value else value.take(max - 1) + "…"

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParityIssues.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParityIssues.kt
@@ -9,13 +9,13 @@ import okio.Path.Companion.toOkioPath
 import okio.Path.Companion.toPath
 
 /** Source-compatible names for the wire types now owned by compose-preview-contracts. */
-typealias ParityIssues = ee.schimke.composeai.parityissues.protocol.ParityIssues
+public typealias ParityIssues = ee.schimke.composeai.parityissues.protocol.ParityIssues
 
-typealias ParityIssue = ee.schimke.composeai.parityissues.protocol.ParityIssue
+public typealias ParityIssue = ee.schimke.composeai.parityissues.protocol.ParityIssue
 
 /** Fail-soft trust boundary for `parity/issues.json`. */
-object ServeParityIssuesStore {
-  const val MAX_ISSUES = 2000
+public object ServeParityIssuesStore {
+  public const val MAX_ISSUES: Int = 2000
   private const val MAX_TEXT = 300
   private val REPOSITORY = Regex("[A-Za-z0-9_.-]{1,100}/[A-Za-z0-9_.-]{1,100}")
   private val ID = Regex("[^\\p{Cc}]{1,300}")
@@ -30,7 +30,7 @@ object ServeParityIssuesStore {
     setOf("regression", "known-difference", "verification-needed", "upstream", "catalog")
   private val JSON = Json { ignoreUnknownKeys = true }
 
-  fun load(bundleDir: File, fileSystem: FileSystem = SystemFileSystem): ParityIssues? {
+  public fun load(bundleDir: File, fileSystem: FileSystem = SystemFileSystem): ParityIssues? {
     val path = bundleDir.toOkioPath() / ParityIssues.DIRECTORY.toPath() / ParityIssues.FILE
     val raw =
       runCatching {
@@ -41,7 +41,7 @@ object ServeParityIssuesStore {
     return sanitize(raw)
   }
 
-  fun sanitize(raw: ParityIssues): ParityIssues? {
+  public fun sanitize(raw: ParityIssues): ParityIssues? {
     if (raw.schema != ParityIssues.SCHEMA || raw.issues.size > MAX_ISSUES) return null
     val generatedAt = raw.generatedAt?.trim()?.takeIf(::isTimestamp)
     // Identity is repository + number + **component**, not repository + number. One issue may name

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRcCompare.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRcCompare.kt
@@ -37,7 +37,7 @@ import okio.Path.Companion.toOkioPath
  * per *daemon* id, so two catalog ids sharing a source preview share one set of files.
  */
 @Serializable
-data class RcCompareManifest(
+public data class RcCompareManifest(
   val schema: String = SCHEMA,
   /**
    * The pixelmatch threshold the build-time diffs used, carried so the client-side player↔player
@@ -48,18 +48,18 @@ data class RcCompareManifest(
   val lanes: List<RcCompareLane> = emptyList(),
   val rows: List<RcCompareRow> = emptyList(),
 ) {
-  companion object {
-    const val SCHEMA = "compose-preview-rc-compare/v1"
-    const val DEFAULT_THRESHOLD = 0.1
+  public companion object {
+    public const val SCHEMA: String = "compose-preview-rc-compare/v1"
+    public const val DEFAULT_THRESHOLD: Double = 0.1
   }
 }
 
 /** One player column. [short] is the compact label used on the per-row score chips. */
-@Serializable data class RcCompareLane(val id: String, val label: String, val short: String)
+@Serializable public data class RcCompareLane(val id: String, val label: String, val short: String)
 
 /** One preview's row: the published renders keyed by lane id. */
 @Serializable
-data class RcCompareRow(
+public data class RcCompareRow(
   /** Served catalog preview id — the same id `/p/<id>` and `/render/<id>.png` use. */
   val previewId: String,
   val width: Int = 0,
@@ -75,7 +75,7 @@ data class RcCompareRow(
 
 /** One lane's published result for one preview. */
 @Serializable
-data class RcCompareCell(
+public data class RcCompareCell(
   val rendered: Boolean = false,
   /**
    * Staged image name (`<lane>/<slot>.png`), served under `/<system>/rc-compare/`. Empty ⇒ none.
@@ -101,7 +101,7 @@ data class RcCompareCell(
  */
 // Public with `ServeRcCompare` above, which exposes `LANES: List<RcLaneSource>`: `internal` is
 // module-scoped and the `:server` call sites moved out of this module.
-data class RcLaneSource(
+public data class RcLaneSource(
   val id: String,
   val label: String,
   val short: String,
@@ -118,10 +118,10 @@ data class RcLaneSource(
 
 // Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
 // and the `:server` call sites are in a different module now. Not a widened API by intent.
-object ServeRcCompare {
+public object ServeRcCompare {
   /** Staged subdir under the served catalog root, and the URL segment it is served at. */
-  const val DIRECTORY = "rc-compare"
-  const val INDEX_FILE = "index.json"
+  public const val DIRECTORY: String = "rc-compare"
+  public const val INDEX_FILE: String = "index.json"
 
   /**
    * The manifest a catalog with nothing to show writes anyway — no lanes, no rows.
@@ -130,7 +130,7 @@ object ServeRcCompare {
    * comparison, which is a different state from "the lane hasn't finished yet". Only the second one
    * makes the compare page's shape provisional, and only that one must stay out of caches.
    */
-  val NONE = RcCompareManifest()
+  public val NONE: RcCompareManifest = RcCompareManifest()
 
   /**
    * Whether the staging lane runs for a session whose catalog-id → daemon-id bridge is [alias].
@@ -141,12 +141,12 @@ object ServeRcCompare {
    * meaningful when a lane is actually coming — so they share this one expression rather than each
    * spelling it out.
    */
-  fun stagesFor(alias: Map<String, String>): Boolean = alias.isNotEmpty()
+  public fun stagesFor(alias: Map<String, String>): Boolean = alias.isNotEmpty()
 
   /** The published summary, branch-relative — the source this whole view is derived from. */
-  const val SUMMARY_FILE = "rc-compare-summary.json"
+  public const val SUMMARY_FILE: String = "rc-compare-summary.json"
 
-  val LANES: List<RcLaneSource> =
+  public val LANES: List<RcLaneSource> =
     listOf(
       RcLaneSource(
         id = "baked",
@@ -243,7 +243,7 @@ object ServeRcCompare {
    * question nothing precomputed can answer.
    */
   @Serializable
-  data class ClientModel(
+  public data class ClientModel(
     val threshold: Double,
     val lanes: List<RcCompareLane>,
     val rows: List<ClientRow>,
@@ -251,7 +251,7 @@ object ServeRcCompare {
 
   /** One row as the browser sees it: [RcCompareCell]s whose paths have been resolved to URLs. */
   @Serializable
-  data class ClientRow(
+  public data class ClientRow(
     val label: String,
     val referenceBlank: Boolean,
     val lanes: Map<String, RcCompareCell>,
@@ -260,10 +260,10 @@ object ServeRcCompare {
   private val MODEL_JSON = Json { encodeDefaults = true }
 
   /** Encode a [ClientModel] for inlining — `<` escaped so a player note can't close the script. */
-  fun encodeClientModel(model: ClientModel): String =
+  public fun encodeClientModel(model: ClientModel): String =
     MODEL_JSON.encodeToString(ClientModel.serializer(), model).replace("<", "\\u003c")
 
-  fun parseSummary(bytes: ByteArray): RcSummary? = runCatching {
+  public fun parseSummary(bytes: ByteArray): RcSummary? = runCatching {
     JSON.decodeFromString<RcSummary>(bytes.decodeToString())
   }
     .getOrNull()
@@ -281,7 +281,7 @@ object ServeRcCompare {
    * Returns null when nothing published matches this catalog, which is the common case (most
    * systems ship no `ir/<id>.rc` at all).
    */
-  fun plan(summary: RcSummary, alias: Map<String, String>): RcComparePlan? {
+  public fun plan(summary: RcSummary, alias: Map<String, String>): RcComparePlan? {
     val byDaemonId = summary.rows.associateBy { it.id }
     val matched = alias.mapNotNull { (catalogId, daemonId) ->
       byDaemonId[daemonId]?.let { catalogId to it }
@@ -347,7 +347,7 @@ object ServeRcCompare {
    * Returns null when nothing survived — there is no page worth publishing then, and the absent
    * manifest is what makes the compare page keep its client-rendered lane.
    */
-  fun retainStaged(manifest: RcCompareManifest, staged: Set<String>): RcCompareManifest? {
+  public fun retainStaged(manifest: RcCompareManifest, staged: Set<String>): RcCompareManifest? {
     val rows =
       manifest.rows.map { row ->
         row.copy(
@@ -374,7 +374,7 @@ object ServeRcCompare {
    * from being a file-read primitive: a request that isn't literally of this shape never reaches
    * the filesystem.
    */
-  fun isStagedImageName(name: String): Boolean {
+  public fun isStagedImageName(name: String): Boolean {
     val (dir, file) = name.split('/').takeIf { it.size == 2 } ?: return false
     val lane = dir.removeSuffix("-diff")
     if (lane !in LANE_IDS) return false
@@ -386,7 +386,7 @@ object ServeRcCompare {
 /** The manifest to stage plus the branch assets (`source path → staged name`) it references. */
 // Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
 // and the `:server` call sites are in a different module now. Not a widened API by intent.
-data class RcComparePlan(val manifest: RcCompareManifest, val assets: Map<String, String>)
+public data class RcComparePlan(val manifest: RcCompareManifest, val assets: Map<String, String>)
 
 /**
  * A published `rc-compare-summary.json`, cut down to the per-row verdicts the serve page replays.
@@ -394,11 +394,14 @@ data class RcComparePlan(val manifest: RcCompareManifest, val assets: Map<String
  * they belong to the parity gate, not to a side-by-side viewer.
  */
 @Serializable
-data class RcSummary(val threshold: Double? = null, val rows: List<RcSummaryRow> = emptyList())
+public data class RcSummary(
+  val threshold: Double? = null,
+  val rows: List<RcSummaryRow> = emptyList(),
+)
 
 /** One preview as the offline run scored it, keyed by the **daemon** preview id. */
 @Serializable
-data class RcSummaryRow(
+public data class RcSummaryRow(
   val id: String = "",
   val width: Int? = null,
   val height: Int? = null,
@@ -434,12 +437,12 @@ data class RcSummaryRow(
  * and only pick the page up on the next refresh. Once a manifest has been read it is kept — a
  * published comparison is a snapshot, and a refresh rebuilds the host anyway.
  */
-class ServeRcCompareStore
+public class ServeRcCompareStore
 private constructor(private val root: Path, private val fileSystem: FileSystem) {
 
   @Volatile private var settled: RcCompareManifest? = null
 
-  fun manifest(): RcCompareManifest? = read()?.takeIf { it.rows.isNotEmpty() }
+  public fun manifest(): RcCompareManifest? = read()?.takeIf { it.rows.isNotEmpty() }
 
   /**
    * True while the background staging lane has yet to write anything — so this catalog's compare
@@ -450,7 +453,7 @@ private constructor(private val root: Path, private val fileSystem: FileSystem) 
    * catalog's page is served uncacheable instead; once the lane settles (with a comparison or with
    * [ServeRcCompare.NONE]) the page is stable and caches like every other one.
    */
-  fun pending(): Boolean = read() == null
+  public fun pending(): Boolean = read() == null
 
   private fun read(): RcCompareManifest? {
     settled?.let {
@@ -469,17 +472,19 @@ private constructor(private val root: Path, private val fileSystem: FileSystem) 
   }
 
   /** Bytes for a staged lane image, or null for anything this catalog didn't stage. */
-  fun image(name: String): ByteArray? {
+  public fun image(name: String): ByteArray? {
     if (!ServeRcCompare.isStagedImageName(name)) return null
     val path = root / ServeRcCompare.DIRECTORY / name
     if (!fileSystem.exists(path)) return null
     return runCatching { fileSystem.read(path) { readByteArray() } }.getOrNull()
   }
 
-  companion object {
+  public companion object {
     private val JSON = Json { ignoreUnknownKeys = true }
 
-    fun load(bundleDir: File, fileSystem: FileSystem = SystemFileSystem): ServeRcCompareStore =
-      ServeRcCompareStore(bundleDir.toOkioPath(), fileSystem)
+    public fun load(
+      bundleDir: File,
+      fileSystem: FileSystem = SystemFileSystem,
+    ): ServeRcCompareStore = ServeRcCompareStore(bundleDir.toOkioPath(), fileSystem)
   }
 }

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -48,8 +48,8 @@ import okio.Path.Companion.toPath
  * A live daemon-backed frame stream. Forward input into the held composition via [input]; [close]
  * tears the stream down. Obtained from [ServeRenderHost.startStream].
  */
-interface StreamHandle : AutoCloseable {
-  fun input(
+public interface StreamHandle : AutoCloseable {
+  public fun input(
     kind: InteractiveInputKind,
     pixelX: Int? = null,
     pixelY: Int? = null,
@@ -71,7 +71,7 @@ interface StreamHandle : AutoCloseable {
    * Default no-op so a handle from a backend without the notification (an older daemon, a test
    * double) degrades to "always visible" rather than failing the socket.
    */
-  fun visibility(visible: Boolean, fps: Int? = null) = Unit
+  public fun visibility(visible: Boolean, fps: Int? = null): Unit = Unit
 }
 
 /** One servable preview: its id, a human label, and which delivery modes it supports. */
@@ -83,7 +83,7 @@ interface StreamHandle : AutoCloseable {
  * readers came for — so the viewer surfaces this as a control beside the still rather than playing
  * it by default, and a preview carrying none is presented exactly as it was before.
  */
-data class ServeMotion(
+public data class ServeMotion(
   /** The route the bytes are served under (`/motion/<id><extension>`). */
   val id: String,
   /** `"interaction"` (a scripted gesture) or `"animation"` (a self-running animation). */
@@ -104,14 +104,14 @@ data class ServeMotion(
  * values; [hasDefault] tells the reader which API surface is optional.
  */
 @Serializable
-data class ServeComponentParameter(
+public data class ServeComponentParameter(
   val name: String,
   val type: String,
   val hasDefault: Boolean = false,
   val composableSlot: Boolean = false,
 )
 
-data class ServePreview(
+public data class ServePreview(
   val id: String,
   val label: String,
   /** Delivery transports available for this preview. Tier 1 is always [PreviewMode.SNAPSHOT]. */
@@ -325,12 +325,12 @@ data class ServePreview(
  * `parent=` case wrong.
  */
 @Serializable
-data class ServeDeviceFrame(
+public data class ServeDeviceFrame(
   val widthDp: Double? = null,
   val heightDp: Double? = null,
   val isRound: Boolean = false,
 ) {
-  companion object {
+  public companion object {
 
     /**
      * The frame for a preview's `@Preview` params, or null when it names no device.
@@ -347,7 +347,7 @@ data class ServeDeviceFrame(
      * handed explicit dimensions, so asking it for both at once reports every sized Wear preview as
      * square, which is exactly the whole set this feature is for.
      */
-    fun from(device: String?, widthDp: Int?, heightDp: Int?): ServeDeviceFrame? {
+    public fun from(device: String?, widthDp: Int?, heightDp: Int?): ServeDeviceFrame? {
       val named = device?.takeIf { it.isNotBlank() } ?: return null
       val resolved = DeviceDimensions.resolve(named)
       val (w, h) = resolved.frameDpOverriddenBy(widthDp, heightDp)
@@ -362,7 +362,7 @@ data class ServeDeviceFrame(
 
 /** Structured, catalog-published render failure. Additive to `design-parity-catalog/v1`. */
 @Serializable
-data class CatalogRenderFailure(
+public data class CatalogRenderFailure(
   val id: String = "",
   val componentId: String? = null,
   val preview: String? = null,
@@ -380,7 +380,11 @@ data class CatalogRenderFailure(
 )
 
 @Serializable
-data class RenderFailureFrame(val file: String = "", val line: Int = 0, val function: String = "")
+public data class RenderFailureFrame(
+  val file: String = "",
+  val line: Int = 0,
+  val function: String = "",
+)
 
 /**
  * Detected per-preview feature support, folded across a discovery
@@ -389,7 +393,7 @@ data class RenderFailureFrame(val file: String = "", val line: Int = 0, val func
  * capture). Returns the two booleans the viewer gates its feature controls on. A preview with
  * neither annotation yields `(false, false)`.
  */
-fun detectedFeaturesOf(
+public fun detectedFeaturesOf(
   preview: ee.schimke.composeai.previewdata.PreviewInfo
 ): Pair<Boolean, Boolean> {
   val focus = preview.captures.any { it.focus != null || it.focusGif != null }
@@ -404,7 +408,7 @@ fun detectedFeaturesOf(
  * [ServePreview]. [providerFqn] is the `PreviewWrapperProvider` FQN sent verbatim as the
  * `themeProvider` override; [name] is the human label; [group] buckets related themes (a brand).
  */
-data class ServeTheme(
+public data class ServeTheme(
   val name: String,
   val providerFqn: String,
   val group: String? = null,
@@ -438,7 +442,7 @@ internal fun inferredThemeMode(name: String, providerFqn: String): String? {
  * theme to some other preview is just `Wrap`, which is platform-agnostic. Entries missing a
  * provider FQN are skipped (nothing to apply). Deduped by FQN.
  */
-fun declaredThemesFromPreviews(
+public fun declaredThemesFromPreviews(
   previews: List<ee.schimke.composeai.previewdata.PreviewInfo>
 ): List<ServeTheme> =
   previews
@@ -459,14 +463,14 @@ fun declaredThemesFromPreviews(
     .distinctBy { it.providerFqn }
 
 /** Result of a snapshot render request. */
-sealed interface RenderOutcome {
-  data class Ok(
+public sealed interface RenderOutcome {
+  public data class Ok(
     val png: ByteArray,
     /** How these bytes were produced, exposed on HTTP responses for remote diagnosis. */
     val generation: Generation = Generation.DAEMON,
   ) : RenderOutcome
 
-  enum class Generation(val wire: String) {
+  public enum class Generation(public val wire: String) {
     /** Read directly from a published bundle; no renderer was involved in this request. */
     BAKED("baked"),
     /** Reused from the catalog host's theme cache, which survives per-preview daemon eviction. */
@@ -490,10 +494,10 @@ sealed interface RenderOutcome {
   }
 
   /** No such preview id in this session's module. */
-  data object NotFound : RenderOutcome
+  public data object NotFound : RenderOutcome
 
   /** The render was attempted but rejected / failed / timed out. [reason] is human-readable. */
-  data class Failed(val reason: String) : RenderOutcome
+  public data class Failed(val reason: String) : RenderOutcome
 
   /**
    * The per-daemon render lock was held by another in-flight render (a cold Android render can hold
@@ -501,12 +505,12 @@ sealed interface RenderOutcome {
    * rather than block a shared HTTP render slot on that wait. NOT an error: the caller should serve
    * the baked fallback immediately (or retry). See [ServeRenderHost.DAEMON_BUSY_WAIT_MS].
    */
-  data object Busy : RenderOutcome
+  public data object Busy : RenderOutcome
 }
 
 /** Result of a figma-svg render request — the SVG counterpart of [RenderOutcome]. */
-sealed interface SvgOutcome {
-  data class Ok(
+public sealed interface SvgOutcome {
+  public data class Ok(
     val svg: ByteArray,
     /**
      * How these bytes were produced, exposed on HTTP responses for remote diagnosis — the same
@@ -518,52 +522,52 @@ sealed interface SvgOutcome {
   ) : SvgOutcome
 
   /** No such preview id, or this host can't produce SVG (a static bundle has no daemon). */
-  data object NotFound : SvgOutcome
+  public data object NotFound : SvgOutcome
 
   /** The render or SVG export was attempted but failed. [reason] is human-readable. */
-  data class Failed(val reason: String) : SvgOutcome
+  public data class Failed(val reason: String) : SvgOutcome
 }
 
 /**
  * Result of a preview-slots request — the [PreviewSlotsPayload] JSON counterpart of
  * [RenderOutcome].
  */
-sealed interface SlotsOutcome {
-  data class Ok(val json: ByteArray) : SlotsOutcome
+public sealed interface SlotsOutcome {
+  public data class Ok(val json: ByteArray) : SlotsOutcome
 
   /** No such preview id, or this host can't extract slots (a static bundle has no daemon). */
-  data object NotFound : SlotsOutcome
+  public data object NotFound : SlotsOutcome
 
   /** The render or semantics fetch was attempted but failed. [reason] is human-readable. */
-  data class Failed(val reason: String) : SlotsOutcome
+  public data class Failed(val reason: String) : SlotsOutcome
 }
 
 /**
  * Result of a design-annotation request — the typography + theme inspection layers derived from a
  * render's own `compose/semantics` tree ([ServeDesignAnnotations]).
  */
-sealed interface AnnotationsOutcome {
-  data class Ok(val json: ByteArray) : AnnotationsOutcome
+public sealed interface AnnotationsOutcome {
+  public data class Ok(val json: ByteArray) : AnnotationsOutcome
 
   /** No such preview id, or this host has no daemon to capture a semantics tree. */
-  data object NotFound : AnnotationsOutcome
+  public data object NotFound : AnnotationsOutcome
 
   /** The render or semantics fetch was attempted but failed. [reason] is human-readable. */
-  data class Failed(val reason: String) : AnnotationsOutcome
+  public data class Failed(val reason: String) : AnnotationsOutcome
 }
 
 /**
  * Result of an accessibility-overlay request — the merged `a11y/hierarchy` + `a11y/atf` +
  * `a11y/touchTargets` JSON the viewer draws its overlay boxes and legend from.
  */
-sealed interface A11yOutcome {
-  data class Ok(val json: ByteArray) : A11yOutcome
+public sealed interface A11yOutcome {
+  public data class Ok(val json: ByteArray) : A11yOutcome
 
   /** No such preview id, or this host has no daemon to produce a11y data products. */
-  data object NotFound : A11yOutcome
+  public data object NotFound : A11yOutcome
 
   /** The a11y re-render / fetch was attempted but failed. [reason] is human-readable. */
-  data class Failed(val reason: String) : A11yOutcome
+  public data class Failed(val reason: String) : A11yOutcome
 }
 
 /**
@@ -585,7 +589,7 @@ sealed interface A11yOutcome {
  * Bound to a module, not a single preview: [previews] is the whole servable set and [render] takes
  * any id in it, so switching previews is just a different request — no session churn.
  */
-class ServeRenderHost
+public class ServeRenderHost
 internal constructor(
   /**
    * Opens the daemon session — called **once, on first use**, not at construction.
@@ -1723,7 +1727,7 @@ internal constructor(
    * Independent of the snapshot render lock — a held stream runs concurrently with snapshot
    * renders.
    */
-  fun startStream(
+  public fun startStream(
     previewId: String,
     overrides: PreviewOverrides,
     codec: StreamCodec? = null,
@@ -1907,10 +1911,10 @@ internal constructor(
     }
   }
 
-  companion object {
+  public companion object {
     // Public rather than `internal` since the move to `:render-host`: `internal` is module-scoped,
     // and the `:server` call sites are in a different module now. Not a widened API by intent.
-    const val SCROLL_LONG_KIND = "render/scroll/long"
+    public const val SCROLL_LONG_KIND: String = "render/scroll/long"
     internal const val SCROLL_EXTENSION_ID = "scroll"
 
     // The accessibility extension + its three product kinds, spelled here rather than imported
@@ -1976,7 +1980,7 @@ internal constructor(
      * Does NOT spawn the daemon — the session opens on first use, so [RenderSessionException] now
      * surfaces at the first request that needs it rather than here.
      */
-    fun open(
+    public fun open(
       descriptorPath: File,
       workspaceRoot: File,
       workspaceName: String,

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSemanticsTags.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSemanticsTags.kt
@@ -49,12 +49,12 @@ import kotlinx.serialization.Serializable
  * failure mode a mismatch here produces — a wrong `element-moved` verdict from bounds nobody
  * converted.
  */
-object ServeSemanticsTags {
+public object ServeSemanticsTags {
 
   /**
    * The coordinate space [TagEntry.bounds] is in. See the class KDoc for why this is on the wire.
    */
-  const val RENDER_PIXELS = "render-pixels"
+  public const val RENDER_PIXELS: String = "render-pixels"
 
   /**
    * One tag's occupancy of the tree. [count] is every node carrying the tag; [bounds] is the first
@@ -73,7 +73,7 @@ object ServeSemanticsTags {
    */
   @OptIn(ExperimentalSerializationApi::class)
   @Serializable
-  data class TagEntry(
+  public data class TagEntry(
     val count: Int,
     val bounds: AnnotationBounds? = null,
     @EncodeDefault val space: String = RENDER_PIXELS,
@@ -85,7 +85,7 @@ object ServeSemanticsTags {
    * Blank tags are skipped: `testTag = ""` is not an identity anything can resolve, and admitting
    * it would give every untagged-but-present node one shared key.
    */
-  fun index(payload: ComposeSemanticsPayload): Map<String, TagEntry> {
+  public fun index(payload: ComposeSemanticsPayload): Map<String, TagEntry> {
     val out = LinkedHashMap<String, TagEntry>()
     fun walk(node: ComposeSemanticsNode) {
       // A trial-measured copy is not a second use of the tag: it was never placed, so it is not on

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionState.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionState.kt
@@ -14,7 +14,7 @@ import java.io.File
  * additionally retain its bounded `previews × declaredThemes` PNG cache here so idle daemon
  * suspension does not discard completed optimization work.
  */
-data class ServeSessionState(
+public data class ServeSessionState(
   /** `build/compose-previews/daemon-launch.json` the daemon relaunches from. */
   val descriptor: File,
   val workspaceRoot: File,

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSpatialAsset.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSpatialAsset.kt
@@ -1,4 +1,4 @@
 package ee.schimke.composeai.cli.serve
 
 /** Bytes and media type for an asset in a preview's portable spatial scene. */
-data class ServeSpatialAsset(val bytes: ByteArray, val contentType: String)
+public data class ServeSpatialAsset(val bytes: ByteArray, val contentType: String)

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeTagIndex.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeTagIndex.kt
@@ -44,13 +44,13 @@ import okio.Path.Companion.toPath
  * `gate-element-vanished` in the conformance fixtures is what keeps both engines there.
  */
 @Serializable
-data class TagIndexManifest(
+public data class TagIndexManifest(
   val schema: String = SCHEMA,
   /** Keyed by the **served** preview id (`button-filled__ideal__default__light`). */
   val previews: Map<String, Map<String, WireTagEntry>> = emptyMap(),
 ) {
-  companion object {
-    const val SCHEMA = "compose-preview-tags/v1"
+  public companion object {
+    public const val SCHEMA: String = "compose-preview-tags/v1"
   }
 }
 
@@ -67,28 +67,28 @@ data class TagIndexManifest(
  * entries are converted to the producer type.
  */
 @Serializable
-data class WireTagEntry(
+public data class WireTagEntry(
   val count: Int = 0,
   val bounds: AnnotationBounds? = null,
   val space: String? = null,
 )
 
 /** Validated, read-only view of a catalog's `tags/index.json`. */
-class ServeTagIndexStore
+public class ServeTagIndexStore
 private constructor(private val byPreview: Map<String, Map<String, ServeSemanticsTags.TagEntry>>) {
 
   /** The tag index for [previewId], empty when the catalog published none for it. */
-  fun forPreview(previewId: String): Map<String, ServeSemanticsTags.TagEntry> =
+  public fun forPreview(previewId: String): Map<String, ServeSemanticsTags.TagEntry> =
     byPreview[previewId].orEmpty()
 
-  val isEmpty: Boolean = byPreview.isEmpty()
+  public val isEmpty: Boolean = byPreview.isEmpty()
 
   /** Previews the catalog published an index for. */
-  val previewIds: Set<String> = byPreview.keys
+  public val previewIds: Set<String> = byPreview.keys
 
-  companion object {
-    const val DIRECTORY = "tags"
-    const val INDEX_FILE = "index.json"
+  public companion object {
+    public const val DIRECTORY: String = "tags"
+    public const val INDEX_FILE: String = "index.json"
 
     /**
      * Cap on indexed previews. A catalog is third-party data and this file is read at staging time
@@ -96,19 +96,21 @@ private constructor(private val byPreview: Map<String, Map<String, ServeSemantic
      * hostile or broken publisher cannot raise. Generous against real use — the largest published
      * catalog is in the hundreds of stickers.
      */
-    const val MAX_PREVIEWS = 4096
+    public const val MAX_PREVIEWS: Int = 4096
 
     private val JSON = Json { ignoreUnknownKeys = true }
 
     /**
      * Empty store — a catalog that publishes no index at all, which is every catalog until it does.
      */
-    val EMPTY = ServeTagIndexStore(emptyMap())
+    public val EMPTY: ServeTagIndexStore = ServeTagIndexStore(emptyMap())
 
-    fun load(bundleDir: File, fileSystem: FileSystem = FileSystem.SYSTEM): ServeTagIndexStore =
-      load(bundleDir.toOkioPath(), fileSystem)
+    public fun load(
+      bundleDir: File,
+      fileSystem: FileSystem = FileSystem.SYSTEM,
+    ): ServeTagIndexStore = load(bundleDir.toOkioPath(), fileSystem)
 
-    fun load(bundleRoot: Path, fileSystem: FileSystem): ServeTagIndexStore {
+    public fun load(bundleRoot: Path, fileSystem: FileSystem): ServeTagIndexStore {
       val index = bundleRoot / DIRECTORY.toPath() / INDEX_FILE.toPath()
       if (!fileSystem.exists(index)) return EMPTY
       val manifest =

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/SvgSanitizer.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/SvgSanitizer.kt
@@ -54,7 +54,7 @@ import org.xml.sax.InputSource
  * fail-soft, like every other reader on this surface. A page that cannot be sanitized is a page the
  * catalog serves without, never a page it serves unsafely.
  */
-object SvgSanitizer {
+public object SvgSanitizer {
 
   /**
    * A ceiling on the export this will parse into a DOM.
@@ -64,7 +64,7 @@ object SvgSanitizer {
    * O(bytes) in both time and heap, it happens at catalog load, and a delivery branch is not
    * trusted to be sane about what it publishes.
    */
-  const val MAX_BYTES: Int = 16 * 1024 * 1024
+  public const val MAX_BYTES: Int = 16 * 1024 * 1024
 
   /**
    * What a specimen sheet is made of: shapes, paint, and text.
@@ -236,7 +236,7 @@ object SvgSanitizer {
   private val UNSAFE_STYLE =
     Regex("""(?i)@import|expression\s*\(|javascript:|url\s*\(\s*(?!#|'#|"#)""")
 
-  fun sanitize(svg: String): String? {
+  public fun sanitize(svg: String): String? {
     val bytes = svg.toByteArray()
     if (bytes.isEmpty() || bytes.size > MAX_BYTES) return null
     val document =

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
@@ -40,7 +40,7 @@ import kotlinx.serialization.json.Json
  * records the inputs so a drop is *explainable* ("renderer 1.13.0 to 1.14.0 invalidated 8,412
  * entries") instead of being another unexplained return to zero.
  */
-class ThemeCacheStore(
+public class ThemeCacheStore(
   private val root: File,
   /**
    * Ceiling for the whole store across every catalog and generation.
@@ -102,7 +102,7 @@ class ThemeCacheStore(
    * Null rather than an exception: persistence is an optimisation, and a box with a read-only or
    * full disk must serve catalogs exactly as it did before this existed.
    */
-  fun open(system: String, fingerprint: String, inputs: GenerationInputs): Generation? {
+  public fun open(system: String, fingerprint: String, inputs: GenerationInputs): Generation? {
     val safeSystem = system.safeName() ?: return null
     val safeFingerprint = fingerprint.safeName() ?: return null
     val dir = File(File(root, safeSystem), safeFingerprint)
@@ -282,7 +282,7 @@ class ThemeCacheStore(
    * The mark is not a lock and does not claim to be one. It cannot stop the old replica writing; it
    * makes what the old replica writes untrusted, which is the outcome that was wanted.
    */
-  fun evictAll(): Int {
+  public fun evictAll(): Int {
     var deleted = 0
     for (systemDir in root.listFiles()?.filter { it.isDirectory }.orEmpty()) {
       for (generationDir in systemDir.listFiles()?.filter { it.isDirectory }.orEmpty()) {
@@ -337,7 +337,7 @@ class ThemeCacheStore(
    * than acted on: it means the cap is too small for the catalog set, which is a configuration
    * answer and not something this can quietly fix.
    */
-  fun sweep(live: Set<GenerationId>, onlySystems: Set<String>? = null): SweepResult {
+  public fun sweep(live: Set<GenerationId>, onlySystems: Set<String>? = null): SweepResult {
     val youngerThan = clock() - graceMillis
     val beforeScan = knownBytes.get()
     val liveDirs = live.mapNotNull { it.dir() }.toSet()
@@ -407,7 +407,7 @@ class ThemeCacheStore(
   }
 
   /** Every system with a directory in the store, whether or not this server still serves it. */
-  fun systems(): Set<String> =
+  public fun systems(): Set<String> =
     root.listFiles()?.filter { it.isDirectory }?.map { it.name }?.toSet().orEmpty()
 
   /**
@@ -420,7 +420,7 @@ class ThemeCacheStore(
    * on the way past and writes add to it from there. Slightly stale between sweeps, which is the
    * right trade for a number nobody acts on within a second.
    */
-  fun snapshot(): ThemeCacheStoreSnapshot =
+  public fun snapshot(): ThemeCacheStoreSnapshot =
     ThemeCacheStoreSnapshot(
       root = root.path,
       generations = knownGenerations.get(),
@@ -454,7 +454,7 @@ class ThemeCacheStore(
   }
 
   /** One `(system, fingerprint)` generation's directory of PNGs. */
-  inner class Generation
+  public inner class Generation
   internal constructor(
     private val dir: File,
     private val system: String,
@@ -484,10 +484,10 @@ class ThemeCacheStore(
       }
 
     /** How many renders were already on disk when this generation was opened. */
-    val loadedEntries: Int = present.size
+    public val loadedEntries: Int = present.size
 
     /** This generation's directory name — the fingerprint it was opened under. */
-    val fingerprint: String = dir.name
+    public val fingerprint: String = dir.name
 
     /**
      * Renders written before this instant came from a build that is not the one running, and are
@@ -625,7 +625,7 @@ class ThemeCacheStore(
     }
 
     /** Whether [cacheKey] is on disk from an older build and has not been re-rendered since. */
-    fun isDirty(cacheKey: String): Boolean = isDirtyName(fileName(cacheKey))
+    public fun isDirty(cacheKey: String): Boolean = isDirtyName(fileName(cacheKey))
 
     /**
      * The same question asked of a **file name** rather than a cache key.
@@ -645,7 +645,7 @@ class ThemeCacheStore(
      * reconcile hangs — see [reconcileAtRiskWrites] for why that costs nothing on the ordinary
      * path.
      */
-    fun dirtyCount(): Int {
+    public fun dirtyCount(): Int {
       reconcileAtRiskWrites()
       return dirtyNames.size
     }
@@ -658,7 +658,7 @@ class ThemeCacheStore(
      * it. Deliberately not a delete: the entries keep serving while the background pass replaces
      * them, so asking for a refresh does not cost every preview a cold render.
      */
-    fun markAllDirty(): Int {
+    public fun markAllDirty(): Int {
       // Under the generation write lock, because the transition races the one thing that undoes it.
       // A render publishing the last dirty entry calls `clearDirtyBoundary` from inside `put`,
       // which holds this lock — so an unlocked mark could write its boundary, be overwritten by
@@ -715,11 +715,11 @@ class ThemeCacheStore(
       }
 
     /** Whether [cacheKey] came from a previous process rather than from this one. */
-    fun wasAdopted(cacheKey: String): Boolean = fileName(cacheKey) in adopted
+    public fun wasAdopted(cacheKey: String): Boolean = fileName(cacheKey) in adopted
 
-    fun contains(cacheKey: String): Boolean = fileName(cacheKey) in present
+    public fun contains(cacheKey: String): Boolean = fileName(cacheKey) in present
 
-    fun get(cacheKey: String): ByteArray? {
+    public fun get(cacheKey: String): ByteArray? {
       val name = fileName(cacheKey)
       if (name !in present) {
         misses.incrementAndGet()
@@ -748,7 +748,7 @@ class ThemeCacheStore(
      * Written to a temp file and renamed, so a crash or a full disk leaves no half-PNG that a later
      * process would read as a valid cached render.
      */
-    fun put(cacheKey: String, png: ByteArray, replaceExisting: Boolean = false) {
+    public fun put(cacheKey: String, png: ByteArray, replaceExisting: Boolean = false) {
       val name = fileName(cacheKey)
       // Presence alone is not proof that no write is needed. While a generation is quarantined a
       // foreground request deliberately misses the adopted copy and renders fresh bytes; returning
@@ -835,7 +835,7 @@ class ThemeCacheStore(
      * Returns -1 when the generation write lock could not be taken, matching [discard]'s "could
      * not" so the caller can keep the entries quarantined rather than assume they are gone.
      */
-    fun discardDirty(): Int {
+    public fun discardDirty(): Int {
       if (dirtyBefore <= 0L) return 0
       return discardNames(dirtyNames.toList(), "dirty")
     }
@@ -855,7 +855,7 @@ class ThemeCacheStore(
      * the sample was drawn from. Adoption is the boundary the sample actually tests, so it is the
      * boundary the discard has to use.
      */
-    fun discardAdopted(): Int = discardNames(adopted.toList(), "adopted")
+    public fun discardAdopted(): Int = discardNames(adopted.toList(), "adopted")
 
     /**
      * Delete [names] under the generation write lock, all-or-nothing, reporting how many went or -1
@@ -914,7 +914,7 @@ class ThemeCacheStore(
         .onFailure { recordFailure(system, "manifest: ${it.message}") }
     }
 
-    fun discard(): Boolean {
+    public fun discard(): Boolean {
       // Retried, because the contended case is transient and the consequence of giving up is not.
       // The lock is held only for the length of one PNG write, so a foreground render that happens
       // to be publishing right now clears in milliseconds; the caller, on the other hand, has just
@@ -995,7 +995,7 @@ class ThemeCacheStore(
      * [ThemeCacheGenerationSnapshot.adopted] is the load-bearing number: it is the only evidence
      * that persistence carried anything across a process boundary at all.
      */
-    fun stats(): ThemeCacheGenerationSnapshot =
+    public fun stats(): ThemeCacheGenerationSnapshot =
       ThemeCacheGenerationSnapshot(
         fingerprint = fingerprint,
         adopted = loadedEntries,
@@ -1012,7 +1012,7 @@ class ThemeCacheStore(
   }
 
   /** A generation's coordinates, for [sweep]'s live set. */
-  data class GenerationId(val system: String, val fingerprint: String)
+  public data class GenerationId(val system: String, val fingerprint: String)
 
   private fun GenerationId.dir(): File? {
     val safeSystem = system.safeName() ?: return null
@@ -1020,12 +1020,12 @@ class ThemeCacheStore(
     return File(File(root, safeSystem), safeFingerprint)
   }
 
-  companion object {
-    const val DEFAULT_MAX_BYTES: Long = 8L * 1024 * 1024 * 1024
+  public companion object {
+    public const val DEFAULT_MAX_BYTES: Long = 8L * 1024 * 1024 * 1024
 
     /** Long enough to cover a rollout's readiness window, short enough to reclaim the same day. */
-    const val DEFAULT_SWEEP_GRACE_MILLIS: Long = 60L * 60 * 1000
-    const val MANIFEST_NAME: String = "manifest.json"
+    public const val DEFAULT_SWEEP_GRACE_MILLIS: Long = 60L * 60 * 1000
+    public const val MANIFEST_NAME: String = "manifest.json"
 
     /**
      * Store-root marker recording the epoch millis of the last [evictAll].
@@ -1035,8 +1035,8 @@ class ThemeCacheStore(
      * survive is what gets written next. A plain integer in a plain file so that an operator
      * looking at a mounted volume can read and clear it without tooling.
      */
-    const val EVICTED_NAME: String = "evicted-at"
-    const val MAX_REASON_CHARS: Int = 200
+    public const val EVICTED_NAME: String = "evicted-at"
+    public const val MAX_REASON_CHARS: Int = 200
     private const val PNG_SUFFIX = ".png"
     private const val TEMP_SUFFIX = ".png.tmp"
     private const val GENERATION_WRITE_LOCK = ".write.lock"
@@ -1079,7 +1079,7 @@ class ThemeCacheStore(
  * can answer "why did the cache reset" from the box itself.
  */
 @Serializable
-data class GenerationInputs(
+public data class GenerationInputs(
   val system: String,
   val fingerprint: String,
   /**
@@ -1112,7 +1112,7 @@ data class GenerationInputs(
 )
 
 /** What one [ThemeCacheStore.sweep] reclaimed. */
-data class SweepResult(
+public data class SweepResult(
   val deletedGenerations: Int,
   val reclaimedBytes: Long,
   val bytes: Long,
@@ -1135,7 +1135,7 @@ data class SweepResult(
  *   stated in two numbers.
  */
 @Serializable
-data class ThemeCacheGenerationSnapshot(
+public data class ThemeCacheGenerationSnapshot(
   /** The generation directory this catalog is reading and writing — its cache key. */
   val fingerprint: String,
   /** Renders already on disk when this process opened the generation. */
@@ -1152,7 +1152,7 @@ data class ThemeCacheGenerationSnapshot(
 
 /** Disk-tier counters for `/status.json` (`themeCache`). */
 @Serializable
-data class ThemeCacheStoreSnapshot(
+public data class ThemeCacheStoreSnapshot(
   val root: String,
   val generations: Int,
   /**


### PR DESCRIPTION
Closes #5184.

`:render-host` publishes as `ee.schimke.composeai:render-host` and is consumed across a repository boundary by compose-preview-server on its own release cadence, but it was the last published module here without `explicitApi()` or a checked ABI dump. That was deliberate in #5137 — annotating 48 files in the same commit that moved 81 would have buried the move — and this is the follow-up.

## What changed

- **`explicitApi()`**, plus the visibility and return-type annotations the compiler demands: 739 `public` modifiers and 110 explicit types across 46 main-source files. Entirely mechanical and **visibility-preserving** — every site was already public by default, so nothing about the resolved surface changes. The explicit types are the ones the compiler already inferred (`const val` literals, `setOf(...)` of strings, the `NONE`/`EMPTY` singletons, and `Unit` for `GitWorktrees.remove` and `StreamHandle.visibility`).
- **`abiValidation()`**, the generated `render-host/api/render-host.api` (4,811 lines, 389 public declarations), and `checkKotlinAbi` wired into `check` — the same shape as `:bundle-coordinates` and `:build-host-protocol`, whose comment about the Kotlin Gradle plugin not wiring the task itself applies here too.

A break in this module now shows up as a review-visible diff in the dump rather than as the server's build failing after a version bump.

## Reviewing the dump

Nothing in it was surprising, which is itself the useful result — the surface is the `serve`-package types the server already writes against (`ServeHost`, `ServeRenderHost`, `ServeBundleDaemon`, the `Serve*Store` family, the `@Serializable` payloads and their generated companions). Two things worth naming rather than leaving for someone to trip over later:

- `PlaygroundSandboxProbeMain` is public because it is a process entry point launched by name (`PlaygroundSandboxProbe.PROBE_MAIN_CLASS`), not because anyone should call it.
- The seven `…Kt` file facades (`ServeHostKt`, `ServeRenderHostKt`, …) are in the dump because the module has top-level functions; that is a JVM-name surface a consumer can bind to, so it belongs there.

No declaration was narrowed to `internal` in this PR. Doing that would be an ABI change hiding inside a mechanical one; the dump is the right place to have that argument, and now there is one.

## Test plan

Non-visual — a build-configuration and modifier change with no rendered surface, so no before/after images.

- `./gradlew :render-host:check` — green, including the new `checkKotlinAbi` and the existing `checkRenderHostIsServerFree`.
- `./gradlew :render-host:checkKotlinAbi` — green against the committed dump.
- `./gradlew :cli:compileKotlin` — green, confirming the downstream consumer in this repo sees no signature change.
- `./gradlew :render-host:ktfmtCheck` — green (main, test, testFixtures and scripts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141BL6atZiWZwS8EzvauDhC

---
_Generated by [Claude Code](https://claude.ai/code/session_0141BL6atZiWZwS8EzvauDhC)_