### PR TITLE
refactor(cli): split the preview-server pin into library and distribution

### DIFF
--- a/.github/ci/check_preview_server_pin.py
+++ b/.github/ci/check_preview_server_pin.py
@@ -5,7 +5,11 @@
 yschimke/compose-preview-server, and since #5183 the CLI fetches it itself on first use rather than
 expecting the installer to: `ServerDistributionProvision` downloads
 `compose-preview-server-<pin>.tar.gz` from the Release tagged `v<pin>`, where `<pin>` is the
-`composeai-preview-serve` entry in `gradle/libs.versions.toml`, baked into the jar at build time.
+`composeai-preview-server-dist` entry in `gradle/libs.versions.toml`, baked into the jar at build
+time. That pin and not `composeai-preview-serve`: since the two were split, the latter names the
+published jar `:cli` compiles its wire-drift tests against, while this one names the RELEASE an
+installed CLI downloads. Only the latter needs a GitHub Release with tarballs attached, which is
+the only thing this gate can check.
 
 So that pin is now load-bearing for a command, not just for a compile. A pin naming a version whose
 Release does not exist — or exists without the distribution attached — is a `serve` that cannot
@@ -51,7 +55,9 @@ CATALOG = Path("gradle/libs.versions.toml")
 SERVER_REPO = "yschimke/compose-preview-server"
 VERSION_KT = Path("cli/src/main/kotlin/ee/schimke/composeai/cli/Version.kt")
 
-PIN_RE = re.compile(r'^\s*composeai-preview-serve\s*=\s*"([^"]+)"', re.MULTILINE)
+# Anchored on the full key: `composeai-preview-serve` is a *different* pin that sits a few lines
+# above this one in the catalog, and a prefix match would silently gate the wrong version.
+PIN_RE = re.compile(r'^\s*composeai-preview-server-dist\s*=\s*"([^"]+)"', re.MULTILINE)
 REPO_CONST_RE = re.compile(r'PREVIEW_SERVER_REPO\s*[:=][^"]*"([^"]+)"')
 
 # Deliberately loose: the pin must look like a release tag a consumer can resolve, not conform to
@@ -64,7 +70,7 @@ RELEASE_API = "https://api.github.com/repos/{repo}/releases/tags/v{version}"
 
 
 def pin_from(text: str) -> str | None:
-    """The `composeai-preview-serve` version declared in a `libs.versions.toml` body, or None."""
+    """The `composeai-preview-server-dist` version in a `libs.versions.toml` body, or None."""
     m = PIN_RE.search(text)
     return m.group(1) if m else None
 
@@ -72,7 +78,7 @@ def pin_from(text: str) -> str | None:
 def current_pin() -> str:
     pin = pin_from((REPO / CATALOG).read_text())
     if pin is None:
-        raise SystemExit(f'could not find `composeai-preview-serve = "…"` in {CATALOG}')
+        raise SystemExit(f'could not find `composeai-preview-server-dist = "…"` in {CATALOG}')
     return pin
 
 
@@ -127,7 +133,7 @@ def main() -> int:
     ap.add_argument(
         "--print-pin",
         action="store_true",
-        help="print the current compose-preview-serve pin and exit",
+        help="print the current compose-preview-server distribution pin and exit",
     )
     ap.add_argument(
         "--print-repo",
@@ -157,7 +163,7 @@ def main() -> int:
 
     if not VERSION_RE.match(pin):
         print(
-            f'::error::`composeai-preview-serve = "{pin}"` in {CATALOG} does not look like a '
+            f'::error::`composeai-preview-server-dist = "{pin}"` in {CATALOG} does not look like a '
             f"release version.\n"
             f"  `compose-preview serve` resolves the server distribution by this value alone, so "
             f"anything that is not a published tag leaves the command unable to start.",
@@ -198,8 +204,8 @@ def main() -> int:
 
     if published is None:
         print(
-            f'::error::`composeai-preview-serve = "{pin}"` in {CATALOG} names a release that does '
-            f"not exist: {declared} has no tag v{pin}.\n"
+            f'::error::`composeai-preview-server-dist = "{pin}"` in {CATALOG} names a release '
+            f"that does not exist: {declared} has no tag v{pin}.\n"
             f"  The CLI fetches the server from that tag on first `serve`, so this pin serves "
             f"nobody.\n"
             f"  Fix: pin a version {declared} has actually released, or cut that release first.",

--- a/.github/ci/test_check_preview_server_pin.py
+++ b/.github/ci/test_check_preview_server_pin.py
@@ -22,19 +22,27 @@ import check_preview_server_pin as gate
 
 class PinParsing(unittest.TestCase):
     def test_reads_the_pin(self):
-        self.assertEqual(gate.pin_from('composeai-preview-serve = "3.0.0"\n'), "3.0.0")
+        self.assertEqual(gate.pin_from('composeai-preview-server-dist = "3.0.0"\n'), "3.0.0")
 
     def test_reads_the_pin_among_neighbours(self):
         catalog = (
             'composeai-contracts = "2.5.0"\n'
-            "# a comment mentioning composeai-preview-serve\n"
-            'composeai-preview-serve = "3.1.0"\n'
+            "# a comment mentioning composeai-preview-server-dist\n"
+            'composeai-preview-server-dist = "3.1.0"\n'
             'rcplayers = "1.57.0"\n'
         )
         self.assertEqual(gate.pin_from(catalog), "3.1.0")
 
     def test_absent_pin_is_none(self):
         self.assertIsNone(gate.pin_from('composeai-contracts = "2.5.0"\n'))
+
+    def test_does_not_match_the_library_pin(self):
+        # The whole point of the split: `composeai-preview-serve` names the published jar `:cli`
+        # compiles against, and sits a few lines above this pin in the same catalog. Gating that
+        # version against GitHub Release assets would check the wrong thing, and would fail the
+        # moment a server-only release moved the two apart - which is the case the split exists
+        # to allow.
+        self.assertIsNone(gate.pin_from('composeai-preview-serve = "3.2.0"\n'))
 
     def test_does_not_match_the_library_coordinate(self):
         # The `[libraries]` entry of the same name is not a version assignment.
@@ -45,6 +53,12 @@ class PinParsing(unittest.TestCase):
                 'version.ref = "composeai-preview-serve" }\n'
             )
         )
+
+    def test_reads_the_real_catalog(self):
+        # Guards the split at the level that actually matters: whatever the regex says, the pin
+        # this gate reads must exist in the committed catalog. A rename on either side that
+        # nobody propagated here makes `current_pin()` raise rather than silently gate nothing.
+        self.assertRegex(gate.current_pin(), gate.VERSION_RE)
 
 
 class VersionShape(unittest.TestCase):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1192,8 +1192,10 @@ jobs:
   #
   # The preview-server pin rides the same job, for the same reason and against the same hazard
   # one degree louder: since #5183 `compose-preview serve` fetches its server from the release
-  # `composeai-preview-serve` names, so a pin naming a release with no distribution attached is
-  # not a degraded render but a command that cannot start at all. The job keeps its name — it is
+  # `composeai-preview-server-dist` names, so a pin naming a release with no distribution attached
+  # is not a degraded render but a command that cannot start at all. That pin and not
+  # `composeai-preview-serve`, which names the published jar `:cli` compiles against and needs no
+  # GitHub Release to exist — see the split in docs/VERSIONING.md § 8.1. The job keeps its name — it is
   # a required check, and renaming a required check blocks every PR until the ruleset catches up.
   xr-composite-pin:
     name: XR Composite Pin

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -965,7 +965,11 @@ val generateCliVersionResource =
     // fetches on first use. The catalog pin, NOT this CLI's version: the server releases on its own
     // cadence from its own repository, and an installed CLI cannot read the catalog. See
     // `SERVE_VERSION`.
-    val serveVersion = libs.versions.composeai.preview.serve.get()
+    //
+    // `composeai-preview-server-dist`, NOT `composeai-preview-serve`. The latter names the jar the
+    // wire-drift tests compile against; this names the release an installed CLI downloads, and a
+    // server-only release moves one without the other.
+    val serveVersion = libs.versions.composeai.preview.server.dist.get()
     inputs.property("version", cliVersion)
     inputs.property("xrCompositeVersion", xrCompositeVersion)
     inputs.property("serveVersion", serveVersion)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ReleasedDistribution.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ReleasedDistribution.kt
@@ -12,9 +12,11 @@ package ee.schimke.composeai.cli
  * because everything except the names below is identical: the same discovery ordering, the same
  * fetch-on-first-use, the same cache layout, the same failure text shape.
  *
- * One pin covers both. The MCP tarball is attached to the *same* release as the server
- * distribution, so a single reviewed pin move keeps the pair in step; a second version would let
- * them skew, and there is no cadence on which they would skew usefully.
+ * One pin — `composeai-preview-server-dist` — covers both. The MCP tarball is attached to the
+ * *same* release as the server distribution, so a single reviewed pin move keeps the pair in step;
+ * a second version would let them skew, and there is no cadence on which they would skew usefully.
+ * That reasoning is about these two archives only, and is why the pin split that separated the
+ * distribution from the published library left this pair together.
  */
 internal data class ReleasedDistribution(
   /** Launcher script name inside `bin/`, and the name looked up on `PATH`. */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServerDistributionProvision.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServerDistributionProvision.kt
@@ -38,12 +38,15 @@ import kotlinx.coroutines.runBlocking
  *
  * # Which server
  *
- * [SERVE_VERSION] — the `composeai-preview-serve` pin in `gradle/libs.versions.toml`, baked into
- * the jar at build time. A **point pin, not "latest"**: the two repositories release on separate
- * cadences, so resolving `latest` at run time would let a server the CLI has never been built
- * against arrive under it without a pull request, which is the skew #5183 names. Moving the pin is
- * a reviewed change, and `.github/ci/check_preview_server_pin.py` fails a PR whose pin names a
- * release with no distribution attached — a pin that 404s is a `serve` that cannot start.
+ * [SERVE_VERSION] — the `composeai-preview-server-dist` pin in `gradle/libs.versions.toml`, baked
+ * into the jar at build time. That pin, not `composeai-preview-serve`: the latter names the
+ * published jar the wire-drift tests compile against, and compose-preview-server can release the
+ * distributions without republishing the library, so the two move independently. A **point pin, not
+ * "latest"**: the two repositories release on separate cadences, so resolving `latest` at run time
+ * would let a server the CLI has never been built against arrive under it without a pull request,
+ * which is the skew #5183 names. Moving the pin is a reviewed change, and
+ * `.github/ci/check_preview_server_pin.py` fails a PR whose pin names a release with no
+ * distribution attached — a pin that 404s is a `serve` that cannot start.
  *
  * `COMPOSE_PREVIEW_SERVER_VERSION` overrides it, for testing a release the pin has not moved to
  * yet. Pointing at a server you already have is [ServerBinaryDiscovery]'s job, not this one.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Version.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Version.kt
@@ -33,9 +33,9 @@ internal val XR_COMPOSITE_VERSION: String by lazy { cliVersionProperty("xrCompos
 /**
  * Release of the preview server `serve` and `browse` launch — see [ServerDistributionProvision].
  *
- * The `composeai-preview-serve` pin from `gradle/libs.versions.toml`, baked in at build time for
- * the same reason [XR_COMPOSITE_VERSION] is: the installed CLI cannot read the version catalog, and
- * the writer of the cache and any later reader of it must derive one directory.
+ * The `composeai-preview-server-dist` pin from `gradle/libs.versions.toml`, baked in at build time
+ * for the same reason [XR_COMPOSITE_VERSION] is: the installed CLI cannot read the version catalog,
+ * and the writer of the cache and any later reader of it must derive one directory.
  *
  * Deliberately NOT [BUNDLE_VERSION]. compose-preview-server releases on its own cadence and its
  * version line is independent — it went to 2.0.0 when it left this repository while this one was
@@ -43,6 +43,10 @@ internal val XR_COMPOSITE_VERSION: String by lazy { cliVersionProperty("xrCompos
  * resolving that at run time would let a server this CLI has never been built against arrive under
  * it without a pull request. Moving the pin is the reviewed act, and `check_preview_server_pin.py`
  * fails a PR whose pin names a release with no distribution attached.
+ *
+ * Deliberately NOT `composeai-preview-serve` either, since the pin split: that one names the
+ * published jar `:cli`'s wire-drift tests compile against, and the server can cut a release that
+ * carries the distributions without republishing the library. This names the release fetched.
  */
 internal val SERVE_VERSION: String by lazy { cliVersionProperty("serveVersion") }
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -203,22 +203,45 @@ on its own cadence — it went to `2.0.0` when it left, while this repository wa
 **the two version lines mean nothing to each other**. A CLI version does not name a server version
 and never will.
 
-What names one is the `composeai-preview-serve` pin in
-[`gradle/libs.versions.toml`](../gradle/libs.versions.toml). It is the single statement of which
-server a given CLI expects:
+What names one is a pin in [`gradle/libs.versions.toml`](../gradle/libs.versions.toml) — **two of
+them since the split**, because "which server does an installed CLI run" and "which jar do we
+compile against" turned out to be different questions:
+
+| Pin | Answers | Consumers |
+|---|---|---|
+| `composeai-preview-server-dist` | Which **release** an installed CLI downloads | `SERVE_VERSION` in the jar; `ServerDistributionProvision`; `check_preview_server_pin.py` |
+| `composeai-preview-serve` | Which **published jar and sources** this repository builds and tests against | `testImplementation` in `:cli`; the `v<pin>` tag ci.yml reads mirror sources from |
+
+The distribution pin is the one with user impact:
 
 - it is baked into the CLI jar at build time as `SERVE_VERSION`, so the installed CLI carries it;
 - `ServerDistributionProvision` fetches exactly that release's distribution
   (`compose-preview-server-<pin>.tar.gz`) on the first `serve` that finds no server, and caches it
   under `<cache>/composeai/preview-server/<pin>/` — keyed on the server's version, so a CLI upgrade
   does not orphan an unchanged server;
+- `compose-preview mcp serve` fetches `compose-preview-mcp-<pin>.tar.gz` from the **same** release,
+  so this one pin still governs that pair — the two archives ride one release and there is no
+  cadence on which they would skew usefully;
 - `compose-preview doctor` reports it, beside whichever binary it actually found (`env.preview-server`).
 
-A **point pin, never a range or `latest`**, for the reason every other cross-repository pin here is
-one: resolving at run time would let a server this CLI has never been built against arrive under it
-without a pull request. Moving it is the reviewed act, and the `XR Composite Pin` CI job fails a PR
-whose pin names a release that does not exist or carries no distribution — a pin that 404s is a
-`serve` that cannot start, which is what
+**Why they are separate.** compose-preview-server's release workflow has two lanes and can cut a
+release that carries the distributions without publishing anything to Maven Central (its
+`release:no-maven` label). A single pin could not name such a release at all: pointing at it would
+break `:cli`'s `testImplementation` even though the thing `serve` launches is exactly what changed.
+Conversely a library-only concern — a wire-drift test, a mirrored source file — has no reason to
+push a new server onto every installed CLI.
+
+They may differ, and when they do the distribution pin is normally the newer. Neither is allowed to
+drift on its own: moving either is a reviewed act in a pull request, and only
+`composeai-preview-server-dist` is gated against the server's Releases, because it is the only one
+that needs a Release to exist. The library pin is checked the ordinary way — by the build failing to
+resolve it.
+
+Both are **point pins, never a range or `latest`**, for the reason every other cross-repository pin
+here is one: resolving at run time would let a server this CLI has never been built against arrive
+under it without a pull request. Moving either is the reviewed act, and the `XR Composite Pin` CI
+job fails a PR whose **distribution** pin names a release that does not exist or carries no
+distribution — a pin that 404s is a `serve` that cannot start, which is what
 [#5183](https://github.com/yschimke/compose-ai-tools/issues/5183) reported.
 
 Skew is still possible and is bounded rather than prevented: an operator may point at any server

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -376,20 +376,48 @@ composeai-contracts = "2.5.0"
 # this repository (compose-preview-server#289), and 3.0.0 retired the old coordinate at its final
 # 2.x. `:cli` depends on `project(":render-host")`; there is no version ref to share any more.
 #
-# This pin is also RUNTIME-load-bearing, not just a compile-time coordinate, and for TWO commands
-# since #5176. `compose-preview serve` is a launcher, and since #5183 the CLI fetches the server
-# itself on first use: the pin is baked into the jar as `SERVE_VERSION` and names the release whose
-# `compose-preview-server-<pin>.tar.gz` `ServerDistributionProvision` downloads. `compose-preview
-# mcp serve` is a launcher over `compose-preview-mcp-<pin>.tar.gz` from the SAME release, so one pin
-# governs the pair. A pin naming a release that does not exist, or one carrying only one of the two
-# archives, is a command that cannot start — `check_preview_server_pin.py` fails the PR rather than
-# letting that reach an install, and it checks both. docs/VERSIONING.md § 8.1.
+# This pin names what this repository BUILDS AND TESTS AGAINST, and nothing else. Two consumers,
+# which must stay equal to each other:
+#
+#   * `testImplementation(libs.composeai.preview.serve)` in `:cli` — the published jar the
+#     wire-drift tests check this CLI's half against;
+#   * the `v<pin>` tag ci.yml's "Fetch the pinned preview-server mirror sources" step reads five
+#     source files from, so the mirror is compared against the same release as the artifact on the
+#     classpath. That step's own comment says why: checking head would fail a PR for drift that has
+#     not been released yet.
+#
+# What this pin no longer names is the server an INSTALLED CLI downloads. See
+# `composeai-preview-server-dist` below.
+composeai-preview-serve = "3.2.0"
+
+# The compose-preview-server RELEASE the installed CLI fetches at run time — a different question
+# from the one above, which is why it is a different pin.
+#
+# RUNTIME-load-bearing, for two commands since #5176. `compose-preview serve` is a launcher, and
+# since #5183 the CLI fetches the server itself on first use: this value is baked into the jar as
+# `SERVE_VERSION` and names the release whose `compose-preview-server-<pin>.tar.gz`
+# `ServerDistributionProvision` downloads. `compose-preview mcp serve` is a launcher over
+# `compose-preview-mcp-<pin>.tar.gz` from the SAME release, so one pin still governs that pair —
+# there is no cadence on which the two archives would skew usefully. A pin naming a release that
+# does not exist, or one carrying only one of the two archives, is a command that cannot start;
+# `check_preview_server_pin.py` fails the PR rather than letting that reach an install, and it
+# checks both archives. docs/VERSIONING.md § 8.1.
+#
+# Split from `composeai-preview-serve` because the two answer different questions and the server
+# now releases on lanes that can move one without the other. compose-preview-server can cut a
+# release carrying only the distributions and no Maven artifacts (its `release:no-maven` label), and
+# a single pin could not name such a release at all: pointing at it would break `:cli`'s
+# `testImplementation` even though the thing `serve` launches was exactly what changed.
+#
+# They may differ, and when they do this one is normally the newer. Moving either is a reviewed act;
+# moving this one changes which server every installed CLI downloads, so it is the one with user
+# impact even though the other is the one that shows up in a compile error.
 #
 # 3.2.0 is the first release carrying the MCP distribution: compose-preview-server#308 moved the
 # module there and #314 released it. 3.1.0 carried the archive but published a `compose-preview-serve`
 # POM naming an unpublished project (`ui-builder-export-jvm:unspecified`), so it resolves for nobody;
 # compose-preview-server#316 fixed that and rides in this release too.
-composeai-preview-serve = "3.2.0"
+composeai-preview-server-dist = "3.2.0"
 
 # The Remote Compose players, published by yschimke/rc-players (the CMP player stack, the vendored
 # AndroidX embedded player, and the Wasm browser bundle). They were project deps here until the


### PR DESCRIPTION
`composeai-preview-serve` answered two questions that have come apart.

It named **the published jar `:cli` compiles its wire-drift tests against** *and* **the release an installed CLI downloads at run time**. compose-preview-server can now cut a release that moves one without the other: [its release workflow has two lanes](https://github.com/yschimke/compose-preview-server/pull/449), and the distribution lane can ship without publishing anything to Maven Central.

A single pin cannot name such a release. Pointing at it would break `:cli`'s `testImplementation` even though the thing `serve` launches is exactly what changed. Conversely, a library-only concern — a wire-drift test, a mirrored source file — has no business pushing a new server onto every installed CLI.

## The two pins

| Pin | Answers | Consumers |
| --- | --- | --- |
| `composeai-preview-serve` | Which **published jar and sources** we build and test against | `testImplementation` in `:cli`; the `v<pin>` tag ci.yml reads mirror sources from |
| `composeai-preview-server-dist` | Which **release** an installed CLI downloads | `SERVE_VERSION` baked into the jar; `ServerDistributionProvision`; `check_preview_server_pin.py` |

Two deliberate groupings, both kept rather than split further:

- **The jar and the mirrored sources stay together.** ci.yml's "Fetch the pinned preview-server mirror sources" step reads five source files at the same tag as the artifact on the classpath — its own comment explains why checking head would fail a PR for drift that has not been released yet.
- **The server and MCP archives stay together** on the distribution pin. They ride the same release, and there is no cadence on which they would skew usefully.

## No behaviour change

Both pins are `3.2.0`, so this is a pure refactor. `cli-version.properties` still emits `serveVersion=3.2.0`. What changes is that the two can now move independently, each as its own reviewed act — and moving the distribution pin is the one with user impact, even though the library pin is the one that shows up in a compile error.

The gate follows the distribution pin, which is the only one that needs a GitHub Release to exist. Its regex is anchored on the full key so it cannot match the library pin sitting a few lines above it in the same catalog — with a test for exactly that.

## Test plan

- `python3 .github/ci/test_check_preview_server_pin.py -v` — **28 tests pass**, including two new ones: the gate does *not* match the library pin, and the pin it reads actually exists in the committed catalog (so a rename on either side fails loudly rather than gating nothing).
- `python3 .github/ci/check_preview_server_pin.py` passes against the real catalog and the live Releases API: `ok: yschimke/compose-preview-server v3.2.0 exists and carries compose-preview-server-3.2.0.tar.gz, compose-preview-mcp-3.2.0.tar.gz`.
- `./gradlew :cli:generateCliVersionResource` emits `serveVersion=3.2.0` — unchanged, proving the new `libs.versions.composeai.preview.server.dist` accessor resolves.
- `./gradlew :cli:test --tests "*ServerDistributionProvisionTest*"` passes.
- ci.yml's mirror-sources `sed` still selects exactly one value and does not match the new key.
- `./gradlew :cli:ktfmtFormatMain :cli:ktfmtFormatTest`; `ci.yml` parses.

## Deliberately not in this PR

**Neither pin is bumped.** Both stay at 3.2.0. Moving them is now two independent decisions, and 3.9.0 is available for both — it is the first compose-preview-server release whose Maven artifacts actually resolve, since `compose-preview-ui-builder-render-bundle` was missing from 3.3.0 through 3.8.0. Worth doing next, but as its own reviewed change rather than smuggled into a refactor.

**No Maven-resolvability gate.** The library pin has no CI check that its coordinate resolves — it never did, so this PR does not regress anything, but given 3.3.0–3.8.0 were unresolvable it is the obvious next guard. Say the word and I will add it.

Non-visual change: no render evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2EDrtyga9GYeZMdXAyzyJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2EDrtyga9GYeZMdXAyzyJ)_