### PR TITLE
test: pin the two preview-selector rules against a shared table

### DIFF
--- a/.github/ci/consumer-contract-notice.py
+++ b/.github/ci/consumer-contract-notice.py
@@ -7,6 +7,7 @@ After the split (#4732) two consumers live elsewhere:
 
   * yschimke/compose-preview-vscode    — the VS Code extension
   * yschimke/compose-preview-contracts — the published wire contracts
+  * yschimke/compose-preview-server    — the preview server behind `serve`
 
 Both pin a *released* version of this repository and vendor copies of what they
 need. Their own gates catch drift — but only against the release they pin, which
@@ -39,6 +40,7 @@ SENTINEL = "NO_CONTRACT_SURFACES"
 
 EXT = "yschimke/compose-preview-vscode"
 CONTRACTS = "yschimke/compose-preview-contracts"
+SERVER = "yschimke/compose-preview-server"
 
 # Each entry: the surface, the paths that constitute it, and per consumer what
 # that consumer has to do once this change is released. Keep the follow-ups
@@ -115,6 +117,27 @@ SURFACES: list[dict] = [
                 "**no gate covers it** — `--check` here compares only the Kotlin and C++ "
                 "mirrors, because this repository cannot write into that one. Regenerate it "
                 "there with `gen-spatial-scene.mjs --emit-typescript`."
+            ),
+        },
+    },
+    {
+        "name": "Preview selector fixtures",
+        "patterns": ["docs/serve/preview-selector-fixtures.json"],
+        "why": (
+            "The golden table for `--id` / `--filter` / `--preview`. Two implementations "
+            "answer that question — `previewIdMatchesRequest` here and "
+            "`previewIdMatchesStandaloneRequest` in the server, which builds "
+            "`ServeCommandOptions` itself now that `serve` is a launcher (#5177) — and this "
+            "table is the only thing pinning them together (#5185). The failure mode is "
+            "silent: a preview that stops matching produces no error, it is just absent."
+        ),
+        "consumers": {
+            SERVER: (
+                "vendors this at `docs/serve/preview-selector-fixtures.json` and runs it through "
+                "its own rule in `PreviewSelectorFixturesTest`. Its `selector-fixtures` CI job "
+                "diffs that copy against the compose-ai-tools release its `composeai-tools` "
+                "version pin names, so it goes red on the pin bump unless the same commit runs "
+                "`scripts/sync-preview-selector-fixtures.sh`."
             ),
         },
     },

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -1329,6 +1329,14 @@ internal val NON_PNG_PREVIEW_KINDS = setOf("XR_SUBSPACE")
  * a manifest or a [PreviewResult] where the metadata is available, or from an already-resolved id
  * list where it isn't). They only affect `--preview`: without them the `Class.function` and bare
  * function-name forms can't be recognised and the ref falls back to its id-only forms.
+ *
+ * **This rule is stated twice.** `compose-preview serve` is a launcher (#5177), so the server
+ * builds its own `ServeCommandOptions` and answers the same question with
+ * `previewIdMatchesStandaloneRequest` in yschimke/compose-preview-server. The two live in separate
+ * repositories and are pinned against each other by a shared golden table,
+ * `docs/serve/preview-selector-fixtures.json`, which both suites run (#5185). Change the rule here
+ * and the table changes in the same PR, or the other side silently disagrees — and a preview that
+ * stops matching raises no error anywhere.
  */
 internal fun previewIdMatchesRequest(
   id: String,

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewSelectorFixturesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewSelectorFixturesTest.kt
@@ -1,0 +1,112 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * The cross-repository pin for the preview-selector rule (issue #5185).
+ *
+ * `--id`, `--filter` and `--preview` are answered twice, by two implementations that live in two
+ * repositories: [previewIdMatchesRequest] here, and `previewIdMatchesStandaloneRequest` in
+ * `yschimke/compose-preview-server`, which builds `ServeCommandOptions` itself now that
+ * `compose-preview serve` is a launcher (#5177) and no longer hands the CLI's rule in. They agreed
+ * by inspection and nothing checked it; the failure mode is silent, because a preview that stops
+ * matching produces no error anywhere.
+ *
+ * [FIXTURES] is the shared table, and this suite is one half of the pin — the server repository
+ * vendors the same file and runs it through its own rule. Change the rule, change the table, in the
+ * same PR: the other half goes red on the next sync either way.
+ *
+ * The table is deliberately a *table* rather than a shared implementation. The rule is small and
+ * pure, and the layer split (docs/design/REPOSITORY_LAYERS.md) puts the two copies on opposite
+ * sides of a boundary that a shared function would have to cross.
+ */
+class PreviewSelectorFixturesTest {
+
+  @Test
+  fun `every fixture case answers the same way here`() {
+    for (case in cases()) {
+      val preview = case.getValue("preview").jsonObject
+      val selectors = case.getValue("selectors").jsonObject
+      val expected = case.getValue("expected").jsonPrimitive.content.toBoolean()
+      val name = case.getValue("name").jsonPrimitive.content
+      assertEquals(
+        expected,
+        previewIdMatchesRequest(
+          id = preview.string("id")!!,
+          exactId = selectors.string("exactId"),
+          filter = selectors.string("filter"),
+          previewRef = selectors.string("previewRef"),
+          className = preview.string("className"),
+          functionName = preview.string("functionName"),
+        ),
+        "$FIXTURES case: $name",
+      )
+    }
+  }
+
+  /**
+   * Every combination of the three selectors is exercised, both ways.
+   *
+   * Without this a rule change could add a branch — a fourth selector, a precedence between two of
+   * them — and land green against a table that never reaches it. The `false` half matters as much
+   * as the `true` half: a rule that accepted everything would satisfy a `true`-only table.
+   */
+  @Test
+  fun `the table covers each selector combination in both outcomes`() {
+    val seen = mutableMapOf<Set<String>, MutableSet<Boolean>>()
+    for (case in cases()) {
+      val selectors = case.getValue("selectors").jsonObject
+      val combination = SELECTORS.filter { selectors.string(it) != null }.toSet()
+      val expected = case.getValue("expected").jsonPrimitive.content.toBoolean()
+      seen.getOrPut(combination) { mutableSetOf() }.add(expected)
+    }
+    for (combination in selectorCombinations()) {
+      val outcomes = seen[combination] ?: emptySet<Boolean>()
+      val label = if (combination.isEmpty()) "(no selectors)" else combination.sorted().toString()
+      // No selectors can only ever keep the preview, so only `true` is required of it.
+      val required = if (combination.isEmpty()) setOf(true) else setOf(true, false)
+      assertTrue(
+        outcomes.containsAll(required),
+        "$FIXTURES covers $label with $outcomes; expected $required",
+      )
+    }
+  }
+
+  private fun cases(): List<JsonObject> =
+    Json.parseToJsonElement(fixtureFile().readText()).jsonObject.getValue("cases").jsonArray.map {
+      it.jsonObject
+    }
+
+  /** `null` for an absent selector, which is not the same request as an empty one. */
+  private fun JsonObject.string(key: String): String? = this[key]?.jsonPrimitive?.content
+
+  private fun selectorCombinations(): List<Set<String>> =
+    (0 until (1 shl SELECTORS.size)).map { mask ->
+      SELECTORS.filterIndexed { index, _ -> (mask shr index) and 1 == 1 }.toSet()
+    }
+
+  private fun fixtureFile(): File = File(repoRoot(), FIXTURES).also { assertTrue(it.isFile, "$it") }
+
+  /** Walk up from the test working dir (the `:cli` project dir) to the repo root. */
+  private fun repoRoot(): File {
+    var dir: File? = File(System.getProperty("user.dir")).absoluteFile
+    while (dir != null) {
+      if (File(dir, "settings.gradle.kts").isFile) return dir
+      dir = dir.parentFile
+    }
+    error("could not locate repo root (settings.gradle.kts) from ${System.getProperty("user.dir")}")
+  }
+
+  private companion object {
+    const val FIXTURES = "docs/serve/preview-selector-fixtures.json"
+    val SELECTORS = listOf("exactId", "filter", "previewRef")
+  }
+}

--- a/docs/serve/preview-selector-fixtures.json
+++ b/docs/serve/preview-selector-fixtures.json
@@ -1,0 +1,174 @@
+{
+  "$comment": [
+    "Golden table for the preview-selector rule: does one preview satisfy an invocation's",
+    "--id / --filter / --preview request? Two implementations answer it, in two repositories,",
+    "and nothing else pins them against each other (compose-ai-tools#5185):",
+    "  * previewIdMatchesRequest        — cli/.../Commands.kt, this repository",
+    "  * previewIdMatchesStandaloneRequest — server/.../StandaloneServerMain.kt,",
+    "    yschimke/compose-preview-server, which builds ServeCommandOptions itself now that",
+    "    `compose-preview serve` is a launcher (#5177) and no longer passes the CLI's rule in.",
+    "This file is that pin. Both suites run every case; a one-sided change to either rule turns",
+    "one of them red. Same shape as docs/daemon/protocol-fixtures/, and the same obligation:",
+    "change the rule, change the table, in the same PR.",
+    "A case with no className/functionName is a call site that only holds an id (a resolved id",
+    "list rather than a manifest entry) — the metadata forms of --preview cannot fire there."
+  ],
+  "cases": [
+    {
+      "name": "no selectors keep every preview",
+      "preview": { "id": "HomePreview", "className": "com.example.HomeKt", "functionName": "HomePreview" },
+      "selectors": {},
+      "expected": true,
+      "why": "An unfiltered invocation renders the module."
+    },
+    {
+      "name": "--id matches its preview exactly",
+      "preview": { "id": "HomePreview", "className": "com.example.HomeKt", "functionName": "HomePreview" },
+      "selectors": { "exactId": "HomePreview" },
+      "expected": true
+    },
+    {
+      "name": "--id is case-sensitive",
+      "preview": { "id": "HomePreview", "className": "com.example.HomeKt", "functionName": "HomePreview" },
+      "selectors": { "exactId": "homepreview" },
+      "expected": false,
+      "why": "Unlike --filter. An id is a name, not a search term."
+    },
+    {
+      "name": "--id is not a prefix rule",
+      "preview": { "id": "HomePreviewDark", "className": "com.example.HomeKt", "functionName": "HomePreviewDark" },
+      "selectors": { "exactId": "HomePreview" },
+      "expected": false,
+      "why": "Row addressing (Foo -> Foo_Crimson) is a separate pass; this predicate never widens --id."
+    },
+    {
+      "name": "--filter is a case-insensitive substring of the id",
+      "preview": { "id": "HomePreview", "className": "com.example.HomeKt", "functionName": "HomePreview" },
+      "selectors": { "filter": "homeprev" },
+      "expected": true
+    },
+    {
+      "name": "--filter reads the id, not the class or function",
+      "preview": { "id": "HomePreview", "className": "com.example.SettingsKt", "functionName": "SettingsPreview" },
+      "selectors": { "filter": "Settings" },
+      "expected": false,
+      "why": "Only --preview consults the metadata."
+    },
+    {
+      "name": "an empty --filter excludes nothing",
+      "preview": { "id": "HomePreview" },
+      "selectors": { "filter": "" },
+      "expected": true,
+      "why": "Substring containment of the empty string. Pinned because the two rules must agree on it."
+    },
+    {
+      "name": "--preview takes an exact id",
+      "preview": { "id": "HomePreview", "className": "com.example.HomeKt", "functionName": "HomePreview" },
+      "selectors": { "previewRef": "HomePreview" },
+      "expected": true
+    },
+    {
+      "name": "--preview takes the fully-qualified Class.function form",
+      "preview": { "id": "HomePreview", "className": "com.example.HomeKt", "functionName": "HomePreview" },
+      "selectors": { "previewRef": "com.example.HomeKt.HomePreview" },
+      "expected": true,
+      "why": "The form `record --preview` and the Gradle --preview option accept; unreachable by substring."
+    },
+    {
+      "name": "the Class.function form needs both halves of the metadata",
+      "preview": { "id": "HomePreview", "className": "com.example.HomeKt" },
+      "selectors": { "previewRef": "com.example.HomeKt.HomePreview" },
+      "expected": false,
+      "why": "No functionName, so the ref falls back to its id-only forms and none of them hold."
+    },
+    {
+      "name": "--preview takes a bare function name even when the id is decorated",
+      "preview": { "id": "Home_Crimson", "className": "com.example.HomeKt", "functionName": "Home" },
+      "selectors": { "previewRef": "Home" },
+      "expected": true
+    },
+    {
+      "name": "a bare function name matches on functionName alone, with no className",
+      "preview": { "id": "Row_1", "functionName": "Home" },
+      "selectors": { "previewRef": "Home" },
+      "expected": true,
+      "why": "The functionName form is independent of className in both rules. Pinned so it stays so."
+    },
+    {
+      "name": "--preview falls back to the case-insensitive substring rule",
+      "preview": { "id": "HomePreview", "className": "com.example.HomeKt", "functionName": "HomePreview" },
+      "selectors": { "previewRef": "homeprev" },
+      "expected": true,
+      "why": "The loose form people already typed at --filter keeps working."
+    },
+    {
+      "name": "--preview matches more than one preview, deliberately",
+      "preview": { "id": "FooBar", "className": "com.example.FooKt", "functionName": "FooBar" },
+      "selectors": { "previewRef": "Foo" },
+      "expected": true,
+      "why": "The forms are OR'ed, not staged, so --preview Foo selects Foo and FooBar. Reach for --id for exactly one."
+    },
+    {
+      "name": "an unrelated --preview matches nothing",
+      "preview": { "id": "HomePreview", "className": "com.example.HomeKt", "functionName": "HomePreview" },
+      "selectors": { "previewRef": "Settings" },
+      "expected": false
+    },
+    {
+      "name": "an empty --preview excludes nothing",
+      "preview": { "id": "HomePreview", "className": "com.example.HomeKt", "functionName": "HomePreview" },
+      "selectors": { "previewRef": "" },
+      "expected": true,
+      "why": "Reaches the substring form, like an empty --filter."
+    },
+    {
+      "name": "--id and --filter intersect",
+      "preview": { "id": "HomePreview", "className": "com.example.HomeKt", "functionName": "HomePreview" },
+      "selectors": { "exactId": "HomePreview", "filter": "home" },
+      "expected": true
+    },
+    {
+      "name": "--id does not override a --filter that misses",
+      "preview": { "id": "HomePreview", "className": "com.example.HomeKt", "functionName": "HomePreview" },
+      "selectors": { "exactId": "HomePreview", "filter": "settings" },
+      "expected": false,
+      "why": "The selectors intersect. A precise selector does not promote a preview past a loose one."
+    },
+    {
+      "name": "--id and --preview intersect",
+      "preview": { "id": "HomePreview", "className": "com.example.HomeKt", "functionName": "HomePreview" },
+      "selectors": { "exactId": "HomePreview", "previewRef": "com.example.HomeKt.HomePreview" },
+      "expected": true
+    },
+    {
+      "name": "--preview can exclude a preview that --id names",
+      "preview": { "id": "HomePreview", "className": "com.example.HomeKt", "functionName": "HomePreview" },
+      "selectors": { "exactId": "HomePreview", "previewRef": "Settings" },
+      "expected": false
+    },
+    {
+      "name": "--filter and --preview intersect",
+      "preview": { "id": "HomePreview", "className": "com.example.HomeKt", "functionName": "HomePreview" },
+      "selectors": { "filter": "home", "previewRef": "HomePreview" },
+      "expected": true
+    },
+    {
+      "name": "--filter can exclude a preview that --preview names exactly",
+      "preview": { "id": "HomePreview", "className": "com.example.HomeKt", "functionName": "HomePreview" },
+      "selectors": { "filter": "settings", "previewRef": "HomePreview" },
+      "expected": false
+    },
+    {
+      "name": "all three selectors hold at once",
+      "preview": { "id": "HomePreview", "className": "com.example.HomeKt", "functionName": "HomePreview" },
+      "selectors": { "exactId": "HomePreview", "filter": "PREVIEW", "previewRef": "com.example.HomeKt.HomePreview" },
+      "expected": true
+    },
+    {
+      "name": "one of three failing is enough to drop the preview",
+      "preview": { "id": "HomePreview", "className": "com.example.HomeKt", "functionName": "HomePreview" },
+      "selectors": { "exactId": "HomePreview", "filter": "PREVIEW", "previewRef": "Settings" },
+      "expected": false
+    }
+  ]
+}

--- a/scripts/check-daemon-launch-schema.py
+++ b/scripts/check-daemon-launch-schema.py
@@ -338,6 +338,56 @@ def kotlin_consts(rel: str) -> dict[str, str]:
     return {m.group(1): m.group(2) for m in KT_CONST.finditer(stripped(rel))}
 
 
+# A `const val` whose value is another constant rather than a literal: `DaemonProperties.Names.
+# SANDBOX_COUNT`. Anchored on the whole value so a string containing a dotted word is not mistaken
+# for one.
+KT_CONST_REF = re.compile(r"^([A-Z]\w*(?:\.\w+)*)\.(\w+)$")
+
+
+def resolve_const(value: str, registries: dict[str, str]) -> tuple[str | None, str | None]:
+    """Resolve a `const val`'s right-hand side to the literal it ultimately holds.
+
+    A mirror that *reads* the shared constant instead of re-typing the string cannot disagree with
+    it, which is strictly better than a mirror — but the value this scanner reads is then the
+    reference text, not the string, and comparing `DaemonProperties.Names.SANDBOX_COUNT` against
+    `"composeai.daemon.sandboxCount"` fails on two spellings of the same key. That is what
+    #5182 hit: the typed sysprop registry landed and this gate went red on main for a change that
+    made the mirrors *safer*.
+
+    So a dotted reference is followed to the file `constantRegistries` names for its qualifier, and
+    the literal there is what gets compared. An unregistered qualifier is still a failure — the gate
+    must never pass on a value it could not read — and it says which line to add.
+
+    Returns `(literal, None)` or `(None, why-it-could-not-be-resolved)`.
+    """
+    ref = KT_CONST_REF.match(value)
+    if ref is None:
+        return value, None
+
+    qualifier, symbol = ref.group(1), ref.group(2)
+    rel = registries.get(qualifier)
+    if rel is None:
+        return None, (
+            f"reads `{value}`, and `{qualifier}` is not a registered constant registry.\n"
+            f"    Add `\"{qualifier}\": \"<path to the file declaring it>\"` to "
+            f"`constantRegistries` in {ALLOWLIST.name} so the value behind the reference is still "
+            f"compared. Reading the shared constant is the right move; the gate just has to be able "
+            f"to follow it."
+        )
+    if not available(rel):
+        return None, None
+
+    declared = kotlin_consts(rel).get(symbol)
+    if declared is None:
+        return None, (
+            f"reads `{value}`, but {rel} declares no `{symbol}`.\n"
+            f"    Either the constant was renamed, or `constantRegistries` points at the wrong file."
+        )
+    # One hop only: a registry entry pointing at another reference is a chain nobody needs, and
+    # refusing it keeps this resolver from having to guard against a cycle.
+    return declared, None
+
+
 # --------------------------------------------------------------------------
 # Checks
 # --------------------------------------------------------------------------
@@ -853,6 +903,8 @@ def check_writer_encoders(allowlist: dict, failures: list[str]) -> None:
 
 def check_mirrored_constants(allowlist: dict, failures: list[str]) -> None:
     """String constants the descriptor carries that other modules re-declare."""
+    registries = allowlist.get("constantRegistries", {})
+
     for name, spec in allowlist["mirroredConstants"].items():
         if not available(spec["declaredBy"]):
             continue
@@ -863,16 +915,28 @@ def check_mirrored_constants(allowlist: dict, failures: list[str]) -> None:
                 f"constant but is not declared there."
             )
             continue
+        source, why = resolve_const(source, registries)
+        if source is None:
+            if why is not None:
+                failures.append(f"  {spec['declaredBy']}: `{name}` {why}")
+            continue
         for rel in spec["mirroredBy"]:
             if not available(rel):
                 continue
-            value = kotlin_consts(rel).get(spec.get("mirrorSymbol", name))
+            symbol = spec.get("mirrorSymbol", name)
+            value = kotlin_consts(rel).get(symbol)
             if value is None:
                 failures.append(
                     f"  {rel}: registered as mirroring `{name}` but no longer declares it. "
                     f"Prune it from `mirroredConstants`."
                 )
-            elif value != source:
+                continue
+            value, why = resolve_const(value, registries)
+            if value is None:
+                if why is not None:
+                    failures.append(f"  {rel}: `{symbol}` {why}")
+                continue
+            if value != source:
                 failures.append(
                     f"  {rel}: `{name}` = {value}, but {spec['declaredBy']} says {source}. "
                     f"{spec['why']}"

--- a/scripts/daemon-launch-schema-allowlist.json
+++ b/scripts/daemon-launch-schema-allowlist.json
@@ -27,6 +27,13 @@
     "mirroredConstants: string constants carried inside the descriptor that another module",
     "re-declares privately. Same hazard as the schema version, one level down.",
     "",
+    "constantRegistries: qualifier -> the file declaring the constants behind it, e.g.",
+    "`DaemonProperties.Names`. A mirror that READS the shared constant instead of re-typing the",
+    "string cannot disagree with it, which is strictly better than a mirror \u2014 but the scanner then",
+    "reads `DaemonProperties.Names.SANDBOX_COUNT` where it expects a string, so the reference is",
+    "followed here and the literal behind it is what gets compared. An unregistered qualifier fails:",
+    "the gate never passes on a value it could not read.",
+    "",
     "versionStampAliases: an identifier that appears as `schemaVersion = \u2026` at a construction site",
     "but is not itself one of the registered constants \u2014 an indirection that forwards one. Recorded",
     "so discovery-by-use can insist on a known name without banning the indirection.",
@@ -100,6 +107,9 @@
       ],
       "why": "The daemon JVM does read this config, but through flattened `composeai.daemon.bta*` system properties (DefaultBtaCompileService.fromSysprops()), not through the descriptor's nested block \u2014 so DaemonLaunchDescriptor has no reason to declare it. The VS Code extension reads the block directly to decide whether calling `compileSources` is worth a round-trip. Survivable only because the JVM reader ignores unknown keys."
     }
+  },
+  "constantRegistries": {
+    "DaemonProperties.Names": "daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/config/DaemonProperties.kt"
   },
   "mirroredConstants": {
     "SANDBOX_COUNT_PROP": {

--- a/scripts/test_check_daemon_launch_schema.py
+++ b/scripts/test_check_daemon_launch_schema.py
@@ -13,6 +13,7 @@ registered site still present — the allowlist has to keep describing the code.
 
 import importlib.util
 import json
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -153,6 +154,107 @@ class WireFingerprint(unittest.TestCase):
     def test_the_digest_is_stable_for_the_same_shape(self):
         a = {"x": ("Int", False), "y": ("String", True)}
         self.assertEqual(mod.wire_fingerprint(a), mod.wire_fingerprint(dict(a)))
+
+
+class ConstReferences(unittest.TestCase):
+    """A mirror that reads the shared constant instead of re-typing the string.
+
+    #5182 gave the `composeai.daemon.*` sysprops a typed registry, so the two android mirrors of
+    `SANDBOX_COUNT_PROP` became `DaemonProperties.Names.SANDBOX_COUNT`. That is the safer
+    declaration — it cannot drift — and it turned this gate red on main, because the scanner
+    compared the reference text against the descriptor's string literal. Resolving the reference is
+    what these pin.
+    """
+
+    REGISTRIES = {"DaemonProperties.Names": "daemon/core/config/DaemonProperties.kt"}
+
+    def setUp(self):
+        self._tree = tempfile.TemporaryDirectory()
+        self._repo_root = mod.REPO_ROOT
+        mod.REPO_ROOT = Path(self._tree.name)
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        mod.REPO_ROOT = self._repo_root
+        self._tree.cleanup()
+
+    def _write(self, rel: str, text: str) -> None:
+        path = Path(self._tree.name) / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+    def _registry(self, value: str = '"composeai.daemon.sandboxCount"') -> None:
+        self._write(
+            self.REGISTRIES["DaemonProperties.Names"],
+            "public object DaemonProperties {\n"
+            "  public object Names {\n"
+            f"    public const val SANDBOX_COUNT: String = {value}\n"
+            "  }\n"
+            "}\n",
+        )
+
+    def test_a_literal_resolves_to_itself(self):
+        self.assertEqual(mod.resolve_const('"a.b"', self.REGISTRIES), ('"a.b"', None))
+
+    def test_a_registered_reference_resolves_to_the_literal_behind_it(self):
+        self._registry()
+        value, why = mod.resolve_const("DaemonProperties.Names.SANDBOX_COUNT", self.REGISTRIES)
+        self.assertEqual(value, '"composeai.daemon.sandboxCount"')
+        self.assertIsNone(why)
+
+    def test_an_unregistered_qualifier_is_a_failure_not_a_pass(self):
+        value, why = mod.resolve_const("SomeOther.Registry.KEY", self.REGISTRIES)
+        self.assertIsNone(value)
+        self.assertIn("constantRegistries", why)
+
+    def test_a_registry_that_no_longer_declares_the_symbol_is_a_failure(self):
+        self._write(self.REGISTRIES["DaemonProperties.Names"], "public object Names {}\n")
+        value, why = mod.resolve_const("DaemonProperties.Names.SANDBOX_COUNT", self.REGISTRIES)
+        self.assertIsNone(value)
+        self.assertIn("declares no `SANDBOX_COUNT`", why)
+
+    def test_a_string_containing_dots_is_not_mistaken_for_a_reference(self):
+        # The value the descriptor itself declares. Quoted, so it is a literal, not a reference.
+        self.assertEqual(
+            mod.resolve_const('"composeai.daemon.sandboxCount"', self.REGISTRIES),
+            ('"composeai.daemon.sandboxCount"', None),
+        )
+
+    def _mirrored(self, mirror_value: str) -> list:
+        self._write(
+            "descriptor.kt",
+            'const val SANDBOX_COUNT_PROP = "composeai.daemon.sandboxCount"\n',
+        )
+        self._write("mirror.kt", f"private const val SANDBOX_COUNT_PROP = {mirror_value}\n")
+        failures: list = []
+        mod.check_mirrored_constants(
+            {
+                "constantRegistries": self.REGISTRIES,
+                "mirroredConstants": {
+                    "SANDBOX_COUNT_PROP": {
+                        "declaredBy": "descriptor.kt",
+                        "mirroredBy": ["mirror.kt"],
+                        "why": "both sides MUST agree.",
+                    }
+                },
+            },
+            failures,
+        )
+        return failures
+
+    def test_a_mirror_reading_the_registry_agrees(self):
+        self._registry()
+        self.assertEqual(self._mirrored("DaemonProperties.Names.SANDBOX_COUNT"), [])
+
+    def test_a_mirror_reading_a_registry_that_says_something_else_still_fails(self):
+        # The check must keep catching real drift through the indirection, not wave it through.
+        self._registry('"composeai.daemon.sandboxSlots"')
+        failures = self._mirrored("DaemonProperties.Names.SANDBOX_COUNT")
+        self.assertEqual(len(failures), 1)
+        self.assertIn("sandboxSlots", failures[0])
+
+    def test_a_mirror_with_a_drifted_literal_still_fails(self):
+        self.assertEqual(len(self._mirrored('"composeai.daemon.sandboxSlots"')), 1)
 
 
 class RealTree(unittest.TestCase):


### PR DESCRIPTION
Closes #5185.

## First, the question the issue asked

The issue asserts that nothing *pins* the two rules, not that they differ. They do not differ. Read side by side:

| | `previewIdMatchesRequest` (`cli/.../Commands.kt`) | `previewIdMatchesStandaloneRequest` (server) |
| --- | --- | --- |
| `--id` | `id != exactId` → drop | same |
| `--filter` | `!id.contains(filter, ignoreCase = true)` → drop | same |
| `--preview` | delegates to `previewMatchesReference`: exact id, `Class.function`, bare function name, case-insensitive substring, OR'ed | the same four forms, inlined |
| combination | intersection | intersection |

The server's copy is a faithful inline of this repository's, down to the `className != null && functionName != null` guard on the qualified form. So this PR pins them rather than fixing a divergence.

## Which of the two options

The issue offered *pin it* or *make one go away*. Making one go away means the CLI calling the server's rule across a repository boundary — the CLI depends on the published `compose-preview-serve`, so it is mechanically possible, but it would promote an internal predicate to published API, make every non-`serve` command's selection semantics move on the server's release line, and put the CLI's behaviour behind a version bump. The rule is small and pure and sits on opposite sides of the layer split (`docs/design/REPOSITORY_LAYERS.md`), which is exactly the case a table settles more cheaply than a dependency.

## What this adds

- **`docs/serve/preview-selector-fixtures.json`** — 24 cases: `(id, className?, functionName?)` × the selectors present → expected outcome, each with the reason it is in the table. Covers the id-only call sites (no metadata, so the `--preview` metadata forms cannot fire), the deliberate looseness of `--preview Foo` also selecting `FooBar`, the empty-string selectors, and that a precise selector never promotes a preview past a loose one that misses.
- **`PreviewSelectorFixturesTest`** — runs every case through `previewIdMatchesRequest`, plus a coverage guard: each of the eight selector combinations must appear, and each non-empty one in **both** outcomes. Without that second test a rule change could add a branch and land green against a table that never reaches it, and a rule that accepted everything would satisfy a `true`-only table.
- **A `Preview selector fixtures` surface in `.github/ci/consumer-contract-notice.py`**, naming `compose-preview-server` and what it owes once this ships.
- KDoc on the rule saying it is stated twice and where the other statement lives.

Same shape as `docs/daemon/protocol-fixtures/`, and the same obligation: change the rule, change the table, in the same PR.

## The other half

[yschimke/compose-preview-server#303](https://github.com/yschimke/compose-preview-server/pull/303) vendors the same file, runs it through `previewIdMatchesStandaloneRequest`, and adds `scripts/sync-preview-selector-fixtures.sh` plus a `selector-fixtures` CI job that diffs the vendored copy against the compose-ai-tools release its `composeai-tools` pin names. It goes red on a pin bump that changed the table — the moment the obligation is real — and no-ops while the pinned release predates the file, so neither side deadlocks on the other.

## Test plan

- `./gradlew :cli:test --tests '*PreviewSelectorFixturesTest*'` — green.
- `./gradlew :cli:ktfmtCheckMain` — green.
- `python3 .github/ci/consumer-contract-notice.py docs/serve/preview-selector-fixtures.json` — reports the new surface; unrelated paths still return `NO_CONTRACT_SURFACES`.
- Server side: `./gradlew :server:test --tests '*PreviewSelectorFixturesTest*'` green on the linked PR, which is the actual agreement check — the same 24 cases, the other implementation.

Not UI-affecting: no rendered surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6te8X7U6KobwV82izPhxe