### PR TITLE
feat(design-artifacts): check that parity locators still name a cell the catalog draws

### DIFF
--- a/scripts/design-artifacts/check-parity-locators.mjs
+++ b/scripts/design-artifacts/check-parity-locators.mjs
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+
+/**
+ * Does every parity locator still name a cell the catalog draws?
+ *
+ * `parity-issues.mjs` validates a locator's SHAPE — required fields, non-empty values, no component
+ * or preview claimed twice in one body. Nothing has ever validated what the `preview` field points
+ * AT, because the producer runs against an issue list and has no catalog to resolve it with. So a
+ * renamed cell turns an issue's locator into a dangling pointer and every check stays green:
+ * `buildIssueIndex` emits the row, the delivery branch carries it, and the compare page simply
+ * never shows it, because no preview on any page has that id any more.
+ *
+ * That is the same place an issue with NO locator lands — skipped, silently, correctly — which is
+ * what makes it invisible. It has happened twice on one repository from one rename
+ * ([wear-m3-catalog#305](https://github.com/yschimke/wear-m3-catalog/issues/305)), and the second
+ * one was found only because somebody distrusted a clean result from the first audit.
+ *
+ * ## What it resolves against, and why not the preview id
+ *
+ * A locator's `preview` is a SERVED id (`appcard__ideal__outlined__compact`) minted by the render
+ * pipeline out of `catalog.json` — see `revision-preview-index.mjs`. A pull request has no
+ * `catalog.json`: it has the discovered `previews.json`, whose ids are fully-qualified Kotlin
+ * (`…CatalogPreviewsKt.AppCardRemote_width=227dp,…_VARIANT_outlined`). Reconstructing one from the
+ * other would mean re-implementing the pipeline's naming in a checker, which is exactly the kind of
+ * fork that lets a validator and its producer drift apart.
+ *
+ * So this resolves the pair the two forms genuinely share: the **component id** and the **cell**.
+ * `component:` is a locator field, and the cell is the served id's third segment — the same segment
+ * the sheet spells `_VARIANT_<cell>` on the manifest side. A rename moves the cell on both sides at
+ * once, which is the whole failure this catches, and neither side has to know how the other builds
+ * a string.
+ *
+ * ## Why a baseline, rather than "every locator must resolve"
+ *
+ * A blanket assertion fails pull requests that had nothing to do with the breakage: one issue
+ * edited to a bad id and every subsequent PR is red, with the fix nowhere in its diff. Given
+ * `--published` — the delivery branch's `preview-index.json`, which is what the catalog last
+ * actually served — an unresolvable id splits in two:
+ *
+ * - it **was** served and is not drawn now: this change broke it. A failure, and the PR that
+ *   renamed the cell is the one holding it.
+ * - it was never served: a typo, or breakage that predates the baseline. Reported as a warning,
+ *   because failing here would punish the wrong commit.
+ *
+ * Without `--published` every unresolvable id is a failure, which is what a scheduled or
+ * publish-side run wants: there, nothing is "somebody else's PR".
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { parseArgs } from "node:util";
+import { parseLocators } from "./parity-issues.mjs";
+
+/** The cell a served preview id names, or null when the id carries no cell segment. */
+export function cellOfPreviewId(previewId) {
+  const segments = String(previewId ?? "").split("__");
+  // `<component-slug>__<theme>__<cell>[__<breakpoint>]`. Two segments is a themed component with no
+  // cell axis at all, which no locator should carry — it would name the component, not a variant.
+  return segments.length >= 3 && segments[2] ? segments[2] : null;
+}
+
+/**
+ * `componentId -> Set<cell>` for one discovered `previews.json`.
+ *
+ * A preview with no `_VARIANT_` suffix is the component's base render, which every sheet spells
+ * `default` in a served id — so the two vocabularies meet on that word rather than on an absence.
+ */
+export function cellsFromManifest(manifest) {
+  const cells = new Map();
+  for (const preview of manifest?.previews ?? []) {
+    const componentId = preview?.catalog?.componentId;
+    if (!componentId) continue;
+    const id = String(preview.id ?? "");
+    const marker = id.indexOf("_VARIANT_");
+    const cell = marker < 0 ? "default" : id.slice(marker + "_VARIANT_".length);
+    if (!cells.has(componentId)) cells.set(componentId, new Set());
+    cells.get(componentId).add(cell);
+  }
+  return cells;
+}
+
+/** Levenshtein distance, capped — only ever run against one component's cell list. */
+function distance(a, b) {
+  const rows = Array.from({ length: a.length + 1 }, (_, i) => [i, ...Array(b.length).fill(0)]);
+  for (let j = 0; j <= b.length; j++) rows[0][j] = j;
+  for (let i = 1; i <= a.length; i++) {
+    for (let j = 1; j <= b.length; j++) {
+      rows[i][j] = Math.min(
+        rows[i - 1][j] + 1,
+        rows[i][j - 1] + 1,
+        rows[i - 1][j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1),
+      );
+    }
+  }
+  return rows[a.length][b.length];
+}
+
+/** Jaccard overlap of two cells' hyphen-separated segments. */
+function overlap(a, b) {
+  const left = new Set(a.split("-"));
+  const right = new Set(b.split("-"));
+  const shared = [...left].filter((token) => right.has(token)).length;
+  return shared / (left.size + right.size - shared);
+}
+
+/**
+ * The cells this one was most likely renamed from, nearest first.
+ *
+ * A failure has two very different fixes — a rename means edit the issue, a typo means fix the id —
+ * and the message can only tell them apart by showing what the component DOES draw.
+ *
+ * TWO measures, because the renames that break locators come in two shapes and neither measure
+ * sees both. A respelling (`outline` -> `outlined`) is one edit away and nothing like it in tokens.
+ * A REORDERING (`outline-icon-gallery-2` -> `icon-outlined-gallery-2`, which is the rename that
+ * actually broke two issues) shares three segments of four and is ten edits away — well past any
+ * edit-distance cap loose enough to be useful. Scoring either as near catches both; requiring both
+ * would catch neither.
+ */
+export function nearestCells(cell, candidates, limit = 2) {
+  const cap = Math.max(2, Math.ceil(cell.length / 3));
+  return [...candidates]
+    .map((candidate) => ({
+      candidate,
+      edits: distance(cell, candidate),
+      shared: overlap(cell, candidate),
+    }))
+    .filter(({ edits, shared }) => edits <= cap || shared >= 0.5)
+    .sort(
+      (a, b) => b.shared - a.shared || a.edits - b.edits || a.candidate.localeCompare(b.candidate),
+    )
+    .slice(0, limit)
+    .map(({ candidate }) => candidate);
+}
+
+/**
+ * Resolve every locator in [issues] against the per-system cell inventories in [manifests].
+ *
+ * [published] is optional and keyed the same way; see the note on the baseline above. A locator
+ * naming a system with no manifest is counted in `skipped` rather than assumed good: one repository
+ * can file issues against a system another repository builds.
+ */
+export function checkLocators({ issues = [], manifests = new Map(), published = new Map() } = {}) {
+  const failures = [];
+  const warnings = [];
+  let checked = 0;
+  let skipped = 0;
+  let unverified = 0;
+  for (const issue of issues) {
+    const parsed = parseLocators(issue?.body);
+    // A body with no locator, or a damaged one, is `emit-parity-issues.mjs`'s to report. Saying it
+    // twice in two jobs trains readers to ignore both.
+    if (!parsed.ok) continue;
+    for (const locator of parsed.locators) {
+      const cells = manifests.get(locator.system);
+      if (!cells) {
+        skipped++;
+        continue;
+      }
+      const servedBefore = published.get(locator.system);
+      for (const [field, id] of [
+        ["preview", locator.previewId],
+        ["reference", locator.referenceId],
+      ]) {
+        // The two are the same string on every locator written by the report form, so checking both
+        // costs nothing and covers a hand-written body that pins them apart.
+        if (field === "reference" && id === locator.previewId) continue;
+        const cell = cellOfPreviewId(id);
+        const drawn = cells.get(locator.component);
+        const row = {
+          number: issue?.number ?? null,
+          system: locator.system,
+          component: locator.component,
+          field,
+          id,
+        };
+        // A component this manifest has never heard of is UNVERIFIABLE here, not broken. A sheet can
+        // publish a component from one source set and not another — `:remote-catalog` builds
+        // `CheckboxButton` and `EdgeButton` on its snapshot lane only — and a run discovers one lane
+        // at a time, so the released-lane manifest is legitimately missing components the delivery
+        // branch serves. Failing on that would redden every pull request for a lane it did not
+        // build. Said out loud rather than dropped, because the same shape covers a component that
+        // really was deleted.
+        if (!drawn) {
+          unverified++;
+          warnings.push({
+            ...row,
+            message:
+              `no component "${locator.component}" in the ${locator.system} manifest — not built ` +
+              "on the discovered lane, or removed",
+          });
+          continue;
+        }
+        checked++;
+        if (cell && drawn.has(cell)) continue;
+        const near = cell ? nearestCells(cell, drawn) : [];
+        const hint = near.length ? ` — did you mean ${near.map((c) => `"${c}"`).join(" or ")}?` : "";
+        const why = cell
+          ? `${locator.component} draws no cell "${cell}"`
+          : `"${id}" carries no cell segment`;
+        // Served once and not drawn now: whatever is in this working tree removed it.
+        if (!servedBefore || servedBefore.has(id)) failures.push({ ...row, message: `${why}${hint}` });
+        else warnings.push({ ...row, message: `${why}${hint}` });
+      }
+    }
+  }
+  return { failures, warnings, checked, skipped, unverified };
+}
+
+/** `--flag system=path` pairs, as a Map. */
+function pairs(values, load) {
+  const map = new Map();
+  for (const value of values ?? []) {
+    const split = value.indexOf("=");
+    if (split <= 0) throw new Error(`expected <system>=<path>, got "${value}"`);
+    map.set(value.slice(0, split), load(value.slice(split + 1)));
+  }
+  return map;
+}
+
+const readJson = (path) => JSON.parse(readFileSync(path, "utf8"));
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const { values } = parseArgs({
+    options: {
+      repo: { type: "string", multiple: true },
+      manifest: { type: "string", multiple: true },
+      published: { type: "string", multiple: true },
+    },
+  });
+  if (!values.repo?.length || !values.manifest?.length) {
+    console.error(
+      "usage: check-parity-locators.mjs --repo <owner/name> [--repo ...]\n" +
+        "         --manifest <system>=<previews.json> [--manifest ...]\n" +
+        "         [--published <system>=<preview-index.json> ...]",
+    );
+    process.exit(2);
+  }
+  const manifests = pairs(values.manifest, (path) => cellsFromManifest(readJson(path)));
+  const published = pairs(values.published, (path) => new Set(readJson(path)?.current ?? []));
+
+  const issues = [];
+  for (const repo of values.repo) {
+    const raw = execFileSync(
+      "gh",
+      ["api", "--paginate", "--slurp", `repos/${repo}/issues?state=all&per_page=100`],
+      { encoding: "utf8", maxBuffer: 25 * 1024 * 1024 },
+    );
+    issues.push(...JSON.parse(raw).flat().filter((issue) => !issue.pull_request));
+  }
+
+  const { failures, warnings, checked, skipped, unverified } = checkLocators({ issues, manifests, published });
+  for (const row of warnings) {
+    console.error(
+      `::warning::parity-locators: #${row.number}: ${row.field} ${row.id} does not resolve, and was ` +
+        `not served at the baseline either — ${row.message}`,
+    );
+  }
+  for (const row of failures) {
+    console.error(`::error::parity-locators: #${row.number}: ${row.field} ${row.id} — ${row.message}`);
+  }
+  console.log(
+    `parity-locators: checked ${checked} id(s); ${failures.length} broken, ` +
+      `${warnings.length - unverified} pre-existing, ${unverified} on components this lane does ` +
+      `not build, ${skipped} for systems not built here`,
+  );
+  if (failures.length) {
+    console.error(
+      "\nA locator names a cell this catalog no longer draws. If the cell was RENAMED, update the " +
+        "`preview` and `reference` fields (and the `variant` line) in the issue body to the new " +
+        "name; the issue is otherwise dropped from the compare page in silence.",
+    );
+    process.exitCode = 1;
+  }
+}

--- a/scripts/design-artifacts/check-parity-locators.mjs
+++ b/scripts/design-artifacts/check-parity-locators.mjs
@@ -184,6 +184,7 @@ export function checkLocators({ issues = [], manifests = new Map(), published = 
           unverified++;
           warnings.push({
             ...row,
+            kind: "unverified",
             message:
               `no component "${locator.component}" in the ${locator.system} manifest — not built ` +
               "on the discovered lane, or removed",
@@ -199,7 +200,7 @@ export function checkLocators({ issues = [], manifests = new Map(), published = 
           : `"${id}" carries no cell segment`;
         // Served once and not drawn now: whatever is in this working tree removed it.
         if (!servedBefore || servedBefore.has(id)) failures.push({ ...row, message: `${why}${hint}` });
-        else warnings.push({ ...row, message: `${why}${hint}` });
+        else warnings.push({ ...row, kind: "unserved", message: `${why}${hint}` });
       }
     }
   }
@@ -250,10 +251,13 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 
   const { failures, warnings, checked, skipped, unverified } = checkLocators({ issues, manifests, published });
   for (const row of warnings) {
-    console.error(
-      `::warning::parity-locators: #${row.number}: ${row.field} ${row.id} does not resolve, and was ` +
-        `not served at the baseline either — ${row.message}`,
-    );
+    // Two different warnings, and saying so matters: one is a locator nobody can check here, the
+    // other is a locator that is wrong but was already wrong before this tree.
+    const why =
+      row.kind === "unverified"
+        ? "cannot be checked on this lane"
+        : "does not resolve, and was not served at the baseline either";
+    console.error(`::warning::parity-locators: #${row.number}: ${row.field} ${row.id} ${why} — ${row.message}`);
   }
   for (const row of failures) {
     console.error(`::error::parity-locators: #${row.number}: ${row.field} ${row.id} — ${row.message}`);

--- a/scripts/design-artifacts/check-parity-locators.test.mjs
+++ b/scripts/design-artifacts/check-parity-locators.test.mjs
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  cellOfPreviewId,
+  cellsFromManifest,
+  checkLocators,
+  nearestCells,
+} from "./check-parity-locators.mjs";
+
+const manifest = (...previews) => ({
+  previews: previews.map(([componentId, id]) => ({ id, catalog: { componentId } })),
+});
+
+const body = (fields) =>
+  "```compose-parity-locator/v1\n" +
+  Object.entries(fields)
+    .map(([key, value]) => `${key}: ${value}`)
+    .join("\n") +
+  "\n```\n";
+
+const locator = (overrides = {}) =>
+  body({
+    repository: "yschimke/wear-m3-catalog",
+    system: "remote-m3",
+    component: "AppCard",
+    scope: "component",
+    preview: "appcard__ideal__outlined__compact",
+    reference: "appcard__ideal__outlined__compact",
+    variant: "ideal/outlined/compact",
+    overrides: "{}",
+    ...overrides,
+  });
+
+const cells = manifest(
+  ["AppCard", "…CatalogPreviewsKt.AppCardRemote_width=227dp_VARIANT_outlined"],
+  ["AppCard", "…CatalogPreviewsKt.AppCardRemote_width=227dp_VARIANT_icon-outlined-gallery-2"],
+  ["AppCard", "…CatalogPreviewsKt.AppCardRemote_width=227dp"],
+);
+
+test("a preview id's cell is its third segment, breakpoint or not", () => {
+  assert.equal(cellOfPreviewId("appcard__ideal__outlined__compact"), "outlined");
+  assert.equal(cellOfPreviewId("titlecard__ideal__title-and-subtitle"), "title-and-subtitle");
+  assert.equal(cellOfPreviewId("appcard__ideal"), null);
+  assert.equal(cellOfPreviewId(""), null);
+});
+
+test("a manifest preview with no _VARIANT_ is the component's `default` cell", () => {
+  assert.deepEqual(cellsFromManifest(cells).get("AppCard"), new Set([
+    "outlined",
+    "icon-outlined-gallery-2",
+    "default",
+  ]));
+});
+
+test("previews with no componentId are not cells of anything", () => {
+  assert.equal(cellsFromManifest({ previews: [{ id: "Sample_VARIANT_x" }] }).size, 0);
+});
+
+test("a locator naming a drawn cell passes", () => {
+  const result = checkLocators({
+    issues: [{ number: 1, body: locator() }],
+    manifests: new Map([["remote-m3", cellsFromManifest(cells)]]),
+  });
+  assert.deepEqual(result.failures, []);
+  assert.equal(result.checked, 1);
+});
+
+test("a renamed cell fails, and the message names the cell it probably moved to", () => {
+  const result = checkLocators({
+    issues: [
+      {
+        number: 284,
+        body: locator({
+          preview: "appcard__ideal__outline-icon-gallery-2__compact",
+          reference: "appcard__ideal__outline-icon-gallery-2__compact",
+        }),
+      },
+    ],
+    manifests: new Map([["remote-m3", cellsFromManifest(cells)]]),
+  });
+  assert.equal(result.failures.length, 1);
+  assert.equal(result.failures[0].number, 284);
+  assert.match(result.failures[0].message, /draws no cell "outline-icon-gallery-2"/);
+  assert.match(result.failures[0].message, /did you mean "icon-outlined-gallery-2"/);
+});
+
+test("preview and reference are one check when they are the same string", () => {
+  const same = checkLocators({
+    issues: [{ number: 1, body: locator({ preview: "appcard__ideal__gone__compact", reference: "appcard__ideal__gone__compact" }) }],
+    manifests: new Map([["remote-m3", cellsFromManifest(cells)]]),
+  });
+  assert.equal(same.checked, 1);
+  assert.equal(same.failures.length, 1);
+});
+
+test("a reference pinned apart from the preview is checked in its own right", () => {
+  const result = checkLocators({
+    issues: [{ number: 1, body: locator({ reference: "appcard__ideal__gone__compact" }) }],
+    manifests: new Map([["remote-m3", cellsFromManifest(cells)]]),
+  });
+  assert.equal(result.checked, 2);
+  assert.equal(result.failures.length, 1);
+  assert.equal(result.failures[0].field, "reference");
+});
+
+test("with a baseline, an id that was served and is not drawn now is this change's failure", () => {
+  const result = checkLocators({
+    issues: [{ number: 284, body: locator({ preview: "appcard__ideal__outline__compact", reference: "appcard__ideal__outline__compact" }) }],
+    manifests: new Map([["remote-m3", cellsFromManifest(cells)]]),
+    published: new Map([["remote-m3", new Set(["appcard__ideal__outline__compact"])]]),
+  });
+  assert.equal(result.failures.length, 1);
+  assert.equal(result.warnings.length, 0);
+});
+
+test("with a baseline, an id that was never served is a warning rather than this PR's fault", () => {
+  const result = checkLocators({
+    issues: [{ number: 9, body: locator({ preview: "appcard__ideal__typo__compact", reference: "appcard__ideal__typo__compact" }) }],
+    manifests: new Map([["remote-m3", cellsFromManifest(cells)]]),
+    published: new Map([["remote-m3", new Set(["appcard__ideal__outlined__compact"])]]),
+  });
+  assert.deepEqual(result.failures, []);
+  assert.equal(result.warnings.length, 1);
+  assert.equal(result.warnings[0].number, 9);
+});
+
+test("without a baseline every unresolvable id fails, which is what a scheduled run wants", () => {
+  const result = checkLocators({
+    issues: [{ number: 9, body: locator({ preview: "appcard__ideal__typo__compact", reference: "appcard__ideal__typo__compact" }) }],
+    manifests: new Map([["remote-m3", cellsFromManifest(cells)]]),
+  });
+  assert.equal(result.failures.length, 1);
+  assert.deepEqual(result.warnings, []);
+});
+
+test("a component this lane does not build warns rather than fails", () => {
+  // `:remote-catalog` builds CheckboxButton and EdgeButton on its snapshot lane only, and a run
+  // discovers one lane at a time — so the released-lane manifest is legitimately missing components
+  // the delivery branch serves. Three real issues failed on exactly this before it was narrowed.
+  const result = checkLocators({
+    issues: [{ number: 1, body: locator({ component: "CheckboxButton" }) }],
+    manifests: new Map([["remote-m3", cellsFromManifest(cells)]]),
+    published: new Map([["remote-m3", new Set(["appcard__ideal__outlined__compact"])]]),
+  });
+  assert.deepEqual(result.failures, []);
+  assert.equal(result.unverified, 1);
+  assert.equal(result.checked, 0);
+  assert.match(
+    result.warnings[0].message,
+    /no component "CheckboxButton" in the remote-m3 manifest — not built on the discovered lane/,
+  );
+});
+
+test("a locator for a system this repository does not build is skipped, not assumed good", () => {
+  const result = checkLocators({
+    issues: [{ number: 1, body: locator({ system: "some-other-system" }) }],
+    manifests: new Map([["remote-m3", cellsFromManifest(cells)]]),
+  });
+  assert.deepEqual(result.failures, []);
+  assert.equal(result.skipped, 1);
+  assert.equal(result.checked, 0);
+});
+
+test("bodies with no locator, or a damaged one, are left to the emitter to report", () => {
+  const result = checkLocators({
+    issues: [
+      { number: 1, body: "no locator here" },
+      { number: 2, body: "```compose-parity-locator/v1\nrepository: x\n" },
+      { number: 3, body: null },
+    ],
+    manifests: new Map([["remote-m3", cellsFromManifest(cells)]]),
+  });
+  assert.deepEqual(result.failures, []);
+  assert.equal(result.checked, 0);
+});
+
+test("a CRLF body parses — the report form writes them, and one hid a real break", () => {
+  const crlf = locator().replace(/\n/g, "\r\n");
+  const result = checkLocators({
+    issues: [{ number: 1, body: crlf }],
+    manifests: new Map([["remote-m3", cellsFromManifest(cells)]]),
+  });
+  assert.deepEqual(result.failures, []);
+  assert.equal(result.checked, 1);
+});
+
+test("a near-miss is offered only when it is actually near", () => {
+  assert.deepEqual(nearestCells("outlined", new Set(["outline", "icon", "default"])), ["outline"]);
+  assert.deepEqual(nearestCells("outlined", new Set(["gallery-1", "default"])), []);
+});


### PR DESCRIPTION
Half one of [yschimke/wear-m3-catalog#305](https://github.com/yschimke/wear-m3-catalog/issues/305) — the checker. The CI caller is a separate PR in that repository.

## The gap

`parity-issues.mjs` validates a locator's **shape**: required fields, non-empty values, no component or preview claimed twice in one body. Nothing has ever validated what its `preview` field points **at**, because the producer runs against an issue list and has no catalog to resolve against.

So renaming a cell turns an issue's locator into a dangling pointer with every check green — `buildIssueIndex` emits the row, the delivery branch carries it, and the compare page never shows it, because no preview on any page has that id any more. That is exactly where an issue with *no* locator lands: skipped, silently, correctly. Which is what makes it invisible.

It has happened twice on one repository from one rename, and the second was found only because someone distrusted a clean result from the first audit.

## What it resolves against, and why not the served id

A locator's `preview` (`appcard__ideal__outlined__compact`) is minted from `catalog.json` by the render pipeline — see `revision-preview-index.mjs`. A pull request has no `catalog.json`; it has the discovered `previews.json`, whose ids are fully-qualified Kotlin (`…CatalogPreviewsKt.AppCardRemote_width=227dp,…_VARIANT_outlined`). Reconstructing one from the other would mean re-implementing the pipeline's naming inside a checker — the fork that lets a validator and its producer drift apart.

So it resolves the pair the two forms genuinely share: the **component id** (a locator field) and the **cell** (the served id's third segment, and the manifest's `_VARIANT_` suffix). A rename moves the cell on both sides at once, which is the whole failure being caught, and neither side has to know how the other builds a string.

It imports `parseLocators` rather than matching fences itself, for the same reason.

## Two design choices worth review

**A baseline, not a blanket assertion.** "Every locator must resolve" fails PRs that had nothing to do with the breakage: one issue edited to a bad id and every subsequent PR is red with the fix nowhere in its diff. Given `--published` (the delivery branch's `preview-index.json`), an unresolvable id splits in two — served once and not drawn now is *this change's* failure; never served is a warning, because failing there punishes the wrong commit. Without `--published` every unresolvable id fails, which is what a scheduled or publish-side run wants.

**An unknown component warns rather than fails.** A sheet can publish a component from one source set and not another — `:remote-catalog` builds `CheckboxButton` and `EdgeButton` on its snapshot lane only — and a run discovers one lane at a time, so a released-lane manifest is legitimately missing components the delivery branch serves. Three real issues failed on exactly that before the contract was narrowed. It is reported rather than dropped, because the same shape covers a component that really was deleted.

## Verified against the data it was written for

Replaying the real situation — `wear-m3-catalog`'s pre-rename published baseline, its pre-fix issue bodies, and its post-rename manifest:

```
checked=35 failures=2 warnings=2 skipped=0
  FAIL #293 preview=appcard__ideal__outline__compact
        AppCard draws no cell "outline" — did you mean "outlined"?
  FAIL #284 preview=appcard__ideal__outline-icon-gallery-2__compact
        AppCard draws no cell "outline-icon-gallery-2" — did you mean "icon-gallery-2" or "icon-outlined-gallery-2"?
```

Both real breaks, each naming the cell it moved to. Against that repository's current (repaired) state, on today's baseline: `checked=53 failures=0 warnings=3`, the three warnings being the snapshot-lane components above.

The near-miss hint scores **token overlap as well as edit distance**, because those two renames are different shapes and neither measure sees both: a respelling (`outline` → `outlined`) is one edit away and shares no tokens; a reordering (`outline-icon-gallery-2` → `icon-outlined-gallery-2`) shares three segments of four and is ten edits away, well past any cap loose enough to be useful.

## Test plan

```
cd scripts/design-artifacts && npm test
```

15 new tests, covering the cell/segment derivation, the baseline split in both directions, the unknown-component and unknown-system cases, preview-vs-reference, and a **CRLF body** — the report form writes them, and a `\n`-anchored fence is what hid one of the two real breaks during the manual audit.

The suite fails the same 8 environment-dependent files before and after this change (browser and mirror-source tests CI supplies and this sandbox does not); confirmed by running it on a clean tree.

Text-only evidence: no rendered surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K338HTJxdDJdHUjC5WmnGd

---
_Generated by [Claude Code](https://claude.ai/code/session_01K338HTJxdDJdHUjC5WmnGd)_