### PR TITLE
feat(screen): let a generated screen preview at every reference size, not just its own

### DIFF
--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
@@ -176,6 +176,64 @@ class ScreenGeneratorTest {
   }
 
   @Test
+  fun `the screen sizes fan-out is a second wrapper carrying no environment`() {
+    val source =
+      generated(
+          screen(),
+          catalog(card, text),
+          ScreenGenerator.Preview(
+            widthDp = 411,
+            heightDp = 914,
+            fontScale = 1.3,
+            darkMode = true,
+            screenSizes = true,
+          ),
+        )
+        .source
+
+    assertThat(source).contains("import androidx.compose.ui.tooling.preview.PreviewScreenSizes")
+    assertThat(source).contains("@PreviewScreenSizes")
+    assertThat(source).contains("private fun HomeScreenPreviewScreenSizesPreview() {")
+    // The design's own frame stays on its own wrapper: a widthDp beside the multipreview would
+    // override the very axis it varies, and a fontScale or uiMode would apply to all of them.
+    val fanOut = source.substringAfter("@PreviewScreenSizes")
+    assertThat(fanOut).doesNotContain("widthDp")
+    assertThat(fanOut).doesNotContain("fontScale")
+    assertThat(fanOut).doesNotContain("uiMode")
+    // Both wrappers call the screen, and both come after it.
+    assertThat(source.indexOf("fun HomeScreen()")).isLessThan(source.indexOf("@PreviewScreenSizes"))
+  }
+
+  /** The fan-out is the caller's second question, not a thing every preview drags along. */
+  @Test
+  fun `a preview without the fan-out names neither the annotation nor the wrapper`() {
+    val source = generated(screen(), catalog(card, text), ScreenGenerator.Preview()).source
+
+    assertThat(source).contains("@Preview")
+    assertThat(source).doesNotContain("PreviewScreenSizes")
+  }
+
+  @Test
+  fun `a component the fan-out wrapper would shadow is qualified instead`() {
+    // Same trap as the plain wrapper's: the emitted function is top-level, so it beats an import
+    // of the same simple name and the body's call would land on the wrapper that calls the screen.
+    val clashing =
+      component(
+        "HomeScreenPreviewScreenSizesPreview",
+        "androidx.compose.material3.HomeScreenPreviewScreenSizesPreview",
+        emptyList(),
+      )
+    val document = ScreenDocument(name = "HomeScreen", root = ScreenNode(clashing.canonicalId))
+
+    val source =
+      generated(document, catalog(clashing), ScreenGenerator.Preview(screenSizes = true)).source
+
+    assertThat(source)
+      .doesNotContain("import androidx.compose.material3.HomeScreenPreviewScreenSizesPreview")
+    assertThat(source).contains("androidx.compose.material3.HomeScreenPreviewScreenSizesPreview()")
+  }
+
+  @Test
   fun `a light design gets no uiMode rather than a light one`() {
     // `@Preview` already previews light; naming it would claim the design said something it did
     // not, and `UI_MODE_NIGHT_NO` is not the same as "unspecified" to a device configuration.

--- a/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -135,6 +135,22 @@ object ScreenGenerator {
      * a rendering fault to the person who pasted it.
      */
     val showBackground: Boolean = true,
+    /**
+     * Also emit a `@PreviewScreenSizes` wrapper, so the screen is drawn at every reference size
+     * rather than only at the one it was designed on.
+     *
+     * A screen is the one artifact whose whole job is to survive a size it was not drawn at, and a
+     * design carries exactly one frame — so the preview that reproduces that frame answers "does it
+     * look right?" and cannot answer "does it still look right?". The platform ships the second
+     * question's answer as a multipreview, so this emits *that* rather than a hand-written list of
+     * devices: `@PreviewScreenSizes` is maintained with the reference devices, and a list written
+     * here would be a copy of it that goes stale.
+     *
+     * Off by default for the same reason [Preview] itself is opt-in — it is a second tooling
+     * annotation, from the same artifact — and because a caller wanting one picture should not be
+     * handed five.
+     */
+    val screenSizes: Boolean = false,
   )
 
   private const val INDENT = "    "
@@ -231,7 +247,11 @@ object ScreenGenerator {
             // in for the component somebody placed.
             (preview == null ||
               (it.symbol.name != PREVIEW_SIMPLE_NAME &&
-                it.symbol.name != previewFunctionName(document.name)))
+                it.symbol.name != previewFunctionName(document.name))) &&
+            // The fan-out spends two more names on the same terms, and only when it is emitted.
+            (preview?.screenSizes != true ||
+              (it.symbol.name != PREVIEW_SCREEN_SIZES_SIMPLE_NAME &&
+                it.symbol.name != screenSizesPreviewFunctionName(document.name)))
         }
         .map { it.canonicalId }
         .toSet()
@@ -384,7 +404,10 @@ object ScreenGenerator {
       (context.imports +
           context.extensionImports +
           "androidx.compose.runtime.Composable" +
-          listOfNotNull(PREVIEW_ANNOTATION.takeIf { preview != null }))
+          listOfNotNull(
+            PREVIEW_ANNOTATION.takeIf { preview != null },
+            PREVIEW_SCREEN_SIZES_ANNOTATION.takeIf { preview?.screenSizes == true },
+          ))
         .distinct()
         .sorted()
     // Kotlin calls two imports of one simple name a conflicting import and compiles neither. The
@@ -445,6 +468,10 @@ object ScreenGenerator {
       if (preview != null) {
         appendLine()
         append(previewFunction(document.name, preview))
+        if (preview.screenSizes) {
+          appendLine()
+          append(screenSizesPreviewFunction(document.name))
+        }
       }
     }
     return Result.Emitted(source = source, requiredOptIns = optIns + androidxOptIns)
@@ -1474,8 +1501,23 @@ object ScreenGenerator {
 
   private const val PREVIEW_SIMPLE_NAME = "Preview"
 
+  /**
+   * The platform's own reference-size multipreview, from the same tooling artifact as `@Preview`.
+   *
+   * Named rather than expanded into a list of `@Preview(device = …)` lines: the set of reference
+   * devices is androidx's to change, and a copy of it here would be the copy that disagrees with
+   * the IDE.
+   */
+  private const val PREVIEW_SCREEN_SIZES_ANNOTATION =
+    "androidx.compose.ui.tooling.preview.PreviewScreenSizes"
+
+  private const val PREVIEW_SCREEN_SIZES_SIMPLE_NAME = "PreviewScreenSizes"
+
   /** The wrapper's name, needed before it is emitted so a component cannot be shadowed by it. */
   private fun previewFunctionName(screenName: String) = "$screenName$PREVIEW_SIMPLE_NAME"
+
+  private fun screenSizesPreviewFunctionName(screenName: String) =
+    "$screenName$PREVIEW_SCREEN_SIZES_SIMPLE_NAME$PREVIEW_SIMPLE_NAME"
 
   /**
    * A language tag this generator is willing to put inside a string literal.
@@ -1539,5 +1581,23 @@ object ScreenGenerator {
       appendLine("$INDENT$screenName()")
       appendLine("}")
     }
+  }
+
+  /**
+   * The `@PreviewScreenSizes` wrapper: the same screen at every reference size.
+   *
+   * It carries none of the design's environment, and that is the point of it being a second
+   * function rather than another annotation on the first. The multipreview supplies each device's
+   * own width, height and density; a `widthDp` beside it would override the very thing being
+   * varied, and a `uiMode` or `fontScale` would quietly apply to all five. The design's own frame,
+   * theme and type scale stay on [previewFunction], where they describe one picture the author
+   * actually approved.
+   */
+  private fun screenSizesPreviewFunction(screenName: String): String = buildString {
+    appendLine("@$PREVIEW_SCREEN_SIZES_SIMPLE_NAME")
+    appendLine("@Composable")
+    appendLine("private fun ${screenSizesPreviewFunctionName(screenName)}() {")
+    appendLine("$INDENT$screenName()")
+    appendLine("}")
   }
 }


### PR DESCRIPTION
## What this changes

A design carries one frame, so the preview a generated screen gets reproduces one picture — the size its author drew it at. That answers *does it look right?* and cannot answer *does it still look right?*, which for a screen is the question that matters: a screen's whole job is to survive a size nobody drew it at.

`ScreenGenerator.Preview` gains `screenSizes`. When set, the generator emits a second wrapper beside the first:

```kotlin
@Preview(
    widthDp = 411,
    heightDp = 914,
    showBackground = true,
)
@Composable
private fun HomeScreenPreview() {
    HomeScreen()
}

@PreviewScreenSizes
@Composable
private fun HomeScreenPreviewScreenSizesPreview() {
    HomeScreen()
}
```

**The platform's own multipreview, not a hand-written device list.** The reference set is androidx's to change; a list of `@Preview(device = …)` lines written here would be the copy that goes stale against what the IDE shows.

**A second function rather than another annotation on the first**, because the two carry different things. The multipreview supplies each device's width, height and density — a `widthDp` beside it would override the very axis being varied, and a `fontScale` or `uiMode` would silently apply to all five. The design's own frame, theme and type scale stay on the first wrapper, where they describe the one picture its author approved.

**Opt-in**, on exactly the terms `Preview` itself already is: it is a second annotation from `androidx.compose.ui.tooling.preview`, an artifact a generator consumer need not have on its compile classpath, and a caller who asked for one picture should not be handed five.

The two names it spends — the annotation's simple name and the wrapper's — join the shadowing guard that already stops a component called `Preview` or `HomeScreenPreview` from resolving to the file's own top-level declarations, and only when the fan-out is emitted.

## Test plan

Three cases in `ScreenGeneratorTest`, beside the existing preview coverage (55 green):

- the fan-out is a second wrapper carrying none of the environment — asserts the emitted `@PreviewScreenSizes` block names no `widthDp`, `fontScale` or `uiMode`, and that both wrappers follow the screen;
- a preview without it names neither the annotation nor the wrapper;
- a component whose name would be shadowed by the fan-out wrapper is called fully qualified instead — the same stack-overflow trap the plain wrapper's guard exists for.

Also `:screen-model:jvmTest`, since `screen/generator/` is a source directory shared by that module and `:gradle-plugin:preview-discovery`.

## Why this, now

The UI builder currently exports a screen with one preview at the design's own frame. This is the generator half of making a design preview across devices; the builder opting in follows once this is released, and the Wear screen exporter already does the equivalent with `@WearPreviewDevices`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9bqpc2okyZebUgQiYjMn4


---
_Generated by [Claude Code](https://claude.ai/code/session_01S9bqpc2okyZebUgQiYjMn4)_