### PR TITLE
fix(design-artifacts): carry locator `scope` in the issue index, and mirror the producer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1108,7 +1108,8 @@ jobs:
             "server/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRcFonts.kt" \
             "server/build.gradle.kts" \
             "server/src/main/resources/ee/schimke/composeai/cli/serve/assets/format-compare.js" \
-            "serve-web/src/scorer/tuning.ts"; do
+            "serve-web/src/scorer/tuning.ts" \
+            "scripts/design-artifacts/parity-issues.mjs"; do
             mkdir -p ".compose-preview-server/$(dirname "$rel")"
             curl -fsSL --retry 3 -o ".compose-preview-server/$rel" "$base/$rel"
           done

--- a/scripts/design-artifacts/fixtures/parity-issues.json
+++ b/scripts/design-artifacts/fixtures/parity-issues.json
@@ -12,6 +12,7 @@
       "parity": "known-difference",
       "system": "m3",
       "component": "IconButton/Tonal",
+      "scope": "component",
       "previewIds": ["iconbutton-tonal__ideal__default__light"],
       "referenceIds": ["iconbutton-tonal-figma"]
     },
@@ -25,6 +26,7 @@
       "parity": "verification-needed",
       "system": "m3",
       "component": "IconButton/Tonal",
+      "scope": "variant",
       "previewIds": ["iconbutton-tonal__ideal__default__light"],
       "referenceIds": ["iconbutton-tonal-figma"]
     }

--- a/scripts/design-artifacts/parity-issues.mjs
+++ b/scripts/design-artifacts/parity-issues.mjs
@@ -56,6 +56,7 @@ const REQUIRED_FIELDS = ["repository", "system", "component", "preview", "refere
  * `v1` therefore accepts only the space both producers actually emit.
  */
 const OPTIONAL_FIELDS = ["element", "bounds"];
+const SCOPES = new Set(["component", "variant"]);
 const BOUNDS_SPACE = "render-pixels";
 /** Code-point order, which is what [canonicalJson] produces and what the writer emits. */
 const BOUNDS_KEYS = ["height", "space", "width", "x", "y"];
@@ -253,7 +254,10 @@ function parseLocatorBlock(content) {
     if (parsed.error) return { ok: false, error: parsed.error };
     bounds = parsed.bounds;
   }
-  return { ok: true, locator: { repository: fields.repository.toLowerCase(), system: fields.system, component: fields.component, previewId: fields.preview, referenceId: fields.reference, variant: fields.variant, overrides: canonicalOverrides, element, bounds, revision: Object.hasOwn(fields, "revision") ? fields.revision : null } };
+  const scope = fields.scope ?? "component";
+  if (!SCOPES.has(scope)) return { ok: false, error: "scope must be component or variant" };
+  const explicitScope = Object.hasOwn(fields, "scope") ? { scope } : {};
+  return { ok: true, locator: { repository: fields.repository.toLowerCase(), system: fields.system, component: fields.component, previewId: fields.preview, referenceId: fields.reference, variant: fields.variant, ...explicitScope, overrides: canonicalOverrides, element, bounds, revision: Object.hasOwn(fields, "revision") ? fields.revision : null } };
 }
 
 function labelValue(labels, prefix, allowed) {
@@ -298,6 +302,7 @@ export function buildIssueIndex(issues, { generatedAt = new Date().toISOString()
         parity: labelValue(issue?.labels, "parity:", PARITY),
         system: locator.system,
         component: locator.component,
+        scope: locator.scope ?? "component",
         previewIds: [locator.previewId],
         referenceIds: [locator.referenceId],
       };

--- a/scripts/design-artifacts/parity-issues.test.mjs
+++ b/scripts/design-artifacts/parity-issues.test.mjs
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { NO_LOCATOR, buildIssueIndex, canonicalIssueUrl, parseLocator, parseLocators } from "./parity-issues.mjs";
 
@@ -17,6 +18,17 @@ revision: yschimke/m3-catalog@main
 
 test("a locator round-trips the exact identity and canonical overrides", () => {
   assert.deepEqual(parseLocator(body), { ok: true, locator: { repository: "yschimke/m3-catalog", system: "m3", component: "IconButton/Tonal", previewId: "iconbutton-tonal__ideal__default__light", referenceId: "iconbutton-tonal-figma", variant: "ideal/default/light", overrides: { fontScale: "1.5", "knob.label": "Send;now=x" }, element: null, bounds: null, revision: "yschimke/m3-catalog@main" } });
+});
+
+test("report scope defaults to the component and carries an explicit variant choice", () => {
+  const component = buildIssueIndex([{ html_url: "https://github.com/yschimke/m3-catalog/issues/40", title: "Glyph colour", body, state: "open" }]);
+  assert.equal(component.issues[0].scope, "component");
+
+  const scoped = body.replace("component: IconButton/Tonal\n", "component: IconButton/Tonal\nscope: variant\n");
+  assert.equal(parseLocator(scoped).locator.scope, "variant");
+  const variant = buildIssueIndex([{ html_url: "https://github.com/yschimke/m3-catalog/issues/41", title: "Large only", body: scoped, state: "open" }]);
+  assert.equal(variant.issues[0].scope, "variant");
+  assert.equal(parseLocator(scoped.replace("scope: variant", "scope: all")).error, "scope must be component or variant");
 });
 
 test("mangled blocks are reported instead of silently skipped", () => {
@@ -224,4 +236,47 @@ test("two blocks may not claim the same reference", () => {
   );
   assert.deepEqual(index.issues, []);
   assert.deepEqual(errors, [shape.parse.error]);
+});
+
+// -----------------------------------------------------------------------------------------------
+// The mirror. Not expressible as a fixture, because it is about two files agreeing rather than about
+// any one parse.
+// -----------------------------------------------------------------------------------------------
+
+// `parity-issues.mjs` exists twice: here, and in yschimke/compose-preview-server, whose
+// ServeIssueReport and serve-web writers are tested against the same `fixtures/parity-locators.json`.
+// The copy in THIS repository is the one that runs in production — `parity-issues-reusable.yml`
+// checks out `yschimke/compose-ai-tools` and runs `emit-parity-issues.mjs`, which imports the local
+// module — so a feature that lands only on the server's copy is dead code everywhere it matters.
+//
+// That is not hypothetical. `scope` was added to the server's copy and not to this one, and because
+// nothing compared them, every `scope: variant` locator was silently flattened to component scope
+// for months: the server and the browser both implement variant-scoped bug pills, and no index ever
+// carried a `scope` field for them to act on (compose-ai-tools#5205).
+//
+// Byte-for-byte, deliberately. The two copies have no repository-specific content — no paths, no
+// imports beyond node builtins — so there is no legitimate reason for them to differ, and a
+// tolerant comparison is how the last divergence survived. Same optional-sibling arrangement the
+// tuning mirror in known-difference-score.test.mjs uses: CI supplies the checkout, and a local run
+// without one SKIPS with a reason rather than passing vacuously.
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SERVER_COPY = join(
+  (process.env.COMPOSE_PREVIEW_SERVER_ROOT ?? "").trim() ||
+    join(HERE, "..", "..", "..", "compose-preview-server"),
+  "scripts/design-artifacts/parity-issues.mjs",
+);
+const NO_SERVER = {
+  skip: existsSync(SERVER_COPY)
+    ? false
+    : "no compose-preview-server checkout (set COMPOSE_PREVIEW_SERVER_ROOT) — the second copy of " +
+      "parity-issues.mjs lives there since #4732",
+};
+
+test("the producer is byte-identical to the preview server's copy", NO_SERVER, () => {
+  assert.equal(
+    readFileSync(SERVER_COPY, "utf8"),
+    readFileSync(join(HERE, "parity-issues.mjs"), "utf8"),
+    "scripts/design-artifacts/parity-issues.mjs has drifted from the copy in compose-preview-server. " +
+      "Both are read by engines that must agree on the wire format; sync them rather than patching one.",
+  );
 });


### PR DESCRIPTION
Closes #5205.

## Summary

`scripts/design-artifacts/parity-issues.mjs` exists twice — here and in yschimke/compose-preview-server — and
the two had drifted. The server's copy parses and emits the locator's `scope`; this one had **no occurrence of
the string at all**:

```
$ grep -c scope compose-ai-tools/scripts/design-artifacts/parity-issues.mjs
0
$ grep -c scope compose-preview-server/scripts/design-artifacts/parity-issues.mjs
4
```

**This copy is the one that runs.** `parity-issues-reusable.yml` checks out `yschimke/compose-ai-tools`
(line 50) and runs `emit-parity-issues.mjs` (line 66), which imports the local module — so the feature was
dead everywhere it mattered. Every `scope: variant` locator was silently flattened to component scope, while
both ends implement variant-scoped bug pills that no index ever gave them a `scope` to act on:

- `serve-web/src/report/scope.ts` writes the `scope:` line into the fence,
- `ServeWeb.issuesForRow` branches on `scope == "variant"` to match by exact preview id,
- `compareBugsCellHtml` emits `data-bug-scope="variant"` + `data-bug-preview-ids`,
- `CompareWall.ts` toggles those pills as the reader switches preview.

The result: a bug affecting one cell of a fifty-cell component is shown against all fifty.

The whole drift was three files, and nothing else — no unrelated changes rode along:

| file | drift |
| --- | --- |
| `parity-issues.mjs` | 3 hunks, all `scope` |
| `fixtures/parity-issues.json` | 2 `"scope"` fields |
| `parity-issues.test.mjs` | 1 test |

Synced all three, leaving the producer **byte-identical** to the server's copy.

## Then guarded, because nothing compared them

That is why this survived. Added a mirror test on the same optional-sibling arrangement the tuning mirror in
`known-difference-score.test.mjs` already uses, and added the file to the pinned mirror sources CI fetches.

The assertion is byte-for-byte on purpose: the two copies carry no repository-specific content — no paths, no
imports beyond node builtins — so there is no legitimate reason for them to differ, and a tolerant comparison
is how the last divergence got through.

## Test plan

- `node --test scripts/design-artifacts/parity-issues.test.mjs` → **34 pass, 0 fail, 0 skipped**.
- **The mirror is not vacuous.** Appending one comment line to `parity-issues.mjs` reddens it:
  ```
  not ok 34 - the producer is byte-identical to the preview server's copy
      scripts/design-artifacts/parity-issues.mjs has drifted from the copy in compose-preview-server.
  ```
  Restoring the file returns 34 pass.
- **It skips honestly and CI catches the skip.** With `COMPOSE_PREVIEW_SERVER_ROOT=/nonexistent`: 33 pass,
  1 skipped. The skip reason contains `no compose-preview-server checkout`, which is the exact string the
  job's existing guard greps for and fails on.
- **Verified against the tag CI actually fetches, not head.** The step pins
  `v$composeai-preview-serve` = **v3.2.0**; that tag's `parity-issues.mjs` is byte-identical to v3.3.0 and to
  the server's head, and all three carry `scope`. Simulating the CI layout
  (`COMPOSE_PREVIEW_SERVER_ROOT` pointed at a tree holding only the v3.2.0 file) gives **34 pass, 0 skipped**.
- **End-to-end through `buildIssueIndex`**, the path the workflow runs:
  ```
  #1 (no scope line)     scope="component"
  #2 scope: component    scope="component"
  #3 scope: variant      scope="variant"
  ```
  An absent `scope` still defaults to `component`, so existing indexes are unaffected.
- `ci.yml` parses and still resolves to 19 jobs.

## Notes

Found while auditing the remote-m3 ↔ wear-m3 parallel comparison, where the bug column turned out to be
served from an index that had never carried a `scope` field.

One divergence is deliberately **not** fixed here: `fixtures/parity-locators.json` differs between the repos
only in its `$comment` prose — this repo's version describes the post-#4732 split, the server's still says
`cli/serve-web`. That is a doc line, not contract, and unifying it means picking a wording that reads
correctly from inside both repos; worth doing, but not under a `fix(...)` that is otherwise byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017oFmCEL1PaZNjJRBgv9QC1

---
_Generated by [Claude Code](https://claude.ai/code/session_017oFmCEL1PaZNjJRBgv9QC1)_