### PR TITLE
fix(daemon): record the ABI :daemon:core actually has

### DIFF
--- a/daemon/core/api/core.api
+++ b/daemon/core/api/core.api
@@ -2573,7 +2573,6 @@ public abstract interface class ee/schimke/composeai/daemon/rpc/RpcMethodHandler
 
 public final class ee/schimke/composeai/daemon/rpc/RpcMethodRegistry {
 	public static final field Companion Lee/schimke/composeai/daemon/rpc/RpcMethodRegistry$Companion;
-	public synthetic fun <init> (Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getMethods ()Ljava/util/Set;
 	public final fun handler (Ljava/lang/String;)Lee/schimke/composeai/daemon/rpc/RpcMethodHandler;
 }
@@ -2594,3 +2593,4 @@ public abstract interface class ee/schimke/composeai/daemon/rpc/RpcPeer {
 	public abstract fun sendErrorResponse (Ljava/lang/Long;ILjava/lang/String;)V
 	public abstract fun sendResponse (JLkotlinx/serialization/json/JsonElement;)V
 }
+


### PR DESCRIPTION
`:daemon:core:checkKotlinAbi` is red on `main` — I reproduced it at [734e906](https://github.com/yschimke/compose-ai-tools/commit/734e906bc) with an untouched checkout — and therefore on every PR branched from it, including [#5200](https://github.com/yschimke/compose-ai-tools/pull/5200), where it surfaced inside `Module Unit Tests`.

The committed dump claims a synthetic constructor `RpcMethodRegistry` no longer emits:

```
-	public synthetic fun <init> (Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
```

The **dump** went stale, not the surface: a synthetic accessor for a private constructor is not source-visible API, and the class's real surface (`Companion`, `getMethods`, `handler`) is unchanged. `updateKotlinAbi` regenerates it. The second hunk is a trailing newline the generator writes and the committed file lacks.

## Test plan

```
./gradlew :daemon:core:checkKotlinAbi
```

Fails on `origin/main` with exactly the diff above; passes with this commit.

Non-visual change: one generated file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Uxgbygt7e2LEBDruCGeKY

---
_Generated by [Claude Code](https://claude.ai/code/session_016Uxgbygt7e2LEBDruCGeKY)_