### PR TITLE
ci: lock each published module's resolved dependencies, with auto-regen

### DIFF
--- a/.github/workflows/dependency-locks.yml
+++ b/.github/workflows/dependency-locks.yml
@@ -91,7 +91,18 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: Regenerate lockfiles
-        run: ./gradlew resolveAndLockAll --write-locks
+        # `--no-configuration-cache` is load-bearing, not tidying. `gradle.properties` sets
+        # `org.gradle.configuration-cache=true` AND `configuration-cache.problems=fail`, and
+        # writing lock state means resolving configurations at execution time — which is
+        # `Task.project` access, one of the things the configuration cache forbids. The task
+        # carries `notCompatibleWithConfigurationCache`, and that is NOT enough on its own: the
+        # first run of this workflow still failed with 152 problems and a discarded entry.
+        #
+        # Turning the cache off for this one invocation is the right trade rather than a
+        # workaround. Regenerating lock state is a maintenance task that runs once per dependency
+        # PR and resolves everything by definition, so it has nothing to gain from a cache whose
+        # whole purpose is to skip configuration.
+        run: ./gradlew resolveAndLockAll --write-locks --no-configuration-cache
 
       - name: Did anything move?
         id: diff

--- a/.github/workflows/dependency-locks.yml
+++ b/.github/workflows/dependency-locks.yml
@@ -1,0 +1,158 @@
+name: Dependency Locks
+
+# Keeps every published module's committed `gradle.lockfile` in step with the dependency
+# declarations that produced it.
+#
+# ## Why a workflow and not Renovate itself
+#
+# Renovate's own `postUpgradeTasks` would be the obvious home for this — it runs a command after an
+# upgrade and folds the result into the same commit. It is not available here: that feature needs a
+# SELF-HOSTED Renovate with the command allow-listed (`allowedPostUpgradeCommands`), and this
+# repository uses the hosted Mend app (there is no renovate workflow; `.github/renovate.json` just
+# extends `github>yschimke/renovate-config`). So the regeneration has to be a workflow that pushes
+# into the pull request branch.
+#
+# ## The automerge hazard this is built around
+#
+# `.github/renovate.json` sets `platformAutomerge: true`, and the shared preset automerges
+# minor/patch/digest/pin. A dependency PR therefore merges the moment the last REQUIRED check of the
+# `Protect Main` ruleset reports green. If the lockfiles were stale at that moment, `main` takes a
+# lock state that does not match its own dependency declarations.
+#
+# Pushing a fix is only half an answer, because of a constraint this repository has already been
+# bitten by once (see docs/RELEASING.md on the retired `refresh-driver-pin.yml`): **a push made with
+# `GITHUB_TOKEN` does not start workflow runs.** So regenerating and pushing with the default token
+# leaves the new head commit with no checks reporting at all — the PR does not merge stale, it
+# simply never merges.
+#
+# Hence the two modes below, and the deliberate refusal in the middle:
+#
+#   * `LOCKFILE_REGEN_TOKEN` set (a GitHub App installation token or fine-grained PAT with
+#     `contents: write`) — the push starts workflow runs like any human push, every check re-runs
+#     against the regenerated commit, and automerge proceeds normally. This is the intended setup.
+#   * No such secret — the job REGENERATES, and if any *tracked* lockfile went stale it FAILS with
+#     the list in the log. Nothing is pushed. Make this a required check and a stale-lock PR is held
+#     open rather than merged, which is the safe direction; a human runs the one command in the
+#     failure message. A lockfile that is merely NEW (untracked) does not fail — see the step
+#     comment on why stale and new are not the same situation.
+#
+# What must never happen is this job passing while the lockfiles are stale, so there is no third
+# branch here that "warns" and goes green.
+#
+# ## Bootstrapping
+#
+# Locking is enabled with `LockMode.DEFAULT` (see `ComposeAiMavenPublishingPlugin`), which does NOT
+# fail a locked configuration that has no lock state — so the repository builds exactly as before
+# until the first lockfile is written. To generate them all the first time, dispatch this workflow
+# on a branch (not `main`): every lockfile is new rather than stale, so the job reports them and —
+# with a token — pushes them to that branch for review, without failing.
+
+on:
+  pull_request:
+    paths:
+      - 'gradle/libs.versions.toml'
+      - '**/build.gradle.kts'
+      - 'build-logic/**'
+      - 'gradle/wrapper/gradle-wrapper.properties'
+      - '**/gradle.lockfile'
+      - '.github/workflows/dependency-locks.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-locks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  regenerate:
+    # A fork PR has no writable token and must not be handed one. Renovate's branches live in this
+    # repository, so the case this job exists for is unaffected.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    # Job level, not step level: a step's own `env:` is not in scope for that step's `if:`.
+    env:
+      HAVE_TOKEN: ${{ secrets.LOCKFILE_REGEN_TOKEN != '' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The PR's head BRANCH, not the merge ref: a push has to land on the branch, and a
+          # detached merge commit cannot be pushed anywhere useful.
+          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          token: ${{ secrets.LOCKFILE_REGEN_TOKEN || github.token }}
+          persist-credentials: true
+
+      - uses: ./.github/actions/setup
+
+      - name: Regenerate lockfiles
+        run: ./gradlew resolveAndLockAll --write-locks
+
+      - name: Did anything move?
+        id: diff
+        # STALE and NEW are different situations and are not treated the same.
+        #
+        # A *tracked* lockfile that changed is stale: the branch moved a dependency and the
+        # recorded lock state no longer matches. That is the case this workflow exists for, and it
+        # must never reach `main` unnoticed.
+        #
+        # An *untracked* lockfile is a module acquiring lock state for the first time — a newly
+        # added module, or the initial bootstrap across the whole repository. Nothing is stale
+        # there, because there was no previous state to go stale, and `LockMode.DEFAULT` means the
+        # build resolved exactly as before. Failing on that would make the very change that
+        # introduces locking fail its own check.
+        #
+        # `git ls-files` rather than a `**/gradle.lockfile` pathspec: that glob misses a lockfile
+        # at the repository root, and `git diff` cannot see an untracked file at all.
+        run: |
+          git ls-files -m | grep -E '(^|/)gradle\.lockfile$' > /tmp/stale-locks.txt || true
+          git ls-files -o --exclude-standard | grep -E '(^|/)gradle\.lockfile$' \
+            > /tmp/new-locks.txt || true
+          cat /tmp/stale-locks.txt /tmp/new-locks.txt > /tmp/moved-locks.txt
+          stale=$(wc -l < /tmp/stale-locks.txt)
+          new=$(wc -l < /tmp/new-locks.txt)
+          echo "stale=${stale}" >> "$GITHUB_OUTPUT"
+          echo "changed=$([ -s /tmp/moved-locks.txt ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "stale lockfiles: ${stale}, new lockfiles: ${new}"
+          [ -s /tmp/stale-locks.txt ] && cat /tmp/stale-locks.txt
+          exit 0
+
+      - name: Push the regenerated lockfiles
+        if: steps.diff.outputs.changed == 'true' && env.HAVE_TOKEN == 'true'
+        run: |
+          git config user.name 'Yuri Schimke'
+          git config user.email 'yuri@schimke.ee'
+          xargs -a /tmp/moved-locks.txt git add --
+          # `chore(deps):` deliberately: a squash merge takes the PR TITLE, so this commit's own
+          # subject never reaches release-please — but a branch commit still shows up in review, and
+          # `chore` is what it is. See docs/RELEASING.md.
+          git commit -m 'chore(deps): regenerate Gradle dependency lockfiles'
+          git push origin HEAD
+
+      - name: Refuse to pass with stale lockfiles
+        # Only STALE (tracked, modified) lockfiles fail. New ones are reported by the step above and,
+        # with a token, pushed; without one they are simply left for a human, since a module with no
+        # lock state is exactly what the build did before this workflow existed.
+        if: steps.diff.outputs.stale != '0' && env.HAVE_TOKEN != 'true'
+        run: |
+          {
+            echo "### Dependency lockfiles are stale"
+            echo
+            echo "This branch changes dependency declarations but its \`gradle.lockfile\`s do not"
+            echo "match. No \`LOCKFILE_REGEN_TOKEN\` secret is configured, so this job will not push"
+            echo "the fix itself — pushing with the default token would leave the new commit with no"
+            echo "checks reporting, and the pull request would never merge."
+            echo
+            echo "Regenerate locally and push:"
+            echo
+            echo '```'
+            echo './gradlew resolveAndLockAll --write-locks'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::error::Lockfiles are stale and no LOCKFILE_REGEN_TOKEN is configured."
+          exit 1

--- a/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiMavenPublishingPlugin.kt
+++ b/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiMavenPublishingPlugin.kt
@@ -4,6 +4,7 @@ import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import com.vanniktech.maven.publish.SourcesJar
+import org.gradle.api.artifacts.dsl.LockMode
 import java.io.File
 import javax.inject.Inject
 import org.gradle.api.Plugin
@@ -47,6 +48,7 @@ class ComposeAiMavenPublishingPlugin : Plugin<Project> {
         ?: project.nextPatchSnapshotVersion()
 
     project.configureAndroidLibraryPublication()
+    project.configureDependencyLocking()
 
     project.afterEvaluate {
       val artifactId =
@@ -134,3 +136,89 @@ private fun Project.nextPatchSnapshotVersion(): String {
   val (major, minor, patch) = current.split(".").map { it.toInt() }
   return "$major.$minor.${patch + 1}-SNAPSHOT"
 }
+
+/**
+ * Record each published module's resolved dependency graph in a committed `gradle.lockfile`.
+ *
+ * ## Why this module and not the whole build
+ *
+ * The release guard ([.github/scripts/maven-publish-needed.sh]) has to answer "could this
+ * artifact's bytes differ from the last published release?". Its crudest rule is that ANY change
+ * to `gradle/libs.versions.toml` dirties all 94 published modules, because a path diff cannot tell
+ * which of them actually resolve the bumped coordinate. Measured over v1.57.0..v1.84.0, that one
+ * rule accounts for ~97% of the publishing the guard cannot eliminate: 16 of 38 release windows
+ * touched a shared build input, 9 of them the version catalog alone.
+ *
+ * A lock state answers the question exactly instead of approximating it. Gradle records what each
+ * module actually resolved, the file is committed, and the guard diffs it — no parsing of catalog
+ * aliases, no upward closure, no guessing. It also catches a case alias-matching would miss: the
+ * POM carries *declared* versions (there is no `versionMapping` here), so a bump to a purely
+ * transitive dependency does not change a consumer's POM — but Kotlin inlines `inline` functions
+ * from the compile classpath into the caller, so the consumer's jar bytes can still move.
+ *
+ * ## LockMode.DEFAULT, deliberately
+ *
+ * DEFAULT does not fail a locked configuration that has no lock state; STRICT does. That is what
+ * makes this safe to land before a single lockfile exists — every module resolves exactly as it
+ * did, and the files arrive when `dependency-locks.yml` first writes them. STRICT is also a known
+ * source of false failures on configurations that are not really resolvable (gradle#12010), which
+ * is the second reason not to reach for it.
+ *
+ * ## Only the configurations that decide a published artifact
+ *
+ * NOT `lockAllConfigurations()`. Locking the test classpaths would mean a test-only dependency
+ * bump rewrote a lockfile and so dirtied a module whose published bytes cannot have changed —
+ * re-introducing, one layer down, exactly the over-reporting this exists to remove. The names
+ * below are the resolvable compile/runtime classpaths of the variants we actually publish: the
+ * plain JVM pair, the Android `release` pair (we publish `AndroidSingleVariantLibrary("release")`),
+ * and the KMP `jvm` pair.
+ *
+ * Known gap, stated rather than discovered later: a KMP module publishing targets beyond `jvm`
+ * has classpaths not named here, so its lock state is incomplete and the guard learns nothing
+ * about those targets' dependencies. The guard fails open on a module with no lock state, so this
+ * is safe — it just does not save anything for those modules yet.
+ */
+private fun Project.configureDependencyLocking() {
+  dependencyLocking { lockMode.set(LockMode.DEFAULT) }
+
+  configurations.configureEach {
+    if (name in LOCKED_CONFIGURATIONS) {
+      resolutionStrategy.activateDependencyLocking()
+    }
+  }
+
+  // `./gradlew resolveAndLockAll --write-locks` regenerates every lockfile in one invocation.
+  // Resolving inside the task (rather than relying on some other task to touch the configuration)
+  // is what makes a module with no consumers still get a lockfile written.
+  tasks.register("resolveAndLockAll") {
+    group = "help"
+    description = "Resolves the published configurations so --write-locks can record them."
+    notCompatibleWithConfigurationCache("Resolves configurations at execution time")
+    doFirst {
+      require(project.gradle.startParameter.isWriteDependencyLocks) {
+        "resolveAndLockAll must be run with --write-locks"
+      }
+    }
+    doLast {
+      configurations
+        .filter { it.isCanBeResolved && it.name in LOCKED_CONFIGURATIONS }
+        .forEach { it.resolve() }
+    }
+  }
+}
+
+/**
+ * The resolvable classpaths that determine a published artifact's POM and bytecode. Explicit names
+ * rather than a pattern: `^(release)?(compile|runtime)Classpath$` would read as if it excluded the
+ * test classpaths by luck of anchoring, and the cost of it one day not doing so is a lockfile that
+ * churns on test-only bumps.
+ */
+private val LOCKED_CONFIGURATIONS =
+  setOf(
+    "compileClasspath",
+    "runtimeClasspath",
+    "releaseCompileClasspath",
+    "releaseRuntimeClasspath",
+    "jvmCompileClasspath",
+    "jvmRuntimeClasspath",
+  )

--- a/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiMavenPublishingPlugin.kt
+++ b/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiMavenPublishingPlugin.kt
@@ -202,7 +202,17 @@ private fun Project.configureDependencyLocking() {
     doLast {
       configurations
         .filter { it.isCanBeResolved && it.name in LOCKED_CONFIGURATIONS }
-        .forEach { it.resolve() }
+        // GRAPH resolution, not `resolve()`. `resolve()` asks for the configuration's *files*,
+        // which forces artifact-variant selection — and on an Android `releaseCompileClasspath`
+        // that fails outright, because AGP normally supplies `artifactType` through its own
+        // ArtifactViews and a raw request cannot choose between `android-classes-jar`,
+        // `android-lint`, `android-manifest`, `jar`, `r-class-jar` and the rest
+        // ("cannot choose between the following variants of project ':data-a11y-core'").
+        //
+        // Lock state records module versions, so the graph is all it needs and no file has to be
+        // selected or downloaded. This is the same path Gradle's own `dependencies` report takes —
+        // which is what the generated lockfile header tells you to run to regenerate it.
+        .forEach { it.incoming.resolutionResult.root }
     }
   }
 }

--- a/docs/design/RELEASE_TRAINS.md
+++ b/docs/design/RELEASE_TRAINS.md
@@ -1,7 +1,8 @@
 # Release trains
 
-**Status: measurement + proposal.** The guard described in § 4 is implemented and running in
-reporting mode; the train split in § 5 is not built. Issue
+**Status: measurement + proposal.** The guard in § 4 is implemented and running in reporting mode.
+The dependency lock state in § 6 is implemented; the guard does not read it yet. The train split in
+§ 5 is not built, and § 6's graph-based measurement supersedes its grouping. Issue
 [#4772](https://github.com/yschimke/compose-ai-tools/issues/4772).
 
 This repository publishes 94 Maven Central artifacts on a version line that cuts a release
@@ -78,6 +79,7 @@ predecessor.
 | Publish only when a published module changed | § 4 | **Implemented, reporting only** |
 | Split the Maven publish into several trains | § 5 | Proposed |
 | Version each module independently | Largest, but contradicts `VERSIONING.md` § 3.1 | **Out of scope** |
+| Narrow the shared-input rule with dependency lock state | § 6 — ~97% of the remaining cost | **Locking implemented; guard not reading it yet** |
 
 Batching is by far the biggest lever and it is deliberately not taken: the release frequency is
 a product decision, not an accident. Everything below therefore reduces *artifacts per release*
@@ -138,6 +140,13 @@ changes, or when a shared build input does):
 The shape of the win is `data/`: 58 modules — 62% of everything we publish — moving on half the
 releases. It is the single largest block of artifacts and close to the slowest-changing.
 
+> **These groups are drawn from directory paths, and the paths do not match the dependency graph.**
+> `render-session` spans layers 0, 2, 3 and 5; `daemon` spans 0, 1 and 4; `data` spans 0, 1 and 2.
+> § 6 measures the same question against the real graph and gets a better answer (−53.4%) than any
+> path-based grouping, which makes this table a costing of one candidate rather than a
+> recommendation. Restructuring the directories to match the layers would buy about three
+> percentage points — see § 6's propagation numbers — and is not worth a 94-module reshuffle.
+
 Each train stays internally all-or-nothing, so no train ever publishes a POM naming a sibling
 version that does not exist. This is **not** per-module versioning (`VERSIONING.md` § 3.1,
 explicitly out of scope): it is five version lines instead of one, each still a lockstep set.
@@ -166,17 +175,73 @@ GitHub Release carries the mapping** — extend the existing
 and the installer already gates on. The CLI uses its own baked value on the fast path and reads
 the marker only when the pin names a different release.
 
-## 6. What limits this further
+## 6. The shared-input rule is what limits this, and lockfiles are the fix
 
-The guard is conservative about shared build inputs, and that conservatism is most of the
-remaining gap: **16 of 38 windows touch a shared input, 13 of them the version catalog.** A
-Renovate bump of one dependency currently forces every train to publish, though it changes only
-the POMs of modules that actually depend on the bumped coordinate.
+The guard is conservative about shared build inputs, and that conservatism is now essentially the
+whole of the remaining cost:
 
-Narrowing this means resolving, per module, whether a catalog entry reaches its POM — a Gradle
-resolution rather than a path diff. It is the obvious next refinement and it is deliberately not
-in the first version: a wrong answer there skips a publish that was needed, which is the one
-failure this design does not tolerate.
+| | Module-publications |
+|---|---|
+| 16 windows forcing all 94 via a shared build input | **1,504** |
+| All other 22 windows **combined** | **50** |
+
+In 9 of those 16, the *only* shared file touched was `gradle/libs.versions.toml`. One Renovate
+dependency bump republishes all 94 modules, when it changes the POM of only those that actually
+resolve the bumped coordinate.
+
+### Why not just parse the catalog
+
+The obvious fix is to read the catalog diff, resolve `[versions]` refs to aliases, find the modules
+referencing those aliases, and take an upward closure. That is a static approximation of a question
+Gradle can answer exactly, and every gap in the approximation fails in the direction that skips a
+publish — the unrepairable one.
+
+It would also have to model something alias-matching handles badly. Published POMs here carry
+**declared** versions, not resolved ones (there is no `versionMapping`), so a bump to a purely
+transitive dependency does not change a consumer's POM at all. But Kotlin inlines `inline` functions
+from the compile classpath into the caller, so that consumer's **jar bytes** can still move. Getting
+that right by grepping means a coarse closure over dependents; getting it right with a resolved
+graph is free.
+
+### Dependency lock state
+
+`ComposeAiMavenPublishingPlugin` enables Gradle dependency locking on the configurations that decide
+a published artifact — the JVM, Android `release` and KMP `jvm` compile/runtime classpaths, and
+deliberately **not** the test classpaths, since a test-only bump cannot change published bytes.
+Gradle records what each module actually resolved in a committed `gradle.lockfile`, and the guard
+diffs that file instead of guessing from the catalog.
+
+`LockMode.DEFAULT`, not `STRICT`: DEFAULT does not fail a locked configuration that has no lock
+state, which is what makes the mechanism safe to land before a single lockfile exists.
+
+Keeping the files current is [`dependency-locks.yml`](../../.github/workflows/dependency-locks.yml).
+Renovate cannot do it — `postUpgradeTasks` needs a self-hosted Renovate with the command
+allow-listed, and this repository uses the hosted Mend app — so a workflow regenerates and pushes
+into the pull request branch. That workflow's header documents the constraint it is built around:
+`platformAutomerge` is on, a `GITHUB_TOKEN` push starts no workflow runs, and so the job either
+pushes with a real token or **fails**, never passes while the lock state is stale.
+
+### Propagation, measured
+
+The worry that a lower module's change would cascade upward and erase the saving does not hold. The
+in-repo graph is shallow and wide — 39 of 94 modules depend on no other published module, and only
+`daemon/core` has a large blast radius (47 modules, changed in 7 of 38 windows).
+
+| Model | Module-publications | vs today |
+|---|---|---|
+| Per-module, **no** propagation | 1,554 | −56.5% |
+| Per-module, **eager** propagation | 1,666 | **−53.4%** |
+
+Propagation costs three percentage points. It is not the thing to design around; the shared-input
+rule is.
+
+### The number that frames all of this
+
+**67 of the 94 modules changed in zero of the 38 windows** — 71% of the published surface, inert for
+a week and republished 38 times each regardless. Over a longer window more of them would move, so
+read it as "inert at this timescale", not "dead". It is the argument for not republishing unchanged
+modules, and not an argument for merging them: of 21 `data/*` families with more than one published
+module, exactly one always changed as a unit.
 
 ## 7. Going live
 


### PR DESCRIPTION
Refs #4772. Replaces the guard's crudest rule with an exact one.

## Why

The guard's worst rule is that **any** change to `gradle/libs.versions.toml` dirties all 94 published modules, because a path diff can't tell which of them actually resolve the bumped coordinate. Over v1.57.0..v1.84.0 that one rule is ~97% of the publishing the guard can't eliminate:

| | Module-publications |
|---|---|
| 16 windows forcing all 94 via a shared build input | **1,504** |
| All other 22 windows **combined** | **50** |

In 9 of those 16, the only shared file touched was the catalog. One Renovate bump republishes all 94.

## Why not just parse the catalog

That was the plan, and it's worse. Resolving `[versions]` refs to aliases, matching modules, taking an upward closure — it's a static approximation of a question Gradle answers exactly, and every gap fails in the direction that *skips* a publish.

It also has to model a case alias-matching handles badly. POMs here carry **declared** versions (there's no `versionMapping`), so a purely transitive bump doesn't change a consumer's POM — but Kotlin inlines `inline` functions from the compile classpath into the caller, so that consumer's **jar bytes** can still move. A resolved graph gets this for free.

## What this does

Enables Gradle dependency locking in `ComposeAiMavenPublishingPlugin`, scoped to the configurations that decide a published artifact — the JVM, Android `release`, and KMP `jvm` compile/runtime classpaths — and **not** the test classpaths, since a test-only bump can't change published bytes. That exclusion is itself saving the current rule doesn't get.

`LockMode.DEFAULT`, not `STRICT`: DEFAULT does not fail a locked configuration that has no lock state ([LockMode](https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.api.artifacts.dsl/-lock-mode/index.html)), which is what makes this safe to land before a single lockfile exists. STRICT is also a known source of false failures on not-really-resolvable configurations ([gradle#12010](https://github.com/gradle/gradle/issues/12010)).

**The guard does not read lock state yet** — that's the next step, same staged pattern as before.

## The auto-regen, and the constraint it's built around

Renovate can't do this itself: `postUpgradeTasks` needs a **self-hosted** Renovate with the command allow-listed, and this repo uses the hosted Mend app (no renovate workflow; `.github/renovate.json` just extends the shared preset). So `dependency-locks.yml` regenerates and pushes into the PR branch.

Two facts make the naive version wrong:

1. `platformAutomerge: true` — a dependency PR merges the moment the last required check goes green. Stale lock state must not be able to slip through that window.
2. **A `GITHUB_TOKEN` push starts no workflow runs** — the same constraint that retired `refresh-driver-pin.yml` (see `docs/RELEASING.md`). Pushing the fix with the default token leaves the new head with no checks reporting, so the PR doesn't merge stale, it never merges at all.

So the job either pushes with a real token or **fails**. There is deliberately no third branch that warns and goes green:

- **`LOCKFILE_REGEN_TOKEN` set** (App installation token or fine-grained PAT, `contents: write`) → pushes, checks re-run normally, automerge proceeds. **This is the setup to aim for and needs you to add the secret — I can't.**
- **Not set** → regenerates, and if a *tracked* lockfile went stale, fails with the list. Make it a required check and the PR is held open rather than merged.

Stale and new are not the same situation: a tracked lockfile that moved is stale and blocks; an untracked one is a module gaining lock state for the first time (a new module, or the bootstrap) and doesn't. Without that distinction this very PR would fail its own new check.

## Test plan

- **`./gradlew -p build-logic compileKotlin` passes.** This is the check that mattered — a build-logic compile failure breaks the entire build.
- **Generated a real lockfile end-to-end** with the new task, `./gradlew :common-web-escaping:resolveAndLockAll --write-locks`:

```
# This is a Gradle generated file for dependency locking.
org.jetbrains.kotlin:kotlin-stdlib:2.4.10=compileClasspath,runtimeClasspath
org.jetbrains:annotations:13.0=compileClasspath,runtimeClasspath
empty=
```

Note it locked **only** `compileClasspath,runtimeClasspath` — the test classpaths are correctly out of scope, which is the property the whole design rests on.
- **No lockfiles are committed here.** `LockMode.DEFAULT` means the build resolves exactly as it does today until they exist; dispatch the workflow on a branch to generate them all, and every one is *new* rather than stale, so it reports and pushes without failing.
- Both workflows parse as YAML; step outputs routed through `env:` rather than `${{ }}` inside `run:`.
- `build-logic` has no `ktfmtFormat` task, so its sources aren't covered by the format gate — verified rather than assumed.
- Attribution scan clean on `origin/main..HEAD`; branch is `agent/…`.

## Also in this PR

`docs/design/RELEASE_TRAINS.md` § 6 rewritten with the graph-based measurement, which **corrects a number I previously put in that doc**. Propagation — a lower module's change cascading upward — costs 3 percentage points, not the large amount I implied:

| Model | Module-publications | vs today |
|---|---|---|
| Per-module, no propagation | 1,554 | −56.5% |
| Per-module, **eager** propagation | 1,666 | **−53.4%** |

The graph is shallow and wide: 39 of 94 modules depend on no other published module, and only `daemon/core` has a large blast radius (47 modules, changed in 7 of 38 windows). § 5's five-train grouping was drawn from directory paths, which don't match the dependency layers (`render-session` spans layers 0/2/3/5), and it is now marked as a costing of one candidate rather than a recommendation.

One more number worth recording: **67 of 94 modules changed in zero of the 38 windows** — inert for a week, republished 38 times each. Over a longer window more would move, so it reads as "inert at this timescale", not "dead".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2)_