### PR TITLE
ci: stop the Maven publish guard from being able to strand a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ env:
   TAG_NAME: ${{ inputs.tag || github.ref_name }}
 
 jobs:
-  # REPORTING ONLY — this job cannot stop a publish, and nothing gates on it yet.
+  # REPORTING ONLY — nothing reads this job's output, and it must never be able to stop a release.
   #
   # The root-level `publishAndReleaseToMavenCentral` below uploads all 94 publishing modules on
   # every release, whether or not one of them changed: over v1.57.0..v1.84.0 that was 3,572 module
@@ -71,8 +71,29 @@ jobs:
   #
   # Its own job because the guard needs full history (`fetch-depth: 0`) and the publish job does
   # not: deepening that checkout would slow the release for a step that only reports. It runs in
-  # parallel with everything else and, having no dependents, cannot delay the release either.
+  # parallel with everything else and has no dependents.
+  #
+  # `continue-on-error` is the load-bearing line here, and "no dependents" is exactly why it was
+  # missed. Nothing needs this job's OUTPUT, but `release-please.yml` gates finalisation on the
+  # RESULT of the whole `release.yml` call:
+  #
+  #     finalize-release:
+  #       needs: [release-please, release]
+  #       if: ... && needs.release.result == 'success'
+  #
+  # A workflow_call's result is the roll-up of every job inside it, so without this line a failure
+  # here — a Maven Central blip while resolving the baseline, a git edge case — skips
+  # `finalize-release` and leaves the GitHub Release a DRAFT: `/releases/latest` and every
+  # `latest/download/…` URL keep serving the previous version, with the new one published to Maven
+  # Central but invisible to installers. `release-draft-sweeper.yml` would recover it within the
+  # hour, which is a backstop, not a reason to allow it.
+  #
+  # This is the same posture, for the same reason, as the release-milestone comment jobs described
+  # in docs/RELEASING.md: pure reporting that runs after a decision has been made must not be able
+  # to touch a publish that already succeeded. A red mark on this job in the run is the intended
+  # signal; a held release is not.
   maven-publish-guard:
+    continue-on-error: true
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Refs #4772. **Land this before cutting v2.0.0.** It fixes a hazard I introduced in #5227.

## The bug

The `maven-publish-guard` job is reporting-only in the sense that nothing reads its output — and that is precisely what made this easy to miss. Nothing depends on its **output**, but `release-please.yml` gates finalisation on the **result** of the whole `release.yml` call:

```yaml
finalize-release:
  needs: [release-please, release]
  if: ... && needs.release.result == 'success'
```

A `workflow_call`'s result is the roll-up of every job inside it. So if the guard fails for any reason — a Maven Central blip while resolving the baseline, a git edge case — `finalize-release` is skipped and the GitHub Release **stays a draft**:

- `/releases/latest` and every `latest/download/…` URL keep serving the previous version
- meanwhile the new version *is* published to Maven Central, irreversibly, and invisible to installers

`release-draft-sweeper.yml` recovers a stranded draft within the hour. That's a backstop, not a reason to allow the failure mode — and it would be a poor first outing for a major.

## The fix

```yaml
maven-publish-guard:
  continue-on-error: true
```

This is the same posture, for the same reason, as the release-milestone comment jobs described in `docs/RELEASING.md`: pure reporting that runs alongside a decision must not be able to touch a publish that already succeeded. A red mark on the job in the run is the intended signal; a held release is not.

I also corrected the job's header comment, which claimed it *"cannot stop a publish, and nothing gates on it yet"*. The first half was true, the second was not — that sentence is what made the hazard invisible, so it's rewritten rather than left to mislead the next reader.

## Test plan

- `release.yml` parses as YAML; `jobs.maven-publish-guard.continue-on-error` reads back as `true` and the job list is unchanged (`maven-publish-guard`, `publish-gradle-plugin`, `build-applications`, `publish-design-map`, `release`).
- Comment-and-attribute only otherwise — no steps, permissions, or step logic touched, so the guard reports exactly as it did on the last run (which passed, logging `stale lockfiles: 0, new lockfiles: 94` on #5231's head).
- Attribution scan clean on `origin/main..HEAD`; branch is `agent/…`.
- `ci:` title, so this does not itself cut a release and the pending release PR #5226 stays at 2.0.0.

**Verification limit, stated plainly:** the failure mode is a job-level roll-up in a `workflow_call`, which can't be exercised without deliberately failing a real release run. The fix rests on the documented behaviour of `continue-on-error` and on the `needs.release.result` gate quoted above, not on an observed repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2)_