### PR TITLE
test: let the consumer notice know its third consumer

### DIFF
--- a/.github/ci/consumer-contract-notice.py
+++ b/.github/ci/consumer-contract-notice.py
@@ -3,14 +3,14 @@
 
 `compose-ai-tools` used to contain every consumer of its own contracts, so a
 protocol change and the code reading it moved in one commit and CI checked both.
-After the split (#4732) two consumers live elsewhere:
+After the split (#4732) three consumers live elsewhere:
 
   * yschimke/compose-preview-vscode    — the VS Code extension
   * yschimke/compose-preview-contracts — the published wire contracts
   * yschimke/compose-preview-server    — the preview server behind `serve`
 
-Both pin a *released* version of this repository and vendor copies of what they
-need. Their own gates catch drift — but only against the release they pin, which
+Each pins a *released* version of this repository and vendors copies of what it
+needs. Their own gates catch drift — but only against the release they pin, which
 means a contract change here is invisible to them until somebody bumps that pin.
 That is the gap #4732 records as "a `daemon-protocol` bump has to fail the
 consumer's CI, not just the producer's".

--- a/.github/ci/test_consumer_contract_notice.py
+++ b/.github/ci/test_consumer_contract_notice.py
@@ -92,8 +92,8 @@ class SurfaceMapIsCurrent(unittest.TestCase):
         for surface in mod.SURFACES:
             self.assertTrue(surface["consumers"], f"{surface['name']} names no consumer")
 
-    def test_consumer_repos_are_the_known_two(self):
-        known = {mod.EXT, mod.CONTRACTS}
+    def test_consumer_repos_are_the_known_three(self):
+        known = {mod.EXT, mod.CONTRACTS, mod.SERVER}
         for surface in mod.SURFACES:
             self.assertLessEqual(set(surface["consumers"]), known, surface["name"])
 


### PR DESCRIPTION
`Actions Script Tests` is red on `main` (and therefore on every PR branched from it, including #5195, which is where I hit it).

#5193 added `yschimke/compose-preview-server` to the surface map for **Preview selector fixtures** — correctly: that golden table has two implementations, `previewIdMatchesRequest` here and `previewIdMatchesStandaloneRequest` in the server, and the map exists to say so. But `test_consumer_repos_are_the_known_two` still allowed only the extension and the contracts repo, so the map and the test guarding it disagreed:

```
FAIL: test_consumer_repos_are_the_known_two (SurfaceMapIsCurrent)
AssertionError: {'yschimke/compose-preview-server'} not less than or equal to
  {'yschimke/compose-preview-vscode', 'yschimke/compose-preview-contracts'} : Preview selector fixtures
```

The map is the half that is right, so the test learns the third consumer (and is renamed to match). `consumer-contract-notice.py`'s docstring already **listed** three consumers under a sentence saying two and "Both pin a released version"; it now says what it lists.

No behaviour change — the notice is informational and never blocking; this is the guard that says the map still describes the repository.

## Test plan

- `python3 .github/ci/test_consumer_contract_notice.py -v` — 13 tests, was `FAILED (failures=1)`, now `OK`. Same command `Actions Script Tests` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yYDifT4DZ9fmuMbraHZLL

---
_Generated by [Claude Code](https://claude.ai/code/session_015yYDifT4DZ9fmuMbraHZLL)_