### PR TITLE
feat(cli): add `ui-builder`, the launcher for the server's `ui` command

### DIFF
--- a/.github/ci/consumer-contract-notice.py
+++ b/.github/ci/consumer-contract-notice.py
@@ -3,14 +3,14 @@
 
 `compose-ai-tools` used to contain every consumer of its own contracts, so a
 protocol change and the code reading it moved in one commit and CI checked both.
-After the split (#4732) two consumers live elsewhere:
+After the split (#4732) three consumers live elsewhere:
 
   * yschimke/compose-preview-vscode    — the VS Code extension
   * yschimke/compose-preview-contracts — the published wire contracts
   * yschimke/compose-preview-server    — the preview server behind `serve`
 
-Both pin a *released* version of this repository and vendor copies of what they
-need. Their own gates catch drift — but only against the release they pin, which
+Each pins a *released* version of this repository and vendors copies of what it
+needs. Their own gates catch drift — but only against the release they pin, which
 means a contract change here is invisible to them until somebody bumps that pin.
 That is the gap #4732 records as "a `daemon-protocol` bump has to fail the
 consumer's CI, not just the producer's".

--- a/.github/ci/test_consumer_contract_notice.py
+++ b/.github/ci/test_consumer_contract_notice.py
@@ -92,8 +92,8 @@ class SurfaceMapIsCurrent(unittest.TestCase):
         for surface in mod.SURFACES:
             self.assertTrue(surface["consumers"], f"{surface['name']} names no consumer")
 
-    def test_consumer_repos_are_the_known_two(self):
-        known = {mod.EXT, mod.CONTRACTS}
+    def test_consumer_repos_are_the_known_three(self):
+        known = {mod.EXT, mod.CONTRACTS, mod.SERVER}
         for surface in mod.SURFACES:
             self.assertLessEqual(set(surface["consumers"]), known, surface["name"])
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
@@ -223,6 +223,32 @@ internal object CliFlagValidation {
             "--trust-store",
             "--wasm-dir",
           ),
+      // A launcher for the server's `ui` command, so the flags are that command's: the selectors
+      // a build needs, the network knobs any local server takes, and the builder's own options.
+      // `--no-open` belongs to the lane rather than the server (it suppresses `--open-browser`),
+      // which is why it is listed here and not among serve's.
+      "ui-builder" to
+        commandBase +
+          setOf(
+            "--build-host",
+            "--discover",
+            "--help",
+            "-h",
+            "--host",
+            "--lan",
+            "--no-open",
+            "--open-path",
+            "--port",
+            "--public",
+            "--server-binary",
+            "--token",
+            "--ui-builder-catalogs",
+            "--ui-builder-components",
+            "--ui-builder-dir",
+            "--ui-builder-migrate-state",
+            "--ui-builder-runtime-dir",
+            "--ui-builder-state-dir",
+          ),
       // The flags a preview server passes when it spawns the Gradle half of `serve`. Deliberately
       // narrow: this command is machine-facing, and every flag here is one the server has to know
       // to send. `--stdio` selects the transport; `--module` and `--variant` are the two selectors

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliRouter.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliRouter.kt
@@ -43,7 +43,9 @@ internal object CliRouter {
       // half of `serve`, addressed over a pipe instead of linked in-process
       // (yschimke/compose-preview-server#180). Machine-facing rather than hidden — a command a
       // server spawns is still a command, and one that cannot be found is one nobody can debug.
-      "share" to listOf("serve", "build-host", "share-preview"),
+      // `ui-builder` joins them because all three are the same binary: `serve` hosts it,
+      // `build-host` is the Gradle half it spawns, and `ui-builder` launches its `ui` command.
+      "share" to listOf("serve", "ui-builder", "build-host", "share-preview"),
       "setup" to listOf("update", "init-script", "pin", "auth"),
     )
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -26,6 +26,7 @@ internal val COMMANDS: Map<String, (List<String>) -> Unit> =
     "devices" to { a -> DevicesCommand(a).run() },
     "browse" to { a -> BrowseCommand(a).run() },
     "serve" to { a -> ServeCommand(a).run() },
+    "ui-builder" to { a -> UiBuilderCommand(a).run() },
     "build-host" to { a -> BuildHostCommand(a).run() },
     "share-preview" to { a -> SharePreviewCommand(a).run() },
     "bundle" to { a -> BundleCommand(a).run() },
@@ -141,7 +142,7 @@ private fun printUsage(full: Boolean = false) {
     Command groups (each command is also callable directly by its name):
       inspect   a11y · diff-semantics · devices · extensions · history · profile
       capture   render-matrix · record · bundle
-      share     serve · share-preview
+      share     serve · ui-builder · share-preview
       setup     update · init-script · pin · auth
     Run `compose-preview <group>` to list a group, or `help --all` for every command + flag.
 
@@ -212,6 +213,9 @@ private fun printFullUsage() {
                        serves them as PNGs with overrides, so you can open or share a network-local
                        link to a specific preview. Read-only; loopback by default, --lan to expose.
                        The shareable link carries an unguessable token (see `serve --help`).
+      ui-builder       Build this project's previews and open the Compose UI builder against
+                       them, so exported code calls your composables. Launches the preview
+                       server's `ui` command; see `ui-builder --help` for its options.
       share-preview    Share rendered previews (a markdown report + images, or a directory of
                        PNGs) somewhere openable. Picks the mechanism by what's available: a gist
                        when the GitHub CLI is installed + authenticated, otherwise a push to a

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -25,7 +25,17 @@ import kotlin.system.exitProcess
  * surface, drifting from the first. `--help` reaches the server too, which is where the answer
  * actually lives.
  */
-class ServeCommand(private val args: List<String>, private val browseProject: Boolean = false) {
+class ServeCommand(
+  private val args: List<String>,
+  private val browseProject: Boolean = false,
+  /**
+   * Which of the server's commands to launch. `serve` for `serve` and `browse`; `ui` for
+   * `ui-builder`, whose whole difference lives on the server side — the builder flags, the
+   * component record and the page to open are the server's business, and a launcher that assembled
+   * them here would be a second copy of a surface that already exists.
+   */
+  private val serverCommand: String = "serve",
+) {
 
   fun run() {
     val choice = ServerBinaryDiscovery.choose(args) ?: provision()
@@ -68,8 +78,7 @@ class ServeCommand(private val args: List<String>, private val browseProject: Bo
    *
    * `--server-binary` is this launcher's own flag and is dropped rather than forwarded — the server
    * has no such option, and passing it through would make every invocation fail on an unknown
-   * argument. Everything else, including the `serve` subcommand the server accepts as an alias, is
-   * the caller's.
+   * argument. Everything else, including a command word the server accepts itself, is the caller's.
    *
    * Nothing is added for the build host. The server discovers `compose-preview` itself, by the same
    * flag/environment/PATH ordering this class uses, and a launcher that guessed a path here would
@@ -77,7 +86,7 @@ class ServeCommand(private val args: List<String>, private val browseProject: Bo
    */
   internal fun launchCommand(binary: String): List<String> = buildList {
     add(binary)
-    add("serve")
+    add(serverCommand)
     addAll(forwardedArgs())
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/UiBuilderCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/UiBuilderCommand.kt
@@ -1,0 +1,27 @@
+package ee.schimke.composeai.cli
+
+/**
+ * `compose-preview ui-builder` — the launcher for the preview server's `ui` command.
+ *
+ * Third of the launchers, beside [ServeCommand] and [BrowseCommand]: the server binary builds this
+ * project's previews and opens the Compose UI builder against them
+ * ([yschimke/compose-preview-server#301](https://github.com/yschimke/compose-preview-server/issues/301)).
+ *
+ * It adds nothing of its own — no defaults, no flag rewriting — because unlike `browse` there is no
+ * project-mode choice to make on this side. Everything `ui` implies (discovery, the packaged
+ * builder distribution, the module's component record, the page to open) is decided by the server,
+ * which is also the half that knows where those things are. `--help` therefore reaches the server
+ * too, which is where the answer lives.
+ *
+ * The Gradle work still travels the other way: the server spawns `compose-preview build-host
+ * --stdio` when it needs a build, so this process is a launcher and not a host.
+ */
+class UiBuilderCommand(private val args: List<String>) {
+  fun run() {
+    ServeCommand(args, serverCommand = SERVER_COMMAND).run()
+  }
+
+  internal companion object {
+    const val SERVER_COMMAND: String = "ui"
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/ServeLauncherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/ServeLauncherTest.kt
@@ -88,6 +88,23 @@ class ServeLauncherTest {
   fun `serve adds no browse defaults`() {
     assertFalse(argv().contains("--component-browser"))
   }
+
+  /**
+   * `ui-builder` launches the server's `ui` command and nothing else: unlike `browse` it adds no
+   * defaults here, because every choice `ui` implies is the server's — and the server is the half
+   * that knows where the packaged builder and the module's component record are.
+   */
+  @Test
+  fun `ui-builder launches the server's ui command with the caller's argv`() {
+    assertEquals(
+      listOf("/opt/compose-preview-server", "ui", "--module", "app", "--no-open"),
+      ServeCommand(
+          listOf("--module", "app", "--no-open"),
+          serverCommand = UiBuilderCommand.SERVER_COMMAND,
+        )
+        .launchCommand("/opt/compose-preview-server"),
+    )
+  }
 }
 
 class ServerBinaryDiscoveryTest {


### PR DESCRIPTION
The CLI half of yschimke/compose-preview-server#301 — the server side is yschimke/compose-preview-server#306, which gives `compose-preview-server` a `ui` command that builds a local project's previews and opens the Compose UI builder against them.

`compose-preview ui-builder` is the third launcher beside `serve` and `browse`.

It adds nothing of its own — no defaults, no flag rewriting — because unlike `browse` there is no project-mode choice to make on this side. Everything `ui` implies (discovery, the packaged builder distribution, the module's component record, the page to open) is decided by the server, which is also the half that knows where those things are. `--help` therefore reaches the server too, which is where the answer lives.

`ServeCommand` gained a `serverCommand` parameter so one launcher covers both commands rather than two copies of the discovery, argv-forwarding and exit-code handling. The Gradle work still travels the other way: the server spawns `compose-preview build-host --stdio` when it needs a build, so this process is a launcher and not a host.

Wiring, all in step because `CliRouterTest` pins it: the dispatch table, the `share` group (`serve · ui-builder · build-host · share-preview` — the same binary, its Gradle half, and now its builder command), `help --all`, and a `CliFlagValidation` allowlist. `--no-open` is listed there because it belongs to the lane rather than the server.

## Test plan

- `ServeLauncherTest` gains a case pinning that `ui-builder` launches the server's `ui` command with the caller's argv and adds nothing.
- `CliRouterTest` already pins that the dispatch table, `KNOWN_FLAT` and `CliFlagValidation.BY_COMMAND` agree — it fails if any of the three is missed.
- `./gradlew :cli:test --tests '*CliRouterTest*' --tests '*ServeLauncherTest*' --tests '*CliFlagsRegistryTest*'` green; `:cli` ktfmt clean.

Non-visual change: a command word and its routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yYDifT4DZ9fmuMbraHZLL

---
_Generated by [Claude Code](https://claude.ai/code/session_015yYDifT4DZ9fmuMbraHZLL)_