### PR TITLE
ci: enforce minor-only releases with always-bump-minor

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -119,14 +119,6 @@ This is `"versioning": "always-bump-minor"` in
 [`release-please-config.json`](../release-please-config.json). The strategy ignores the version
 and the commits it is handed and returns a minor update unconditionally.
 
-> **Staged: not live yet.** The `always-bump-minor` key is *not* in the config as of this commit.
-> release-please reads its config from `main` at run time, so a single PR that both added the key
-> and carried a `!` would have applied its own new setting to itself and cut a minor instead of
-> 2.0.0. The key lands in the follow-up PR, once 2.0.0 has published. Until then the table above
-> describes the intended policy and the old mapping (`fix:` → patch, `feat:` → minor, `feat!:` →
-> major) is what actually runs. This note goes away with that PR.
-
-
 **Why.** At ~44 releases a week the distinction between a patch and a minor had stopped carrying
 information: a release is whatever landed since the last one, usually a mix, and the number was
 being read as a bump size when it only ever meant "later". Cutting a major on a `!` was worse

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -49,15 +49,6 @@ releases and no further majors — 2.0.0 is the last one this repository cuts by
 The mechanism, the reason, and the guard that keeps `chore:`-only windows from cutting a
 release are in [RELEASING.md → Versioning after 2.0.0](RELEASING.md#versioning-after-200).
 
-> **Staged: not live yet.** The `always-bump-minor` key is *not* in
-> `release-please-config.json` as of this commit, and it deliberately cannot be — release-please
-> reads its config from `main` at run time, so the PR that cuts 2.0.0 with a `!` and the PR that
-> stops `!` mapping to a major have to be two commits, in that order. Until the follow-up lands,
-> the machinery still does `fix:` → patch, `feat:` → minor, `feat!:` → major. This paragraph goes
-> away with that PR. Recorded here rather than left implicit because § 10 exists to stop exactly
-> this document describing machinery that is not running.
-
-
 **So the version number no longer tells a consumer what kind of change they are taking.** It
 orders releases and nothing else. What the number used to promise now has to be read out of §§ 3–5
 and the changelog: § 3 still defines what counts as breaking, § 5 still governs the deprecation

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
   "packages": {
     ".": {
       "package-name": "compose-ai-tools",
+      "versioning": "always-bump-minor",
       "include-component-in-tag": false,
       "draft": true,
       "extra-files": [


### PR DESCRIPTION
Refs #4772. The staged half of #5229 — that PR documented the policy and cut the major; this one makes the machinery do it.

**`v2.0.0` published at 15:06:48 UTC**, tag `v2.0.0` at `e23d67be6`, manifest on `main` now reads `2.0.0`. That was the precondition.

## The change

```json
".": {
  "package-name": "compose-ai-tools",
+ "versioning": "always-bump-minor",
```

`always-bump-minor` ignores the version and the commits it is handed and returns a minor update unconditionally:

| Commit type | Before | After |
|---|---|---|
| `fix:` | patch | **minor** |
| `feat:` | minor | minor |
| `feat!:` | **major** | **minor** |
| `chore:`, `docs:`, `ci:`, `refactor:`, `test:` | no release | no release |

So 2.0.0 stays the last major cut by rule. A future one has to be forced with `release-as`, deliberately, rather than falling out of a PR title.

## Why this had to be a separate PR

Two ordering constraints, both hard:

1. **release-please reads its config from `main` at run time.** A single PR carrying both this key and the `!` would have applied its own new setting to itself and cut `1.86.0` instead of `2.0.0`.
2. **The key had to wait until 2.0.0 was actually recorded** in `.release-please-manifest.json` — otherwise it would have applied to the very release meant to be the major.

The alternative, `release-as: "2.0.0"` alongside the key in one PR, was rejected because `release-as` is sticky and has wedged this repo twice (the 0.7.0 override, and 1.0.0). I've asserted in the test plan that no `release-as` key crept in.

## The detail that makes this safe

The obvious worry is that every `chore(deps)` and `ci:` PR now cuts a release — which at ~44 releases/week and 94 Maven artifacts each would be the exact opposite of #4772.

It doesn't. The versioning strategy sets the *size* of a bump but not that there is one. A separate guard in release-please (`changelogEmpty` in `strategies/base.ts`) returns no release PR when the window's commits produce empty release notes, and `chore:`, `ci:`, `docs:`, `refactor:` and `test:` are hidden from the changelog by default. A window of only those still cuts nothing — unchanged from today.

Verified against release-please `main` when #5229 was written:
- `src/factories/versioning-strategy-factory.ts` — registered types are `default`, `always-bump-patch`, `always-bump-minor`, `always-bump-major`, `service-pack`, `prerelease`; `buildVersioningStrategy` **throws `ConfigurationError`** on an unknown type rather than silently falling back, so a typo in this key fails the Release PR run loudly instead of quietly reverting to the old mapping.
- `src/versioning-strategies/always-bump-minor.ts` — `determineReleaseType` takes `_version` and `_commits` unused and returns `MinorVersionUpdate()`.

## Docs

Removes the two `> **Staged: not live yet.**` blocks (`docs/VERSIONING.md` § 2, `docs/RELEASING.md` under "Versioning after 2.0.0"). Both documents now describe machinery that is actually running, which is what `VERSIONING.md` § 10 exists to insist on.

## Test plan

- `release-please-config.json` parses as JSON; `packages["."].versioning == "always-bump-minor"`; the 10 `extra-files` entries are untouched.
- **No `release-as` key present** — asserted explicitly, since a stray one is the failure mode this repo has hit twice.
- Both docs re-read after the block removal; the surrounding prose still flows and no stray double blank lines were left. The diff is `+1 / −17` — one config line, the rest removals.
- `ci:` title, so this does not itself cut a release.
- Attribution scan clean on `origin/main..HEAD`; branch is `agent/…`.

**The real test is the next release**: with a `fix:`-only window it must propose `2.1.0`, not `2.0.1`. Worth glancing at the first release PR after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2)_