### PR TITLE
feat(screen): express a scoped modifier, so a layout weight is generable

### DIFF
--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenValueVocabularyTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenValueVocabularyTest.kt
@@ -74,6 +74,22 @@ class ScreenValueVocabularyTest {
       componentIds = listOf("m3/button"),
     )
 
+  private val column =
+    component(
+      "Column",
+      "androidx.compose.foundation.layout.Column",
+      listOf(
+        TargetParameter(
+          "content",
+          "@Composable ColumnScope.() -> Unit",
+          composableSlot = true,
+          composableSlotReceiver = COLUMN_SCOPE,
+        )
+      ),
+      componentIds = listOf("layout/column"),
+      canonicalId = "app/androidx.compose.foundation.layout.ColumnKt.Column",
+    )
+
   private fun catalog(vararg records: ComponentRecord) =
     ComponentRecordFile(module = "app", variant = "debug", components = records.toList())
 
@@ -277,6 +293,131 @@ class ScreenValueVocabularyTest {
     assertThat(result.source).contains("import androidx.compose.foundation.layout.fillMaxWidth")
     assertThat(result.source).contains("import androidx.compose.foundation.layout.padding")
     assertThat(result.source).contains("import androidx.compose.ui.unit.dp")
+  }
+
+  @Test
+  fun `a scoped link resolves inside the slot whose receiver declares it`() {
+    // `Modifier.weight` is declared on `ColumnScope`, so whether it compiles is a fact about where
+    // the node sits rather than about the value. Inside a `content` slot whose receiver is that
+    // scope, the receiver supplies it and the simple name resolves — with no import, because a
+    // member extension cannot be imported.
+    val result =
+      emitted(
+        ScreenNode(
+          componentId = column.canonicalId,
+          slots =
+            mapOf(
+              "content" to
+                listOf(
+                  textNode(
+                    "modifier" to
+                      ScreenValue.Chain(
+                        receiver = ScreenValue.Reference(modifier, typeFqn = modifier),
+                        links =
+                          listOf(
+                            ChainLink(
+                              "androidx.compose.foundation.layout.ColumnScope.weight",
+                              positional = listOf(ScreenValue.Fractional32(1f)),
+                              receiverScopeFqn = COLUMN_SCOPE,
+                            )
+                          ),
+                        typeFqn = modifier,
+                      )
+                  )
+                )
+            ),
+        ),
+        catalog(text, column),
+      )
+    assertThat(result.source).contains("modifier = Modifier.weight(1.0f)")
+    assertThat(result.source).doesNotContain("import androidx.compose.foundation.layout.ColumnScope")
+  }
+
+  @Test
+  fun `a scoped link in the wrong slot is refused, naming both scopes`() {
+    // The check that makes the claim worth making. A `RowScope` modifier inside a `Column` is an
+    // unresolved reference, and emitting it would be exactly the guess this vocabulary refuses.
+    assertThat(
+        refusal(
+          ScreenNode(
+            componentId = column.canonicalId,
+            slots =
+              mapOf(
+                "content" to
+                  listOf(
+                    textNode(
+                      "modifier" to
+                        ScreenValue.Chain(
+                          receiver = ScreenValue.Reference(modifier, typeFqn = modifier),
+                          links =
+                            listOf(
+                              ChainLink(
+                                "androidx.compose.foundation.layout.RowScope.weight",
+                                positional = listOf(ScreenValue.Fractional32(1f)),
+                                receiverScopeFqn = ROW_SCOPE,
+                              )
+                            ),
+                          typeFqn = modifier,
+                        )
+                    )
+                  )
+              ),
+          ),
+          catalog(text, column),
+        )
+      )
+      .containsExactly(
+        "`Text`.`modifier` links `weight`, which is declared on `$ROW_SCOPE` and is in scope only " +
+          "inside a slot with that receiver; this node sits in a `$COLUMN_SCOPE` slot"
+      )
+  }
+
+  @Test
+  fun `a scoped link at the root is refused, because there is no receiver at all`() {
+    assertThat(
+        refusal(
+          textNode(
+            "modifier" to
+              ScreenValue.Chain(
+                receiver = ScreenValue.Reference(modifier, typeFqn = modifier),
+                links =
+                  listOf(
+                    ChainLink(
+                      "androidx.compose.foundation.layout.ColumnScope.weight",
+                      positional = listOf(ScreenValue.Fractional32(1f)),
+                      receiverScopeFqn = COLUMN_SCOPE,
+                    )
+                  ),
+                typeFqn = modifier,
+              )
+          ),
+          catalog(text),
+        )
+      )
+      .containsExactly(
+        "`Text`.`modifier` links `weight`, which is declared on `$COLUMN_SCOPE` and is in scope " +
+          "only inside a slot with that receiver; this node sits at the root, which has no receiver"
+      )
+  }
+
+  @Test
+  fun `a float literal is the one nested fraction that is not a Double`() {
+    // Nested, there is no declared type to render against, so each literal kind has one spelling
+    // and a `Fractional` is always a `Double`. `Modifier.weight(1.0)` does not compile, which is
+    // why the float kind exists at all.
+    val result =
+      emitted(
+        textNode(
+          "color" to
+            ScreenValue.Construct(
+              callableFqn = "androidx.compose.ui.graphics.Color",
+              positional = listOf(ScreenValue.Fractional32(0.5f), ScreenValue.Fractional(0.5)),
+              typeFqn = color,
+            )
+        ),
+        catalog(text),
+      )
+    assertThat(result.source).contains("Color(0.5f, 0.5)")
   }
 
   @Test
@@ -1471,4 +1612,9 @@ class ScreenValueVocabularyTest {
 
     assertThat(reasons.single()).contains("has no `onLongPress`")
   }
+  private companion object {
+    const val COLUMN_SCOPE = "androidx.compose.foundation.layout.ColumnScope"
+    const val ROW_SCOPE = "androidx.compose.foundation.layout.RowScope"
+  }
+
 }

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ScreenGeneratorCompileFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ScreenGeneratorCompileFunctionalTest.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.plugin
 
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
+import ee.schimke.composeai.discovery.ChainLink
 import ee.schimke.composeai.discovery.ComponentRecordFile
 import ee.schimke.composeai.discovery.ScreenDocument
 import ee.schimke.composeai.discovery.ScreenGenerator
@@ -170,7 +171,32 @@ class ScreenGeneratorCompileFunctionalTest {
                   listOf(
                     ScreenNode(
                       componentId = idOf(components, "Text"),
-                      arguments = mapOf("text" to ScreenValue.Text("Good morning")),
+                      arguments =
+                        mapOf(
+                          "text" to ScreenValue.Text("Good morning"),
+                          // `Modifier.weight` is declared on `ColumnScope`, and this `Text` is in
+                          // `Card`'s `ColumnScope` content slot. Nothing in the value says it
+                          // compiles — the generator checks the claim against the slot it emitted
+                          // this node into, and the compile below is what settles it.
+                          "modifier" to
+                            ScreenValue.Chain(
+                              receiver =
+                                ScreenValue.Reference(
+                                  "androidx.compose.ui.Modifier",
+                                  typeFqn = "androidx.compose.ui.Modifier",
+                                ),
+                              links =
+                                listOf(
+                                  ChainLink(
+                                    "androidx.compose.foundation.layout.ColumnScope.weight",
+                                    positional = listOf(ScreenValue.Fractional32(1f)),
+                                    receiverScopeFqn =
+                                      "androidx.compose.foundation.layout.ColumnScope",
+                                  )
+                                ),
+                              typeFqn = "androidx.compose.ui.Modifier",
+                            ),
+                        ),
                     ),
                     ScreenNode(
                       componentId = idOf(components, "Button"),
@@ -190,7 +216,12 @@ class ScreenGeneratorCompileFunctionalTest {
           ),
       )
 
-    val result = ScreenGenerator.generate(screen, components)
+    val result =
+      ScreenGenerator.generate(
+        screen,
+        components,
+        expressionPackages = setOf("androidx.compose"),
+      )
     val emitted =
       assertWithMessage(
           "generation refused: %s",
@@ -201,7 +232,12 @@ class ScreenGeneratorCompileFunctionalTest {
         .let { result as ScreenGenerator.Result.Emitted }
 
     // The designed values reached the source, rather than the placeholders a call site prints.
-    assertThat(emitted.source).contains("""Text(text = "Good morning")""")
+    assertThat(emitted.source).contains("""Text(text = "Good morning""")
+    // A scoped modifier, by simple name and imported nowhere: `weight` is a member of `ColumnScope`
+    // and comes from the lambda's receiver, so an import of it would not resolve.
+    assertThat(emitted.source).contains("modifier = Modifier.weight(1.0f)")
+    assertThat(emitted.source)
+      .doesNotContain("import androidx.compose.foundation.layout.ColumnScope")
     assertThat(emitted.source).contains("""Text(text = "Continue")""")
     // And by their *simple* names, imported once. Both `Text`s sit inside a receiver slot —
     // `Card`'s `ColumnScope` and `Button`'s `RowScope` — which the generator used to qualify on

--- a/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ScreenDocument.kt
+++ b/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ScreenDocument.kt
@@ -179,6 +179,23 @@ sealed interface ScreenValue {
   @Serializable data class Fractional(val value: Double) : ScreenValue
 
   /**
+   * A `Float` literal — `1f`.
+   *
+   * Distinct from [Fractional] because the two differ only in a **spelling** the generator cannot
+   * recover anywhere else. Against a declared parameter it does not need to: `Fractional` renders
+   * as `1f` for a `kotlin.Float` and `1.0` for a `kotlin.Double`, because the parameter decides. In
+   * a **nested** position — a constructor argument, a chain link's argument — there is no declared
+   * type to render against, so the rule there is one fixed spelling per literal kind and a fraction
+   * is always a `Double`.
+   *
+   * That rule left `Modifier.weight(…)` inexpressible. It takes a `Float`, it is an argument to a
+   * chain link, and `weight(1.0)` does not compile — so a layout weight, which is one of the first
+   * things anybody sets in a design tool, had no expression at all. This is the narrow addition
+   * that gives it one, rather than making a nested `Fractional` guess at its own precision.
+   */
+  @Serializable data class Fractional32(val value: Float) : ScreenValue
+
+  /**
    * A read through a fully-qualified path — `androidx.compose.material3.MaterialTheme.colorScheme
    * .primary`, `androidx.compose.ui.text.style.TextAlign.Center`.
    *
@@ -285,4 +302,22 @@ data class ChainLink(
   val positional: List<ScreenValue> = emptyList(),
   val named: Map<String, ScreenValue> = emptyMap(),
   val property: Boolean = false,
+  /**
+   * The **implicit receiver** this link's extension is declared on, when it is a member extension
+   * of a slot's scope rather than a top-level one — `androidx.compose.foundation.layout.RowScope`
+   * for `Modifier.weight`, `androidx.compose.foundation.layout.BoxScope` for `matchParentSize`.
+   *
+   * Such a link is *not* imported. `RowScope.weight` is a member of `RowScope`, supplied by the
+   * lambda's receiver, and neither `import …layout.RowScope.weight` nor a package-level
+   * `…layout.weight` resolves — which is why a capitalised qualifier is otherwise refused outright.
+   * What makes it legal instead is **where the node sits**: inside a slot whose
+   * [TargetParameter.composableSlotReceiver] is this type, the receiver is in scope and the simple
+   * name resolves.
+   *
+   * So this is a claim the generator **checks** rather than trusts, and it is the only thing that
+   * makes a scoped modifier expressible without guessing. A node in a `Column` claiming `RowScope`
+   * is refused by name, as is one claiming any scope at the root, where there is no receiver at
+   * all. Null for an ordinary top-level extension, which imports as before.
+   */
+  val receiverScopeFqn: String? = null,
 )

--- a/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -534,6 +534,16 @@ object ScreenGenerator {
      */
     var initializerScope: Set<String>? = null
 
+    /**
+     * The receiver scope of the slot the node currently being emitted sits in, or null at the root.
+     *
+     * Depth-first and single-threaded, so one field with save/restore is the whole mechanism. It
+     * exists for [ChainLink.receiverScopeFqn]: whether `Modifier.weight` compiles is not a fact
+     * about the value, it is a fact about **where the node was placed**, and this is the only place
+     * that knows.
+     */
+    private var slotScope: String? = null
+
     fun node(node: ScreenNode, depth: Int): String {
       val pad = INDENT.repeat(depth)
       val record =
@@ -645,7 +655,14 @@ object ScreenGenerator {
             children.forEach { node(it, depth + 1) }
           }
           children != null && parameter.composableSlot -> {
-            val nested = children.joinToString("\n") { node(it, depth + 1) }
+            val outer = slotScope
+            slotScope = parameter.composableSlotReceiver
+            val nested =
+              try {
+                children.joinToString("\n") { node(it, depth + 1) }
+              } finally {
+                slotScope = outer
+              }
             arguments += "${ComponentSnippets.escapeIfKeyword(parameter.name)} = {\n$nested\n$pad}"
           }
           // Untouched by the document. A default may be omitted; anything else still has to be
@@ -847,6 +864,11 @@ object ScreenGenerator {
               "kotlin.Long" -> long(value.value)
               else -> null
             }
+          is ScreenValue.Fractional32 ->
+            // Its own spelling, so it fits `Float` and nothing else — a `Double` parameter handed
+            // one would compile as `1f` only by widening, which is the coercion this vocabulary
+            // exists to avoid.
+            if (type == "kotlin.Float" && value.value.isFinite()) "${value.value}f" else null
           is ScreenValue.Fractional ->
             when {
               // Neither `NaN` nor `Infinity` is a Kotlin literal, so both would emit source the
@@ -910,6 +932,14 @@ object ScreenGenerator {
             reasons += "$where is ${value.value}, which is not a Kotlin literal"
             null
           }
+        // The one nested fraction that is not a `Double`, which is the whole reason this kind
+        // exists — see `ScreenValue.Fractional32`.
+        is ScreenValue.Fractional32 ->
+          if (value.value.isFinite()) "${value.value}f"
+          else {
+            reasons += "$where is ${value.value}, which is not a Kotlin literal"
+            null
+          }
         is ScreenValue.StateRead -> stateRead(value, where)
         is ScreenValue.Reference -> {
           val root = importedName(value.rootFqn, where) ?: return null
@@ -942,6 +972,32 @@ object ScreenGenerator {
               // file this generator had already called compilable.
               val imported = qualifiedName(link.callableFqn, where) ?: return null
               val simple = link.callableFqn.substringAfterLast('.')
+              // A member extension of the slot's receiver. Not imported — the receiver supplies it
+              // — and legal only where that receiver is actually in scope, which is what makes
+              // `Modifier.weight` expressible without guessing. See `ChainLink.receiverScopeFqn`.
+              val scope = link.receiverScopeFqn
+              if (scope != null) {
+                if (slotScope != scope) {
+                  reasons +=
+                    "$where links `$simple`, which is declared on `$scope` and is in scope only " +
+                      "inside a slot with that receiver; this node sits " +
+                      (slotScope?.let { "in a `$it` slot" } ?: "at the root, which has no receiver")
+                  return null
+                }
+                append(".")
+                append(ComponentSnippets.escapeIfKeyword(simple))
+                if (link.property) {
+                  if (link.positional.isNotEmpty() || link.named.isNotEmpty()) {
+                    reasons += "$where reads `$simple` as a property and also passes it arguments"
+                    return null
+                  }
+                } else {
+                  val arguments =
+                    arguments(link.positional, link.named, where, depth) ?: return null
+                  append("(").append(arguments).append(")")
+                }
+                continue
+              }
               // A chain link is *imported* and called by its simple name, so it has to be a
               // top-level declaration. `RowScope.weight` is not: it is a member extension of the
               // scope, supplied by an implicit receiver, and neither


### PR DESCRIPTION
`Modifier.weight` had no expression at all, and a layout weight is one of the first things anybody
sets in a design tool — it accounts for 20 of the 22 remaining refusals on a real m3-catalog design
(yschimke/compose-preview-server#337). Two independent blockers, both in this repository.

## 1. It takes a `Float`, and a nested fraction was always a `Double`

Against a declared parameter the spelling is decided by the parameter: `Fractional` renders `1f` for
a `kotlin.Float` and `1.0` for a `kotlin.Double`. In a **nested** position — a chain link's
argument, a constructor argument — there is no declared type, so the documented rule is one fixed
spelling per literal kind, and a fraction is a `Double`. `weight(1.0)` does not compile.

`ScreenValue.Fractional32` is the narrow addition that gives a nested float one spelling of its own,
rather than making `Fractional` guess at its own precision. It fits a `kotlin.Float` parameter and
nothing else; a `Double` parameter handed one is refused rather than widened.

## 2. It is declared on `ColumnScope`, so it cannot be imported

A member extension comes from an implicit receiver. Neither `import …layout.ColumnScope.weight` nor
a package-level `…layout.weight` resolves, which is exactly why a capitalised qualifier on a chain
link is refused outright today. What makes it legal is not the value — it is **where the node
sits**.

So `ChainLink.receiverScopeFqn` states the scope the link needs, and the generator checks it rather
than trusting it. `Emission` now tracks the receiver of the slot it is emitting into (from the
record's `composableSlotReceiver`), and:

- matched → written by simple name, imported nowhere;
- mismatched → refused, naming both scopes: `` `Text`.`modifier` links `weight`, which is declared
  on `…RowScope` and is in scope only inside a slot with that receiver; this node sits in a
  `…ColumnScope` slot ``;
- at the root → refused, because there is no receiver at all.

This is the same question `matchParentSize` is refused for. It is answered once, for both, rather
than guessed for either — and a projection can now express either by saying which scope it needs.

## The proof

`ScreenGeneratorCompileFunctionalTest` puts a `Modifier.weight(1f)` on a `Text` inside a real
`Card`'s `ColumnScope` slot and **compiles the result against real Material 3**. Assertions on the
emitted text would pass for a spelling that does not resolve; the compile is what settles it.

```kotlin
Text(text = "Good morning", modifier = Modifier.weight(1.0f))
```

## Test plan

- `./gradlew :screen-model:jvmTest :gradle-plugin:preview-discovery:test ktfmtCheckAll` — green.
- `./gradlew :gradle-plugin:functionalTest --tests '*ScreenGeneratorCompile*'` — green, and now
  covers the scoped modifier end to end.
- Four new cases in `ScreenValueVocabularyTest`: a scoped link resolves in the slot whose receiver
  declares it; one in the wrong slot is refused naming both scopes; one at the root is refused; and
  a float literal is the one nested fraction that is not a `Double`.

Follow-up, not in this PR: `compose-preview-server`'s projection has to map its `weight` property
and `matchParentSize` modifier onto these, which it can do once this ships in a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQy2y5LekQNW5sy47L1jx5

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQy2y5LekQNW5sy47L1jx5)_