### PR TITLE
fix(screen): import a generated screen's references instead of qualifying them

### DIFF
--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenValueVocabularyTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenValueVocabularyTest.kt
@@ -107,7 +107,7 @@ class ScreenValueVocabularyTest {
   private val modifier = "androidx.compose.ui.Modifier"
 
   @Test
-  fun `a reference is emitted fully qualified and imported nowhere`() {
+  fun `a reference imports its root and is written from the root's simple name`() {
     val result =
       emitted(
         textNode(
@@ -120,13 +120,16 @@ class ScreenValueVocabularyTest {
         ),
         catalog(text),
       )
+    // `MaterialTheme.colorScheme.primary`, not the 52-character path it used to be. A screen names
+    // the theme once per coloured node, so this is most of what a generated file says.
+    assertThat(result.source).contains("color = MaterialTheme.colorScheme.primary")
+    assertThat(result.source).contains("import androidx.compose.material3.MaterialTheme")
     assertThat(result.source)
-      .contains("color = androidx.compose.material3.MaterialTheme.colorScheme.primary")
-    assertThat(result.source).doesNotContain("import androidx.compose.material3.MaterialTheme")
+      .doesNotContain("androidx.compose.material3.MaterialTheme.colorScheme")
   }
 
   @Test
-  fun `a reference with no members is a bare qualified read`() {
+  fun `a reference with no members is the imported simple name`() {
     val result =
       emitted(
         textNode(
@@ -134,7 +137,8 @@ class ScreenValueVocabularyTest {
         ),
         catalog(text),
       )
-    assertThat(result.source).contains("color = androidx.compose.ui.graphics.Color")
+    assertThat(result.source).contains("color = Color")
+    assertThat(result.source).contains("import androidx.compose.ui.graphics.Color")
   }
 
   @Test
@@ -159,7 +163,7 @@ class ScreenValueVocabularyTest {
   }
 
   @Test
-  fun `a construct is a qualified call with positional then named arguments`() {
+  fun `a construct is an imported call with positional then named arguments`() {
     val result =
       emitted(
         textNode(
@@ -173,8 +177,68 @@ class ScreenValueVocabularyTest {
         ),
         catalog(text),
       )
-    assertThat(result.source)
-      .contains("color = androidx.compose.ui.graphics.Color(0.5, alpha = 1.0)")
+    assertThat(result.source).contains("color = Color(0.5, alpha = 1.0)")
+    assertThat(result.source).contains("import androidx.compose.ui.graphics.Color")
+  }
+
+  @Test
+  fun `a construct that is a member of an object imports the object, not the member`() {
+    // `CardDefaults.cardColors(…)` is what a person writes. Importing the member instead would
+    // emit a bare `cardColors(…)`, which compiles and reads like a local function.
+    val result =
+      emitted(
+        textNode(
+          "color" to
+            ScreenValue.Construct(
+              callableFqn = "androidx.compose.material3.ColorDefaults.brand",
+              typeFqn = color,
+            )
+        ),
+        catalog(text),
+      )
+    assertThat(result.source).contains("color = ColorDefaults.brand()")
+    assertThat(result.source).contains("import androidx.compose.material3.ColorDefaults")
+    assertThat(result.source).doesNotContain("import androidx.compose.material3.ColorDefaults.brand")
+  }
+
+  @Test
+  fun `two references claiming one simple name are refused rather than resolved`() {
+    // The check that makes importing references safe enough to be worth the readability. Before
+    // they imported, two `Color`s from two packages could not collide because neither was written
+    // short; now the file-wide conflict check is what stands between them.
+    assertThat(
+        refusal(
+          textNode(
+            "color" to ScreenValue.Reference("androidx.compose.ui.graphics.Color", typeFqn = color),
+            "modifier" to
+              ScreenValue.Chain(
+                receiver = ScreenValue.Reference("com.example.paint.Color", typeFqn = modifier),
+                links = listOf(ChainLink("androidx.compose.foundation.layout.fillMaxWidth")),
+                typeFqn = modifier,
+              ),
+          ),
+          catalog(text),
+        )
+      )
+      .contains(
+        "`Color` would be imported from androidx.compose.ui.graphics.Color and " +
+          "com.example.paint.Color, which Kotlin rejects as a conflicting import"
+      )
+  }
+
+  @Test
+  fun `a reference root named after the screen is refused, as a link is`() {
+    // The generated function would shadow the import, so the expression would name the screen.
+    // The chain-link path already refused this; a reference reaches the same rule now that it
+    // imports.
+    assertThat(
+        refusal(
+          textNode("color" to ScreenValue.Reference("com.example.paint.Screen", typeFqn = color)),
+          catalog(text),
+          name = "Screen",
+        )
+      )
+      .containsExactly("`Text`.`color` imports `Screen`, which is the screen's own name")
   }
 
   @Test
@@ -205,8 +269,11 @@ class ScreenValueVocabularyTest {
         ),
         catalog(text),
       )
-    assertThat(result.source)
-      .contains("modifier = androidx.compose.ui.Modifier.fillMaxWidth().padding(16.dp)")
+    // The line the qualification cost most: `Modifier` is the chain's receiver — a reference — and
+    // was spelled out while the `fillMaxWidth` beside it was already imported, so one expression
+    // carried two conventions.
+    assertThat(result.source).contains("modifier = Modifier.fillMaxWidth().padding(16.dp)")
+    assertThat(result.source).contains("import androidx.compose.ui.Modifier")
     assertThat(result.source).contains("import androidx.compose.foundation.layout.fillMaxWidth")
     assertThat(result.source).contains("import androidx.compose.foundation.layout.padding")
     assertThat(result.source).contains("import androidx.compose.ui.unit.dp")
@@ -351,7 +418,7 @@ class ScreenValueVocabularyTest {
         catalog(text),
       )
     assertThat(result.source)
-      .contains("color = androidx.compose.ui.graphics.Color(4284960932L, 2.0)")
+      .contains("color = Color(4284960932L, 2.0)")
   }
 
   @Test
@@ -379,7 +446,10 @@ class ScreenValueVocabularyTest {
         ),
         catalog(text),
       )
-    assertThat(result.source).contains("color = com.example.`in`.Palette.brand")
+    // The keyword is in the *import* now rather than in the expression, which is where a person
+    // would have put it: `import com.example.`in`.Palette`, then a plain `Palette.brand`.
+    assertThat(result.source).contains("color = Palette.brand")
+    assertThat(result.source).contains("import com.example.`in`.Palette")
   }
 
   @Test
@@ -1211,7 +1281,7 @@ class ScreenValueVocabularyTest {
         as ScreenGenerator.Result.Emitted
 
     assertThat(result.source)
-      .contains("val tintInitial = androidx.compose.material3.MaterialTheme.colorScheme.primary")
+      .contains("val tintInitial = MaterialTheme.colorScheme.primary")
     assertThat(result.source)
       .contains("mutableStateOf<androidx.compose.ui.graphics.Color>(tintInitial)")
   }
@@ -1289,7 +1359,7 @@ class ScreenValueVocabularyTest {
         as ScreenGenerator.Result.Emitted
 
     assertThat(result.source)
-      .contains("val tintInitial_ = androidx.compose.material3.MaterialTheme.colorScheme.primary")
+      .contains("val tintInitial_ = MaterialTheme.colorScheme.primary")
   }
 
   @Test

--- a/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ScreenDocument.kt
+++ b/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ScreenDocument.kt
@@ -182,10 +182,21 @@ sealed interface ScreenValue {
    * A read through a fully-qualified path — `androidx.compose.material3.MaterialTheme.colorScheme
    * .primary`, `androidx.compose.ui.text.style.TextAlign.Center`.
    *
-   * Emitted fully qualified and therefore imported nowhere. That is not tidiness: an import can be
-   * shadowed by a same-named declaration in the package the caller chose for the generated file,
-   * and a qualified path cannot. It is also what keeps this case honest — there is no receiver to
-   * infer and no overload to resolve, so the only thing the generator is trusting is [typeFqn].
+   * The [rootFqn] is **imported** and the path written from its simple name, so this reads
+   * `Alignment.Start` and `MaterialTheme.colorScheme.primary` — what a person writes.
+   *
+   * It was emitted fully qualified for a while, and imported nowhere, on the reasoning that an
+   * import can be shadowed by a same-named declaration in the package the caller chose for the
+   * generated file while a qualified path cannot. The hazard is real and the trade was wrong: a
+   * screen names `Modifier` and `MaterialTheme` on nearly every node, so the whole file paid for it
+   * — `modifier = androidx.compose.ui.Modifier.size(24.dp)` is not a line anybody writes, and it is
+   * half qualified anyway, since the `size` beside it is a [Chain] link and imports. What survives
+   * of the reasoning is the conflict check, which refuses two roots claiming one simple name; the
+   * caller's own package remains unknowable here, and a collision with it fails at the import line
+   * rather than resolving to something else.
+   *
+   * Nothing about the type claim changes: there is no receiver to infer and no overload to resolve,
+   * so the only thing the generator is trusting is still [typeFqn].
    *
    * @property rootFqn the qualified name the path starts from. A class (`…MaterialTheme`), an
    *   object, or a top-level property.
@@ -204,10 +215,13 @@ sealed interface ScreenValue {
    * A call to a fully-qualified callable — `androidx.compose.ui.graphics.Color(0xFF6750A4)`,
    * `androidx.compose.foundation.layout.PaddingValues(16.dp)`.
    *
-   * Qualified for the same reason [Reference] is. A constructor and a top-level factory function
-   * are the same shape here on purpose: `Color(…)` is a function and `PaddingValues(…)` a
-   * constructor, the distinction is invisible at the call site, and a record that made a projection
-   * declare which one would only give it a second thing to get wrong.
+   * Imported for the same reason [Reference] is, and by the same rule: a top-level declaration
+   * imports itself and is written by simple name, while a member of an object imports the object,
+   * so `CardDefaults.cardColors(…)` keeps the qualifier a person would write rather than collapsing
+   * to a bare `cardColors(…)`. A constructor and a top-level factory function are the same shape
+   * here on purpose: `Color(…)` is a function and `PaddingValues(…)` a constructor, the distinction
+   * is invisible at the call site, and a record that made a projection declare which one would only
+   * give it a second thing to get wrong.
    *
    * @property positional arguments in declaration order.
    * @property named arguments by parameter name, appended after [positional].

--- a/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -389,8 +389,11 @@ object ScreenGenerator {
         .sorted()
     // Kotlin calls two imports of one simple name a conflicting import and compiles neither. The
     // component half of this can't collide — `simplyImportable` already withholds a simple name two
-    // records want — but an extension link is imported from wherever a projection said, so
-    // `foundation.layout.padding` and `some.other.padding` in one screen have to be caught here.
+    // records want — but everything else here is imported from wherever a projection said: an
+    // extension link, and since `importedName`, a reference's root and a construct's callable too.
+    // So `foundation.layout.padding` and `some.other.padding` in one screen, or two `Color`s from
+    // two packages, have to be caught here. This is the check that makes importing references safe
+    // enough to be worth the readability.
     val conflicts =
       imports
         .groupBy { it.substringAfterLast('.') }
@@ -909,12 +912,12 @@ object ScreenGenerator {
           }
         is ScreenValue.StateRead -> stateRead(value, where)
         is ScreenValue.Reference -> {
-          val root = qualifiedName(value.rootFqn, where) ?: return null
+          val root = importedName(value.rootFqn, where) ?: return null
           val members = value.members.map { name(it, where) ?: return null }
           (listOf(root) + members).joinToString(".")
         }
         is ScreenValue.Construct -> {
-          val callable = qualifiedName(value.callableFqn, where) ?: return null
+          val callable = importedName(value.callableFqn, where) ?: return null
           val arguments = arguments(value.positional, value.named, where, depth) ?: return null
           "$callable($arguments)"
         }
@@ -1036,6 +1039,55 @@ object ScreenGenerator {
         return null
       }
       return ComponentSnippets.escapeIfKeyword(name)
+    }
+
+    /**
+     * A name **imported** and written the way a person writes it, or null having said why not.
+     *
+     * The rule this replaces qualified every reference and construct in place —
+     * `androidx.compose.ui.Modifier.size(24.dp)`, `androidx.compose.ui.Alignment.Start` — and
+     * imported neither. `ScreenDocument` gave the reason and the reason was real but narrower than
+     * the cost: an import can be shadowed by a same-named declaration in the package the caller
+     * chose for the generated file, and a qualified path cannot.
+     *
+     * Three things were already true when that was written, and together they make the shadowing
+     * case small enough to trade away. Conflicting imports are refused for the whole file, so two
+     * roots claiming one simple name cannot silently pick one. `simplyImportable` already withholds
+     * a simple name two component records both want. And an import shadowed by the caller's own
+     * declaration fails **at the import line**, loudly, rather than resolving to the wrong thing —
+     * which keeps the generator's promise that its output compiles or it refuses.
+     *
+     * What was traded away for that is every generated file: `Modifier` and `MaterialTheme` appear
+     * once per node, so the qualification was paid on every line and read like nothing anybody
+     * writes. The one thing this cannot check is the caller's own package, because the generator is
+     * writing into it rather than reading it.
+     *
+     * **What gets imported is the qualifier a reader expects to see.** A top-level declaration
+     * imports itself — `RoundedCornerShape`, `Color`, `Modifier`. A member of an object imports its
+     * **owner**, so `CardDefaults.cardColors(…)` keeps the `CardDefaults` a person would write
+     * instead of collapsing to a bare `cardColors(…)`. The two are told apart by the qualifier's
+     * case, exactly as a chain link tells a member extension from a top-level one: Kotlin packages
+     * are lower case and classifiers are capitalised by universal convention.
+     */
+    private fun importedName(fqn: String, where: String): String? {
+      qualifiedName(fqn, where) ?: return null
+      val owner = fqn.substringBeforeLast('.')
+      // A capitalised penultimate segment names a classifier, so the declaration is a member of it
+      // and the classifier is what imports. Same convention, same caveat, as the chain-link check.
+      val memberOfClassifier = owner.substringAfterLast('.').firstOrNull()?.isUpperCase() == true
+      val imported = if (memberOfClassifier) owner else fqn
+      val simple = imported.substringAfterLast('.')
+      if (simple == screenName) {
+        // The generated function shadows an import of its own name, so the expression would name
+        // the screen rather than the declaration. The chain-link path refuses this already.
+        reasons += "$where imports `$simple`, which is the screen's own name"
+        return null
+      }
+      imports += ComponentSnippets.escapeCallableIfKeyword(imported)
+      val written = ComponentSnippets.escapeIfKeyword(simple)
+      return if (memberOfClassifier)
+        "$written.${name(fqn.substringAfterLast('.'), where) ?: return null}"
+      else written
     }
 
     /** A dotted path, each segment escaped, or null having said why. */

--- a/screen/model/src/jvmTest/kotlin/ee/schimke/composeai/screen/M3PaletteScreenTest.kt
+++ b/screen/model/src/jvmTest/kotlin/ee/schimke/composeai/screen/M3PaletteScreenTest.kt
@@ -154,7 +154,7 @@ class M3PaletteScreenTest {
     val source = source(screen)
     assertTrue(
       source,
-      source.contains("color = androidx.compose.material3.MaterialTheme.colorScheme.background"),
+      source.contains("color = MaterialTheme.colorScheme.background"),
     )
     assertTrue(source, source.contains("Modifier.fillMaxWidth().padding(16.dp)"))
     assertTrue(source, source.contains("Arrangement.spacedBy(12.dp)"))


### PR DESCRIPTION
Fixes #5206.

A generated screen wrote every `ScreenValue.Reference` and `ScreenValue.Construct` as a
fully-qualified path and imported neither, while components and chain links imported and were
written short. One file carried two conventions, and the half that dominates the body was the
unreadable one.

The sharpest line, because it shows both conventions inside one expression:

```kotlin
modifier = androidx.compose.ui.Modifier.size(24.dp)
```

`size` is a chain link — imported, reads right. `Modifier` is the chain's **receiver**, a
`Reference`, so it was spelled out. Nobody writes that line; it is `Modifier.size(24.dp)`.

## Before / after

A real m3-catalog export, generated by `compose-preview-server` against its shipped record
(yschimke/compose-preview-server#363):

```kotlin
// before
Surface(shape = androidx.compose.foundation.shape.RoundedCornerShape(12.dp), color = androidx.compose.material3.MaterialTheme.colorScheme.surfaceContainer, content = {
    Column(verticalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(8.dp), horizontalAlignment = androidx.compose.ui.Alignment.Start, content = {
        Text(text = "Discover", fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold, style = androidx.compose.material3.MaterialTheme.typography.headlineSmall)
        Row(horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(4.dp), verticalAlignment = androidx.compose.ui.Alignment.CenterVertically, content = {
            Icon(imageVector = androidx.compose.material.icons.Icons.Filled.AccountCircle, contentDescription = "Account", modifier = androidx.compose.ui.Modifier.size(24.dp), tint = androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant)
```

```kotlin
// after
Surface(shape = RoundedCornerShape(12.dp), color = MaterialTheme.colorScheme.surfaceContainer, content = {
    Column(verticalArrangement = Arrangement.spacedBy(8.dp), horizontalAlignment = Alignment.Start, content = {
        Text(text = "Discover", fontWeight = FontWeight.SemiBold, style = MaterialTheme.typography.headlineSmall)
        Row(horizontalArrangement = Arrangement.spacedBy(4.dp), verticalAlignment = Alignment.CenterVertically, content = {
            Icon(imageVector = Icons.Filled.AccountCircle, contentDescription = "Account", modifier = Modifier.size(24.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
```

1641 → 1172 characters of body, and it is the file a person would have written.

## What imports, and what it is written as

`importedName` imports the qualifier a reader expects to see:

- a **top-level declaration** imports itself and is written by its simple name — `Modifier`,
  `Color`, `RoundedCornerShape`;
- a **member of an object** imports the **object**, so `CardDefaults.cardColors(…)` and
  `Arrangement.spacedBy(…)` keep the qualifier a person writes rather than collapsing to a bare
  `cardColors(…)`.

The two are told apart by the qualifier's case — Kotlin packages are lower case, classifiers are
capitalised — which is the same convention, with the same stated caveat, that the chain-link check
already uses to tell a member extension from a top-level one.

A keyword in the path now lands in the import rather than the expression, which is also where a
person would have put it: `import com.example.`in`.Palette`, then a plain `Palette.brand`.

## Why the trade is right, not just nicer

`ScreenDocument` gave a real reason for qualifying: an import can be shadowed by a same-named
declaration in the package the caller chose for the generated file, and a qualified path cannot.
What makes it worth trading is that the guards were already there and references simply were not
reaching them:

- the **file-wide conflicting-import check** refuses two roots claiming one simple name, so nothing
  silently picks one — references and constructs now go through it;
- **`simplyImportable`** already withholds a simple name two component records both want;
- the **screen-name shadow refusal** already covered chain links, and now covers a reference root
  too.

What is left is the caller's own package, which the generator writes into rather than reads. A
collision there fails **at the import line** rather than resolving to something else, so the
contract still holds: the output compiles, or the generator refuses. The cost being removed, by
contrast, was paid on every line of every generated screen.

## Test plan

- `./gradlew :screen-model:jvmTest :gradle-plugin:preview-discovery:test ktfmtCheckAll` — green.
- `./gradlew :gradle-plugin:functionalTest --tests '*ScreenGeneratorCompile*'` — green. This is the
  one that matters: it compiles the generated source, so it is what says the imports resolve.
- Three new cases in `ScreenValueVocabularyTest`: a construct that is a member of an object imports
  the object rather than the member; two references claiming one simple name are refused; a
  reference root named after the screen is refused. The first is the readability rule, the other two
  are the guards the trade depends on.
- Existing goldens updated to the new spelling rather than around it —
  `ScreenValueVocabularyTest` and `M3PaletteScreenTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQy2y5LekQNW5sy47L1jx5

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQy2y5LekQNW5sy47L1jx5)_