### PR TITLE
fix(discovery): look through a theme lambda Kotlin 2.3+ stores as a static method

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
@@ -126,8 +126,9 @@ object PreviewTargetInference {
    * lambdas rather than one the preview body makes itself. The distinction has to be recorded here
    * because the two are indistinguishable afterwards, and because **whether a lambda is even
    * reachable depends on the Kotlin compiler, not on the preview**: a non-capturing composable
-   * lambda is lifted into a `ComposableSingletons$…` class (walked, narrowly, by
-   * [extractComposeSingletonLambdaCalls]), while one that captures compiles to a
+   * lambda is lifted into the file's `ComposableSingletons$…` class — as a class of its own or,
+   * from Kotlin 2.3, as a static method of it (both walked, narrowly, by
+   * [extractComposeSingletonLambdaCalls]) — while one that captures compiles to a
    * `<preview>$lambda$N` method of the preview's own class, which the nested-method walk follows
    * wholesale. Adding a single defaulted parameter to a preview flips it from the first shape to
    * the second, so without this flag `infer`'s "how many project composables did this preview
@@ -499,10 +500,23 @@ object PreviewTargetInference {
   private data class MethodBody(val calls: List<Invocation>, val nestedMethods: Set<MethodKey>)
 
   /**
-   * Compose 2.x stores non-capturing composable lambdas in generated
-   * `ComposableSingletons$…$lambda$<key>$…` classes. A preview only calls the matching
-   * `getLambda$<key>$…` getter, so walk that narrowly identified generated class to find the
-   * component rendered inside `Theme { … }` / `Wrap { … }`.
+   * The calls inside a preview's **non-capturing** composable lambdas — the `{ … }` of `Theme {
+   * Component() }` — which the Compose compiler lifts out of the preview body into the file's
+   * generated `ComposableSingletons$…` class. A preview only calls the matching `getLambda$<key>$…`
+   * getter, so the lambda is found by that key and walked narrowly.
+   *
+   * Where the body lives depends on the compiler, and both places are read:
+   * - **A class of its own**, `ComposableSingletons$…$lambda$<key>$…`, with the body in its
+   *   `invoke(Composer, Int)` — what Compose compilers up to Kotlin 2.2 emit.
+   * - **A static method of the singletons class**, `lambda_<key>$lambda$<n>(Composer, Int)`, wired
+   *   to the field by `invokedynamic` — what Kotlin 2.3+ emits. Until this half existed every
+   *   `Theme { Component() }` preview compiled by a current Kotlin reported the *theme* as its
+   *   subject, because the walker looked for a class that was no longer generated: Confetti's Wear
+   *   component catalog recorded `ConfettiThemeFixed` for every one of its stickers, and
+   *   `SessionCard` reached no record at all. The name is matched with `$` and `-` normalised
+   *   (`lambda$-767012711` is stored under `lambda__767012711$lambda$0`), and the descent follows
+   *   the body's own nested `$lambda$n$…` methods — the callbacks it declares — since a call made
+   *   from one of those is still a call the lambda makes.
    */
   private fun extractComposeSingletonLambdaCalls(
     directCalls: List<Invocation>,
@@ -522,33 +536,65 @@ object PreviewTargetInference {
         val lambdaClassPrefix = getter.ownerFqn + "\$lambda\$$lambdaKey\$"
         val ownerResource = scanResult.getClassInfo(getter.ownerFqn)?.resource
         if (ownerResource == null) return@flatMap emptySequence()
-        referencedClasses(ownerResource, lambdaClassPrefix)
-          .asSequence()
-          .flatMap { lambdaClassFqn ->
-            scanResult
-              .getResourcesWithPathIgnoringAccept(lambdaClassFqn.replace('.', '/') + ".class")
-              .asSequence()
-              .map { lambdaClassFqn to it }
-          }
-          .filter { it.second.classpathElementURI == ownerResource.classpathElementURI }
-          .flatMap { (lambdaClassFqn, resource) ->
-            try {
-              extractCalls(
-                  resource = resource,
-                  ownerFqn = lambdaClassFqn,
-                  isRoot = { key ->
-                    key.name == "invoke" && "Landroidx/compose/runtime/Composer;" in key.descriptor
-                  },
-                  shouldFollow = { false },
-                )
+        val lambdaClasses =
+          referencedClasses(ownerResource, lambdaClassPrefix)
+            .asSequence()
+            .flatMap { lambdaClassFqn ->
+              scanResult
+                .getResourcesWithPathIgnoringAccept(lambdaClassFqn.replace('.', '/') + ".class")
                 .asSequence()
-            } catch (_: Throwable) {
-              emptySequence()
+                .map { lambdaClassFqn to it }
             }
+            .filter { it.second.classpathElementURI == ownerResource.classpathElementURI }
+            .flatMap { (lambdaClassFqn, resource) ->
+              try {
+                extractCalls(
+                    resource = resource,
+                    ownerFqn = lambdaClassFqn,
+                    isRoot = { key ->
+                      key.name == "invoke" &&
+                        "Landroidx/compose/runtime/Composer;" in key.descriptor
+                    },
+                    shouldFollow = { false },
+                  )
+                  .asSequence()
+              } catch (_: Throwable) {
+                emptySequence()
+              }
+            }
+        val lambdaMethods =
+          try {
+            val bodyPrefix = "_" + normaliseLambdaName(lambdaKey) + "_lambda_"
+            extractCalls(
+                resource = ownerResource,
+                ownerFqn = getter.ownerFqn,
+                isRoot = { key ->
+                  isSingletonLambdaMethod(key.name, bodyPrefix) &&
+                    "Landroidx/compose/runtime/Composer;" in key.descriptor
+                },
+                shouldFollow = { key -> isSingletonLambdaMethod(key.name, bodyPrefix) },
+              )
+              .asSequence()
+          } catch (_: Throwable) {
+            emptySequence()
           }
+        lambdaClasses + lambdaMethods
       }
       .distinct()
       .toList()
+
+  /**
+   * Whether [methodName] is the static body of the singleton lambda whose normalised key gives
+   * [bodyPrefix], or one of that body's own nested lambdas. `lambda__767012711$lambda$0` and
+   * `lambda__767012711$lambda$0$1$0` both are, for the key `-767012711`; `lambda_1578330026$…` is
+   * not.
+   */
+  private fun isSingletonLambdaMethod(methodName: String, bodyPrefix: String): Boolean =
+    methodName.startsWith("lambda") &&
+      normaliseLambdaName(methodName.removePrefix("lambda")).startsWith(bodyPrefix)
+
+  /** `$` and `-` both become `_`, which is how the compiler spells a lambda key into a method. */
+  private fun normaliseLambdaName(name: String): String = name.replace('$', '_').replace('-', '_')
 
   private fun referencedClasses(resource: Resource, classFqnPrefix: String): Set<String> {
     val internalPrefix = classFqnPrefix.replace('.', '/')
@@ -710,6 +756,13 @@ object PreviewTargetInference {
     if (nameMatches(previewMethodName, callerSourceName)) {
       score += 2
       signals += TargetSignal.NAME_MATCH
+    } else if (nameQualifies(previewMethodName, callerSourceName)) {
+      // `SessionCardPopulatedPreview` is a preview *of* `SessionCard` as surely as
+      // `SessionCard_Populated_Preview` is; the qualifier is spelled in CamelCase rather than with
+      // an underscore. Worth one rather than two, so a candidate the preview names exactly still
+      // outranks one it merely starts with — `FooBarPreview` prefers `FooBar` to `Foo`.
+      score += 1
+      signals += TargetSignal.NAME_MATCH
     }
 
     // +1 if the candidate lives in a different .class file than the preview. Top-level functions
@@ -763,6 +816,16 @@ object PreviewTargetInference {
    * `FooScreen`. Internal-mangled JVM names (`InternalPreview$module`) are stripped first.
    */
   internal fun nameMatches(previewMethodName: String, candidateName: String): Boolean {
+    val stripped = strippedPreviewName(previewMethodName)
+    if (stripped.isBlank()) return false
+    if (stripped == candidateName) return true
+    // `Foo_Light_Preview` → `Foo_Light` → leading segment `Foo`.
+    val leadingSegment = stripped.substringBefore('_')
+    return leadingSegment.isNotBlank() && leadingSegment == candidateName
+  }
+
+  /** The preview's name with its `Preview` affixes, separators and JVM mangle removed. */
+  private fun strippedPreviewName(previewMethodName: String): String {
     // Strip the JVM `internal fun` mangle (`name$module`) before any name-shape work.
     val cleaned = previewMethodName.substringBefore('$')
     // Order matters: try the more specific affixes (`_Preview` / `Preview_`) before the bare ones,
@@ -774,11 +837,21 @@ object PreviewTargetInference {
         .removePrefix("Preview_")
         .removePrefix("Preview")
         .trim('_')
-    if (stripped.isBlank()) return false
-    if (stripped == candidateName) return true
-    // Allow `Foo_Light_Preview` → `Foo_Light` → match `Foo` by the leading segment.
-    val leadingSegment = stripped.substringBefore('_')
-    return leadingSegment.isNotBlank() && leadingSegment == candidateName
+    return stripped
+  }
+
+  /**
+   * `SessionCardPopulatedPreview` ↔ `SessionCard`: the stripped preview name starts with the
+   * candidate's and continues with a CamelCase qualifier — an upper-case letter or a digit, so
+   * `FooBarPreview` qualifies `Foo` while `FoobarPreview` does not. Never true where [nameMatches]
+   * already is.
+   */
+  internal fun nameQualifies(previewMethodName: String, candidateName: String): Boolean {
+    val stripped = strippedPreviewName(previewMethodName)
+    if (stripped.isBlank() || candidateName.isBlank()) return false
+    if (!stripped.startsWith(candidateName) || stripped.length == candidateName.length) return false
+    val next = stripped[candidateName.length]
+    return next.isUpperCase() || next.isDigit()
   }
 
   /**

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewTargetInferenceTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewTargetInferenceTest.kt
@@ -38,6 +38,27 @@ class PreviewTargetInferenceTest {
   }
 
   @Test
+  fun `nameQualifies accepts a CamelCase qualifier after the candidate name`() {
+    // Confetti's `SessionCardPopulatedPreview`, `SessionCardLoadingPreview` and
+    // `SessionCardBookmarkedPreview` are all previews of `SessionCard`.
+    assertThat(PreviewTargetInference.nameQualifies("SessionCardPopulatedPreview", "SessionCard"))
+      .isTrue()
+    assertThat(PreviewTargetInference.nameQualifies("FooBar2Preview", "FooBar")).isTrue()
+    assertThat(PreviewTargetInference.nameQualifies("PreviewFooBar", "Foo")).isTrue()
+  }
+
+  @Test
+  fun `nameQualifies rejects a name that merely shares a prefix`() {
+    // `Foobar` is not `Foo` plus a qualifier — the continuation is lower-case.
+    assertThat(PreviewTargetInference.nameQualifies("FoobarPreview", "Foo")).isFalse()
+    // An exact match is `nameMatches`'s, and never both.
+    assertThat(PreviewTargetInference.nameQualifies("FooPreview", "Foo")).isFalse()
+    assertThat(PreviewTargetInference.nameQualifies("FooPreview", "FooBar")).isFalse()
+    assertThat(PreviewTargetInference.nameQualifies("Preview", "Foo")).isFalse()
+    assertThat(PreviewTargetInference.nameQualifies("FooBarPreview", "")).isFalse()
+  }
+
+  @Test
   fun `nameMatches rejects bare Preview when nothing left after strip`() {
     assertThat(PreviewTargetInference.nameMatches("Preview", "Anything")).isFalse()
   }

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -16,7 +16,15 @@ class DiscoveryFunctionalTest {
 
   private val json = Json { ignoreUnknownKeys = true }
 
-  private fun createCmpTestProject(): File {
+  /**
+   * @param kotlinVersion the Kotlin and Compose compiler the fixture compiles with. The default is
+   *   the oldest toolchain the plugin supports; a test about a **bytecode shape** a newer compiler
+   *   emits (see the singleton-lambda case) names the version that emits it.
+   */
+  private fun createCmpTestProject(
+    kotlinVersion: String = "2.2.21",
+    composeVersion: String = "1.10.3",
+  ): File {
     val projectDir = tempDir.root
 
     // settings.gradle.kts
@@ -48,9 +56,9 @@ class DiscoveryFunctionalTest {
         """
         @file:Suppress("DEPRECATION")
         plugins {
-            kotlin("jvm") version "2.2.21"
-            kotlin("plugin.compose") version "2.2.21"
-            id("org.jetbrains.compose") version "1.10.3"
+            kotlin("jvm") version "$kotlinVersion"
+            kotlin("plugin.compose") version "$kotlinVersion"
+            id("org.jetbrains.compose") version "$composeVersion"
             id("ee.schimke.composeai.preview")
         }
         dependencies {
@@ -4155,6 +4163,89 @@ class DiscoveryFunctionalTest {
     // left null so a consumer never has to write `jvmName ?: functionName`.
     assertThat(themeTarget.jvmName).isEqualTo("HomeScreen")
     assertThat(themeTarget.descriptor).isNotNull()
+  }
+
+  /**
+   * The same `Theme { Component() }` shape, compiled by a Kotlin whose Compose compiler stores the
+   * non-capturing lambda as a **static method** of `ComposableSingletons$…` rather than as a class
+   * of its own. The walker used to look only for the class, so under a current Kotlin every such
+   * preview reported the *theme* as its subject — which is how Confetti's Wear component catalog
+   * came to record `ConfettiThemeFixed` for every sticker and no `SessionCard` at all.
+   *
+   * The wrapper is deliberately not one `isPreviewOnlyWrapper` recognises by name, and the preview
+   * is named the way Confetti names its variants — `SessionCardPopulatedPreview`, a CamelCase
+   * qualifier after the component — so the test also pins that such a name counts for the component
+   * it starts with.
+   */
+  @Test
+  fun `composePreviewDiscover looks through a theme lambda stored as a static method`() {
+    val projectDir = createCmpTestProject(kotlinVersion = "2.4.10", composeVersion = "1.11.1")
+
+    val srcDir = File(projectDir, "src/main/kotlin/test")
+    File(srcDir, "Previews.kt").delete()
+
+    File(srcDir, "Components.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.material3.Text
+        import androidx.compose.runtime.Composable
+
+        @Composable
+        fun SessionCard(title: String) {
+            Text(title)
+        }
+        """
+          .trimIndent()
+      )
+
+    File(srcDir, "Previews.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.tooling.preview.Preview
+
+        @Composable
+        fun DemoThemeFixed(content: @Composable () -> Unit) {
+            content()
+        }
+
+        @Preview
+        @Composable
+        fun SessionCardPopulatedPreview() {
+            DemoThemeFixed { SessionCard("Compose everywhere") }
+        }
+        """
+          .trimIndent()
+      )
+
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("composePreviewDiscover", "--stacktrace")
+      .withPluginClasspath()
+      .build()
+
+    // The shape under test, asserted rather than assumed: the singletons class exists and no
+    // `$lambda$…` class was generated beside it, so the lambda body can only be a method of it.
+    val classes = File(projectDir, "build/classes/kotlin/main/test").listFiles().orEmpty()
+    assertThat(classes.map { it.name }).contains("ComposableSingletons\$PreviewsKt.class")
+    assertThat(classes.filter { it.name.startsWith("ComposableSingletons\$PreviewsKt\$") })
+      .isEmpty()
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+    val target =
+      manifest.previews.single { it.functionName == "SessionCardPopulatedPreview" }.targets.single()
+    assertThat(target.functionName).isEqualTo("SessionCard")
+    assertThat(target.sourceFile).contains("Components.kt")
+    assertThat(target.signals)
+      .containsAtLeast(TargetSignal.WRAPPER_UNWRAPPED, TargetSignal.NAME_MATCH)
+    assertThat(target.parameters.map { it.name }).containsExactly("title")
   }
 
   @Test


### PR DESCRIPTION
## Summary

Two things `PreviewTargetInference` got wrong for a `Theme { Component() }` preview compiled by a current Kotlin, found while exercising Confetti's Wear module as a UI-builder component pack (yschimke/compose-preview-server, `UI_BUILDER_COMPONENT_PACKS.md`):

- **The lambda body was invisible.** The walker descended into a preview's non-capturing content lambda only when the Compose compiler had lifted it into a `ComposableSingletons$…$lambda$<key>$…` class. Kotlin 2.3+ stores that body as a **static method** of the singletons class (`lambda_<key>$lambda$0(Composer, Int)`, wired to the field by `invokedynamic`), so nothing was found and the *wrapper* won as the preview's single project call. Over Confetti's published `confetti-wear` bundle, every component sticker recorded `ConfettiThemeFixed` as its subject and the record held no `SessionCard`, `SectionHeader` or `PlaceholderButton` at all. The walker now reads both shapes, matching the method by the lambda key with `$`/`-` normalised and following the body's own nested callbacks.
- **A CamelCase-qualified preview name counted for nothing.** `SessionCardPopulatedPreview` is a preview of `SessionCard` as surely as `SessionCard_Populated_Preview` is, but only the underscore form matched. `nameQualifies` now scores the CamelCase form at one point, under the exact match's two, so `FooBarPreview` still prefers `FooBar` to `Foo`.

Checked against the real thing: discovery run over the published `confetti-wear` bundle's classes goes from 5 recorded project composables (three theme scaffolds, two refused) to 15, with `SessionCard`, `SectionHeader`, `ScreenHeader`, `PlaceholderButton`, `SessionSpeakerChip` and `SocialIcon` each recorded from its own sticker at `MEDIUM` with `NAME_MATCH` + `WRAPPER_UNWRAPPED`.

## Test plan

- New `DiscoveryFunctionalTest` case compiles a fixture with Kotlin 2.4.10 / Compose 1.11.1 (`createCmpTestProject` now takes the toolchain versions), asserts the bytecode really has no `ComposableSingletons$PreviewsKt$…` class beside the singletons class, and that `DemoThemeFixed { SessionCard("…") }` under `SessionCardPopulatedPreview` records `SessionCard` with `WRAPPER_UNWRAPPED` and `NAME_MATCH`. The existing Kotlin 2.2.21 theme/catalog-lambda case still passes, so both shapes are covered.
- `PreviewTargetInferenceTest`: `nameQualifies` accepts a CamelCase or digit continuation, rejects a shared prefix (`Foobar`/`Foo`), an exact match, and blanks.
- `:preview-discovery:test` and the touched files' `ktfmtCheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FwgYSqaWHzhRmfBaSQ6gg6

---
_Generated by [Claude Code](https://claude.ai/code/session_01FwgYSqaWHzhRmfBaSQ6gg6)_