### PR TITLE
chore(deps): pin the preview server to 3.2.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -376,13 +376,20 @@ composeai-contracts = "2.5.0"
 # this repository (compose-preview-server#289), and 3.0.0 retired the old coordinate at its final
 # 2.x. `:cli` depends on `project(":render-host")`; there is no version ref to share any more.
 #
-# This pin is also RUNTIME-load-bearing, not just a compile-time coordinate. `compose-preview serve`
-# is a launcher, and since #5183 the CLI fetches the server itself on first use: the pin is baked
-# into the jar as `SERVE_VERSION` and names the release whose `compose-preview-server-<pin>.tar.gz`
-# `ServerDistributionProvision` downloads. So a pin naming a release that does not exist, or one
-# with no distribution attached, is a `serve` that cannot start — `check_preview_server_pin.py`
-# fails the PR rather than letting that reach an install. docs/VERSIONING.md § 8.1.
-composeai-preview-serve = "3.0.0"
+# This pin is also RUNTIME-load-bearing, not just a compile-time coordinate, and for TWO commands
+# since #5176. `compose-preview serve` is a launcher, and since #5183 the CLI fetches the server
+# itself on first use: the pin is baked into the jar as `SERVE_VERSION` and names the release whose
+# `compose-preview-server-<pin>.tar.gz` `ServerDistributionProvision` downloads. `compose-preview
+# mcp serve` is a launcher over `compose-preview-mcp-<pin>.tar.gz` from the SAME release, so one pin
+# governs the pair. A pin naming a release that does not exist, or one carrying only one of the two
+# archives, is a command that cannot start — `check_preview_server_pin.py` fails the PR rather than
+# letting that reach an install, and it checks both. docs/VERSIONING.md § 8.1.
+#
+# 3.2.0 is the first release carrying the MCP distribution: compose-preview-server#308 moved the
+# module there and #314 released it. 3.1.0 carried the archive but published a `compose-preview-serve`
+# POM naming an unpublished project (`ui-builder-export-jvm:unspecified`), so it resolves for nobody;
+# compose-preview-server#316 fixed that and rides in this release too.
+composeai-preview-serve = "3.2.0"
 
 # The Remote Compose players, published by yschimke/rc-players (the CMP player stack, the vendored
 # AndroidX embedded player, and the Wasm browser bundle). They were project deps here until the


### PR DESCRIPTION
**main is red on `check_preview_server_pin.py`, and `compose-preview mcp serve` has nothing to fetch.** [#5200](https://github.com/yschimke/compose-ai-tools/pull/5200) landed the MCP launcher with the pin still at 3.0.0, whose release carries no `compose-preview-mcp-3.0.0.tar.gz`. This is the one line that closes that.

```
ok: yschimke/compose-preview-server v3.2.0 exists and carries
    compose-preview-server-3.2.0.tar.gz, compose-preview-mcp-3.2.0.tar.gz
```

**3.1.0 is skipped deliberately**, and the comment now records why: it carried the MCP archive but published a `compose-preview-serve` POM naming an unpublished project — `compose-preview-server:ui-builder-export-jvm:unspecified` — so the coordinate resolved for nobody, this module's two wire-drift tests included. [compose-preview-server#316](https://github.com/yschimke/compose-preview-server/pull/316) fixed that and rides in this release; the published 3.2.0 POM contains no `unspecified` entry.

The comment above the pin also now says what it did not before: since #5176 this pin is load-bearing for **two** commands, because both archives ride the same release.

## Test plan

```
python3 .github/ci/check_preview_server_pin.py   # both assets on the pinned release
./gradlew :cli:test checkHttpServerFloor
```

Green. `:cli:test` resolving at all is the second proof — it compiles the wire-drift tests against the published 3.2.0 POM, which is exactly what 3.1.0 could not do.

Non-visual change: one version pin and its comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Uxgbygt7e2LEBDruCGeKY

---
_Generated by [Claude Code](https://claude.ai/code/session_016Uxgbygt7e2LEBDruCGeKY)_