### PR TITLE
feat(screen): let a generated screen carry an opt-in @Preview

### DIFF
--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
@@ -64,6 +64,39 @@ class ScreenGeneratorTest {
   private fun refusal(document: ScreenDocument, catalog: ComponentRecordFile) =
     (ScreenGenerator.generate(document, catalog) as ScreenGenerator.Result.Refused).reasons
 
+  private fun generated(
+    document: ScreenDocument,
+    catalog: ComponentRecordFile,
+    preview: ScreenGenerator.Preview,
+  ) =
+    ScreenGenerator.generate(document, catalog, preview = preview) as ScreenGenerator.Result.Emitted
+
+  private fun previewRefusal(
+    document: ScreenDocument,
+    catalog: ComponentRecordFile,
+    preview: ScreenGenerator.Preview,
+  ) =
+    (ScreenGenerator.generate(document, catalog, preview = preview)
+        as ScreenGenerator.Result.Refused)
+      .reasons
+
+  /** The same nested card-and-text screen several preview tests generate from. */
+  private fun screen() =
+    ScreenDocument(
+      name = "HomeScreen",
+      root =
+        ScreenNode(
+          componentId = card.canonicalId,
+          slots =
+            mapOf(
+              "content" to
+                listOf(
+                  ScreenNode(text.canonicalId, arguments = mapOf("text" to ScreenValue.Text("Hi")))
+                )
+            ),
+        ),
+    )
+
   @Test
   fun `a screen binds the document's values and nests children into slots`() {
     val screen =
@@ -99,6 +132,118 @@ class ScreenGeneratorTest {
     assertThat(source).doesNotContain("androidx.compose.material3.Text(text = ")
     // `modifier` is defaulted and untouched, so it is omitted rather than guessed at.
     assertThat(source).doesNotContain("modifier =")
+  }
+
+  @Test
+  fun `no preview is emitted unless one is asked for`() {
+    // The annotation lives in an Android tooling dependency a consumer of this generator need not
+    // have, so the default has to stay "source that compiles wherever the screen does".
+    val source = emitted(screen(), catalog(card, text)).source
+
+    assertThat(source).doesNotContain("@Preview")
+    assertThat(source).doesNotContain("androidx.compose.ui.tooling.preview")
+  }
+
+  @Test
+  fun `a preview reproduces the design environment and calls the screen`() {
+    val source =
+      generated(
+          screen(),
+          catalog(card, text),
+          ScreenGenerator.Preview(
+            widthDp = 411,
+            heightDp = 914,
+            fontScale = 1.3,
+            locale = "en-US",
+            darkMode = true,
+          ),
+        )
+        .source
+
+    assertThat(source).contains("import androidx.compose.ui.tooling.preview.Preview")
+    assertThat(source).contains("widthDp = 411,")
+    assertThat(source).contains("heightDp = 914,")
+    // A Float literal: `@Preview.fontScale` is a Float, and an unsuffixed decimal is a Double.
+    assertThat(source).contains("fontScale = 1.3f,")
+    assertThat(source).contains("""locale = "en-US",""")
+    assertThat(source).contains("showBackground = true,")
+    assertThat(source).contains("uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,")
+    // A wrapper, not an annotation on the screen: the screen stays callable without dragging a
+    // preview onto every call site.
+    assertThat(source).contains("private fun HomeScreenPreview() {")
+    assertThat(source).contains("    HomeScreen()")
+    assertThat(source.indexOf("fun HomeScreen()")).isLessThan(source.indexOf("@Preview"))
+  }
+
+  @Test
+  fun `a light design gets no uiMode rather than a light one`() {
+    // `@Preview` already previews light; naming it would claim the design said something it did
+    // not, and `UI_MODE_NIGHT_NO` is not the same as "unspecified" to a device configuration.
+    val source =
+      generated(screen(), catalog(card, text), ScreenGenerator.Preview(darkMode = false)).source
+
+    assertThat(source).doesNotContain("uiMode")
+  }
+
+  @Test
+  fun `a locale that is not a language tag is refused rather than escaped into the file`() {
+    // The locale is wire data reaching a string literal. A quote would close it and continue in
+    // code, so the shape is checked rather than trusted.
+    val reasons =
+      previewRefusal(screen(), catalog(card, text), ScreenGenerator.Preview(locale = """en", x="""))
+
+    assertThat(reasons.single()).contains("is not a language tag")
+  }
+
+  @Test
+  fun `a nonsensical preview size or font scale is refused, and every problem is named`() {
+    val reasons =
+      previewRefusal(
+        screen(),
+        catalog(card, text),
+        ScreenGenerator.Preview(widthDp = 0, heightDp = -1, fontScale = 0.0),
+      )
+
+    assertThat(reasons).hasSize(3)
+    assertThat(reasons.joinToString("\n")).contains("widthDp must be positive")
+    assertThat(reasons.joinToString("\n")).contains("heightDp must be positive")
+    assertThat(reasons.joinToString("\n")).contains("fontScale must be finite and positive")
+  }
+
+  @Test
+  fun `a component named Preview is qualified only when a preview is emitted`() {
+    val previewComponent =
+      component("Preview", "androidx.compose.material3.Preview", parameters = emptyList())
+    val document =
+      ScreenDocument(name = "HomeScreen", root = ScreenNode(previewComponent.canonicalId))
+
+    // Without one, nothing has spent the name and the ordinary simple import stands.
+    val plain = emitted(document, catalog(previewComponent)).source
+    assertThat(plain).contains("import androidx.compose.material3.Preview")
+    assertThat(plain).contains("    Preview()")
+
+    // With one, the file's own `Preview` would make the call ambiguous, so the component is
+    // called fully qualified instead — the same answer a two-package collision gets.
+    val withPreview =
+      generated(document, catalog(previewComponent), ScreenGenerator.Preview()).source
+    assertThat(withPreview).doesNotContain("import androidx.compose.material3.Preview")
+    assertThat(withPreview).contains("androidx.compose.material3.Preview()")
+  }
+
+  @Test
+  fun `a component the preview wrapper would shadow is qualified instead`() {
+    // The wrapper is a top-level declaration, so it beats an import of the same simple name. Left
+    // alone, `HomeScreenPreview()` in the body would call the wrapper, which calls the screen —
+    // a stack overflow standing in for the component somebody placed.
+    val clashing =
+      component("HomeScreenPreview", "androidx.compose.material3.HomeScreenPreview", emptyList())
+    val document = ScreenDocument(name = "HomeScreen", root = ScreenNode(clashing.canonicalId))
+
+    val source = generated(document, catalog(clashing), ScreenGenerator.Preview()).source
+
+    assertThat(source).doesNotContain("import androidx.compose.material3.HomeScreenPreview")
+    assertThat(source).contains("androidx.compose.material3.HomeScreenPreview()")
+    assertThat(source).contains("private fun HomeScreenPreview() {")
   }
 
   @Test
@@ -555,7 +700,8 @@ class ScreenGeneratorTest {
   fun `a child inside a receiver slot is imported, like any other child`() {
     // This reverses a deliberate decision, so it records both halves. The hazard it avoided is
     // real: Kotlin resolves a simple name against implicit receivers before imports, so a
-    // `ColumnScope` declaring a member `Text` would outrank `import androidx.compose.material3.Text`
+    // `ColumnScope` declaring a member `Text` would outrank `import
+    // androidx.compose.material3.Text`
     // and draw something else. The receiver's members are not in the record, so it was avoided
     // rather than checked.
     //

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -376,13 +376,20 @@ composeai-contracts = "2.5.0"
 # this repository (compose-preview-server#289), and 3.0.0 retired the old coordinate at its final
 # 2.x. `:cli` depends on `project(":render-host")`; there is no version ref to share any more.
 #
-# This pin is also RUNTIME-load-bearing, not just a compile-time coordinate. `compose-preview serve`
-# is a launcher, and since #5183 the CLI fetches the server itself on first use: the pin is baked
-# into the jar as `SERVE_VERSION` and names the release whose `compose-preview-server-<pin>.tar.gz`
-# `ServerDistributionProvision` downloads. So a pin naming a release that does not exist, or one
-# with no distribution attached, is a `serve` that cannot start — `check_preview_server_pin.py`
-# fails the PR rather than letting that reach an install. docs/VERSIONING.md § 8.1.
-composeai-preview-serve = "3.0.0"
+# This pin is also RUNTIME-load-bearing, not just a compile-time coordinate, and for TWO commands
+# since #5176. `compose-preview serve` is a launcher, and since #5183 the CLI fetches the server
+# itself on first use: the pin is baked into the jar as `SERVE_VERSION` and names the release whose
+# `compose-preview-server-<pin>.tar.gz` `ServerDistributionProvision` downloads. `compose-preview
+# mcp serve` is a launcher over `compose-preview-mcp-<pin>.tar.gz` from the SAME release, so one pin
+# governs the pair. A pin naming a release that does not exist, or one carrying only one of the two
+# archives, is a command that cannot start — `check_preview_server_pin.py` fails the PR rather than
+# letting that reach an install, and it checks both. docs/VERSIONING.md § 8.1.
+#
+# 3.2.0 is the first release carrying the MCP distribution: compose-preview-server#308 moved the
+# module there and #314 released it. 3.1.0 carried the archive but published a `compose-preview-serve`
+# POM naming an unpublished project (`ui-builder-export-jvm:unspecified`), so it resolves for nobody;
+# compose-preview-server#316 fixed that and rides in this release too.
+composeai-preview-serve = "3.2.0"
 
 # The Remote Compose players, published by yschimke/rc-players (the CMP player stack, the vendored
 # AndroidX embedded player, and the Wasm browser bundle). They were project deps here until the

--- a/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -93,6 +93,50 @@ object ScreenGenerator {
     data class Refused(val reasons: List<String>) : Result
   }
 
+  /**
+   * The design environment a generated `@Preview` should reproduce, or null for no preview.
+   *
+   * Opt-in, and deliberately so. `@Preview` lives in `androidx.compose.ui.tooling.preview`, which
+   * is an Android tooling dependency a consumer of this generator need not have on its compile
+   * classpath — the Gradle plugin generates screens into builds that do not. Emitting it always
+   * would trade "the file compiles" for "the file previews", which is the wrong way round for the
+   * caller that only wanted source.
+   *
+   * The values are the design's own environment rather than `@Preview` defaults, because a design
+   * authored at 411x914 in dark at a 1.3 font scale and previewed at Android Studio's defaults is a
+   * different picture from the one its author approved — and the whole point of pasting the export
+   * into an IDE is to see that picture.
+   *
+   * [locale] is wire data. It reaches the emitted file inside a string literal, so it is validated
+   * against a language-tag shape rather than escaped: a value that is not one is a projection bug
+   * worth a refusal, not something to quietly pass through into source this generator signs.
+   */
+  data class Preview(
+    /** Design width in dp. Omitted from the annotation when null, so `@Preview` decides. */
+    val widthDp: Int? = null,
+    /** Design height in dp. Omitted when null. */
+    val heightDp: Int? = null,
+    /** Font scale, emitted as a `Float` literal. Omitted when null. */
+    val fontScale: Double? = null,
+    /** BCP-47-ish language tag, e.g. `en-US`. Omitted when null. */
+    val locale: String? = null,
+    /**
+     * Whether the design is dark, emitted as `uiMode = …UI_MODE_NIGHT_YES`.
+     *
+     * Fully qualified through `android.content.res.Configuration` rather than imported: the
+     * constant is Android-only and this keeps it out of the import list, where it would collide
+     * with nothing today but would still be a name the file spends for one integer.
+     */
+    val darkMode: Boolean = false,
+    /**
+     * Paints the preview's background rather than compositing on transparency.
+     *
+     * True by default because a transparent preview of a screen designed against a surface reads as
+     * a rendering fault to the person who pasted it.
+     */
+    val showBackground: Boolean = true,
+  )
+
   private const val INDENT = "    "
 
   fun generate(
@@ -100,6 +144,7 @@ object ScreenGenerator {
     components: ComponentRecordFile,
     packageName: String = "generated.screen",
     expressionPackages: Set<String> = emptySet(),
+    preview: Preview? = null,
   ): Result {
     if (components.schemaVersion > COMPONENT_RECORD_SCHEMA_VERSION) {
       // A record from a newer producer may mean things by fields this build has never seen.
@@ -121,6 +166,10 @@ object ScreenGenerator {
       return Result.Refused(
         listOf("screen name `${document.name}` is not a usable Kotlin function name")
       )
+    }
+    if (preview != null) {
+      val bad = previewRefusals(preview)
+      if (bad.isNotEmpty()) return Result.Refused(bad)
     }
     // **Schema 1 is refused outright**, rather than read with a growing list of exceptions.
     //
@@ -172,7 +221,17 @@ object ScreenGenerator {
         .filter {
           claimants.getValue(it.symbol.name).size == 1 &&
             it.symbol.name != document.name &&
-            it.symbol.name !in RESERVED_BY_THE_WRAPPER
+            it.symbol.name !in RESERVED_BY_THE_WRAPPER &&
+            // Both only when a preview is emitted, because only then does the file spend these
+            // names; reserving them always would needlessly qualify a component in every other
+            // screen. `Preview` is the annotation's own simple name, and the wrapper is a
+            // top-level declaration that would *win* over an import of the same name — so a
+            // component called `HomeScreenPreview` in a `HomeScreen` would silently become a call
+            // to the wrapper, which calls the screen, which renders it: a stack overflow standing
+            // in for the component somebody placed.
+            (preview == null ||
+              (it.symbol.name != PREVIEW_SIMPLE_NAME &&
+                it.symbol.name != previewFunctionName(document.name)))
         }
         .map { it.canonicalId }
         .toSet()
@@ -322,7 +381,10 @@ object ScreenGenerator {
     val androidxOptIns = context.androidxOptIns.distinct().sorted()
     val optIns = (context.optIns - context.androidxOptIns).distinct().sorted()
     val imports =
-      (context.imports + context.extensionImports + "androidx.compose.runtime.Composable")
+      (context.imports +
+          context.extensionImports +
+          "androidx.compose.runtime.Composable" +
+          listOfNotNull(PREVIEW_ANNOTATION.takeIf { preview != null }))
         .distinct()
         .sorted()
     // Kotlin calls two imports of one simple name a conflicting import and compiles neither. The
@@ -377,6 +439,10 @@ object ScreenGenerator {
       declarations.forEach { appendLine("    $it") }
       appendLine(body)
       appendLine("}")
+      if (preview != null) {
+        appendLine()
+        append(previewFunction(document.name, preview))
+      }
     }
     return Result.Emitted(source = source, requiredOptIns = optIns + androidxOptIns)
   }
@@ -1166,4 +1232,76 @@ object ScreenGenerator {
    * the screen's own name and a two-package collision already get.
    */
   private val RESERVED_BY_THE_WRAPPER = setOf("Composable")
+
+  /** The tooling annotation a [Preview] emits, imported only when one is asked for. */
+  private const val PREVIEW_ANNOTATION = "androidx.compose.ui.tooling.preview.Preview"
+
+  private const val PREVIEW_SIMPLE_NAME = "Preview"
+
+  /** The wrapper's name, needed before it is emitted so a component cannot be shadowed by it. */
+  private fun previewFunctionName(screenName: String) = "$screenName$PREVIEW_SIMPLE_NAME"
+
+  /**
+   * A language tag this generator is willing to put inside a string literal.
+   *
+   * Letters, digits and separators only. `@Preview(locale = …)` takes a tag such as `en-US`, and
+   * anything outside this shape is either not a tag or is trying to be something other than a tag —
+   * a quote or a newline would close the literal and continue in code. Escaping it would also work
+   * and is what [ScreenValue.Text] does for values a designer typed; a locale is not typed prose,
+   * so a wrong one is worth naming rather than smuggling through as an escaped string that no
+   * Android runtime will resolve anyway.
+   */
+  private val LANGUAGE_TAG = Regex("[A-Za-z0-9]+(?:[-_][A-Za-z0-9]+)*")
+
+  /** Every problem with [preview], so a caller fixes them in one pass rather than one per run. */
+  private fun previewRefusals(preview: Preview): List<String> = buildList {
+    preview.widthDp?.let { if (it <= 0) add("preview widthDp must be positive, not $it") }
+    preview.heightDp?.let { if (it <= 0) add("preview heightDp must be positive, not $it") }
+    preview.fontScale?.let {
+      // `!(it > 0)` rather than `it <= 0` so a NaN — which loses every comparison — is caught here
+      // instead of reaching the file as `fontScale = NaNf`, which does not compile.
+      if (!(it > 0.0) || it.isInfinite())
+        add("preview fontScale must be finite and positive, not $it")
+    }
+    preview.locale?.let {
+      if (!LANGUAGE_TAG.matches(it)) add("preview locale `$it` is not a language tag")
+    }
+  }
+
+  /**
+   * The `@Preview` wrapper: a private, zero-argument composable that calls the screen.
+   *
+   * A wrapper rather than the annotation on the screen itself. The screen is the artifact a caller
+   * pastes and then *calls* from their own code; annotating it would make every call site carry a
+   * preview, and a `@Preview` function is expected to take no arguments — a constraint that belongs
+   * to the preview, not to the screen it previews.
+   */
+  private fun previewFunction(screenName: String, preview: Preview): String {
+    val arguments = buildList {
+      preview.widthDp?.let { add("widthDp = $it") }
+      preview.heightDp?.let { add("heightDp = $it") }
+      // `Float` literal: `@Preview.fontScale` is a Float and an unsuffixed decimal is a Double.
+      preview.fontScale?.let { add("fontScale = ${it}f") }
+      preview.locale?.let { add("locale = \"$it\"") }
+      if (preview.showBackground) add("showBackground = true")
+      if (preview.darkMode) {
+        add("uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES")
+      }
+    }
+    return buildString {
+      if (arguments.isEmpty()) {
+        appendLine("@$PREVIEW_SIMPLE_NAME")
+      } else {
+        // One argument per line, always. A design carrying a locale and a uiMode runs well past
+        // 100 columns on one line, and ktfmt is not run over what this emits.
+        appendLine("@$PREVIEW_SIMPLE_NAME(")
+        arguments.forEach { appendLine("$INDENT$it,") }
+        appendLine(")")
+      }
+      appendLine("@Composable")
+      appendLine("private fun ${previewFunctionName(screenName)}() {")
+      appendLine("$INDENT$screenName()")
+      appendLine("}")
+    }
+  }
 }


### PR DESCRIPTION
## Summary

A UI-builder design exported as Compose comes back as a bare `@Composable` — correct Kotlin, but pasting it into Android Studio shows nothing until you hand-write a `@Preview` wrapper and its import. This adds one, as an **opt-in** parameter:

```kotlin
ScreenGenerator.generate(document, components, preview = ScreenGenerator.Preview(
  widthDp = 411, heightDp = 914, fontScale = 1.3, locale = "en-US", darkMode = true,
))
```

emits, after the screen:

```kotlin
import androidx.compose.ui.tooling.preview.Preview
…
@Preview(
    widthDp = 411,
    heightDp = 914,
    fontScale = 1.3f,
    locale = "en-US",
    showBackground = true,
    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
)
@Composable
private fun HomeScreenPreview() {
    HomeScreen()
}
```

**Opt-in rather than always.** `@Preview` lives in `androidx.compose.ui.tooling.preview`, an Android tooling dependency a consumer of this generator need not have on its compile classpath — the Gradle plugin generates screens into builds that do not. Emitting it unconditionally would trade "the file compiles" for "the file previews", which is backwards for a caller that only wanted source. Default is `null`; nothing changes for existing callers.

**A wrapper, not an annotation on the screen.** The screen is the artifact you paste and then *call* from your own code; annotating it directly would put a preview on every call site, and `@Preview` expects a zero-argument function — a constraint belonging to the preview, not the screen.

**The design's environment, not `@Preview`'s defaults.** A design authored at 411×914 in dark at 1.3 font scale, previewed at Android Studio's defaults, is a different picture from the one its author approved — which defeats the point of pasting it in. A light design gets no `uiMode` at all rather than `UI_MODE_NIGHT_NO`: unspecified and "explicitly not night" are not the same thing to a device configuration.

## Two hazards this closes rather than leaves open

**`locale` is wire data reaching a string literal.** It arrives from a design document over HTTP. A value carrying a quote would close the literal and continue in code — in a file this generator signs. It is validated against a language-tag shape and refused otherwise, rather than escaped: a locale is not typed prose, and a wrong one no Android runtime resolves is worth naming, not smuggling through.

**Two names the file now spends can shadow a catalog component.** `Preview` itself, and the wrapper `<Screen>Preview`. The second is the sharper one — the wrapper is a top-level declaration, so it *beats* an import of the same simple name, and a component called `HomeScreenPreview` placed in a `HomeScreen` would silently become a call to the wrapper, which calls the screen, which renders it: a stack overflow standing in for the component somebody placed. Both are added to the existing simple-import exclusion, and **only when a preview is emitted**, so no other screen pays for it.

Non-finite/non-positive sizes and font scales are refused too, all problems at once rather than one per run. `!(it > 0)` for the scale so `NaN` — which loses every comparison — is caught here instead of reaching the file as `fontScale = NaNf`.

## Test plan

Six new tests in `ScreenGeneratorTest`:

- no preview unless asked for (no annotation, no tooling import)
- the full environment maps through, `fontScale` as a `Float` literal, wrapper emitted after the screen
- a light design gets no `uiMode`
- a locale that is not a language tag is refused, not escaped in
- zero/negative size and zero font scale are refused, and all three problems are named
- a component named `Preview`, and one named `HomeScreenPreview`, are called fully qualified when a preview is emitted — and still simply imported when it is not

Verified locally:

- `:gradle-plugin:preview-discovery:test` — green
- `:screen-model:compileKotlinWasmJs` — green; this generator is shared with the browser editor via the `screen/generator` source directory, so the wasm target has to keep compiling
- `:gradle-plugin:preview-discovery:ktfmtCheckMain` / `ktfmtCheckTest` — clean

No ABI dump covers these modules, so none needed updating.

## Follow-up

`compose-preview-server`'s `ScreenGeneratorComposeExportExecutor` is the caller that should pass this, built from `DesignEnvironmentV1`. That needs a release of `screen-model` first, so it lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA6pgDdzR5xgKh6F7dG6eJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UA6pgDdzR5xgKh6F7dG6eJ)_