### PR TITLE
feat!: adopt minor-only versioning and cut 2.0.0 as the last major

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -12,11 +12,11 @@ In **Settings → Actions → General → Workflow permissions**, tick **"Allow 
 
 [release-please](https://github.com/googleapis/release-please) watches `main` for conventional-commit history and keeps a release PR up to date. Merging the PR is the only manual step.
 
-1. **Land conventional-commit PRs to `main`.** `fix:` and `feat:` trigger a release, and a `!` in the PR title (`feat!:`) cuts a major. `chore:`, `docs:`, `ci:`, `refactor:`, and `test:` do not. To force a bump with no releasable commit, set `"release-as": "0.3.4"` in `release-please-config.json`, let the release land, then revert that key in a follow-up PR — that is the **only** route.
+1. **Land conventional-commit PRs to `main`.** `fix:` and `feat:` trigger a release; `chore:`, `docs:`, `ci:`, `refactor:`, and `test:` do not. **Which** of those you write no longer changes the version — every release is a minor bump (see [Versioning after 2.0.0](#versioning-after-200)) — but it still decides whether a release happens at all, and which changelog section the entry lands in. To force a bump with no releasable commit, set `"release-as": "0.3.4"` in `release-please-config.json`, let the release land, then revert that key in a follow-up PR — that is the **only** route.
 
    > **Dispatching `Release PR` does not force a bump.** [`release-please.yml`](../.github/workflows/release-please.yml) declares `workflow_dispatch` with no inputs and runs the same release-please invocation, against the same config, that a push to `main` runs. It re-computes the answer; it cannot change it. Dispatch it to re-run a calculation that failed or raced — not to manufacture a release out of a history that warrants none, which just produces the same no-op however many times it is pressed.
 
-   > **A `BREAKING CHANGE:` footer does not reach release-please either**, for the reason below: it is a *body* footer, and the body is discarded. Only the `!` in the PR title survives the squash, so a breaking change has to be spelled `feat!:` / `fix!:` in the title. Writing `BREAKING CHANGE:` in the body and a plain `feat:` in the title yields a **minor** bump.
+   > **A `BREAKING CHANGE:` footer does not reach release-please**, for the reason below: it is a *body* footer, and the body is discarded by the squash. Only the `!` in the PR title survives it. Since 2.0.0 neither one changes the number — every release is a minor — but the `!` is still worth writing: it is what puts the change in the changelog's breaking section, which is now the only place a consumer sees it.
 
    > **A `Release-As:` footer does not work here.** release-please parses it from a commit's body, and this repo squash-merges with `squash_merge_commit_message=BLANK` — the squashed commit on `main` keeps the **PR title only**, so every body a human writes is discarded and the footer never arrives. Putting it in a branch commit, in the PR description, or in an empty commit all fail for the same reason (an empty commit additionally contributes no commit at all to a squash). `release-as` is the one route that survives.
    >
@@ -103,21 +103,84 @@ To move the pin by hand (or to repair a missed release), run it locally:
 
 `--check` runs in `ci` on every PR. It fails on an abbreviated, upper-case or missing SHA, a malformed tag, and a duplicated key — all of which otherwise fail *at runtime in a consumer's repo*, after that run has already paid for a checkout and a JDK. It is covered by `.github/scripts/test-refresh-driver-pin.sh`, also run by `ci`, which additionally pins the exact `sed` expression the workflow uses to read the file, so the reader and the validator cannot drift apart. Change either only with those passing.
 
-## Versioning after 1.0.0
+## Versioning after 2.0.0
 
-`v1.0.0` was cut by pinning `"release-as": "1.0.0"` in [`release-please-config.json`](../release-please-config.json). **That override has been removed, and it had to be** — `release-as` is sticky, not consumed by the release it forces, so left in place every subsequent release PR proposes 1.0.0 again, the tag already exists, and the release wedges. This repo had been bitten by it once before, by an override pinning 0.7.0 that outlived its release. If you ever force a version this way again, delete the key in the first PR after the release publishes.
-
-Removed alongside it: `bump-minor-pre-major` and `bump-patch-for-minor-pre-major`, which only ever applied while the major version was `0`.
-
-**Those two keys are what made `feat:` land as a *patch* bump for the whole `0.x` line**, which is how a repo with this much history spent so long on `0.19.x`. With them gone the usual semver mapping applies:
+**Every release is a minor bump.** `2.4.0 → 2.5.0`, whatever the commits said. There are no
+patch releases, and no further majors.
 
 | Commit type | Bump |
 |---|---|
-| `fix:` | patch |
+| `fix:` | minor |
 | `feat:` | minor |
-| `feat!:` (the `!`, in the **PR title**) | **major** |
+| `feat!:` / `fix!:` (the `!`, in the **PR title**) | minor |
+| `chore:`, `docs:`, `ci:`, `refactor:`, `test:` | no release |
 
-So a PR titled `feat!:` now cuts **2.0.0**, not 1.0.1. Watch PR titles accordingly — this is the single most likely way to cut an unintended major.
+This is `"versioning": "always-bump-minor"` in
+[`release-please-config.json`](../release-please-config.json). The strategy ignores the version
+and the commits it is handed and returns a minor update unconditionally.
+
+> **Staged: not live yet.** The `always-bump-minor` key is *not* in the config as of this commit.
+> release-please reads its config from `main` at run time, so a single PR that both added the key
+> and carried a `!` would have applied its own new setting to itself and cut a minor instead of
+> 2.0.0. The key lands in the follow-up PR, once 2.0.0 has published. Until then the table above
+> describes the intended policy and the old mapping (`fix:` → patch, `feat:` → minor, `feat!:` →
+> major) is what actually runs. This note goes away with that PR.
+
+
+**Why.** At ~44 releases a week the distinction between a patch and a minor had stopped carrying
+information: a release is whatever landed since the last one, usually a mix, and the number was
+being read as a bump size when it only ever meant "later". Cutting a major on a `!` was worse
+than uninformative — it was a hazard, and `RELEASING.md` used to say so in as many words
+("the single most likely way to cut an unintended major"). One monotonic counter that nobody has
+to reason about beats a three-way choice that a PR title could get wrong.
+
+**What still decides whether a release happens at all.** The versioning strategy sets the *size*
+of a bump; it does not decide that there is one. That is a separate guard in release-please
+(`changelogEmpty` in `strategies/base.ts`): a window whose commits produce empty release notes
+proposes no release PR. `chore:`, `ci:`, `docs:`, `refactor:` and `test:` are hidden from the
+changelog by default, so a window containing only those still cuts nothing — exactly as before.
+**This is the load-bearing detail.** Had the release decision run off the versioning strategy,
+`always-bump-minor` would have cut a release for every dependency bump and every CI tweak, which
+at this repository's volume would have been a serious regression rather than a simplification.
+
+**Forcing a specific version.** `"release-as": "X.Y.Z"` in the config remains the only route, and
+it is still sticky — it is not consumed by the release it forces, so left in place every
+subsequent release PR re-proposes it, the tag already exists, and the release wedges. This repo
+has been bitten twice: an override pinning 0.7.0 that outlived its release, and `1.0.0`. Delete
+the key in the first PR after the forced release publishes.
+
+### How 2.0.0 was cut, and why it is the last major
+
+`v2.0.0` came from a PR titled `feat!:`, under the *previous* configuration, where the `!` still
+mapped to a major. That ordering was forced: release-please reads its config from `main` at run
+time, so a PR that both added `always-bump-minor` and carried a `!` would have had its own new
+setting applied to it and cut a minor. The policy change and the major it announces could not be
+the same commit.
+
+Under `always-bump-minor` the `!` no longer reaches the version number at all, so 2.0.0 is the
+last major this repository cuts by rule. A future one would have to be forced with `release-as`,
+deliberately, as a decision rather than a side effect of a PR title.
+
+### What this costs, stated plainly
+
+A breaking change is no longer legible from the version number. Two consequences follow, and
+neither is fixed by this change:
+
+- **`versionsIncompatible`** (`cli/src/main/kotlin/ee/schimke/composeai/cli/Version.kt`) compares
+  major versions to decide whether a pin/CLI skew is a `warning` or a `note`, on the documented
+  grounds that "a major release changes the render/daemon wire format". It backs the skew
+  diagnostics in `warnOnCliSkew` and two in `DoctorCommand`. Once no major is ever cut, that
+  predicate is permanently false across 2.x and every skew reports as a `note`. It stays correct
+  across the 1.x → 2.x boundary, which is why it is not being changed here, but it stops being a
+  signal after that.
+- **The changelog is now the only place a break is announced**, which is why `feat!:` is still
+  worth writing even though it moves no number.
+
+The honest framing: this repository was already not using majors to communicate breakage — the
+`0.x` line ran to `0.19.x` under `bump-minor-pre-major`, and `1.0.0` was forced with `release-as`
+rather than earned by a `!`. See [VERSIONING.md § 10](VERSIONING.md#10-what-is-and-is-not-enforced)
+for what is and is not actually enforced. This change stops the version number implying a promise
+the machinery never kept.
 
 ## Fallback paths
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -34,15 +34,39 @@ the `install` / `apply` composite actions alike, so a project can't render again
 three different releases depending on which door it was entered through. Full
 reference: [VERSION_PIN.md](VERSION_PIN.md). Set it with `compose-preview pin --cli`.
 
-## 2. Semver rules for the published artifacts
+## 2. Version bumps for the published artifacts
 
-For plugin, CLI, extension, MCP, annotations:
+**Every release is a minor bump.** `release-please` runs
+`"versioning": "always-bump-minor"`, so the version goes `2.4.0 → 2.5.0` whatever the commits
+said: a `fix:`, a `feat:` and a `feat!:` are indistinguishable to it. There are no patch
+releases and no further majors — 2.0.0 is the last one this repository cuts by rule.
 
-- **Major** — breaking change to any public contract on the artifact. See § 3.
-- **Minor** — additive change: new feature, new flag, new DSL property, new annotation, new CLI subcommand, new MCP tool. New optional fields on existing types.
-- **Patch** — bug fix with no contract change. No new public surface.
+| Commit type | Bump |
+|---|---|
+| `fix:` / `feat:` / `feat!:` | minor |
+| `chore:`, `docs:`, `ci:`, `refactor:`, `test:` | no release |
 
-Through the `0.x` line, minor bumps could carry breaking changes with a clear note in CHANGELOG. From `1.0.0` they may not — see § 10.
+The mechanism, the reason, and the guard that keeps `chore:`-only windows from cutting a
+release are in [RELEASING.md → Versioning after 2.0.0](RELEASING.md#versioning-after-200).
+
+> **Staged: not live yet.** The `always-bump-minor` key is *not* in
+> `release-please-config.json` as of this commit, and it deliberately cannot be — release-please
+> reads its config from `main` at run time, so the PR that cuts 2.0.0 with a `!` and the PR that
+> stops `!` mapping to a major have to be two commits, in that order. Until the follow-up lands,
+> the machinery still does `fix:` → patch, `feat:` → minor, `feat!:` → major. This paragraph goes
+> away with that PR. Recorded here rather than left implicit because § 10 exists to stop exactly
+> this document describing machinery that is not running.
+
+
+**So the version number no longer tells a consumer what kind of change they are taking.** It
+orders releases and nothing else. What the number used to promise now has to be read out of §§ 3–5
+and the changelog: § 3 still defines what counts as breaking, § 5 still governs the deprecation
+cycle, and a `!` in a PR title still routes the entry to the changelog's breaking section. Writing
+the `!` matters more now, not less — it is the only place the break is announced.
+
+This is a narrowing of what the number claims, not of the underlying policy. § 10 already recorded
+that most of the enforcement these documents describe is not implemented; pinning the bump to
+minor stops the version implying a guarantee that was never mechanically kept.
 
 ## 3. What counts as breaking
 


### PR DESCRIPTION
Refs #4772. **Merging this cuts `v2.0.0`** — the `!` in the title is what does it.

## What changes

From 2.0.0, every release is a minor bump. `fix:`, `feat:` and `feat!:` all move the minor; there are no patch releases and no further majors by rule.

| Commit type | Before | After |
|---|---|---|
| `fix:` | patch | minor |
| `feat:` | minor | minor |
| `feat!:` | **major** | minor |
| `chore:`, `docs:`, `ci:`, `refactor:`, `test:` | no release | no release |

At ~44 releases a week the patch/minor distinction had stopped carrying information — a release is whatever landed since the last one, usually a mix, and the number was read as a bump size when it only ever meant "later". Cutting a major off a PR title was worse than uninformative; `RELEASING.md` called it "the single most likely way to cut an unintended major".

## This has to be two PRs, and this is the first

`release-please` reads its config from `main` **at run time**. A single PR that both added `"versioning": "always-bump-minor"` and carried a `!` would have had its own new setting applied to it and cut `1.86.0` instead of `2.0.0`. The policy change and the major it announces cannot be the same commit.

So:

1. **This PR** — carries the `!` that cuts 2.0.0, plus the documented policy. Under the config still in force, `!` → major.
2. **Follow-up, after 2.0.0 publishes** — adds `"versioning": "always-bump-minor"` to `release-please-config.json` and deletes the two `> **Staged: not live yet.**` blocks this PR adds.

Both documents mark that gap explicitly. `VERSIONING.md` § 10 exists precisely to stop these files describing machinery that is not running, so the interim state is recorded rather than left implicit.

The alternative — `release-as: "2.0.0"` alongside the key in one PR — was rejected: `release-as` is sticky, and this repo has been wedged by it twice already (an override pinning 0.7.0, and 1.0.0). A stuck release pipeline is a worse failure than a documented two-step.

## The detail that makes this safe

`always-bump-minor` ignores the version and the commits it is handed and returns a minor update unconditionally. The obvious worry is that every `chore(deps)` and `ci:` PR would start cutting a release — which, at this repo's volume and with 94 Maven artifacts per release, would be a serious regression and the exact opposite of #4772.

It doesn't, and the reason is that the versioning strategy sets the *size* of a bump but does not decide there is one. That is a separate guard in release-please (`changelogEmpty` in `strategies/base.ts`) which returns no release PR when the window's commits produce empty release notes. `chore:`, `ci:`, `docs:`, `refactor:` and `test:` are hidden from the changelog by default, so a window of only those still cuts nothing — unchanged from today.

Verified against release-please `main`:
- `src/factories/versioning-strategy-factory.ts` — registered strategies are `default`, `always-bump-patch`, `always-bump-minor`, `always-bump-major`, `service-pack`, `prerelease`.
- `src/versioning-strategies/always-bump-minor.ts` — `determineReleaseType` takes `_version` and `_commits` unused and returns `MinorVersionUpdate()`.
- `src/strategies/base.ts` — `buildReleasePullRequest` returns undefined on the no-commits check and on `changelogEmpty(releaseNotesBody)`.

## What this costs, stated rather than discovered later

A breaking change is no longer legible from the version number.

- **`versionsIncompatible`** (`cli/src/main/kotlin/ee/schimke/composeai/cli/Version.kt:143`) compares major versions to decide whether a pin/CLI skew is a `warning` or a `note`, on the documented grounds that "a major release changes the render/daemon wire format". It backs `warnOnCliSkew` and two `DoctorCommand` diagnostics. Once no major is ever cut it is permanently false across 2.x and every skew reports as a `note`. It stays correct across the 1.x → 2.x boundary, so it is left alone here — but it stops being a signal after that, and that is a real loss.
- **The changelog becomes the only place a break is announced**, which is why `feat!:` is still worth writing even though it no longer moves a number.

The honest framing: this repo was already not using majors to communicate breakage. The `0.x` line ran to `0.19.x` under `bump-minor-pre-major`, and `1.0.0` was forced with `release-as` rather than earned by a `!`. This stops the number implying a promise the machinery never kept.

## Test plan

Docs only — no code, no workflows, no config in this PR.

- `docs/RELEASING.md` is a release-please `extra-files` target, so the rewritten section was checked against `origin/main` for lost version markers: **3 `x-release-please-start-version` / `-end` pairs before and after**, none inside the replaced range (the `0.7.0` / `1.0.0` / `2.0.0` strings there were prose).
- Anchors resolve: `RELEASING.md#versioning-after-200`, `VERSIONING.md#10-what-is-and-is-not-enforced`.
- Grepped for surviving claims that `feat!` cuts a major — the only hit is this PR's own quotation of the old text.
- `agent-attribution-scan.sh --range origin/main..HEAD` clean; branch is `agent/…`.

**Do not merge this alongside a release PR in flight** — let 1.85.x settle, merge this, and let the 2.0.0 release publish before the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2)_