### PR TITLE
docs: correct the versioning policy — patch for fixes, frozen major

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -105,82 +105,48 @@ To move the pin by hand (or to repair a missed release), run it locally:
 
 ## Versioning after 2.0.0
 
-**Every release is a minor bump.** `2.4.0 → 2.5.0`, whatever the commits said. There are no
-patch releases, and no further majors.
+**Ordinary semver, with the major effectively frozen.**
 
-| Commit type | Bump |
-|---|---|
-| `fix:` | minor |
-| `feat:` | minor |
-| `feat!:` / `fix!:` (the `!`, in the **PR title**) | minor |
-| `chore:`, `docs:`, `ci:`, `refactor:`, `test:` | no release |
+| Commit type | Bump | Example |
+|---|---|---|
+| `fix:` | patch | `2.8.0 → 2.8.1` |
+| `feat:` | minor | `2.8.0 → 2.9.0` |
+| `chore:`, `docs:`, `ci:`, `refactor:`, `test:` | no release | — |
+| a new major | **basically never** | only a from-scratch rewrite |
 
-This is `"versioning": "always-bump-minor"` in
-[`release-please-config.json`](../release-please-config.json). The strategy ignores the version
-and the commits it is handed and returns a minor update unconditionally.
+This is release-please's **default** versioning strategy — there is deliberately no `versioning`
+key in [`release-please-config.json`](../release-please-config.json). The default already does
+what we want for `fix:` and `feat:`; the only thing that needed changing was our willingness to
+cut majors.
 
-> **Staged: not live yet.** The `always-bump-minor` key is *not* in the config as of this commit.
-> release-please reads its config from `main` at run time, so a single PR that both added the key
-> and carried a `!` would have applied its own new setting to itself and cut a minor instead of
-> 2.0.0. The key lands in the follow-up PR, once 2.0.0 has published. Until then the table above
-> describes the intended policy and the old mapping (`fix:` → patch, `feat:` → minor, `feat!:` →
-> major) is what actually runs. This note goes away with that PR.
+**What "basically never" means in practice.** A major is reserved for a rewrite from scratch, not
+for a breaking change. Breaking changes ship in minors and are announced in the changelog, which is
+where a consumer has to read them — see [VERSIONING.md § 3](VERSIONING.md#3-what-counts-as-breaking)
+for what counts as breaking, and § 5 for the deprecation cycle that softens it.
 
+> **The one way to cut a major by accident is a `!` in a PR title.** `feat!:` / `fix!:` still maps
+> to a major under the default strategy, and the squash merge means the PR title *is* the commit
+> headline, so nothing downstream filters it. `RELEASING.md` used to call this "the single most
+> likely way to cut an unintended major" and that has not changed. **Don't write the `!`.** Write
+> `feat:` and describe the break in the body and the changelog.
 
-**Why.** At ~44 releases a week the distinction between a patch and a minor had stopped carrying
-information: a release is whatever landed since the last one, usually a mix, and the number was
-being read as a bump size when it only ever meant "later". Cutting a major on a `!` was worse
-than uninformative — it was a hazard, and `RELEASING.md` used to say so in as many words
-("the single most likely way to cut an unintended major"). One monotonic counter that nobody has
-to reason about beats a three-way choice that a PR title could get wrong.
-
-**What still decides whether a release happens at all.** The versioning strategy sets the *size*
-of a bump; it does not decide that there is one. That is a separate guard in release-please
-(`changelogEmpty` in `strategies/base.ts`): a window whose commits produce empty release notes
-proposes no release PR. `chore:`, `ci:`, `docs:`, `refactor:` and `test:` are hidden from the
-changelog by default, so a window containing only those still cuts nothing — exactly as before.
-**This is the load-bearing detail.** Had the release decision run off the versioning strategy,
-`always-bump-minor` would have cut a release for every dependency bump and every CI tweak, which
-at this repository's volume would have been a serious regression rather than a simplification.
-
-**Forcing a specific version.** `"release-as": "X.Y.Z"` in the config remains the only route, and
-it is still sticky — it is not consumed by the release it forces, so left in place every
-subsequent release PR re-proposes it, the tag already exists, and the release wedges. This repo
-has been bitten twice: an override pinning 0.7.0 that outlived its release, and `1.0.0`. Delete
+**A deliberate major** goes through `"release-as": "3.0.0"` in the config, which is the same route
+`1.0.0` used. It is sticky — not consumed by the release it forces, so left in place every
+subsequent release PR re-proposes it, the tag already exists, and the release wedges. This repo has
+been bitten twice: an override pinning 0.7.0 that outlived its release, and `1.0.0` itself. Delete
 the key in the first PR after the forced release publishes.
 
-### How 2.0.0 was cut, and why it is the last major
+**What decides whether a release happens at all**, independently of the bump size: release-please's
+`changelogEmpty` guard proposes no release PR when a window's commits produce empty release notes.
+`chore:`, `ci:`, `docs:`, `refactor:` and `test:` are hidden from the changelog by default, so a
+window of only those cuts nothing.
 
-`v2.0.0` came from a PR titled `feat!:`, under the *previous* configuration, where the `!` still
-mapped to a major. That ordering was forced: release-please reads its config from `main` at run
-time, so a PR that both added `always-bump-minor` and carried a `!` would have had its own new
-setting applied to it and cut a minor. The policy change and the major it announces could not be
-the same commit.
+### How 2.0.0 was cut
 
-Under `always-bump-minor` the `!` no longer reaches the version number at all, so 2.0.0 is the
-last major this repository cuts by rule. A future one would have to be forced with `release-as`,
-deliberately, as a decision rather than a side effect of a PR title.
-
-### What this costs, stated plainly
-
-A breaking change is no longer legible from the version number. Two consequences follow, and
-neither is fixed by this change:
-
-- **`versionsIncompatible`** (`cli/src/main/kotlin/ee/schimke/composeai/cli/Version.kt`) compares
-  major versions to decide whether a pin/CLI skew is a `warning` or a `note`, on the documented
-  grounds that "a major release changes the render/daemon wire format". It backs the skew
-  diagnostics in `warnOnCliSkew` and two in `DoctorCommand`. Once no major is ever cut, that
-  predicate is permanently false across 2.x and every skew reports as a `note`. It stays correct
-  across the 1.x → 2.x boundary, which is why it is not being changed here, but it stops being a
-  signal after that.
-- **The changelog is now the only place a break is announced**, which is why `feat!:` is still
-  worth writing even though it moves no number.
-
-The honest framing: this repository was already not using majors to communicate breakage — the
-`0.x` line ran to `0.19.x` under `bump-minor-pre-major`, and `1.0.0` was forced with `release-as`
-rather than earned by a `!`. See [VERSIONING.md § 10](VERSIONING.md#10-what-is-and-is-not-enforced)
-for what is and is not actually enforced. This change stops the version number implying a promise
-the machinery never kept.
+`v2.0.0` came from a PR titled `feat!:` (#5229) — the `!` mapping to a major under the default
+strategy, exactly as described above. It marked the point at which this repository stopped cutting
+majors as a matter of course. Under the policy above the next major is a rewrite, not a version
+number that falls out of a PR title.
 
 ## Fallback paths
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -36,37 +36,33 @@ reference: [VERSION_PIN.md](VERSION_PIN.md). Set it with `compose-preview pin --
 
 ## 2. Version bumps for the published artifacts
 
-**Every release is a minor bump.** `release-please` runs
-`"versioning": "always-bump-minor"`, so the version goes `2.4.0 → 2.5.0` whatever the commits
-said: a `fix:`, a `feat:` and a `feat!:` are indistinguishable to it. There are no patch
-releases and no further majors — 2.0.0 is the last one this repository cuts by rule.
+Ordinary semver, with the major effectively frozen:
 
-| Commit type | Bump |
-|---|---|
-| `fix:` / `feat:` / `feat!:` | minor |
-| `chore:`, `docs:`, `ci:`, `refactor:`, `test:` | no release |
+| Commit type | Bump | Example |
+|---|---|---|
+| `fix:` | patch | `2.8.0 → 2.8.1` |
+| `feat:` | minor | `2.8.0 → 2.9.0` |
+| `chore:`, `docs:`, `ci:`, `refactor:`, `test:` | no release | — |
+| a new major | **basically never** | only a from-scratch rewrite |
 
-The mechanism, the reason, and the guard that keeps `chore:`-only windows from cutting a
-release are in [RELEASING.md → Versioning after 2.0.0](RELEASING.md#versioning-after-200).
+This is release-please's **default** strategy — there is deliberately no `versioning` key in the
+config. The mechanism, the `!`-in-a-PR-title hazard, and how a deliberate major is forced are in
+[RELEASING.md → Versioning after 2.0.0](RELEASING.md#versioning-after-200).
 
-> **Staged: not live yet.** The `always-bump-minor` key is *not* in
-> `release-please-config.json` as of this commit, and it deliberately cannot be — release-please
-> reads its config from `main` at run time, so the PR that cuts 2.0.0 with a `!` and the PR that
-> stops `!` mapping to a major have to be two commits, in that order. Until the follow-up lands,
-> the machinery still does `fix:` → patch, `feat:` → minor, `feat!:` → major. This paragraph goes
-> away with that PR. Recorded here rather than left implicit because § 10 exists to stop exactly
-> this document describing machinery that is not running.
+**A major no longer signals a breaking change; it signals a rewrite.** Breaking changes ship in
+minors. What the major used to promise now has to be read out of §§ 3–5 and the changelog: § 3
+defines what counts as breaking, § 5 governs the deprecation cycle, and the changelog is where a
+consumer actually sees it. That is a narrowing of what the number claims, not of the policy behind
+it — § 10 already recorded that most of the enforcement these documents describe is not
+implemented, and freezing the major stops the number implying a guarantee that was never
+mechanically kept.
 
-
-**So the version number no longer tells a consumer what kind of change they are taking.** It
-orders releases and nothing else. What the number used to promise now has to be read out of §§ 3–5
-and the changelog: § 3 still defines what counts as breaking, § 5 still governs the deprecation
-cycle, and a `!` in a PR title still routes the entry to the changelog's breaking section. Writing
-the `!` matters more now, not less — it is the only place the break is announced.
-
-This is a narrowing of what the number claims, not of the underlying policy. § 10 already recorded
-that most of the enforcement these documents describe is not implemented; pinning the bump to
-minor stops the version implying a guarantee that was never mechanically kept.
+**One consequence, recorded rather than discovered later.** `versionsIncompatible`
+(`cli/src/main/kotlin/ee/schimke/composeai/cli/Version.kt`) compares major versions to decide
+whether a pin/CLI skew is a `warning` or a `note`, on the documented grounds that "a major release
+changes the render/daemon wire format". With the major frozen that predicate is false across all of
+`2.x`, so every skew reports as a `note`. It stays correct across the `1.x → 2.x` boundary, which
+is why it is unchanged, but it stops being a signal after that.
 
 ## 3. What counts as breaking
 


### PR DESCRIPTION
Refs #4772. Replaces #5237, which is closed rather than merged.

## What was wrong

#5229 documented the wrong policy. It read "only minor releases" as *every release is a minor bump* and described `always-bump-minor` — which would have made `fix:` cut `2.9.0` instead of `2.8.1`, removing patch releases entirely.

The intent is ordinary semver with the major effectively frozen:

| Commit type | Bump | Example |
|---|---|---|
| `fix:` | patch | `2.8.0 → 2.8.1` |
| `feat:` | minor | `2.8.0 → 2.9.0` |
| a new major | **basically never** | only a from-scratch rewrite |

## The correct configuration change is none

That mapping **is release-please's default strategy**. So there is deliberately no `versioning` key, and this PR does not add one — `release-please-config.json` is untouched. Only the documents were wrong.

This is worth stating plainly because #5237 was built on the opposite premise: it added `"versioning": "always-bump-minor"` and was minutes from auto-merging. Auto-merge is now disabled and it's closed.

## What the docs say now

- A major is reserved for a **rewrite**, not for a breaking change. Breaking changes ship in minors and are announced in the changelog.
- **The one way to cut a major by accident is a `!` in a PR title.** `feat!:` / `fix!:` still maps to a major under the default strategy, and the squash merge makes the PR title the commit headline, so nothing filters it. The rule is: don't write the `!`. `RELEASING.md` already called this "the single most likely way to cut an unintended major" and that hasn't changed.
- A deliberate major goes through `release-as`, with the same stickiness warning that applied to `1.0.0`.
- `VERSIONING.md` § 2 records a consequence rather than leaving it to be discovered: with the major frozen, `versionsIncompatible` compares majors and so reports every `2.x` skew as a `note` rather than a `warning`. Correct across `1.x → 2.x`, so unchanged — but it stops being a signal after that.

## About v2.0.0

Worth saying: **2.0.0 was cut to announce a policy that turned out not to be the policy you wanted.** Under the corrected rule — majors only for a rewrite — a versioning-policy change wouldn't warrant one. It's published and irreversible, and the practical cost is a version number plus the spurious cross-major skew warning noted above. Recorded here rather than quietly left out of the history.

## Optional follow-up, not included

Making "basically never" mechanical rather than conventional means rejecting `!` in PR titles. `pr-title.yml` uses `amannn/action-semantic-pull-request`, which validates the type list but has no option for this, so it'd be a small extra step. **Not added here** — I've already over-inferred once on this topic and would rather you say whether you want it.

## Test plan

- `release-please-config.json` **not modified**; asserted that neither `versioning` nor `release-as` is present.
- `docs/RELEASING.md` is a release-please `extra-files` target: **3 `x-release-please-start-version` / `-end` pairs before and after**, none inside the rewritten range.
- Grepped the whole of `docs/` for `always-bump-minor`, "Every release is a minor" and the staged-notice blocks — all gone.
- Docs-only; `docs:` title so it cuts no release.
- Attribution scan clean; branch is `agent/…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2)_