### PR TITLE
feat(serve): fetch the preview server on first use instead of demanding one

### DIFF
--- a/.github/ci/check_preview_server_pin.py
+++ b/.github/ci/check_preview_server_pin.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Fail a PR whose preview-server pin does not name a release carrying a server distribution.
+
+`compose-preview serve` and `browse` are launchers (#5177). The thing they launch ships from
+yschimke/compose-preview-server, and since #5183 the CLI fetches it itself on first use rather than
+expecting the installer to: `ServerDistributionProvision` downloads
+`compose-preview-server-<pin>.tar.gz` from the Release tagged `v<pin>`, where `<pin>` is the
+`composeai-preview-serve` entry in `gradle/libs.versions.toml`, baked into the jar at build time.
+
+So that pin is now load-bearing for a command, not just for a compile. A pin naming a version whose
+Release does not exist — or exists without the distribution attached — is a `serve` that cannot
+start for anyone who installed the documented way. That is exactly the state #5183 reported, and it
+went unnoticed because nothing checked. This gate checks.
+
+Two halves, in order:
+
+1. **Offline.** The pin parses as a release version, and the repository this gate resolves against
+   is the one the CLI actually downloads from (`PREVIEW_SERVER_REPO` in `Version.kt`). Verifying a
+   different repository than consumers fetch from proves nothing.
+2. **Online.** The `v<pin>` Release exists on that repository and carries the asset
+   `ServerDistributionProvision.assetName` derives.
+
+The online half distinguishes an *answer* from *no answer*, and only the former fails the build. A
+404, or a Release without the distribution, is GitHub telling us the pin is broken — fail closed. A
+transport error or rate-limit is GitHub telling us nothing; warn and pass, because a gate that goes
+red for reasons unrelated to the diff stops being read.
+
+`--print-pin` and `--print-repo` print the pin and the release repository and exit, so a caller that
+needs to fetch the distribution derives both from here rather than keeping a second copy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+CATALOG = Path("gradle/libs.versions.toml")
+
+# Where the server is released from. Must equal `PREVIEW_SERVER_REPO` in the CLI's Version.kt —
+# `declared_repo()` proves it rather than trusting this copy.
+SERVER_REPO = "yschimke/compose-preview-server"
+VERSION_KT = Path("cli/src/main/kotlin/ee/schimke/composeai/cli/Version.kt")
+
+PIN_RE = re.compile(r'^\s*composeai-preview-serve\s*=\s*"([^"]+)"', re.MULTILINE)
+REPO_CONST_RE = re.compile(r'PREVIEW_SERVER_REPO\s*[:=][^"]*"([^"]+)"')
+
+# Deliberately loose: the pin must look like a release tag a consumer can resolve, not conform to
+# full semver. A prerelease suffix is allowed; `-SNAPSHOT` is not, because it is this repository's
+# own dev-version convention and is the likeliest way a pin ends up naming something nobody
+# published.
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:-(?!SNAPSHOT$)[0-9A-Za-z.-]+)?$", re.IGNORECASE)
+
+RELEASE_API = "https://api.github.com/repos/{repo}/releases/tags/v{version}"
+
+
+def pin_from(text: str) -> str | None:
+    """The `composeai-preview-serve` version declared in a `libs.versions.toml` body, or None."""
+    m = PIN_RE.search(text)
+    return m.group(1) if m else None
+
+
+def current_pin() -> str:
+    pin = pin_from((REPO / CATALOG).read_text())
+    if pin is None:
+        raise SystemExit(f'could not find `composeai-preview-serve = "…"` in {CATALOG}')
+    return pin
+
+
+def repo_from(kotlin: str) -> str | None:
+    """The `PREVIEW_SERVER_REPO` constant declared in a Version.kt body, or None."""
+    m = REPO_CONST_RE.search(kotlin)
+    return m.group(1) if m else None
+
+
+def declared_repo() -> str | None:
+    return repo_from((REPO / VERSION_KT).read_text())
+
+
+def asset_name(version: str) -> str:
+    """Mirror of `ServerDistributionProvision.assetName` — the two must derive one filename."""
+    return f"compose-preview-server-{version}.tar.gz"
+
+
+class Unanswered(Exception):
+    """GitHub told us nothing — a transport error or a rate-limit, not a verdict on the pin."""
+
+
+def fetch_release_assets(repo: str, version: str, token: str | None = None) -> set[str] | None:
+    """Asset names on the `v<version>` Release, or None when there is no such Release.
+
+    Raises [Unanswered] when the API could not be reached or refused to answer, which the caller
+    must not read as "the pin is broken".
+    """
+    req = urllib.request.Request(RELEASE_API.format(repo=repo, version=version))
+    req.add_header("Accept", "application/vnd.github+json")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            body = json.load(resp)
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return None
+        raise Unanswered(f"HTTP {e.code} from the releases API") from e
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        raise Unanswered(f"could not reach the releases API: {e}") from e
+    return {a.get("name", "") for a in body.get("assets", [])}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--print-pin",
+        action="store_true",
+        help="print the current compose-preview-serve pin and exit",
+    )
+    ap.add_argument(
+        "--print-repo",
+        action="store_true",
+        help="print the repository the server is released from and exit",
+    )
+    ap.add_argument(
+        "--offline",
+        action="store_true",
+        help="run only the offline checks (pin shape, repo agreement)",
+    )
+    args = ap.parse_args()
+
+    pin = current_pin()
+    if args.print_pin:
+        print(pin)
+        return 0
+    if args.print_repo:
+        # From Version.kt, not this file's SERVER_REPO: a caller fetching the distribution must
+        # resolve the same repository the CLI does, and the two are checked against each other
+        # below.
+        declared = declared_repo()
+        if declared is None:
+            raise SystemExit(f"could not find `PREVIEW_SERVER_REPO` in {VERSION_KT}")
+        print(declared)
+        return 0
+
+    if not VERSION_RE.match(pin):
+        print(
+            f'::error::`composeai-preview-serve = "{pin}"` in {CATALOG} does not look like a '
+            f"release version.\n"
+            f"  `compose-preview serve` resolves the server distribution by this value alone, so "
+            f"anything that is not a published tag leaves the command unable to start.",
+            file=sys.stderr,
+        )
+        return 1
+
+    declared = declared_repo()
+    if declared is None:
+        print(
+            f"::error::could not find `PREVIEW_SERVER_REPO` in {VERSION_KT}. This gate verifies "
+            f"the pin against a repository, and it must be the one the CLI downloads from.",
+            file=sys.stderr,
+        )
+        return 1
+    if declared != SERVER_REPO:
+        print(
+            f"::error::this gate checks {SERVER_REPO} but the CLI downloads from {declared} "
+            f"({VERSION_KT}). Verifying a different repository than the one consumers fetch from "
+            f"proves nothing.\n"
+            f"  Fix: update SERVER_REPO in {Path(__file__).relative_to(REPO)} to match.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.offline:
+        print(f"ok (offline): pin {pin} is well-formed and resolves against {declared}")
+        return 0
+
+    try:
+        published = fetch_release_assets(declared, pin, os.environ.get("GITHUB_TOKEN"))
+    except Unanswered as e:
+        print(
+            f"::warning::could not verify the preview-server pin {pin}: {e}",
+            file=sys.stderr,
+        )
+        return 0
+
+    if published is None:
+        print(
+            f'::error::`composeai-preview-serve = "{pin}"` in {CATALOG} names a release that does '
+            f"not exist: {declared} has no tag v{pin}.\n"
+            f"  The CLI fetches the server from that tag on first `serve`, so this pin serves "
+            f"nobody.\n"
+            f"  Fix: pin a version {declared} has actually released, or cut that release first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    wanted = asset_name(pin)
+    if wanted not in published:
+        have = "\n".join(f"    {a}" for a in sorted(published)) or "    (none)"
+        print(
+            f"::error::{declared} v{pin} does not carry {wanted}.\n"
+            f"  Attached to that Release:\n{have}\n"
+            f"  Without it `compose-preview serve` has nothing to fetch and exits with an "
+            f"installation hint. Re-run compose-preview-server's release workflow for v{pin} to "
+            f"attach the distribution, or move the pin to a release that has one.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"ok: {declared} v{pin} exists and carries {wanted}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/ci/test_check_preview_server_pin.py
+++ b/.github/ci/test_check_preview_server_pin.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Tests for the preview-server pin resolution gate.
+
+The gate's value is that it fires on the one case that broke `compose-preview serve` for every
+documented install (#5183) — a pin whose release carries no server distribution — and stays quiet
+otherwise. Both halves are worth pinning: a gate that never fires is the bug it exists to prevent,
+and one that goes red because api.github.com hiccuped gets disabled.
+
+Hermetic: the online half runs against a fake `urlopen`. The real API is what the CI job calls.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import unittest
+import urllib.error
+from unittest import mock
+
+import check_preview_server_pin as gate
+
+
+class PinParsing(unittest.TestCase):
+    def test_reads_the_pin(self):
+        self.assertEqual(gate.pin_from('composeai-preview-serve = "3.0.0"\n'), "3.0.0")
+
+    def test_reads_the_pin_among_neighbours(self):
+        catalog = (
+            'composeai-contracts = "2.5.0"\n'
+            "# a comment mentioning composeai-preview-serve\n"
+            'composeai-preview-serve = "3.1.0"\n'
+            'rcplayers = "1.57.0"\n'
+        )
+        self.assertEqual(gate.pin_from(catalog), "3.1.0")
+
+    def test_absent_pin_is_none(self):
+        self.assertIsNone(gate.pin_from('composeai-contracts = "2.5.0"\n'))
+
+    def test_does_not_match_the_library_coordinate(self):
+        # The `[libraries]` entry of the same name is not a version assignment.
+        self.assertIsNone(
+            gate.pin_from(
+                "composeai-preview-serve = { module = "
+                '"ee.schimke.composeai:compose-preview-serve", '
+                'version.ref = "composeai-preview-serve" }\n'
+            )
+        )
+
+
+class VersionShape(unittest.TestCase):
+    def test_releases_are_accepted(self):
+        for v in ("3.0.0", "0.1.2", "10.20.30", "3.1.0-rc.1"):
+            with self.subTest(v=v):
+                self.assertRegex(v, gate.VERSION_RE)
+
+    def test_snapshots_and_placeholders_are_rejected(self):
+        # Each of these downloads as a 404, which is a `serve` that cannot start.
+        for v in ("3.0.0-SNAPSHOT", "latest", "main", "v3.0.0", "3.0", ""):
+            with self.subTest(v=v):
+                self.assertNotRegex(v, gate.VERSION_RE)
+
+
+class RepoAgreement(unittest.TestCase):
+    def test_reads_the_constant(self):
+        src = 'internal const val PREVIEW_SERVER_REPO = "yschimke/compose-preview-server"\n'
+        self.assertEqual(gate.repo_from(src), "yschimke/compose-preview-server")
+
+    def test_absent_constant_is_none(self):
+        self.assertIsNone(gate.repo_from('internal const val BUNDLE_VERSION = "1.2.3"\n'))
+
+    def test_the_real_cli_constant_matches_what_this_gate_checks(self):
+        # The load-bearing one: verifying a repository the CLI does not download from proves
+        # nothing, so the gate's own copy is asserted against the source of truth.
+        self.assertEqual(gate.declared_repo(), gate.SERVER_REPO)
+
+
+class AssetName(unittest.TestCase):
+    def test_matches_the_provisioner_derivation(self):
+        # Byte-for-byte what `ServerDistributionProvision.assetName` builds, and what
+        # compose-preview-server's release workflow uploads.
+        self.assertEqual(gate.asset_name("3.0.0"), "compose-preview-server-3.0.0.tar.gz")
+
+
+def _http_error(code: int) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError("https://api.github.com", code, "boom", {}, None)
+
+
+def _response(payload: dict):
+    ctx = mock.MagicMock()
+    ctx.__enter__.return_value = io.BytesIO(json.dumps(payload).encode())
+    ctx.__exit__.return_value = False
+    return ctx
+
+
+class FetchReleaseAssets(unittest.TestCase):
+    def test_returns_asset_names(self):
+        payload = {"assets": [{"name": "a.tar.gz"}, {"name": "b.tar.gz"}]}
+        with mock.patch.object(gate.urllib.request, "urlopen", return_value=_response(payload)):
+            self.assertEqual(gate.fetch_release_assets("o/r", "3.0.0"), {"a.tar.gz", "b.tar.gz"})
+
+    def test_a_release_with_no_assets_is_an_empty_set_not_none(self):
+        # Distinct from "no such Release", and reported differently: one says cut the release, the
+        # other says re-attach the distribution.
+        with mock.patch.object(gate.urllib.request, "urlopen", return_value=_response({})):
+            self.assertEqual(gate.fetch_release_assets("o/r", "3.0.0"), set())
+
+    def test_404_is_a_verdict_not_an_error(self):
+        with mock.patch.object(gate.urllib.request, "urlopen", side_effect=_http_error(404)):
+            self.assertIsNone(gate.fetch_release_assets("o/r", "3.0.0"))
+
+    def test_rate_limit_and_server_errors_are_unanswered(self):
+        for code in (403, 429, 500, 502):
+            with self.subTest(code=code):
+                with mock.patch.object(
+                    gate.urllib.request, "urlopen", side_effect=_http_error(code)
+                ):
+                    with self.assertRaises(gate.Unanswered):
+                        gate.fetch_release_assets("o/r", "3.0.0")
+
+    def test_transport_failure_is_unanswered(self):
+        with mock.patch.object(
+            gate.urllib.request, "urlopen", side_effect=urllib.error.URLError("dns")
+        ):
+            with self.assertRaises(gate.Unanswered):
+                gate.fetch_release_assets("o/r", "3.0.0")
+
+    def test_a_token_is_sent_when_present_and_omitted_when_not(self):
+        seen = []
+
+        def capture(req, timeout=None):
+            seen.append(dict(req.header_items()))
+            return _response({"assets": []})
+
+        with mock.patch.object(gate.urllib.request, "urlopen", side_effect=capture):
+            gate.fetch_release_assets("o/r", "3.0.0", token="t0ken")
+            gate.fetch_release_assets("o/r", "3.0.0", token=None)
+        self.assertEqual(seen[0].get("Authorization"), "Bearer t0ken")
+        self.assertNotIn("Authorization", seen[1])
+
+
+class EndToEnd(unittest.TestCase):
+    """`main()` against the repository's real catalog and Version.kt, with the API faked."""
+
+    def _run(self, argv, **patch):
+        with mock.patch.object(gate.sys, "argv", ["check_preview_server_pin.py", *argv]):
+            with mock.patch.object(gate, "fetch_release_assets", **patch):
+                return gate.main()
+
+    def test_the_committed_pin_passes_offline(self):
+        with mock.patch.object(gate.sys, "argv", ["x", "--offline"]):
+            self.assertEqual(gate.main(), 0)
+
+    def test_a_release_carrying_the_distribution_passes(self):
+        pin = gate.current_pin()
+        self.assertEqual(self._run([], return_value={gate.asset_name(pin)}), 0)
+
+    def test_a_missing_release_fails(self):
+        self.assertEqual(self._run([], return_value=None), 1)
+
+    def test_a_release_without_the_distribution_fails(self):
+        # The exact #5183 shape at the release level: the tag exists, the thing `serve` fetches
+        # does not.
+        self.assertEqual(self._run([], return_value={"checksums.txt"}), 1)
+
+    def test_another_versions_distribution_does_not_count(self):
+        self.assertEqual(self._run([], return_value={gate.asset_name("0.0.1")}), 1)
+
+    def test_extra_assets_are_ignored(self):
+        pin = gate.current_pin()
+        assets = {gate.asset_name(pin), "checksums.txt"}
+        self.assertEqual(self._run([], return_value=assets), 0)
+
+    def test_an_unanswered_api_passes(self):
+        # The deliberate soft spot: no answer is not a failed answer.
+        self.assertEqual(self._run([], side_effect=gate.Unanswered("offline")), 0)
+
+    def test_a_bad_pin_fails_before_any_network_call(self):
+        with mock.patch.object(gate, "current_pin", return_value="3.0.0-SNAPSHOT"):
+            with mock.patch.object(gate, "fetch_release_assets") as fetch:
+                with mock.patch.object(gate.sys, "argv", ["x"]):
+                    self.assertEqual(gate.main(), 1)
+        fetch.assert_not_called()
+
+    def test_a_repo_mismatch_fails_before_any_network_call(self):
+        with mock.patch.object(gate, "declared_repo", return_value="someone/else"):
+            with mock.patch.object(gate, "fetch_release_assets") as fetch:
+                with mock.patch.object(gate.sys, "argv", ["x"]):
+                    self.assertEqual(gate.main(), 1)
+        fetch.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1181,6 +1181,12 @@ jobs:
   # one: a 404 on download is a graceful skip, so the render still succeeds, just without a
   # composite. Deliberately NOT behind a `changes` path filter: a gate that can be scheduled away
   # is not a gate, and this one costs a second.
+  #
+  # The preview-server pin rides the same job, for the same reason and against the same hazard
+  # one degree louder: since #5183 `compose-preview serve` fetches its server from the release
+  # `composeai-preview-serve` names, so a pin naming a release with no distribution attached is
+  # not a degraded render but a command that cannot start at all. The job keeps its name — it is
+  # a required check, and renaming a required check blocks every PR until the ruleset catches up.
   xr-composite-pin:
     name: XR Composite Pin
     if: ${{ github.event_name == 'pull_request' && !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
@@ -1202,6 +1208,14 @@ jobs:
         run: python3 .github/ci/check_xr_composite_pin.py
       - name: Check the renderer pin resolves on Maven Central
         run: python3 .github/ci/check_xr_renderer_pin.py
+      - name: Run preview-server pin gate tests
+        run: python3 .github/ci/test_check_preview_server_pin.py -v
+      - name: Check the preview-server pin resolves to a release carrying the distribution
+        env:
+          # Same reason as above: authenticated so the releases API answers from a shared runner IP
+          # rather than rate-limiting into a warn-and-pass. Read-only.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 .github/ci/check_preview_server_pin.py
 
   # `cli/serve-wasm` and compose-preview-server's `wasm-ui` are the same Compose/Wasm frontend
   # compiled twice — each repository against its own M3 catalog, which is why neither can consume

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -934,13 +934,21 @@ val generateCliVersionResource =
     // shared cache and the plugin-side reader resolve the same directory; the plugin bakes the
     // same value through `generatePluginVersionResource`. See `XrCompositeProvision`.
     val xrCompositeVersion = libs.versions.xr.composite.get()
+    // The preview-server release `serve`/`browse` launch, and which `ServerDistributionProvision`
+    // fetches on first use. The catalog pin, NOT this CLI's version: the server releases on its own
+    // cadence from its own repository, and an installed CLI cannot read the catalog. See
+    // `SERVE_VERSION`.
+    val serveVersion = libs.versions.composeai.preview.serve.get()
     inputs.property("version", cliVersion)
     inputs.property("xrCompositeVersion", xrCompositeVersion)
+    inputs.property("serveVersion", serveVersion)
     outputs.dir(outputDir)
     doLast {
       val file = outputDir.get().file("ee/schimke/composeai/cli/cli-version.properties").asFile
       file.parentFile.mkdirs()
-      file.writeText("version=$cliVersion\nxrCompositeVersion=$xrCompositeVersion\n")
+      file.writeText(
+        "version=$cliVersion\nxrCompositeVersion=$xrCompositeVersion\nserveVersion=$serveVersion\n"
+      )
     }
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -29,6 +29,9 @@ import okio.Path.Companion.toPath
  *   passes only on the response its URL gives with healthy egress — a 2xx, or the documented 404 on
  *   `fonts.gstatic.com/`; an intercepting proxy's 403/407 is a warning, not a tick. Warnings only;
  *   set `COMPOSE_PREVIEW_DOCTOR_SKIP_NETWORK=1` to skip.
+ * - `env.preview-server` — which `compose-preview-server` `serve` / `browse` would exec (the
+ *   `--server-binary` flag, `COMPOSE_PREVIEW_SERVER`, `PATH`, then the CLI's own fetched copy), and
+ *   the server release this CLI is pinned to. Never fetches one; see [ServerDistributionProvision].
  * - `env.desktop-natives` — only when the project has a CMP Desktop module: resolves skiko's four
  *   native dependencies the way the *render JVM's* loader would, catching the
  *   `UnsatisfiedLinkError: libGL.so.1: cannot open shared object file` class of failure before a
@@ -146,6 +149,7 @@ class DoctorCommand(
     checkPathJava()
     checkArgEncoding()
     checkClaudeCloud()
+    checkServerBinary()
 
     val projectDir = resolveProjectDir()
 
@@ -213,6 +217,65 @@ class DoctorCommand(
         category = "env",
         status = "ok",
         message = listOf(name, version, arch).filter { it.isNotBlank() }.joinToString(" "),
+      )
+    )
+  }
+
+  /**
+   * Which `compose-preview-server` `serve` and `browse` would exec, and where it came from.
+   *
+   * The only environment fact in this report that is about a *second program*, and it earns its
+   * line because #5177 made `serve` a launcher and nothing installed the thing it launches: for a
+   * while the answer to "why does serve not work" was invisible from inside the CLI. It is now
+   * fetched on first use ([ServerDistributionProvision]), so "none yet" is a normal state on a
+   * fresh install rather than a fault — reported as such, with the release that would be fetched
+   * named so a skew between the two is readable here rather than from a stack trace.
+   *
+   * Never fetches. Doctor is expected to be cheap and to work offline; a 120 MB download behind an
+   * environment check is neither.
+   */
+  private fun checkServerBinary() {
+    val pinned = ServerDistributionProvision.version()
+    val choice = ServerBinaryDiscovery.choose(emptyList())
+    if (choice != null) {
+      val pin =
+        if (choice.source == ServerBinaryDiscovery.CACHE) "This CLI is pinned to server $pinned"
+        else "This CLI is pinned to server $pinned, which it fetches when it finds none"
+      addCheck(
+        DoctorCheck(
+          id = "env.preview-server",
+          category = "env",
+          status = "ok",
+          message = "preview server ${choice.binary} (from ${choice.source})",
+          detail = "`serve` and `browse` exec this; every other command needs no server. $pin",
+        )
+      )
+      return
+    }
+    val offline =
+      System.getProperty("composeai.bundle.offline").toBoolean() ||
+        System.getenv("COMPOSE_PREVIEW_OFFLINE") == "1"
+    addCheck(
+      DoctorCheck(
+        id = "env.preview-server",
+        category = "env",
+        status = if (offline) "warning" else "ok",
+        message =
+          if (offline) "no preview server, and offline mode is set"
+          else "no preview server yet; `serve` fetches $pinned on first use",
+        detail =
+          "checked ${ServerBinaryDiscovery.FLAG}, ${ServerBinaryDiscovery.ENV}, PATH and " +
+            "${ServerDistributionProvision.cacheDir(pinned).absolutePath}",
+        remediation =
+          if (!offline) null
+          else
+            DoctorRemediation(
+              summary =
+                "run `compose-preview serve` once with network access to cache the server, or " +
+                  "unpack the distribution yourself and set ${ServerBinaryDiscovery.ENV}",
+              commands =
+                listOf("curl -L -o server.tar.gz ${ServerDistributionProvision.assetUrl(pinned)}"),
+            ),
       )
     )
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -15,6 +15,11 @@ import kotlin.system.exitProcess
  * server spawns `compose-preview build-host --stdio` (see [BuildHostCommand]) when it wants a local
  * build. Neither side links the other.
  *
+ * **The binary is found, and failing that fetched.** [ServerBinaryDiscovery] answers which one to
+ * run — an explicit flag, the environment, `PATH`, then a copy this CLI has already downloaded —
+ * and [ServerDistributionProvision] fetches the pinned release when the machine has none, because
+ * nothing else installs it (#5183). Only a failed fetch is fatal.
+ *
  * **Arguments pass through untouched.** This deliberately parses nothing beyond finding the binary:
  * the server owns its own flags, and a launcher that validated them would be a second copy of that
  * surface, drifting from the first. `--help` reaches the server too, which is where the answer
@@ -23,7 +28,7 @@ import kotlin.system.exitProcess
 class ServeCommand(private val args: List<String>, private val browseProject: Boolean = false) {
 
   fun run() {
-    val choice = ServerBinaryDiscovery.choose(args)
+    val choice = ServerBinaryDiscovery.choose(args) ?: provision()
     if (choice == null) {
       System.err.println(ServerBinaryDiscovery.installationHint())
       exitProcess(1)
@@ -43,6 +48,20 @@ class ServeCommand(private val args: List<String>, private val browseProject: Bo
       }
     exitProcess(exit)
   }
+
+  /**
+   * Fetch the pinned server when the machine has none, and name the copy that results.
+   *
+   * Nothing installs this binary — that is #5183, and it made `serve` fail for everyone who
+   * installed the documented way — so a miss means "not fetched yet", not "not wanted". The fetch
+   * happens once, prints what it is doing (a 120 MB transfer that appeared as silence would read as
+   * a hang), and returns null having explained any failure, which the caller turns into
+   * [ServerBinaryDiscovery.installationHint].
+   */
+  private fun provision(): ServerBinaryDiscovery.Choice? =
+    ServerDistributionProvision.ensure()?.let {
+      ServerBinaryDiscovery.Choice(it.path, ServerBinaryDiscovery.CACHE)
+    }
 
   /**
    * The argv handed to the server.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServerBinaryDiscovery.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServerBinaryDiscovery.kt
@@ -3,15 +3,23 @@ package ee.schimke.composeai.cli
 import java.io.File
 
 /**
- * Finds the published `compose-preview-server` binary that `serve` and `browse` exec.
+ * Finds the `compose-preview-server` binary that `serve` and `browse` exec.
  *
  * The mirror image of the server's own build-host discovery, and deliberately the same shape, so an
  * operator who has learned one has learned both: an explicit flag, then the environment, then
  * `PATH`. Most explicit first, because the failure this ordering prevents is running a binary the
  * user did not mean.
  *
- * Unlike the server's, a miss here IS a failure. `serve` has nothing to fall back to — the server
- * body left this repository — so the caller reports how to install it rather than degrading.
+ * A fourth source sits after those three: the copy [ServerDistributionProvision] has already
+ * fetched into the CLI's cache. It is **last** for the same reason `PATH` is above it — an operator
+ * who installed a server chose that one, and a cached download must never quietly win over a
+ * deliberate choice.
+ *
+ * A miss is not yet a failure. Nothing installs this binary (#5183 — the documented one-liner
+ * fetches the CLI and the skills, and knows nothing about the server), so the caller asks
+ * [ServerDistributionProvision] to fetch the pinned release before giving up; only a *failed* fetch
+ * reports [installationHint] and exits. `serve` has nothing to degrade to — the server body left
+ * this repository.
  */
 internal object ServerBinaryDiscovery {
 
@@ -19,12 +27,16 @@ internal object ServerBinaryDiscovery {
   const val ENV: String = "COMPOSE_PREVIEW_SERVER"
   const val BINARY: String = "compose-preview-server"
 
+  /** Source name a [Choice] carries when it came from the CLI's own provisioned cache. */
+  const val CACHE: String = "cache"
+
   data class Choice(val binary: String, val source: String)
 
   fun choose(
     args: List<String>,
     env: (String) -> String? = System::getenv,
     pathLookup: (String) -> File? = ::onPath,
+    cacheLookup: () -> File? = { ServerDistributionProvision.cached(env) },
   ): Choice? {
     flagValue(args)?.let {
       return Choice(it, FLAG)
@@ -34,7 +46,10 @@ internal object ServerBinaryDiscovery {
       ?.let {
         return Choice(it.trim(), ENV)
       }
-    return pathLookup(BINARY)?.let { Choice(it.path, "PATH") }
+    pathLookup(BINARY)?.let {
+      return Choice(it.path, "PATH")
+    }
+    return cacheLookup()?.let { Choice(it.path, CACHE) }
   }
 
   private fun flagValue(args: List<String>): String? {
@@ -57,18 +72,31 @@ internal object ServerBinaryDiscovery {
       ?.map { File(it, binary) }
       ?.firstOrNull { it.isFile && it.canExecute() }
 
-  /** What to tell someone who has not got one. */
+  /**
+   * What to tell someone who has not got one *and* could not be given one.
+   *
+   * Reached only after [ServerDistributionProvision.ensure] has failed and said why, so this does
+   * not repeat the reason — it says what a person can do about it. Both halves matter: an offline
+   * or firewalled machine needs the manual route, and a machine that can reach GitHub needs to know
+   * the automatic one exists and will be retried.
+   */
   fun installationHint(): String =
     """
-    compose-preview serve needs the preview server binary, which ships separately.
+    compose-preview serve needs the preview server, which ships separately from this CLI.
 
-    The server moved to yschimke/compose-preview-server and is published as
-    `ee.schimke.composeai:compose-preview-serve`; its distribution provides `$BINARY`.
-    Install it, then either put it on PATH, set $ENV=/path/to/$BINARY, or pass
-    $FLAG /path/to/$BINARY.
+    The CLI normally fetches it for you on first use, from the pinned release of
+    yschimke/compose-preview-server, into its own cache. That did not work this time — the
+    line above says why (no network, a proxy, or no room on disk are the usual ones). Running
+    the command again retries it.
 
-    Everything else this CLI does — render, show, bundle, history, a11y — is unaffected and
-    needs no server.
+    To supply one yourself instead: the server is published as
+    `ee.schimke.composeai:compose-preview-serve`, and its distribution
+    (`$BINARY-<version>.tar.gz`, on that repository's releases) provides `$BINARY`.
+    Unpack it, then either put it on PATH, set $ENV=/path/to/$BINARY, or pass
+    $FLAG /path/to/$BINARY. `compose-preview doctor` reports which one it finds.
+
+    Everything else this CLI does — render, show, bundle, history, a11y, mcp — is unaffected
+    and needs no server.
     """
       .trimIndent()
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServerDistributionProvision.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServerDistributionProvision.kt
@@ -1,0 +1,240 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.io.composeAiCacheDir
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.request.prepareGet
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.jvm.javaio.copyTo
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.util.UUID
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Fetches the `compose-preview-server` distribution `serve` and `browse` exec, so a documented
+ * install can serve without a second install step.
+ *
+ * [ServerBinaryDiscovery] answers *which* binary to run; this answers *where one comes from* when
+ * the machine has none. #5177 turned `serve` into a launcher and closed the dependency cycle, but
+ * left the binary to be installed by hand: the one-line installer in `yschimke/skills` fetches the
+ * CLI and the skill bundle and knows nothing about the server, so everyone who installed the
+ * documented way got an installation hint instead of a server (#5183).
+ *
+ * The fix is here rather than in the installer, and that is the decision #5183 asked for. An
+ * installer that fetched the server unconditionally would put a 120 MB download in front of every
+ * user of `render`, `show`, `bundle`, `history`, `a11y` and `mcp` — none of which open a socket —
+ * to serve the two commands that do. Fetching on first use is the same trade the CLI already makes
+ * for the Skiko native ([SkikoNativeProvision]) and the XR compositor ([XrCompositeProvision]), it
+ * costs the installer nothing, and it keeps the install story inside one repository.
+ *
+ * # Which server
+ *
+ * [SERVE_VERSION] — the `composeai-preview-serve` pin in `gradle/libs.versions.toml`, baked into
+ * the jar at build time. A **point pin, not "latest"**: the two repositories release on separate
+ * cadences, so resolving `latest` at run time would let a server the CLI has never been built
+ * against arrive under it without a pull request, which is the skew #5183 names. Moving the pin is
+ * a reviewed change, and `.github/ci/check_preview_server_pin.py` fails a PR whose pin names a
+ * release with no distribution attached — a pin that 404s is a `serve` that cannot start.
+ *
+ * `COMPOSE_PREVIEW_SERVER_VERSION` overrides it, for testing a release the pin has not moved to
+ * yet. Pointing at a server you already have is [ServerBinaryDiscovery]'s job, not this one.
+ *
+ * # Where it lands
+ *
+ * `<cache>/preview-server/<version>/`, unpacked, holding the distribution's own `bin/` + `lib/`
+ * layout. Keyed on the server's version rather than the CLI's, for the reason
+ * [XR_COMPOSITE_VERSION] gives: a CLI upgrade must not orphan a cached copy of a server that did
+ * not change. Nothing here is ever written to a path a reader can observe half-built — the unpack
+ * goes to a staging directory and is moved into place once validated.
+ */
+internal object ServerDistributionProvision {
+
+  /** Overrides [SERVE_VERSION] for the release fetched. See the class note. */
+  const val VERSION_ENV: String = "COMPOSE_PREVIEW_SERVER_VERSION"
+
+  /**
+   * Fetch seam, faked in tests. Downloads [url] to [dest], throwing on a non-2xx or transport
+   * error.
+   */
+  fun interface Fetcher {
+    fun fetchTo(url: String, dest: File)
+  }
+
+  private val defaultFetcher = Fetcher { url, dest ->
+    HttpClient(OkHttp).use { client ->
+      runBlocking {
+        client.prepareGet(url).execute { response ->
+          if (!response.status.isSuccess()) error("HTTP ${response.status.value}")
+          dest.outputStream().use { out -> response.bodyAsChannel().copyTo(out) }
+        }
+      }
+    }
+  }
+
+  /** The release this CLI fetches: the environment override, else the pin it was built against. */
+  fun version(env: (String) -> String? = System::getenv): String =
+    env(VERSION_ENV)?.trim()?.takeIf { it.isNotBlank() } ?: SERVE_VERSION
+
+  /**
+   * The launcher script name inside the distribution's `bin/`. Gradle's application plugin writes
+   * both; Windows needs the `.bat` because the POSIX script is not executable there.
+   */
+  fun binaryName(osName: String = System.getProperty("os.name") ?: ""): String =
+    if (osName.lowercase().contains("windows")) "${ServerBinaryDiscovery.BINARY}.bat"
+    else ServerBinaryDiscovery.BINARY
+
+  /**
+   * Release asset name — exactly what compose-preview-server's `release.yml` uploads
+   * (`server/build/distributions/compose-preview-server-<version>.tar.gz`).
+   */
+  fun assetName(version: String): String = "${ServerBinaryDiscovery.BINARY}-$version.tar.gz"
+
+  /**
+   * Download URL for [version]'s distribution on the [PREVIEW_SERVER_REPO] release tagged
+   * `v<version>`.
+   */
+  fun assetUrl(version: String): String =
+    "https://github.com/$PREVIEW_SERVER_REPO/releases/download/v$version/${assetName(version)}"
+
+  /** Per-version cache directory holding the unpacked distribution. */
+  fun cacheDir(version: String, cacheRoot: File = defaultCacheRoot()): File =
+    File(cacheRoot, version)
+
+  /** The launcher inside [cacheDir], whether or not it exists yet. */
+  fun cacheBinary(
+    version: String,
+    cacheRoot: File = defaultCacheRoot(),
+    osName: String = System.getProperty("os.name") ?: "",
+  ): File = File(File(cacheDir(version, cacheRoot), "bin"), binaryName(osName))
+
+  /**
+   * The provisioned binary, or null when this machine has not fetched one. Never downloads — this
+   * is the question [ServerBinaryDiscovery] and `doctor` ask, and neither may block on a 120 MB
+   * transfer to answer it.
+   */
+  fun cached(
+    env: (String) -> String? = System::getenv,
+    cacheRoot: File = defaultCacheRoot(),
+    osName: String = System.getProperty("os.name") ?: "",
+  ): File? = cacheBinary(version(env), cacheRoot, osName).takeIf { isComplete(it) }
+
+  /**
+   * Whether [binary] is a launcher from a *complete* distribution — the script itself, plus a
+   * non-empty sibling `lib/`.
+   *
+   * A partial unpack is deliberately not complete. Without the second half, an interrupted fetch
+   * that happened to write `bin/` would short-circuit every later run and leave `serve` failing on
+   * a missing main class until someone thought to wipe the cache by hand.
+   */
+  fun isComplete(binary: File): Boolean {
+    if (!binary.isFile) return false
+    val lib = File(binary.parentFile?.parentFile, "lib")
+    return lib.isDirectory && (lib.listFiles()?.isNotEmpty() == true)
+  }
+
+  /**
+   * Ensure the cache holds [version]'s distribution, fetching it when it does not, and return its
+   * launcher. Returns null — never throws — on any failure, having explained it through [log]; the
+   * caller reports [ServerBinaryDiscovery.installationHint] and exits, since `serve` has nothing to
+   * degrade to.
+   *
+   * Offline (`COMPOSE_PREVIEW_OFFLINE=1` / `-Dcomposeai.bundle.offline=true`, the same gate the
+   * bundle resolver and the Skiko provisioner read) never reaches the network: an air-gapped
+   * machine gets the hint, not a hung download.
+   */
+  fun ensure(
+    version: String = version(),
+    cacheRoot: File = defaultCacheRoot(),
+    osName: String = System.getProperty("os.name") ?: "",
+    offline: Boolean = defaultOffline(),
+    fetcher: Fetcher = defaultFetcher,
+    log: (String) -> Unit = { System.err.println(it) },
+  ): File? {
+    val binary = cacheBinary(version, cacheRoot, osName)
+    if (isComplete(binary)) return binary
+
+    val url = assetUrl(version)
+    if (offline) {
+      log(
+        "compose-preview: the preview server $version is not cached at " +
+          "${cacheDir(version, cacheRoot).absolutePath}, and offline mode is enabled. Fetch " +
+          "$url while online, or point at a server you already have."
+      )
+      return null
+    }
+
+    val dir = cacheDir(version, cacheRoot)
+    val parent = dir.parentFile
+    val archive = File(parent, ".$version.dl-${UUID.randomUUID()}.tar.gz")
+    val stage = File(parent, ".$version.stage-${UUID.randomUUID()}")
+    return try {
+      parent?.mkdirs()
+      log("compose-preview: fetching the preview server $version (this happens once) from $url")
+      fetcher.fetchTo(url, archive)
+      unpackTarGz(archive, stage)
+      val root =
+        distributionRoot(stage, binaryName(osName))
+          ?: run {
+            log(
+              "compose-preview: $url unpacked without a bin/${binaryName(osName)} beside a lib/ " +
+                "directory, so it is not a server distribution."
+            )
+            return null
+          }
+      File(File(root, "bin"), binaryName(osName)).setExecutable(true, false)
+      dir.deleteRecursively()
+      try {
+        Files.move(root.toPath(), dir.toPath(), StandardCopyOption.ATOMIC_MOVE)
+      } catch (_: Exception) {
+        Files.move(root.toPath(), dir.toPath())
+      }
+      log("compose-preview: installed the preview server $version into ${dir.absolutePath}")
+      binary.takeIf { isComplete(it) }
+    } catch (e: Exception) {
+      log("compose-preview: could not fetch the preview server from $url (${e.message ?: e})")
+      null
+    } finally {
+      archive.delete()
+      stage.deleteRecursively()
+    }
+  }
+
+  /**
+   * The distribution directory inside an unpacked [stage] — the tarball's own
+   * `compose-preview-server-<version>/` wrapper, or [stage] itself if a future release ever packs
+   * flat. Found by looking for the layout rather than by rebuilding the wrapper's name, so a
+   * renamed archive root is not a broken install.
+   */
+  fun distributionRoot(stage: File, binaryName: String): File? {
+    fun looksRight(dir: File) = isComplete(File(File(dir, "bin"), binaryName))
+    if (looksRight(stage)) return stage
+    return stage.listFiles().orEmpty().filter { it.isDirectory }.firstOrNull { looksRight(it) }
+  }
+
+  /**
+   * Unpack a `.tar.gz` into [destDir] by shelling out to the system `tar`, exactly as
+   * [XrCompositeProvision.unpackTarGz] does and for the same reason: `tar` is present on
+   * Linux/macOS and ships as `bsdtar` on Windows 10+, and one call site does not justify a new
+   * archive dependency. Throws on a non-zero exit, which [ensure] reports.
+   */
+  fun unpackTarGz(tarGz: File, destDir: File) {
+    destDir.mkdirs()
+    val proc =
+      ProcessBuilder("tar", "-xzf", tarGz.absolutePath, "-C", destDir.absolutePath)
+        .redirectErrorStream(true)
+        .start()
+    val output = proc.inputStream.bufferedReader().readText()
+    val code = proc.waitFor()
+    if (code != 0) error("tar exited $code: ${output.trim().takeLast(300)}")
+  }
+
+  /** `${XDG_CACHE_HOME:-~/.cache}/composeai/preview-server`, via the shared cache convention. */
+  fun defaultCacheRoot(): File = composeAiCacheDir("preview-server")
+
+  private fun defaultOffline(): Boolean =
+    System.getProperty("composeai.bundle.offline").toBoolean() ||
+      System.getenv("COMPOSE_PREVIEW_OFFLINE") == "1"
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Version.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Version.kt
@@ -30,6 +30,22 @@ internal val BUNDLE_VERSION: String by lazy { cliVersionProperty("version") }
  */
 internal val XR_COMPOSITE_VERSION: String by lazy { cliVersionProperty("xrCompositeVersion") }
 
+/**
+ * Release of the preview server `serve` and `browse` launch — see [ServerDistributionProvision].
+ *
+ * The `composeai-preview-serve` pin from `gradle/libs.versions.toml`, baked in at build time for
+ * the same reason [XR_COMPOSITE_VERSION] is: the installed CLI cannot read the version catalog, and
+ * the writer of the cache and any later reader of it must derive one directory.
+ *
+ * Deliberately NOT [BUNDLE_VERSION]. compose-preview-server releases on its own cadence and its
+ * version line is independent — it went to 2.0.0 when it left this repository while this one was
+ * still on 1.x — so the CLI's own version names no server at all. Deliberately not "latest" either:
+ * resolving that at run time would let a server this CLI has never been built against arrive under
+ * it without a pull request. Moving the pin is the reviewed act, and `check_preview_server_pin.py`
+ * fails a PR whose pin names a release with no distribution attached.
+ */
+internal val SERVE_VERSION: String by lazy { cliVersionProperty("serveVersion") }
+
 /** Read one key from the build-time-generated `cli-version.properties`. */
 private fun cliVersionProperty(key: String): String {
   val props = Properties()
@@ -64,6 +80,18 @@ internal const val SKILLS_REPO = "yschimke/skills"
  * one here, and that is the point.
  */
 internal const val XR_COMPOSITE_REPO = "yschimke/compose-preview-xr"
+
+/**
+ * GitHub repo slug the preview server is released from, and whose release assets carry the
+ * distribution [ServerDistributionProvision] fetches.
+ *
+ * Separate from [REPO] since the server was extracted (#4732): `compose-preview serve` is a
+ * launcher for a binary built, versioned and released there. The Maven coordinate
+ * `ee.schimke.composeai:compose-preview-serve` names the same software; the *distribution* — the
+ * launcher script and its `lib/` — is a release asset, not a Maven artifact, which is why this is a
+ * GitHub slug rather than a coordinate.
+ */
+internal const val PREVIEW_SERVER_REPO = "yschimke/compose-preview-server"
 
 /**
  * Compare two version strings componentwise (`major.minor.patch[-suffix]`), returning -1/0/1.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/ServeLauncherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/ServeLauncherTest.kt
@@ -93,6 +93,7 @@ class ServeLauncherTest {
 class ServerBinaryDiscoveryTest {
 
   private val nothingOnPath: (String) -> File? = { null }
+  private val nothingCached: () -> File? = { null }
 
   @Test
   fun `the flag wins over the environment`() {
@@ -101,6 +102,7 @@ class ServerBinaryDiscoveryTest {
         listOf(ServerBinaryDiscovery.FLAG, "/opt/from-flag"),
         env = { "/opt/from-env" },
         pathLookup = nothingOnPath,
+        cacheLookup = nothingCached,
       )
 
     assertEquals("/opt/from-flag", assertNotNull(choice).binary)
@@ -114,6 +116,7 @@ class ServerBinaryDiscoveryTest {
         emptyList(),
         env = { "/opt/from-env" },
         pathLookup = { File("/usr/bin/compose-preview-server") },
+        cacheLookup = nothingCached,
       )
 
     assertEquals("/opt/from-env", assertNotNull(choice).binary)
@@ -127,6 +130,9 @@ class ServerBinaryDiscoveryTest {
         emptyList(),
         env = { null },
         pathLookup = { File("/usr/bin/compose-preview-server") },
+        cacheLookup = {
+          File("/home/u/.cache/composeai/preview-server/3.0.0/bin/compose-preview-server")
+        },
       )
 
     assertEquals("/usr/bin/compose-preview-server", assertNotNull(choice).binary)
@@ -137,10 +143,34 @@ class ServerBinaryDiscoveryTest {
    * Unlike the server's build-host discovery, a miss here is a failure — `serve` has nothing to
    * fall back to. The caller reports [ServerBinaryDiscovery.installationHint] and exits.
    */
+  /**
+   * The CLI's own fetched copy is the LAST resort, behind `PATH`: an operator who installed a
+   * server chose that one, and a download must never quietly win over a deliberate choice.
+   */
+  @Test
+  fun `the provisioned cache is the last resort`() {
+    val cached = File("/home/u/.cache/composeai/preview-server/3.0.0/bin/compose-preview-server")
+    val choice =
+      ServerBinaryDiscovery.choose(
+        emptyList(),
+        env = { null },
+        pathLookup = nothingOnPath,
+        cacheLookup = { cached },
+      )
+
+    assertEquals(cached.path, assertNotNull(choice).binary)
+    assertEquals(ServerBinaryDiscovery.CACHE, choice.source)
+  }
+
   @Test
   fun `nothing found is null`() {
     assertNull(
-      ServerBinaryDiscovery.choose(emptyList(), env = { null }, pathLookup = nothingOnPath)
+      ServerBinaryDiscovery.choose(
+        emptyList(),
+        env = { null },
+        pathLookup = nothingOnPath,
+        cacheLookup = nothingCached,
+      )
     )
   }
 
@@ -151,12 +181,16 @@ class ServerBinaryDiscoveryTest {
         listOf(ServerBinaryDiscovery.FLAG),
         env = { null },
         pathLookup = nothingOnPath,
+        cacheLookup = nothingCached,
       )
     )
   }
 
   /**
    * Someone who has not got the binary needs to be told how to get it, not just that it is absent.
+   * The hint is now reached only after an automatic fetch has failed, so it must also say that one
+   * was attempted — otherwise it reads as "you were always supposed to install this yourself",
+   * which is the state #5183 fixed.
    */
   @Test
   fun `the installation hint names the binary, the variable and the flag`() {
@@ -166,5 +200,6 @@ class ServerBinaryDiscoveryTest {
     assertContains(hint, ServerBinaryDiscovery.ENV)
     assertContains(hint, ServerBinaryDiscovery.FLAG)
     assertTrue(hint.contains("compose-preview-server"), "the hint does not say where it comes from")
+    assertTrue(hint.contains("fetches it for you"), "the hint does not say a fetch was attempted")
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/ServerDistributionProvisionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/ServerDistributionProvisionTest.kt
@@ -1,0 +1,267 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * [ServerDistributionProvision] — the CLI fetching the server `serve` launches, which is what makes
+ * a documented install able to serve at all (#5183).
+ *
+ * No network: the fetch seam is faked with a tarball this test builds, so the unpack, the
+ * completeness rule and the staging swap are exercised on real bytes rather than mocked away. The
+ * URL and asset name are pinned as literals — they are the contract with compose-preview-server's
+ * release workflow, and a test that derived them from the same constants the code derives them from
+ * would pass through a repointing, including a wrong one.
+ */
+class ServerDistributionProvisionTest {
+
+  private val tmp = Files.createTempDirectory("server-provision-test-").toFile()
+  private val cacheRoot = File(tmp, "cache")
+
+  @AfterTest
+  fun cleanup() {
+    tmp.deleteRecursively()
+  }
+
+  @Test
+  fun `the asset name and url are the release workflow's`() {
+    assertEquals(
+      "compose-preview-server-3.0.0.tar.gz",
+      ServerDistributionProvision.assetName("3.0.0"),
+    )
+    assertEquals(
+      "https://github.com/yschimke/compose-preview-server/releases/download/" +
+        "v3.0.0/compose-preview-server-3.0.0.tar.gz",
+      ServerDistributionProvision.assetUrl("3.0.0"),
+    )
+  }
+
+  /** Gradle's application plugin writes both launchers; only one of them runs on Windows. */
+  @Test
+  fun `the launcher name follows the host`() {
+    assertEquals("compose-preview-server", ServerDistributionProvision.binaryName("Linux"))
+    assertEquals("compose-preview-server", ServerDistributionProvision.binaryName("Mac OS X"))
+    assertEquals("compose-preview-server.bat", ServerDistributionProvision.binaryName("Windows 11"))
+  }
+
+  @Test
+  fun `the environment overrides the pinned version`() {
+    assertEquals("9.9.9", ServerDistributionProvision.version { "9.9.9" })
+    assertEquals("9.9.9", ServerDistributionProvision.version { "  9.9.9 " })
+  }
+
+  /**
+   * A blank override is not a version. Left unguarded, `COMPOSE_PREVIEW_SERVER_VERSION=` — which is
+   * what an unset shell variable expands to in a script — would build a URL ending in `v/` and 404.
+   */
+  @Test
+  fun `a blank override falls back to the pin`() {
+    assertEquals(SERVE_VERSION, ServerDistributionProvision.version { "  " })
+    assertEquals(SERVE_VERSION, ServerDistributionProvision.version { null })
+  }
+
+  @Test
+  fun `a fetched distribution is unpacked, made executable and cached`() {
+    val log = mutableListOf<String>()
+
+    val binary =
+      ServerDistributionProvision.ensure(
+        version = "3.0.0",
+        cacheRoot = cacheRoot,
+        osName = "Linux",
+        offline = false,
+        fetcher = fakeRelease("compose-preview-server-3.0.0"),
+        log = log::add,
+      )
+
+    val resolved = assertNotNull(binary, log.toString())
+    assertEquals(File(cacheRoot, "3.0.0/bin/compose-preview-server").path, resolved.path)
+    assertTrue(resolved.canExecute(), "the launcher is not executable")
+    assertTrue(File(cacheRoot, "3.0.0/lib/server.jar").isFile, "the distribution's lib/ is missing")
+    // The tarball's own wrapper directory must not survive into the cache path — a reader deriving
+    // `<cache>/<version>/bin/…` would miss it.
+    assertFalse(File(cacheRoot, "3.0.0/compose-preview-server-3.0.0").exists())
+  }
+
+  /** The one download is worth a word: silence for 120 MB reads as a hang. */
+  @Test
+  fun `the first fetch says what it is doing`() {
+    val log = mutableListOf<String>()
+
+    ServerDistributionProvision.ensure(
+      version = "3.0.0",
+      cacheRoot = cacheRoot,
+      osName = "Linux",
+      offline = false,
+      fetcher = fakeRelease("compose-preview-server-3.0.0"),
+      log = log::add,
+    )
+
+    assertContains(log.joinToString("\n"), "fetching the preview server 3.0.0")
+  }
+
+  @Test
+  fun `a cached distribution is not fetched again`() {
+    stageComplete(File(cacheRoot, "3.0.0"))
+    var fetches = 0
+
+    val binary =
+      ServerDistributionProvision.ensure(
+        version = "3.0.0",
+        cacheRoot = cacheRoot,
+        osName = "Linux",
+        offline = false,
+        fetcher = { _, _ -> fetches++ },
+        log = {},
+      )
+
+    assertNotNull(binary)
+    assertEquals(0, fetches)
+  }
+
+  /**
+   * An interrupted unpack that left `bin/` behind must not short-circuit every later run — that is
+   * a `serve` that fails on a missing main class until someone wipes the cache by hand.
+   */
+  @Test
+  fun `a half-written cache is re-fetched rather than trusted`() {
+    val dir = File(cacheRoot, "3.0.0")
+    File(dir, "bin").mkdirs()
+    File(dir, "bin/compose-preview-server").writeText("#!/bin/sh\n")
+    assertNull(ServerDistributionProvision.cached({ "3.0.0" }, cacheRoot, "Linux"))
+
+    val binary =
+      ServerDistributionProvision.ensure(
+        version = "3.0.0",
+        cacheRoot = cacheRoot,
+        osName = "Linux",
+        offline = false,
+        fetcher = fakeRelease("compose-preview-server-3.0.0"),
+        log = {},
+      )
+
+    assertNotNull(binary)
+    assertTrue(File(cacheRoot, "3.0.0/lib/server.jar").isFile)
+  }
+
+  @Test
+  fun `offline explains itself rather than reaching the network`() {
+    val log = mutableListOf<String>()
+    var fetches = 0
+
+    val binary =
+      ServerDistributionProvision.ensure(
+        version = "3.0.0",
+        cacheRoot = cacheRoot,
+        osName = "Linux",
+        offline = true,
+        fetcher = { _, _ -> fetches++ },
+        log = log::add,
+      )
+
+    assertNull(binary)
+    assertEquals(0, fetches)
+    assertContains(log.joinToString("\n"), "offline mode is enabled")
+  }
+
+  /** A failed download is a null and a sentence, never an exception out of `serve`. */
+  @Test
+  fun `a download failure is reported, not thrown`() {
+    val log = mutableListOf<String>()
+
+    val binary =
+      ServerDistributionProvision.ensure(
+        version = "3.0.0",
+        cacheRoot = cacheRoot,
+        osName = "Linux",
+        offline = false,
+        fetcher = { _, _ -> error("HTTP 404") },
+        log = log::add,
+      )
+
+    assertNull(binary)
+    assertContains(log.joinToString("\n"), "HTTP 404")
+    assertFalse(File(cacheRoot, "3.0.0").exists(), "a failed fetch left a cache directory behind")
+  }
+
+  /** An archive that is not a server distribution is refused rather than cached as one. */
+  @Test
+  fun `an archive without the expected layout is refused`() {
+    val log = mutableListOf<String>()
+
+    val binary =
+      ServerDistributionProvision.ensure(
+        version = "3.0.0",
+        cacheRoot = cacheRoot,
+        osName = "Linux",
+        offline = false,
+        fetcher = { _, dest -> tarGzOf(File(tmp, "junk").apply { mkdirs() }, dest) },
+        log = log::add,
+      )
+
+    assertNull(binary)
+    assertContains(log.joinToString("\n"), "not a server distribution")
+  }
+
+  /**
+   * The wrapper directory is found by its layout, not by rebuilding its name, so a release that
+   * renames or drops the wrapper still installs.
+   */
+  @Test
+  fun `the distribution root is found whatever the wrapper is called`() {
+    val flat = File(tmp, "flat").also { stageComplete(it) }
+    assertEquals(flat, ServerDistributionProvision.distributionRoot(flat, "compose-preview-server"))
+
+    val wrapped = File(tmp, "wrapped")
+    stageComplete(File(wrapped, "some-other-name-1.2.3"))
+    assertEquals(
+      File(wrapped, "some-other-name-1.2.3"),
+      ServerDistributionProvision.distributionRoot(wrapped, "compose-preview-server"),
+    )
+
+    assertNull(
+      ServerDistributionProvision.distributionRoot(
+        File(tmp, "empty").apply { mkdirs() },
+        "compose-preview-server",
+      )
+    )
+  }
+
+  // --- helpers ------------------------------------------------------------
+
+  /**
+   * A fetcher that writes a tarball shaped like the real release asset: `<wrapper>/bin` + `lib`.
+   */
+  private fun fakeRelease(wrapper: String) = ServerDistributionProvision.Fetcher { _, dest ->
+    val staging = File(tmp, "release-${wrapper}")
+    staging.deleteRecursively()
+    stageComplete(File(staging, wrapper))
+    tarGzOf(staging, dest)
+  }
+
+  /** The two halves `isComplete` requires: an executable launcher and a non-empty `lib/`. */
+  private fun stageComplete(dir: File) {
+    File(dir, "bin").mkdirs()
+    File(dir, "lib").mkdirs()
+    File(dir, "bin/compose-preview-server").writeText("#!/bin/sh\necho serve\n")
+    File(dir, "lib/server.jar").writeText("jar")
+  }
+
+  private fun tarGzOf(contents: File, dest: File) {
+    dest.parentFile?.mkdirs()
+    val proc =
+      ProcessBuilder("tar", "-czf", dest.absolutePath, "-C", contents.absolutePath, ".")
+        .redirectErrorStream(true)
+        .start()
+    val output = proc.inputStream.bufferedReader().readText()
+    check(proc.waitFor() == 0) { "tar failed: $output" }
+  }
+}

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -170,6 +170,38 @@ Single release train governed by release-please. The plugin, CLI, MCP, extension
 
 Daemon protocol versions and per-data-product schema versions are decoupled — a release may bump `protocolVersion` from 1 to 2 without bumping the artifact major (the artifact major bumps for *consumer-visible* breakage; the protocol bump is invisible to plugin/CLI consumers as long as the daemon supports the previous version).
 
+### 8.1 The preview server is on its own train
+
+`compose-preview serve` and `browse` do not contain a server; they launch one. Since
+[#5177](https://github.com/yschimke/compose-ai-tools/issues/5177) the server body lives in
+[yschimke/compose-preview-server](https://github.com/yschimke/compose-preview-server) and releases
+on its own cadence — it went to `2.0.0` when it left, while this repository was still on `1.x`, so
+**the two version lines mean nothing to each other**. A CLI version does not name a server version
+and never will.
+
+What names one is the `composeai-preview-serve` pin in
+[`gradle/libs.versions.toml`](../gradle/libs.versions.toml). It is the single statement of which
+server a given CLI expects:
+
+- it is baked into the CLI jar at build time as `SERVE_VERSION`, so the installed CLI carries it;
+- `ServerDistributionProvision` fetches exactly that release's distribution
+  (`compose-preview-server-<pin>.tar.gz`) on the first `serve` that finds no server, and caches it
+  under `<cache>/composeai/preview-server/<pin>/` — keyed on the server's version, so a CLI upgrade
+  does not orphan an unchanged server;
+- `compose-preview doctor` reports it, beside whichever binary it actually found (`env.preview-server`).
+
+A **point pin, never a range or `latest`**, for the reason every other cross-repository pin here is
+one: resolving at run time would let a server this CLI has never been built against arrive under it
+without a pull request. Moving it is the reviewed act, and the `XR Composite Pin` CI job fails a PR
+whose pin names a release that does not exist or carries no distribution — a pin that 404s is a
+`serve` that cannot start, which is what
+[#5183](https://github.com/yschimke/compose-ai-tools/issues/5183) reported.
+
+Skew is still possible and is bounded rather than prevented: an operator may point at any server
+they like with `COMPOSE_PREVIEW_SERVER` or `--server-binary` (that choice always wins over the
+fetched copy), and `COMPOSE_PREVIEW_SERVER_VERSION` overrides which release is fetched. Both are
+deliberate escape hatches; `doctor` is where you see which one is in effect.
+
 ## 9. Compatibility testing
 
 Three layers were designed; this is what each one actually does today.

--- a/docs/design/REPOSITORY_LAYERS.md
+++ b/docs/design/REPOSITORY_LAYERS.md
@@ -107,6 +107,20 @@ became launchers over the published server binary. An empty positive allowlist m
 `ee.schimke.composeai:compose-preview-*` coordinate reaching a runtime classpath fails, with no
 exceptions to argue about.
 
+**A launcher needs something to launch, and nothing installed it.** Closing the cycle moved a
+problem rather than removing one: the documented one-line installer in
+[`yschimke/skills`](https://github.com/yschimke/skills) fetches the CLI and the skill bundle and
+knows nothing about the server, so for everyone who installed the documented way `serve` printed an
+installation hint and exited
+([#5183](https://github.com/yschimke/compose-ai-tools/issues/5183)). The fix is on this side, not
+the installer's: `ServerDistributionProvision` fetches the pinned release's distribution on the
+first `serve` that finds no server and caches it under `<cache>/composeai/preview-server/<version>/`,
+the same first-use provisioning the CLI already does for the Skiko native and the XR compositor.
+Fetching it in the installer instead would have put a 120 MB download in front of everyone who only
+ever runs `render`, and would have made the install story span two repositories. Which server is
+fetched, and how the two version lines relate:
+[`docs/VERSIONING.md` § 8.1](../VERSIONING.md#81-the-preview-server-is-on-its-own-train).
+
 One edge survives, deliberately, and this task cannot see it. `compose-preview-serve` is still a
 `testImplementation` of `:cli`: two tests drive the CLI's own HTTP clients against a real
 `ServeHttpServer` to catch the two repositories' independently-declared wire types drifting apart,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -375,6 +375,13 @@ composeai-contracts = "2.5.0"
 # GONE from this catalog: the module moved here in 1.77.0 (#5137), the server now consumes it from
 # this repository (compose-preview-server#289), and 3.0.0 retired the old coordinate at its final
 # 2.x. `:cli` depends on `project(":render-host")`; there is no version ref to share any more.
+#
+# This pin is also RUNTIME-load-bearing, not just a compile-time coordinate. `compose-preview serve`
+# is a launcher, and since #5183 the CLI fetches the server itself on first use: the pin is baked
+# into the jar as `SERVE_VERSION` and names the release whose `compose-preview-server-<pin>.tar.gz`
+# `ServerDistributionProvision` downloads. So a pin naming a release that does not exist, or one
+# with no distribution attached, is a `serve` that cannot start — `check_preview_server_pin.py`
+# fails the PR rather than letting that reach an install. docs/VERSIONING.md § 8.1.
 composeai-preview-serve = "3.0.0"
 
 # The Remote Compose players, published by yschimke/rc-players (the CMP player stack, the vendored


### PR DESCRIPTION
Fixes #5183.

## The problem

#5177 turned `serve` and `browse` into launchers, and nothing installs the binary they launch. The documented one-liner in `yschimke/skills` fetches the CLI and the skill bundle and knows nothing about the server, so every install done the documented way got an installation hint and exit 1 instead of a server.

## The decision

#5183 asked which side fixes it. **This side.** An installer that fetched the server unconditionally would put a 120 MB download in front of everyone who only runs `render`, `show`, `bundle`, `history`, `a11y` or `mcp` — none of which open a socket — and would spread the install story across two repositories. Fetching on first use is the same trade the CLI already makes for the Skiko native (`SkikoNativeProvision`) and the XR compositor (`XrCompositeProvision`), and it needs **no installer change at all**.

## What changed

- **`ServerDistributionProvision`** (new) fetches `compose-preview-server-<pin>.tar.gz` from the pinned release on the first `serve` that finds no server, unpacks it through a staging directory and moves it into `<cache>/composeai/preview-server/<version>/`. Keyed on the *server's* version, so a CLI upgrade does not orphan an unchanged server. A partial unpack is not treated as complete, so an interrupted fetch re-provisions instead of poisoning the cache forever. Offline (`COMPOSE_PREVIEW_OFFLINE=1`) never reaches the network, it explains itself.
- **Discovery gained a fourth source, last.** `--server-binary` → `COMPOSE_PREVIEW_SERVER` → `PATH` → the fetched copy. A server an operator installed always wins over one we downloaded.
- **A miss is no longer fatal on its own.** Only a *failed* fetch prints the installation hint, which now says a fetch was attempted, why it failed, and that re-running retries it.
- **`doctor` reports it** (`env.preview-server`): which binary, from which source, and the server release this CLI is pinned to. Never fetches — doctor stays cheap and works offline. Offline with no server is a warning with a remediation; a fresh online install is simply "`serve` fetches 3.0.0 on first use".
- **The version relationship is stated and gated.** `composeai-preview-serve` in the catalog is baked into the jar as `SERVE_VERSION`; a point pin, never `latest`, so a server this CLI was never built against cannot arrive without a PR. `docs/VERSIONING.md` § 8.1 is the written statement, and `.github/ci/check_preview_server_pin.py` (riding the existing pin-gate job) fails a PR whose pin names a release that does not exist or carries no distribution — the release-level shape of this very bug.

## Test plan

- `./gradlew :cli:test` — green, including the new `ServerDistributionProvisionTest` (unpack, staging swap, cache short-circuit, half-written cache, offline, download failure, non-distribution archive, wrapper-name independence) and the updated launcher/discovery tests.
- `./gradlew :cli:ktfmtCheckMain :cli:ktfmtCheckTest` — green.
- `python3 .github/ci/test_check_preview_server_pin.py` — 25 tests green; `python3 .github/ci/check_preview_server_pin.py` against the live API: `ok: yschimke/compose-preview-server v3.0.0 exists and carries compose-preview-server-3.0.0.tar.gz`.
- **End to end, on a machine with no server**, against an empty cache:

```
$ XDG_CACHE_HOME=$PWD/cache compose-preview serve --help
compose-preview: fetching the preview server 3.0.0 (this happens once) from https://github.com/…/compose-preview-server-3.0.0.tar.gz
compose-preview: installed the preview server 3.0.0 into …/cache/composeai/preview-server/3.0.0
compose-preview serve [options]
…
```

  and the second run execs it from the cache with no download. `doctor` on the same cache:

```
  ✓ preview server …/cache/composeai/preview-server/3.0.0/bin/compose-preview-server (from cache)
      `serve` and `browse` exec this; every other command needs no server. This CLI is pinned to server 3.0.0
```

Non-visual change: no renders are affected, so no before/after images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AC84sgCkieo2oFY14UDMoJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AC84sgCkieo2oFY14UDMoJ)_