### PR TITLE
fix(cli): make optional captures visible in show output

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -64,8 +64,32 @@ data class PreviewListResponse(
   val counts: PreviewCounts? = null,
 )
 
+/**
+ * The `counts` block of a `show` / `a11y` JSON envelope.
+ *
+ * The four buckets **partition** [total] — every preview lands in exactly one, and `changed +
+ * unchanged + missing + skipped == total` for any run (asserted in `PreviewCountsPartitionTest`).
+ * Consumers can therefore compute a residual from them, which they could not before [skipped]
+ * existed: a preview whose only captures were `optional` and produced no PNG fell into no bucket at
+ * all, so on a project with best-effort captures the counts silently stopped adding up
+ * (issue #5174).
+ *
+ * @property changed at least one capture's sha256 differs from the previous run.
+ * @property unchanged nothing changed, and at least one capture has a PNG.
+ * @property missing no PNG at all, and the miss is a render failure — the set `--missing-renders`
+ *   gates on (see [previewsMissingPng]).
+ * @property skipped no PNG at all, and the miss is **expected**: every absent capture is
+ *   `optional`, or the preview is one of [NON_PNG_PREVIEW_KINDS]. Text output tags these rows `[no
+ *   PNG, optional]` / `[no PNG, by design]` rather than a bare `[no PNG]`.
+ */
 @Serializable
-data class PreviewCounts(val total: Int, val changed: Int, val unchanged: Int, val missing: Int)
+data class PreviewCounts(
+  val total: Int,
+  val changed: Int,
+  val unchanged: Int,
+  val missing: Int,
+  val skipped: Int = 0,
+)
 
 /**
  * Compact response shape emitted under `--brief`. Drops everything an agent already had from a
@@ -898,8 +922,7 @@ abstract class Command(
   }
 
   /** True if the preview has at least one capture with `changed = true`. */
-  protected fun PreviewResult.anyChanged(): Boolean =
-    captures.any { it.changed == true } || changed == true
+  protected fun PreviewResult.anyChanged(): Boolean = hasChangedCapture()
 
   /** Filters by `--id` / `--filter` and (optionally) `--changed-only`. */
   protected fun applyFilters(all: List<PreviewResult>): List<PreviewResult> =
@@ -959,22 +982,7 @@ abstract class Command(
     )
   }
 
-  private fun countsOf(results: List<PreviewResult>) =
-    PreviewCounts(
-      total = results.size,
-      changed = results.count { it.anyChanged() },
-      unchanged = results.count { !it.anyChanged() && it.captures.any { c -> c.pngPath != null } },
-      // Exclude kinds that never emit a PNG (see [NON_PNG_PREVIEW_KINDS]) and `optional` captures
-      // so `counts.missing` matches what `--missing-renders` actually gates on — an
-      // `@XrSubspacePreview` with no composite or a desktop `@ColorCatalog` sheet still isn't a
-      // render failure.
-      missing =
-        results.count { r ->
-          r.params.kind !in NON_PNG_PREVIEW_KINDS &&
-            r.captures.all { c -> c.pngPath == null } &&
-            r.captures.any { c -> !c.optional }
-        },
-    )
+  private fun countsOf(results: List<PreviewResult>): PreviewCounts = previewCountsOf(results)
 
   protected fun matchesRequest(preview: PreviewInfo): Boolean =
     previewIdMatchesRequest(
@@ -1638,9 +1646,97 @@ internal fun readableRenderModules(
  * standing up a Gradle render.
  */
 internal fun previewsMissingPng(results: List<PreviewResult>): List<PreviewResult> =
-  results.filter { r ->
-    r.params.kind !in NON_PNG_PREVIEW_KINDS && r.captures.any { it.pngPath == null && !it.optional }
+  results.filter {
+    previewMissesRequiredPng(it)
   }
+
+/**
+ * [previewsMissingPng] for a single row — the one predicate that decides whether a missing PNG is a
+ * render failure. Kept as the single source of truth for the gate, the `counts.missing` bucket and
+ * the `[no PNG]` text tag, so the three channels a consumer reads cannot disagree about the same
+ * preview (issue #5174: four rows tagged `[no PNG]` above a summary that said one).
+ */
+internal fun previewMissesRequiredPng(r: PreviewResult): Boolean =
+  r.params.kind !in NON_PNG_PREVIEW_KINDS && r.captures.any { it.pngPath == null && !it.optional }
+
+/** True if the preview has at least one capture with `changed = true`. */
+internal fun PreviewResult.hasChangedCapture(): Boolean =
+  captures.any { it.changed == true } || changed == true
+
+/** Which [PreviewCounts] bucket a preview belongs to. Exhaustive, and mutually exclusive. */
+internal enum class PreviewCountBucket {
+  CHANGED,
+  UNCHANGED,
+  MISSING,
+  SKIPPED,
+}
+
+/**
+ * Classify one preview into its [PreviewCounts] bucket.
+ *
+ * Written as a `when` cascade rather than four predicates precisely because the buckets have to
+ * partition the result set: a row that matches no branch is impossible here, where it used to be
+ * the normal fate of a preview whose only captures were `optional`.
+ */
+internal fun previewCountBucket(r: PreviewResult): PreviewCountBucket =
+  when {
+    r.hasChangedCapture() -> PreviewCountBucket.CHANGED
+    r.captures.any { it.pngPath != null } -> PreviewCountBucket.UNCHANGED
+    previewMissesRequiredPng(r) -> PreviewCountBucket.MISSING
+    else -> PreviewCountBucket.SKIPPED
+  }
+
+/**
+ * The `counts` block for a set of results.
+ *
+ * Bucketed through [previewCountBucket] rather than four independent `count {}` predicates, so the
+ * buckets partition `total` by construction — the expected-miss rows that used to fall between the
+ * predicates now land in `skipped` instead of in no bucket at all (issue #5174).
+ */
+internal fun previewCountsOf(results: List<PreviewResult>): PreviewCounts {
+  val byBucket = results.groupingBy { previewCountBucket(it) }.eachCount()
+  return PreviewCounts(
+    total = results.size,
+    changed = byBucket[PreviewCountBucket.CHANGED] ?: 0,
+    unchanged = byBucket[PreviewCountBucket.UNCHANGED] ?: 0,
+    missing = byBucket[PreviewCountBucket.MISSING] ?: 0,
+    skipped = byBucket[PreviewCountBucket.SKIPPED] ?: 0,
+  )
+}
+
+/**
+ * The trailing tag on a `show` row: `[changed]`, `[no PNG]`, or — new in issue #5174 — a tag that
+ * says the absent PNG was *expected*.
+ *
+ * A bare `[no PNG]` is reserved for the misses [previewMissesRequiredPng] flags, i.e. exactly the
+ * ones the "produced no PNG for N of M preview(s)" summary below the listing enumerates. A
+ * best-effort capture (`Capture.optional` — a non-launcher activity that needs intent extras, a
+ * desktop `@ColorCatalog` sheet) and a kind that never emits a PNG get their own tags, so a reader
+ * can tell which of the untagged rows is the real failure without reimplementing the policy off the
+ * JSON.
+ */
+internal fun previewStatusTag(r: PreviewResult): String =
+  when {
+    r.pngPath != null -> if (r.hasChangedCapture()) " [changed]" else ""
+    previewMissesRequiredPng(r) -> " [no PNG]"
+    r.params.kind in NON_PNG_PREVIEW_KINDS -> NO_PNG_BY_DESIGN_TAG
+    else -> NO_PNG_OPTIONAL_TAG
+  }
+
+/** [previewStatusTag] for one capture row of a multi-capture preview. */
+internal fun captureStatusTag(c: CaptureResult, kind: String): String =
+  when {
+    c.pngPath != null -> if (c.changed == true) " [changed]" else ""
+    c.optional -> NO_PNG_OPTIONAL_TAG
+    kind in NON_PNG_PREVIEW_KINDS -> NO_PNG_BY_DESIGN_TAG
+    else -> " [no PNG]"
+  }
+
+/** Best-effort capture (`Capture.optional`) that produced nothing — expected, not a failure. */
+internal const val NO_PNG_OPTIONAL_TAG = " [no PNG, optional]"
+
+/** A [NON_PNG_PREVIEW_KINDS] preview, whose empty `pngPath` is the normal outcome. */
+internal const val NO_PNG_BY_DESIGN_TAG = " [no PNG, by design]"
 
 /**
  * Whether `show` can still emit a useful report after gradle reported failure.
@@ -1771,24 +1867,14 @@ class ShowCommand(args: List<String>) : Command(args) {
           println("[${r.module}]")
           lastModule = r.module
         }
-        val statusTag =
-          when {
-            r.pngPath == null -> " [no PNG]"
-            r.anyChanged() -> " [changed]"
-            else -> ""
-          }
+        val statusTag = previewStatusTag(r)
         val shaTag = r.sha256?.let { "  sha=${it.take(12)}" } ?: ""
         println("${r.functionName} (${r.id})$statusTag$shaTag")
         if (r.captures.size <= 1) {
           if (r.pngPath != null) println("  ${r.pngPath}")
         } else {
           for (c in r.captures) {
-            val tag =
-              when {
-                c.pngPath == null -> " [no PNG]"
-                c.changed == true -> " [changed]"
-                else -> ""
-              }
+            val tag = captureStatusTag(c, r.params.kind)
             println("  [${captureCoordLabel(c)}]$tag ${c.pngPath ?: ""}")
           }
         }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ResourceCommands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ResourceCommands.kt
@@ -115,6 +115,32 @@ data class ResourcePreviewResult(
 internal fun ResourcePreviewResult.anyChanged(): Boolean = captures.any { it.changed == true }
 
 /**
+ * `skipped` in [ResourceCaptureResult.errorStatus] — the renderer met a known degradation (an
+ * unsupported drawable form) rather than failing. The resource-side counterpart of `Capture
+ * .optional`: the missing PNG is expected, so the text tag says so instead of reading as a render
+ * failure (issue #5174).
+ */
+internal const val RESOURCE_ERROR_STATUS_SKIPPED = "skipped"
+
+/** Tag for one `show-resources` row — see `previewStatusTag` for the composable-side rule. */
+internal fun resourceStatusTag(r: ResourcePreviewResult): String =
+  when {
+    r.pngPath != null -> if (r.anyChanged()) " [changed]" else ""
+    r.captures.isNotEmpty() &&
+      r.captures.all { it.pngPath != null || it.errorStatus == RESOURCE_ERROR_STATUS_SKIPPED } ->
+      " [no PNG, skipped]"
+    else -> " [no PNG]"
+  }
+
+/** [resourceStatusTag] for one capture row of a multi-variant resource. */
+internal fun resourceCaptureStatusTag(c: ResourceCaptureResult): String =
+  when {
+    c.pngPath != null -> if (c.changed == true) " [changed]" else ""
+    c.errorStatus == RESOURCE_ERROR_STATUS_SKIPPED -> " [no PNG, skipped]"
+    else -> " [no PNG]"
+  }
+
+/**
  * Versioned envelope for `compose-preview show-resources --json`. Distinct schema from the
  * composable side (`compose-preview-show/v1`) so agents can dispatch on shape without inspecting
  * field names — bump the version when [ResourcePreviewResult]'s shape changes.
@@ -470,24 +496,14 @@ class ShowResourcesCommand(args: List<String>) : Command(args) {
         println("[${r.module}]")
         lastModule = r.module
       }
-      val statusTag =
-        when {
-          r.pngPath == null -> " [no PNG]"
-          r.anyChanged() -> " [changed]"
-          else -> ""
-        }
+      val statusTag = resourceStatusTag(r)
       val shaTag = r.sha256?.let { "  sha=${it.take(12)}" } ?: ""
       println("${r.id} (${r.type})$statusTag$shaTag")
       if (r.captures.size <= 1) {
         if (r.pngPath != null) println("  ${r.pngPath}")
       } else {
         for (c in r.captures) {
-          val tag =
-            when {
-              c.pngPath == null -> " [no PNG]"
-              c.changed == true -> " [changed]"
-              else -> ""
-            }
+          val tag = resourceCaptureStatusTag(c)
           val coord =
             listOfNotNull(c.variant?.qualifiers, c.variant?.shape).joinToString(" · ").ifEmpty {
               "default"

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/OptionalCaptureVisibilityTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/OptionalCaptureVisibilityTest.kt
@@ -1,0 +1,192 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.previewdata.CaptureResult
+import ee.schimke.composeai.previewdata.PreviewParams
+import ee.schimke.composeai.previewdata.PreviewResult
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Issue #5174: an `optional` capture that produced no PNG was reported through two channels that
+ * disagreed. The row was tagged with a bare `[no PNG]`, indistinguishable from a genuine render
+ * failure, while the summary underneath — and `counts.missing` — correctly left it out; and the
+ * `counts` buckets then didn't add up to `total`, because the row belonged to none of them.
+ *
+ * These tests pin both halves: the tag says which misses are expected, and the buckets partition.
+ */
+class OptionalCaptureVisibilityTest {
+
+  private fun result(
+    id: String,
+    kind: String = "COMPOSE",
+    captures: List<CaptureResult>,
+  ): PreviewResult =
+    PreviewResult(
+      id = id,
+      module = "samples:demo",
+      functionName = id.substringAfterLast('.'),
+      className = id.substringBeforeLast('.'),
+      params = PreviewParams(kind = kind),
+      captures = captures,
+      pngPath = captures.firstOrNull()?.pngPath,
+      sha256 = captures.firstOrNull()?.sha256,
+      changed = captures.firstOrNull()?.changed,
+    )
+
+  @Test
+  fun `a required miss keeps the bare no-PNG tag`() {
+    val r = result("p.Broken", captures = listOf(CaptureResult(pngPath = null)))
+    assertEquals(" [no PNG]", previewStatusTag(r))
+  }
+
+  @Test
+  fun `an optional miss is tagged as optional`() {
+    // The non-launcher activity previews of issue #5174: discovery marks them best-effort because
+    // a real screen may need intent extras it can't guess.
+    val r =
+      result(
+        "activity__RedirectUriReceiverActivity",
+        captures = listOf(CaptureResult(pngPath = null, optional = true)),
+      )
+    assertEquals(NO_PNG_OPTIONAL_TAG, previewStatusTag(r))
+  }
+
+  @Test
+  fun `a required miss beside an optional one still reads as a failure`() {
+    val r =
+      result(
+        "p.Mixed",
+        captures =
+          listOf(CaptureResult(pngPath = null, optional = true), CaptureResult(pngPath = null)),
+      )
+    assertEquals(" [no PNG]", previewStatusTag(r))
+  }
+
+  @Test
+  fun `a kind that never emits a PNG says so`() {
+    val r = result("p.Spatial", kind = "XR_SUBSPACE", captures = listOf(CaptureResult()))
+    assertEquals(NO_PNG_BY_DESIGN_TAG, previewStatusTag(r))
+  }
+
+  @Test
+  fun `rendered previews keep their changed and empty tags`() {
+    val rendered = CaptureResult(pngPath = "/r/a.png", sha256 = "a", changed = false)
+    assertEquals("", previewStatusTag(result("p.Same", captures = listOf(rendered))))
+    assertEquals(
+      " [changed]",
+      previewStatusTag(result("p.Diff", captures = listOf(rendered.copy(changed = true)))),
+    )
+  }
+
+  @Test
+  fun `a bare no-PNG tag appears on the gate's rows and only those`() {
+    // The invariant the two channels used to break: a bare `[no PNG]` — at the preview level or on
+    // one of the capture lines under it — marks exactly the rows the "produced no PNG for N of M
+    // preview(s)" summary enumerates. A partially-rendered fan-out is why the capture lines count:
+    // its first capture rendered, so the preview-level tag stays `[changed]`/empty and the miss is
+    // reported on the capture line that has it.
+    val results =
+      listOf(
+        result("p.Ok", captures = listOf(CaptureResult(pngPath = "/r/ok.png", sha256 = "a"))),
+        result("p.Broken", captures = listOf(CaptureResult(pngPath = null))),
+        result("p.Optional", captures = listOf(CaptureResult(pngPath = null, optional = true))),
+        result("p.Spatial", kind = "XR_SUBSPACE", captures = listOf(CaptureResult())),
+        result(
+          "p.FanOut",
+          captures =
+            listOf(
+              CaptureResult(advanceTimeMillis = 0, pngPath = "/r/a.png", sha256 = "a"),
+              CaptureResult(advanceTimeMillis = 500, pngPath = null),
+            ),
+        ),
+      )
+    fun tagsBareNoPng(r: PreviewResult) =
+      previewStatusTag(r) == " [no PNG]" ||
+        r.captures.any { captureStatusTag(it, r.params.kind) == " [no PNG]" }
+
+    assertEquals(
+      previewsMissingPng(results).map { it.id },
+      results.filter { tagsBareNoPng(it) }.map { it.id },
+    )
+  }
+
+  @Test
+  fun `capture tags distinguish an optional row from a failed one`() {
+    assertEquals(
+      " [no PNG]",
+      captureStatusTag(CaptureResult(advanceTimeMillis = 0, pngPath = null), "COMPOSE"),
+    )
+    assertEquals(
+      NO_PNG_OPTIONAL_TAG,
+      captureStatusTag(
+        CaptureResult(advanceTimeMillis = 0, pngPath = null, optional = true),
+        "COMPOSE",
+      ),
+    )
+    assertEquals(NO_PNG_BY_DESIGN_TAG, captureStatusTag(CaptureResult(), "XR_SUBSPACE"))
+    assertEquals(
+      " [changed]",
+      captureStatusTag(CaptureResult(pngPath = "/r/a.png", changed = true), "COMPOSE"),
+    )
+    assertEquals(
+      "",
+      captureStatusTag(CaptureResult(pngPath = "/r/a.png", changed = false), "COMPOSE"),
+    )
+  }
+
+  @Test
+  fun `counts partition total`() {
+    // The reported run in miniature: one changed, one unchanged, one required miss, one optional
+    // miss. `0 + 33 + 1 != 37` was the bug; here `1 + 1 + 1 + 1 == 4`.
+    val results =
+      listOf(
+        result(
+          "p.Changed",
+          captures = listOf(CaptureResult(pngPath = "/r/c.png", sha256 = "c", changed = true)),
+        ),
+        result(
+          "p.Same",
+          captures = listOf(CaptureResult(pngPath = "/r/s.png", sha256 = "s", changed = false)),
+        ),
+        result("p.Broken", captures = listOf(CaptureResult(pngPath = null))),
+        result("p.Optional", captures = listOf(CaptureResult(pngPath = null, optional = true))),
+      )
+    val counts = previewCountsOf(results)
+    assertEquals(
+      PreviewCounts(total = 4, changed = 1, unchanged = 1, missing = 1, skipped = 1),
+      counts,
+    )
+    assertEquals(counts.total, counts.changed + counts.unchanged + counts.missing + counts.skipped)
+  }
+
+  @Test
+  fun `every classifiable shape lands in exactly one bucket`() {
+    val shapes =
+      listOf(
+        result("p.Changed", captures = listOf(CaptureResult(pngPath = "/r/c.png", changed = true))),
+        result("p.Same", captures = listOf(CaptureResult(pngPath = "/r/s.png", changed = false))),
+        result("p.Broken", captures = listOf(CaptureResult(pngPath = null))),
+        result("p.Optional", captures = listOf(CaptureResult(pngPath = null, optional = true))),
+        result("p.Spatial", kind = "XR_SUBSPACE", captures = listOf(CaptureResult())),
+        result("p.NoCaptures", captures = emptyList()),
+        result(
+          "p.PartialFanOut",
+          captures = listOf(CaptureResult(pngPath = "/r/a.png"), CaptureResult(pngPath = null)),
+        ),
+      )
+    val counts = previewCountsOf(shapes)
+    assertEquals(shapes.size, counts.changed + counts.unchanged + counts.missing + counts.skipped)
+    assertEquals(
+      listOf(
+        PreviewCountBucket.CHANGED,
+        PreviewCountBucket.UNCHANGED,
+        PreviewCountBucket.MISSING,
+        PreviewCountBucket.SKIPPED,
+        PreviewCountBucket.SKIPPED,
+        PreviewCountBucket.SKIPPED,
+        PreviewCountBucket.UNCHANGED,
+      ),
+      shapes.map { previewCountBucket(it) },
+    )
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/ResourceCommandsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/ResourceCommandsTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.cli
 
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -24,6 +25,45 @@ class ResourceCommandsTest {
   fun `show resources command accepts the resource-specific filter surface`() {
     ShowResourcesCommand(
       listOf("--json", "--changed-only", "--module", ":app", "--id", "drawable/icon")
+    )
+  }
+
+  @Test
+  fun `a skipped capture is tagged apart from a failed one`() {
+    // Resource-side counterpart of issue #5174's `optional` captures: `skipped` is a known
+    // degradation the renderer reports, not a render failure, so the row shouldn't read like one.
+    val skipped = ResourceCaptureResult(errorStatus = "skipped", error = "adaptive icon")
+    val failed = ResourceCaptureResult(errorStatus = "failed", error = "boom")
+    val rendered = ResourceCaptureResult(pngPath = "/r/icon.png", changed = false)
+
+    assertEquals(" [no PNG, skipped]", resourceCaptureStatusTag(skipped))
+    assertEquals(" [no PNG]", resourceCaptureStatusTag(failed))
+    assertEquals("", resourceCaptureStatusTag(rendered))
+    assertEquals(" [changed]", resourceCaptureStatusTag(rendered.copy(changed = true)))
+
+    assertEquals(
+      " [no PNG, skipped]",
+      resourceStatusTag(
+        ResourcePreviewResult("id", ":app", "drawable", captures = listOf(skipped))
+      ),
+    )
+    assertEquals(
+      " [no PNG]",
+      resourceStatusTag(
+        ResourcePreviewResult("id", ":app", "drawable", captures = listOf(skipped, failed))
+      ),
+    )
+    assertEquals(
+      " [changed]",
+      resourceStatusTag(
+        ResourcePreviewResult(
+          "id",
+          ":app",
+          "drawable",
+          captures = listOf(rendered.copy(changed = true)),
+          pngPath = rendered.pngPath,
+        )
+      ),
     )
   }
 }

--- a/scripts/check-daemon-launch-schema.py
+++ b/scripts/check-daemon-launch-schema.py
@@ -338,6 +338,56 @@ def kotlin_consts(rel: str) -> dict[str, str]:
     return {m.group(1): m.group(2) for m in KT_CONST.finditer(stripped(rel))}
 
 
+# A `const val` whose value is another constant rather than a literal: `DaemonProperties.Names.
+# SANDBOX_COUNT`. Anchored on the whole value so a string containing a dotted word is not mistaken
+# for one.
+KT_CONST_REF = re.compile(r"^([A-Z]\w*(?:\.\w+)*)\.(\w+)$")
+
+
+def resolve_const(value: str, registries: dict[str, str]) -> tuple[str | None, str | None]:
+    """Resolve a `const val`'s right-hand side to the literal it ultimately holds.
+
+    A mirror that *reads* the shared constant instead of re-typing the string cannot disagree with
+    it, which is strictly better than a mirror — but the value this scanner reads is then the
+    reference text, not the string, and comparing `DaemonProperties.Names.SANDBOX_COUNT` against
+    `"composeai.daemon.sandboxCount"` fails on two spellings of the same key. That is what
+    #5182 hit: the typed sysprop registry landed and this gate went red on main for a change that
+    made the mirrors *safer*.
+
+    So a dotted reference is followed to the file `constantRegistries` names for its qualifier, and
+    the literal there is what gets compared. An unregistered qualifier is still a failure — the gate
+    must never pass on a value it could not read — and it says which line to add.
+
+    Returns `(literal, None)` or `(None, why-it-could-not-be-resolved)`.
+    """
+    ref = KT_CONST_REF.match(value)
+    if ref is None:
+        return value, None
+
+    qualifier, symbol = ref.group(1), ref.group(2)
+    rel = registries.get(qualifier)
+    if rel is None:
+        return None, (
+            f"reads `{value}`, and `{qualifier}` is not a registered constant registry.\n"
+            f"    Add `\"{qualifier}\": \"<path to the file declaring it>\"` to "
+            f"`constantRegistries` in {ALLOWLIST.name} so the value behind the reference is still "
+            f"compared. Reading the shared constant is the right move; the gate just has to be able "
+            f"to follow it."
+        )
+    if not available(rel):
+        return None, None
+
+    declared = kotlin_consts(rel).get(symbol)
+    if declared is None:
+        return None, (
+            f"reads `{value}`, but {rel} declares no `{symbol}`.\n"
+            f"    Either the constant was renamed, or `constantRegistries` points at the wrong file."
+        )
+    # One hop only: a registry entry pointing at another reference is a chain nobody needs, and
+    # refusing it keeps this resolver from having to guard against a cycle.
+    return declared, None
+
+
 # --------------------------------------------------------------------------
 # Checks
 # --------------------------------------------------------------------------
@@ -853,6 +903,8 @@ def check_writer_encoders(allowlist: dict, failures: list[str]) -> None:
 
 def check_mirrored_constants(allowlist: dict, failures: list[str]) -> None:
     """String constants the descriptor carries that other modules re-declare."""
+    registries = allowlist.get("constantRegistries", {})
+
     for name, spec in allowlist["mirroredConstants"].items():
         if not available(spec["declaredBy"]):
             continue
@@ -863,16 +915,28 @@ def check_mirrored_constants(allowlist: dict, failures: list[str]) -> None:
                 f"constant but is not declared there."
             )
             continue
+        source, why = resolve_const(source, registries)
+        if source is None:
+            if why is not None:
+                failures.append(f"  {spec['declaredBy']}: `{name}` {why}")
+            continue
         for rel in spec["mirroredBy"]:
             if not available(rel):
                 continue
-            value = kotlin_consts(rel).get(spec.get("mirrorSymbol", name))
+            symbol = spec.get("mirrorSymbol", name)
+            value = kotlin_consts(rel).get(symbol)
             if value is None:
                 failures.append(
                     f"  {rel}: registered as mirroring `{name}` but no longer declares it. "
                     f"Prune it from `mirroredConstants`."
                 )
-            elif value != source:
+                continue
+            value, why = resolve_const(value, registries)
+            if value is None:
+                if why is not None:
+                    failures.append(f"  {rel}: `{symbol}` {why}")
+                continue
+            if value != source:
                 failures.append(
                     f"  {rel}: `{name}` = {value}, but {spec['declaredBy']} says {source}. "
                     f"{spec['why']}"

--- a/scripts/daemon-launch-schema-allowlist.json
+++ b/scripts/daemon-launch-schema-allowlist.json
@@ -27,6 +27,13 @@
     "mirroredConstants: string constants carried inside the descriptor that another module",
     "re-declares privately. Same hazard as the schema version, one level down.",
     "",
+    "constantRegistries: qualifier -> the file declaring the constants behind it, e.g.",
+    "`DaemonProperties.Names`. A mirror that READS the shared constant instead of re-typing the",
+    "string cannot disagree with it, which is strictly better than a mirror \u2014 but the scanner then",
+    "reads `DaemonProperties.Names.SANDBOX_COUNT` where it expects a string, so the reference is",
+    "followed here and the literal behind it is what gets compared. An unregistered qualifier fails:",
+    "the gate never passes on a value it could not read.",
+    "",
     "versionStampAliases: an identifier that appears as `schemaVersion = \u2026` at a construction site",
     "but is not itself one of the registered constants \u2014 an indirection that forwards one. Recorded",
     "so discovery-by-use can insist on a known name without banning the indirection.",
@@ -100,6 +107,9 @@
       ],
       "why": "The daemon JVM does read this config, but through flattened `composeai.daemon.bta*` system properties (DefaultBtaCompileService.fromSysprops()), not through the descriptor's nested block \u2014 so DaemonLaunchDescriptor has no reason to declare it. The VS Code extension reads the block directly to decide whether calling `compileSources` is worth a round-trip. Survivable only because the JVM reader ignores unknown keys."
     }
+  },
+  "constantRegistries": {
+    "DaemonProperties.Names": "daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/config/DaemonProperties.kt"
   },
   "mirroredConstants": {
     "SANDBOX_COUNT_PROP": {

--- a/scripts/test_check_daemon_launch_schema.py
+++ b/scripts/test_check_daemon_launch_schema.py
@@ -13,6 +13,7 @@ registered site still present — the allowlist has to keep describing the code.
 
 import importlib.util
 import json
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -153,6 +154,107 @@ class WireFingerprint(unittest.TestCase):
     def test_the_digest_is_stable_for_the_same_shape(self):
         a = {"x": ("Int", False), "y": ("String", True)}
         self.assertEqual(mod.wire_fingerprint(a), mod.wire_fingerprint(dict(a)))
+
+
+class ConstReferences(unittest.TestCase):
+    """A mirror that reads the shared constant instead of re-typing the string.
+
+    #5182 gave the `composeai.daemon.*` sysprops a typed registry, so the two android mirrors of
+    `SANDBOX_COUNT_PROP` became `DaemonProperties.Names.SANDBOX_COUNT`. That is the safer
+    declaration — it cannot drift — and it turned this gate red on main, because the scanner
+    compared the reference text against the descriptor's string literal. Resolving the reference is
+    what these pin.
+    """
+
+    REGISTRIES = {"DaemonProperties.Names": "daemon/core/config/DaemonProperties.kt"}
+
+    def setUp(self):
+        self._tree = tempfile.TemporaryDirectory()
+        self._repo_root = mod.REPO_ROOT
+        mod.REPO_ROOT = Path(self._tree.name)
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        mod.REPO_ROOT = self._repo_root
+        self._tree.cleanup()
+
+    def _write(self, rel: str, text: str) -> None:
+        path = Path(self._tree.name) / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+    def _registry(self, value: str = '"composeai.daemon.sandboxCount"') -> None:
+        self._write(
+            self.REGISTRIES["DaemonProperties.Names"],
+            "public object DaemonProperties {\n"
+            "  public object Names {\n"
+            f"    public const val SANDBOX_COUNT: String = {value}\n"
+            "  }\n"
+            "}\n",
+        )
+
+    def test_a_literal_resolves_to_itself(self):
+        self.assertEqual(mod.resolve_const('"a.b"', self.REGISTRIES), ('"a.b"', None))
+
+    def test_a_registered_reference_resolves_to_the_literal_behind_it(self):
+        self._registry()
+        value, why = mod.resolve_const("DaemonProperties.Names.SANDBOX_COUNT", self.REGISTRIES)
+        self.assertEqual(value, '"composeai.daemon.sandboxCount"')
+        self.assertIsNone(why)
+
+    def test_an_unregistered_qualifier_is_a_failure_not_a_pass(self):
+        value, why = mod.resolve_const("SomeOther.Registry.KEY", self.REGISTRIES)
+        self.assertIsNone(value)
+        self.assertIn("constantRegistries", why)
+
+    def test_a_registry_that_no_longer_declares_the_symbol_is_a_failure(self):
+        self._write(self.REGISTRIES["DaemonProperties.Names"], "public object Names {}\n")
+        value, why = mod.resolve_const("DaemonProperties.Names.SANDBOX_COUNT", self.REGISTRIES)
+        self.assertIsNone(value)
+        self.assertIn("declares no `SANDBOX_COUNT`", why)
+
+    def test_a_string_containing_dots_is_not_mistaken_for_a_reference(self):
+        # The value the descriptor itself declares. Quoted, so it is a literal, not a reference.
+        self.assertEqual(
+            mod.resolve_const('"composeai.daemon.sandboxCount"', self.REGISTRIES),
+            ('"composeai.daemon.sandboxCount"', None),
+        )
+
+    def _mirrored(self, mirror_value: str) -> list:
+        self._write(
+            "descriptor.kt",
+            'const val SANDBOX_COUNT_PROP = "composeai.daemon.sandboxCount"\n',
+        )
+        self._write("mirror.kt", f"private const val SANDBOX_COUNT_PROP = {mirror_value}\n")
+        failures: list = []
+        mod.check_mirrored_constants(
+            {
+                "constantRegistries": self.REGISTRIES,
+                "mirroredConstants": {
+                    "SANDBOX_COUNT_PROP": {
+                        "declaredBy": "descriptor.kt",
+                        "mirroredBy": ["mirror.kt"],
+                        "why": "both sides MUST agree.",
+                    }
+                },
+            },
+            failures,
+        )
+        return failures
+
+    def test_a_mirror_reading_the_registry_agrees(self):
+        self._registry()
+        self.assertEqual(self._mirrored("DaemonProperties.Names.SANDBOX_COUNT"), [])
+
+    def test_a_mirror_reading_a_registry_that_says_something_else_still_fails(self):
+        # The check must keep catching real drift through the indirection, not wave it through.
+        self._registry('"composeai.daemon.sandboxSlots"')
+        failures = self._mirrored("DaemonProperties.Names.SANDBOX_COUNT")
+        self.assertEqual(len(failures), 1)
+        self.assertIn("sandboxSlots", failures[0])
+
+    def test_a_mirror_with_a_drifted_literal_still_fails(self):
+        self.assertEqual(len(self._mirrored('"composeai.daemon.sandboxSlots"')), 1)
 
 
 class RealTree(unittest.TestCase):


### PR DESCRIPTION
Fixes #5174.

`Capture.optional` was honoured by the render gate and by `counts.missing`, but not by the two channels a consumer actually reads per preview. A best-effort miss that is expected by design looked exactly like a render failure, and the JSON counts silently stopped adding up.

## What changed

**1. The status tag is optional-aware.** A bare `[no PNG]` is now reserved for the misses the missing-render gate flags — exactly the rows the "produced no PNG for N of M preview(s)" summary below the listing enumerates. Everything else says why it is empty:

```
WidgetPreviewActivity (activity__WidgetPreviewActivity) [no PNG, optional]
MainActivity (activity__MainActivity) [no PNG]
RedirectUriReceiverActivity (activity__RedirectUriReceiverActivity) [no PNG, optional]
AuthorizationManagementActivity (activity__AuthorizationManagementActivity) [no PNG, optional]
Render task completed but produced no PNG for 1 of 37 preview(s):
  - activity__MainActivity (app) — no PNG for: default
```

An `XR_SUBSPACE` preview, whose empty `pngPath` was never a failure either, reads `[no PNG, by design]`. Both the preview-level tag and the per-capture tag are covered, in `Commands.kt` and `ResourceCommands.kt` alike.

The gate predicate is extracted as `previewMissesRequiredPng` and now drives the tag, the diagnostic and the counts bucket, so the three channels a consumer reads cannot disagree about the same preview — which is what went wrong here. A test asserts the agreement over a mixed result set.

**2. The counts partition `total`.** `PreviewCounts` gains a `skipped` bucket, and `countsOf` classifies each preview exactly once (`previewCountBucket`) instead of evaluating four independent predicates. An optional-missing preview used to land in no bucket at all:

```json
"counts": { "total": 37, "changed": 0, "unchanged": 33, "missing": 1 }
```

Now `changed + unchanged + missing + skipped == total` holds by construction, and a unit test pins it across every result shape (changed, unchanged, required miss, optional miss, non-PNG kind, no captures, partial fan-out). The addition is backwards compatible: `skipped` defaults to `0`, the other three buckets keep their existing meanings and values, and no consumer in the repo reads a residual.

**3. `show-resources` too.** Resource captures have no `optional` flag; their equivalent is the renderer's `skipped` error status (a known degradation, not a failure), which now tags `[no PNG, skipped]`. Resource counts already partitioned, so they are unchanged.

## Not done

Suggestion (3) in the issue — surfacing the `.error.json` reason beside an optional skip — is left out. That reason comes from `diagnoseMissingRenders`, whose output is a carefully invariant-checked diagnostic paragraph (`MissingRenderMessage.kt`), and extending it to expected misses is a larger change than the visibility bug needs. The tag now answers "is this one a problem?"; `--json` still carries `optional` per capture for the follow-up question.

## Test plan

- `./gradlew :cli:test` — green. New `OptionalCaptureVisibilityTest` covers the tags, the tag/gate agreement and the counts partition; `ResourceCommandsTest` gains the resource-side tag case.
- `./gradlew :cli:ktfmtFormatMain :cli:ktfmtFormatTest` — clean.

Text-only change (CLI stdout tags and a JSON field), so there is no rendered surface to show before/after; the console excerpt above is the affected output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZxi7UdPeKoss1yyGmWkwB

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZxi7UdPeKoss1yyGmWkwB)_