### PR TITLE
feat(design-artifacts): publish the component record beside catalog.json

### DIFF
--- a/docs/design/COMPONENT_RECORD.md
+++ b/docs/design/COMPONENT_RECORD.md
@@ -228,7 +228,13 @@ document → Kotlin → compile → render → pixel-compare round trip to pass.
 
 A new `components.json`, emitted by the Gradle plugin beside `previews.json` and
 carried in the bundle (`components.json` + per-component sidecars, the same
-convention `previews/<id>.overrides.json` already uses).
+convention `previews/<id>.overrides.json` already uses). The design-artifacts
+pipeline copies it out of the primary bundle onto the delivery branch root and
+declares it on `catalog.json` as `componentsFile`
+(`scripts/design-artifacts/catalog-component-record.mjs`), so a consumer that
+wants only the record — compose-preview-server's UI builder, offering a served
+catalog's composables as a component pack — fetches one file rather than the
+live bundle it also travels in.
 
 ```jsonc
 {

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -102,7 +102,8 @@ Each run renders the catalog module with `compose-preview bundle pack --with-sem
 to a **`design-artifacts/<system>`** branch — `design-artifacts/compose-m3`,
 `design-artifacts/wear-m3`, … — that a designer pulls into Figma / Stitch /
 Claude Design. The branch holds only the generated bundle (`catalog.json`,
-`tokens.dtcg.json`, `figma-variables.json`, `images/` PNGs, and `figma/` — the
+`tokens.dtcg.json`, `figma-variables.json`, `components.json` — the discovered
+component record, declared as `componentsFile` — `images/` PNGs, and `figma/` — the
 per-sticker layered **`compose/figma-svg`** vectors), regenerated from the code
 on each catalog change so it never drifts. Each component ships both the raster PNG (in
 `images/`) and its editable vector (`figma/<slug>.svg`): import the PNG for a

--- a/scripts/design-artifacts/catalog-component-record.mjs
+++ b/scripts/design-artifacts/catalog-component-record.mjs
@@ -1,0 +1,71 @@
+/**
+ * Publish the render bundle's discovered component record (`components.json`) beside `catalog.json`.
+ *
+ * The Gradle plugin writes `components.json` — the composables a module's previews render, with
+ * their recovered signatures and a proven call site for each — into every bundle it packs, and the
+ * UI builder in compose-preview-server reads it to offer a served catalog's composables as a
+ * component pack and to export against them. A catalog that publishes a live bundle therefore
+ * carries the record already, inside a 15–50 MB polyglot a consumer has to fetch and unzip to reach
+ * one ~1 MB JSON file; a catalog that publishes no live bundle carries it nowhere a reader can reach.
+ *
+ * So the record is copied out to the branch root and declared on the manifest as `componentsFile`,
+ * the way `tokensFile` declares the token set: a consumer fetches the one file it wants, and a
+ * catalog with no executable bundle is still authorable from. Same rule as the motion captures —
+ * bytes a reader is told about must exist somewhere the reader can reach.
+ *
+ * Primary bundle only. A multi-module catalog's additional bundles each carry their own record
+ * (`combinedBundleEntries` is primary-wins), and publishing those under `bundle/modules/<key>/`
+ * is a follow-up for the day a consumer wants them; the primary's is the record the catalog's own
+ * previews were discovered from.
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+/** The bundle entry and the published branch path — one name, by construction. */
+export const COMPONENT_RECORD_FILE = "components.json";
+
+/**
+ * Whether `bytes` are a component record a consumer will read: a JSON object carrying a numeric
+ * `schemaVersion` and a `components` array. Structural only — which versions a consumer generates
+ * from is the consumer's to decide and say, and refusing an unknown future version here would
+ * report a newer plugin's record as a broken bundle.
+ */
+export function parseComponentRecord(bytes) {
+  if (!bytes) return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(bytes).toString("utf8"));
+  } catch {
+    return null;
+  }
+  if (
+    !parsed ||
+    typeof parsed !== "object" ||
+    Array.isArray(parsed) ||
+    typeof parsed.schemaVersion !== "number" ||
+    !Array.isArray(parsed.components)
+  ) {
+    return null;
+  }
+  return parsed;
+}
+
+/**
+ * Copy the record out of the bundle `entries` into `<outPath>/components.json`.
+ *
+ * Returns `{ path, schemaVersion, components }` — what the caller stamps on the manifest and logs —
+ * or `null` when the bundle carries no readable record, in which case nothing is written and the
+ * manifest says nothing: a consumer falls back to the live bundle's own copy where there is one.
+ */
+export async function publishComponentRecord(entries, outPath) {
+  const record = parseComponentRecord(entries?.[COMPONENT_RECORD_FILE]);
+  if (!record) return null;
+  const target = join(outPath, COMPONENT_RECORD_FILE);
+  await mkdir(dirname(target), { recursive: true });
+  await writeFile(target, Buffer.from(entries[COMPONENT_RECORD_FILE]));
+  return {
+    path: COMPONENT_RECORD_FILE,
+    schemaVersion: record.schemaVersion,
+    components: record.components.length,
+  };
+}

--- a/scripts/design-artifacts/catalog-component-record.test.mjs
+++ b/scripts/design-artifacts/catalog-component-record.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  COMPONENT_RECORD_FILE,
+  parseComponentRecord,
+  publishComponentRecord,
+} from "./catalog-component-record.mjs";
+
+async function withOutDir(body) {
+  const out = await mkdtemp(join(tmpdir(), "component-record-"));
+  try {
+    await body(out);
+  } finally {
+    await rm(out, { recursive: true, force: true });
+  }
+}
+
+const record = JSON.stringify({
+  schemaVersion: 2,
+  module: ":catalog",
+  variant: "main",
+  components: [
+    {
+      canonicalId: "catalog/dev.example.CardKt.SessionCard",
+      componentIds: [],
+      symbol: {
+        jvmOwner: "dev.example.CardKt",
+        callable: "dev.example.SessionCard",
+        name: "SessionCard",
+        origin: "PROJECT",
+      },
+      code: { call: "SessionCard()", imports: ["dev.example.SessionCard"] },
+      signatureKnown: true,
+    },
+  ],
+});
+
+test("the bundle's record is copied to the branch root and described for the manifest", async () => {
+  await withOutDir(async (out) => {
+    const bytes = new TextEncoder().encode(record);
+    const published = await publishComponentRecord(
+      { "bundle.json": new Uint8Array([123, 125]), [COMPONENT_RECORD_FILE]: bytes },
+      out,
+    );
+
+    assert.deepEqual(published, { path: "components.json", schemaVersion: 2, components: 1 });
+    // Byte-for-byte: the consumer parses the same file the plugin wrote, not a re-serialisation
+    // that could reorder or drop what this script does not understand.
+    assert.equal(await readFile(join(out, "components.json"), "utf8"), record);
+  });
+});
+
+test("a bundle without a record publishes nothing and says so", async () => {
+  await withOutDir(async (out) => {
+    // A bundle packed by a plugin from before component records existed.
+    assert.equal(await publishComponentRecord({ "bundle.json": new Uint8Array([123, 125]) }, out), null);
+    await assert.rejects(stat(join(out, "components.json")));
+  });
+});
+
+test("an entry that is not a record is left in the bundle rather than published", async () => {
+  await withOutDir(async (out) => {
+    for (const bytes of [
+      new TextEncoder().encode("not json"),
+      new TextEncoder().encode("[]"),
+      new TextEncoder().encode('{"components":[]}'),
+      new TextEncoder().encode('{"schemaVersion":"2","components":[]}'),
+    ]) {
+      assert.equal(await publishComponentRecord({ [COMPONENT_RECORD_FILE]: bytes }, out), null);
+    }
+    await assert.rejects(stat(join(out, "components.json")));
+  });
+});
+
+test("a newer schema is published, not refused", () => {
+  // The consumer names the versions it generates from; this script only checks the shape.
+  const parsed = parseComponentRecord(
+    new TextEncoder().encode('{"schemaVersion":7,"components":[],"future":true}'),
+  );
+  assert.equal(parsed.schemaVersion, 7);
+});

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -55,6 +55,7 @@ import {
   motionPreviewFor,
 } from "./catalog-motion.mjs";
 import { publishMotionArtifacts } from "./catalog-motion-publish.mjs";
+import { publishComponentRecord } from "./catalog-component-record.mjs";
 import { checkMotionCarried } from "./motion-carried.mjs";
 import {
   unclaimedMotionPreviews,
@@ -1666,6 +1667,25 @@ if (values["publish-live-bundle"]) {
   }
 }
 
+// The discovered component record, out of the primary bundle and onto the branch root, so a
+// consumer that wants only the record (the UI builder, offering this catalog's composables as a
+// component pack) fetches one file rather than the live bundle it also travels in — and so a
+// catalog that publishes no live bundle still carries it somewhere a reader can reach.
+const componentRecord = await publishComponentRecord(
+  combinedBundleEntries(allBundles),
+  outPath,
+);
+if (componentRecord) {
+  console.log(
+    `[${spec.system}] published component record → ${componentRecord.path} ` +
+      `(schema ${componentRecord.schemaVersion}, ${componentRecord.components} component(s))`,
+  );
+} else {
+  console.log(
+    `[${spec.system}] bundle carries no component record — the catalog is not authorable from`,
+  );
+}
+
 {
   const catalogJsonPath = join(outPath, "catalog.json");
   const manifest = JSON.parse(await readFile(catalogJsonPath, "utf8"));
@@ -1761,6 +1781,8 @@ if (values["publish-live-bundle"]) {
   if (webRender) manifest.webRender = webRender;
   if (liveBundle) manifest.liveBundle = liveBundle;
   if (liveBundles.length > 0) manifest.liveBundles = liveBundles;
+  // Declared the way `tokensFile` is: a branch-relative path a consumer fetches by name.
+  if (componentRecord) manifest.componentsFile = componentRecord.path;
   // Deferred (live-only) coverage, recorded alongside the baked components rather than inside
   // `components[].images` — an image with no `path` would reach every consumer that assumes
   // `images[]` is the baked sticker set (index.html, compare.html, matches.html, the per-variant

--- a/scripts/design-artifacts/merge-catalog-section.mjs
+++ b/scripts/design-artifacts/merge-catalog-section.mjs
@@ -26,7 +26,8 @@
  *
  * A catalog's **top-level** files stay the host's: the manifest (`catalog.json`,
  * merged separately above), the token/Figma projections, the `code-connect.json`
- * mappings, and the generated `index.html` / `compare.html` / `README.md` pages
+ * mappings, the `components.json` component record (the host module's own
+ * discovery output), and the generated `index.html` / `compare.html` / `README.md` pages
  * — each is derived from that catalog's own component set, and both catalogs
  * (produced by the same generator) carry them, so copying the borrowed ones would
  * collide. The host's generated pages therefore don't reflect the folded section;


### PR DESCRIPTION
## Summary

The producer half of compose-preview-server#437 (component packs read their record from the served catalog).

The Gradle plugin packs `components.json` into every render bundle, so a catalog that publishes a live bundle already carries its discovered component record — inside a 15–50 MB polyglot a consumer has to fetch and unzip to reach one ~1 MB JSON file — and a catalog that publishes no live bundle carries it nowhere a reader can reach.

- New `scripts/design-artifacts/catalog-component-record.mjs`: `publishComponentRecord(entries, out)` copies the primary bundle's `components.json` byte-for-byte to the delivery branch root and reports `{ path, schemaVersion, components }`; a bundle without a record, or with an entry that is not one (not JSON, no numeric `schemaVersion`, no `components` array), publishes nothing. Shape check only — which schema versions a consumer generates from is the consumer's to say, and a newer plugin's record is published rather than refused.
- `generate-design-catalog.mjs` calls it after the live-bundle carriage and stamps `manifest.componentsFile = "components.json"` in the manifest post-process, the way `tokensFile` is declared. Nothing changes for the workflow: `out/` is uploaded and pushed wholesale, and the file is regenerated every run so it is deliberately not in `CARRY_FORWARD_PATHS`.
- `merge-catalog-section.mjs` header lists `components.json` among the top-level files that stay the host's (the fold-in already only copies subdirectories; this is documentation of the existing behaviour).
- Docs: the delivery-branch contents sentence in `DESIGN_CATALOGS.md`, and a note in `COMPONENT_RECORD.md` §3.

Primary bundle only: a multi-module catalog's additional bundles carry their own records, and publishing those under `bundle/modules/<key>/` is a follow-up for when a consumer wants them.

## Test plan

- `scripts/design-artifacts/catalog-component-record.test.mjs`: copied byte-for-byte and described; absent record publishes nothing; non-record entries (not JSON, an array, no `schemaVersion`, a string `schemaVersion`) publish nothing; a newer schema is accepted.
- `cd scripts/design-artifacts && npm ci && node --test` — 1440 pass, 0 fail, 29 skipped (the same skips as before).
- `node --check generate-design-catalog.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FwgYSqaWHzhRmfBaSQ6gg6

---
_Generated by [Claude Code](https://claude.ai/code/session_01FwgYSqaWHzhRmfBaSQ6gg6)_