### PR TITLE
chore(deps): move both preview-server pins to 3.9.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -388,7 +388,15 @@ composeai-contracts = "2.5.0"
 #
 # What this pin no longer names is the server an INSTALLED CLI downloads. See
 # `composeai-preview-server-dist` below.
-composeai-preview-serve = "3.2.0"
+#
+# 3.9.0 is the first release since 3.2.0 whose POM a consumer can actually resolve. 3.3.0 through
+# 3.8.0 each published a `compose-preview-ui-builder-runtime` POM naming
+# `compose-preview-ui-builder-render-bundle` at compile scope, an artifact that was never uploaded —
+# so `compose-preview-serve` was unresolvable for six consecutive releases and this pin could not
+# have moved off 3.2.0 even if something had wanted it to. compose-preview-server#449 made the
+# publish set derive from the modules that apply the publishing plugin, and #452's release published
+# the missing coordinate.
+composeai-preview-serve = "3.9.0"
 
 # The compose-preview-server RELEASE the installed CLI fetches at run time — a different question
 # from the one above, which is why it is a different pin.
@@ -413,11 +421,11 @@ composeai-preview-serve = "3.2.0"
 # moving this one changes which server every installed CLI downloads, so it is the one with user
 # impact even though the other is the one that shows up in a compile error.
 #
-# 3.2.0 is the first release carrying the MCP distribution: compose-preview-server#308 moved the
-# module there and #314 released it. 3.1.0 carried the archive but published a `compose-preview-serve`
-# POM naming an unpublished project (`ui-builder-export-jvm:unspecified`), so it resolves for nobody;
-# compose-preview-server#316 fixed that and rides in this release too.
-composeai-preview-server-dist = "3.2.0"
+# 3.2.0 was the first release carrying the MCP distribution (compose-preview-server#308 moved the
+# module there, #314 released it), which is why this pin sat there. Every release since has carried
+# both archives; 3.9.0 is verified to carry `compose-preview-server-3.9.0.tar.gz` and
+# `compose-preview-mcp-3.9.0.tar.gz`, which is the property `check_preview_server_pin.py` enforces.
+composeai-preview-server-dist = "3.9.0"
 
 # The Remote Compose players, published by yschimke/rc-players (the CMP player stack, the vendored
 # AndroidX embedded player, and the Wasm browser bundle). They were project deps here until the


### PR DESCRIPTION
Follow-up to #5232, which split the pin. Both halves move to 3.9.0.

## Why 3.2.0 was stuck

Not by choice. 3.3.0 through 3.8.0 each published a `compose-preview-ui-builder-runtime` POM naming `compose-preview-ui-builder-render-bundle` at `compile` scope — an artifact that was never uploaded — so `compose-preview-serve` was **unresolvable for six consecutive releases**. There was nowhere for the library pin to go.

[compose-preview-server#449](https://github.com/yschimke/compose-preview-server/pull/449) made the publish set derive from the modules that apply the publishing plugin rather than a hand-written list, and 3.9.0 published the missing coordinate:

```
compose-preview-ui-builder-runtime:3.9.0 → render-bundle:3.9.0   JAR: 200
                                  3.8.0 → render-bundle:3.8.0    JAR: 404
```

## Both, together

They are separate pins so they *can* differ, not so that they must. Nothing has happened since the split that would make them differ, and moving both keeps the wire-drift tests checking against the same server the CLI actually launches.

| Pin | What moving it changes |
| --- | --- |
| `composeai-preview-serve` | What `:cli` compiles its wire-drift tests against, and the tag ci.yml reads five mirror sources from |
| `composeai-preview-server-dist` | The release an installed CLI downloads on the first `serve` / `browse` / `mcp serve` that finds no server — **the one with user impact** |

## Test plan — one item per consumer of the two pins

- **Distribution pin.** `check_preview_server_pin.py` passes against the live Releases API: `ok: yschimke/compose-preview-server v3.9.0 exists and carries compose-preview-server-3.9.0.tar.gz, compose-preview-mcp-3.9.0.tar.gz`.
- **Library pin, resolution.** `:cli:compileTestKotlin` resolves and compiles against `compose-preview-serve:3.9.0`.
- **Library pin, the halves against each other.** `AgentAccessClientIntegrationTest`, `BundleRenderKnobTest`, `SharePreviewServeUploadTest`, `HistoryManifestCommandTest`, `PreviewRowResultSelectionTest`, `ServerDistributionProvisionTest` — all pass.
- **Library pin, mirror sources.** All five mirrored paths still exist at `v3.9.0`. The driver suite passes against sources fetched at that tag, run the way ci.yml runs it (`COMPOSE_PREVIEW_SERVER_ROOT` pointed at the fetched tree): **1469 tests, 0 failures**, and CI's *"cross-repo mirror tests SKIPPED"* guard is satisfied — the mirrors genuinely ran rather than self-skipping.

  Worth recording how that nearly went wrong: the mirror tests fall back to a **sibling checkout** when the env var is unset, and my first run silently used a local `compose-preview-server` clone on an unrelated branch instead of v3.9.0. The result looked identical. Only setting the env var explicitly, as CI does, actually tests the pin.

- **No lockfile churn.** No `gradle.lockfile` is tracked yet, so the new Dependency Locks job (#5231) sees new-not-stale.

## Noted, not changed

`:cli`'s `testImplementation` still carries `exclude(module = "compose-preview-render-host")`, whose comment says it can go "once a server release names the new coordinate". Both 3.2.0 and 3.9.0 already name plain `render-host`, so the exclusion is **already a no-op and the comment is stale** — but removing it changes dependency resolution and deserves its own verification rather than riding along in a version bump. Happy to do it separately.

Non-visual change: no render evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2EDrtyga9GYeZMdXAyzyJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2EDrtyga9GYeZMdXAyzyJ)_