### PR TITLE
fix(ci): follow a sysprop mirror that reads the shared constant

### DIFF
--- a/scripts/check-daemon-launch-schema.py
+++ b/scripts/check-daemon-launch-schema.py
@@ -338,6 +338,56 @@ def kotlin_consts(rel: str) -> dict[str, str]:
     return {m.group(1): m.group(2) for m in KT_CONST.finditer(stripped(rel))}
 
 
+# A `const val` whose value is another constant rather than a literal: `DaemonProperties.Names.
+# SANDBOX_COUNT`. Anchored on the whole value so a string containing a dotted word is not mistaken
+# for one.
+KT_CONST_REF = re.compile(r"^([A-Z]\w*(?:\.\w+)*)\.(\w+)$")
+
+
+def resolve_const(value: str, registries: dict[str, str]) -> tuple[str | None, str | None]:
+    """Resolve a `const val`'s right-hand side to the literal it ultimately holds.
+
+    A mirror that *reads* the shared constant instead of re-typing the string cannot disagree with
+    it, which is strictly better than a mirror — but the value this scanner reads is then the
+    reference text, not the string, and comparing `DaemonProperties.Names.SANDBOX_COUNT` against
+    `"composeai.daemon.sandboxCount"` fails on two spellings of the same key. That is what
+    #5182 hit: the typed sysprop registry landed and this gate went red on main for a change that
+    made the mirrors *safer*.
+
+    So a dotted reference is followed to the file `constantRegistries` names for its qualifier, and
+    the literal there is what gets compared. An unregistered qualifier is still a failure — the gate
+    must never pass on a value it could not read — and it says which line to add.
+
+    Returns `(literal, None)` or `(None, why-it-could-not-be-resolved)`.
+    """
+    ref = KT_CONST_REF.match(value)
+    if ref is None:
+        return value, None
+
+    qualifier, symbol = ref.group(1), ref.group(2)
+    rel = registries.get(qualifier)
+    if rel is None:
+        return None, (
+            f"reads `{value}`, and `{qualifier}` is not a registered constant registry.\n"
+            f"    Add `\"{qualifier}\": \"<path to the file declaring it>\"` to "
+            f"`constantRegistries` in {ALLOWLIST.name} so the value behind the reference is still "
+            f"compared. Reading the shared constant is the right move; the gate just has to be able "
+            f"to follow it."
+        )
+    if not available(rel):
+        return None, None
+
+    declared = kotlin_consts(rel).get(symbol)
+    if declared is None:
+        return None, (
+            f"reads `{value}`, but {rel} declares no `{symbol}`.\n"
+            f"    Either the constant was renamed, or `constantRegistries` points at the wrong file."
+        )
+    # One hop only: a registry entry pointing at another reference is a chain nobody needs, and
+    # refusing it keeps this resolver from having to guard against a cycle.
+    return declared, None
+
+
 # --------------------------------------------------------------------------
 # Checks
 # --------------------------------------------------------------------------
@@ -853,6 +903,8 @@ def check_writer_encoders(allowlist: dict, failures: list[str]) -> None:
 
 def check_mirrored_constants(allowlist: dict, failures: list[str]) -> None:
     """String constants the descriptor carries that other modules re-declare."""
+    registries = allowlist.get("constantRegistries", {})
+
     for name, spec in allowlist["mirroredConstants"].items():
         if not available(spec["declaredBy"]):
             continue
@@ -863,16 +915,28 @@ def check_mirrored_constants(allowlist: dict, failures: list[str]) -> None:
                 f"constant but is not declared there."
             )
             continue
+        source, why = resolve_const(source, registries)
+        if source is None:
+            if why is not None:
+                failures.append(f"  {spec['declaredBy']}: `{name}` {why}")
+            continue
         for rel in spec["mirroredBy"]:
             if not available(rel):
                 continue
-            value = kotlin_consts(rel).get(spec.get("mirrorSymbol", name))
+            symbol = spec.get("mirrorSymbol", name)
+            value = kotlin_consts(rel).get(symbol)
             if value is None:
                 failures.append(
                     f"  {rel}: registered as mirroring `{name}` but no longer declares it. "
                     f"Prune it from `mirroredConstants`."
                 )
-            elif value != source:
+                continue
+            value, why = resolve_const(value, registries)
+            if value is None:
+                if why is not None:
+                    failures.append(f"  {rel}: `{symbol}` {why}")
+                continue
+            if value != source:
                 failures.append(
                     f"  {rel}: `{name}` = {value}, but {spec['declaredBy']} says {source}. "
                     f"{spec['why']}"

--- a/scripts/daemon-launch-schema-allowlist.json
+++ b/scripts/daemon-launch-schema-allowlist.json
@@ -27,6 +27,13 @@
     "mirroredConstants: string constants carried inside the descriptor that another module",
     "re-declares privately. Same hazard as the schema version, one level down.",
     "",
+    "constantRegistries: qualifier -> the file declaring the constants behind it, e.g.",
+    "`DaemonProperties.Names`. A mirror that READS the shared constant instead of re-typing the",
+    "string cannot disagree with it, which is strictly better than a mirror \u2014 but the scanner then",
+    "reads `DaemonProperties.Names.SANDBOX_COUNT` where it expects a string, so the reference is",
+    "followed here and the literal behind it is what gets compared. An unregistered qualifier fails:",
+    "the gate never passes on a value it could not read.",
+    "",
     "versionStampAliases: an identifier that appears as `schemaVersion = \u2026` at a construction site",
     "but is not itself one of the registered constants \u2014 an indirection that forwards one. Recorded",
     "so discovery-by-use can insist on a known name without banning the indirection.",
@@ -100,6 +107,9 @@
       ],
       "why": "The daemon JVM does read this config, but through flattened `composeai.daemon.bta*` system properties (DefaultBtaCompileService.fromSysprops()), not through the descriptor's nested block \u2014 so DaemonLaunchDescriptor has no reason to declare it. The VS Code extension reads the block directly to decide whether calling `compileSources` is worth a round-trip. Survivable only because the JVM reader ignores unknown keys."
     }
+  },
+  "constantRegistries": {
+    "DaemonProperties.Names": "daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/config/DaemonProperties.kt"
   },
   "mirroredConstants": {
     "SANDBOX_COUNT_PROP": {

--- a/scripts/test_check_daemon_launch_schema.py
+++ b/scripts/test_check_daemon_launch_schema.py
@@ -13,6 +13,7 @@ registered site still present — the allowlist has to keep describing the code.
 
 import importlib.util
 import json
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -153,6 +154,107 @@ class WireFingerprint(unittest.TestCase):
     def test_the_digest_is_stable_for_the_same_shape(self):
         a = {"x": ("Int", False), "y": ("String", True)}
         self.assertEqual(mod.wire_fingerprint(a), mod.wire_fingerprint(dict(a)))
+
+
+class ConstReferences(unittest.TestCase):
+    """A mirror that reads the shared constant instead of re-typing the string.
+
+    #5182 gave the `composeai.daemon.*` sysprops a typed registry, so the two android mirrors of
+    `SANDBOX_COUNT_PROP` became `DaemonProperties.Names.SANDBOX_COUNT`. That is the safer
+    declaration — it cannot drift — and it turned this gate red on main, because the scanner
+    compared the reference text against the descriptor's string literal. Resolving the reference is
+    what these pin.
+    """
+
+    REGISTRIES = {"DaemonProperties.Names": "daemon/core/config/DaemonProperties.kt"}
+
+    def setUp(self):
+        self._tree = tempfile.TemporaryDirectory()
+        self._repo_root = mod.REPO_ROOT
+        mod.REPO_ROOT = Path(self._tree.name)
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        mod.REPO_ROOT = self._repo_root
+        self._tree.cleanup()
+
+    def _write(self, rel: str, text: str) -> None:
+        path = Path(self._tree.name) / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+    def _registry(self, value: str = '"composeai.daemon.sandboxCount"') -> None:
+        self._write(
+            self.REGISTRIES["DaemonProperties.Names"],
+            "public object DaemonProperties {\n"
+            "  public object Names {\n"
+            f"    public const val SANDBOX_COUNT: String = {value}\n"
+            "  }\n"
+            "}\n",
+        )
+
+    def test_a_literal_resolves_to_itself(self):
+        self.assertEqual(mod.resolve_const('"a.b"', self.REGISTRIES), ('"a.b"', None))
+
+    def test_a_registered_reference_resolves_to_the_literal_behind_it(self):
+        self._registry()
+        value, why = mod.resolve_const("DaemonProperties.Names.SANDBOX_COUNT", self.REGISTRIES)
+        self.assertEqual(value, '"composeai.daemon.sandboxCount"')
+        self.assertIsNone(why)
+
+    def test_an_unregistered_qualifier_is_a_failure_not_a_pass(self):
+        value, why = mod.resolve_const("SomeOther.Registry.KEY", self.REGISTRIES)
+        self.assertIsNone(value)
+        self.assertIn("constantRegistries", why)
+
+    def test_a_registry_that_no_longer_declares_the_symbol_is_a_failure(self):
+        self._write(self.REGISTRIES["DaemonProperties.Names"], "public object Names {}\n")
+        value, why = mod.resolve_const("DaemonProperties.Names.SANDBOX_COUNT", self.REGISTRIES)
+        self.assertIsNone(value)
+        self.assertIn("declares no `SANDBOX_COUNT`", why)
+
+    def test_a_string_containing_dots_is_not_mistaken_for_a_reference(self):
+        # The value the descriptor itself declares. Quoted, so it is a literal, not a reference.
+        self.assertEqual(
+            mod.resolve_const('"composeai.daemon.sandboxCount"', self.REGISTRIES),
+            ('"composeai.daemon.sandboxCount"', None),
+        )
+
+    def _mirrored(self, mirror_value: str) -> list:
+        self._write(
+            "descriptor.kt",
+            'const val SANDBOX_COUNT_PROP = "composeai.daemon.sandboxCount"\n',
+        )
+        self._write("mirror.kt", f"private const val SANDBOX_COUNT_PROP = {mirror_value}\n")
+        failures: list = []
+        mod.check_mirrored_constants(
+            {
+                "constantRegistries": self.REGISTRIES,
+                "mirroredConstants": {
+                    "SANDBOX_COUNT_PROP": {
+                        "declaredBy": "descriptor.kt",
+                        "mirroredBy": ["mirror.kt"],
+                        "why": "both sides MUST agree.",
+                    }
+                },
+            },
+            failures,
+        )
+        return failures
+
+    def test_a_mirror_reading_the_registry_agrees(self):
+        self._registry()
+        self.assertEqual(self._mirrored("DaemonProperties.Names.SANDBOX_COUNT"), [])
+
+    def test_a_mirror_reading_a_registry_that_says_something_else_still_fails(self):
+        # The check must keep catching real drift through the indirection, not wave it through.
+        self._registry('"composeai.daemon.sandboxSlots"')
+        failures = self._mirrored("DaemonProperties.Names.SANDBOX_COUNT")
+        self.assertEqual(len(failures), 1)
+        self.assertIn("sandboxSlots", failures[0])
+
+    def test_a_mirror_with_a_drifted_literal_still_fails(self):
+        self.assertEqual(len(self._mirrored('"composeai.daemon.sandboxSlots"')), 1)
 
 
 class RealTree(unittest.TestCase):


### PR DESCRIPTION
**main is red on this**, and has been since [#5182](https://github.com/yschimke/compose-ai-tools/pull/5182) — `Actions Script Tests` → *Run daemon-launch schema gate tests* fails on [f018302](https://github.com/yschimke/compose-ai-tools/actions/runs/33961037190/job/101292898802), and on every PR branched from it.

## What broke

#5182 gave the `composeai.daemon.*` sysprops a typed registry, so the two android mirrors of `SANDBOX_COUNT_PROP` became:

```kotlin
private const val SANDBOX_COUNT_PROP = DaemonProperties.Names.SANDBOX_COUNT
```

That is the **safer** declaration — a mirror that reads the shared constant cannot disagree with it. But `check-daemon-launch-schema.py` reads the right-hand side as text, so it compared `DaemonProperties.Names.SANDBOX_COUNT` against the descriptor's `"composeai.daemon.sandboxCount"` and reported drift between two spellings of the same key. The gate went red for a change that made the thing it guards stronger.

## The fix

`resolve_const` follows a dotted reference to the file `constantRegistries` names for its qualifier, and compares the literal behind it. Three properties it keeps:

- **An unregistered qualifier is a failure, not a pass** — the gate must never wave through a value it could not read. The message names the line to add.
- **Real drift still fails through the indirection**: a registry that says `sandboxSlots` where the descriptor says `sandboxCount` is still reported.
- **One hop only.** A registry entry pointing at another reference is a chain nobody needs, and refusing it means no cycle guard.

`constantRegistries` is one entry today: `DaemonProperties.Names` → `daemon/core/.../config/DaemonProperties.kt`.

## Test plan

```
python3 scripts/test_check_daemon_launch_schema.py
```

51 tests, green — 8 new, covering literal pass-through, reference resolution, the unregistered qualifier, a registry that dropped the symbol, a dotted string that must not be mistaken for a reference, and drift both through and without the indirection.

Reverting the script and re-running the new cases reproduces the CI message verbatim: ``mirror.kt: `SANDBOX_COUNT_PROP` = DaemonProperties.Names.SANDBOX_COUNT, but descriptor.kt says "composeai.daemon.sandboxCount"``.

Non-visual change: a CI gate script and its tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Uxgbygt7e2LEBDruCGeKY

---
_Generated by [Claude Code](https://claude.ai/code/session_016Uxgbygt7e2LEBDruCGeKY)_