### PR TITLE
ci: reject the breaking-change marker in PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -10,6 +10,9 @@ name: PR Title
 # The allowed types mirror what release-please understands: `feat` and `fix`
 # drive minor/patch bumps; the rest (`chore`, `docs`, `refactor`, …) still land
 # in the changelog under their section and keep history scannable.
+#
+# A second job rejects the conventional-commit breaking marker (`feat!:`), which
+# is the only way a major can be cut by accident here. See its own comment.
 
 on:
   pull_request:
@@ -68,3 +71,64 @@ jobs:
             style
             revert
           requireScope: false
+
+  # The `!` is the ONLY way this repository can cut a major version by accident.
+  #
+  # release-please runs its default versioning strategy, so `fix:` is a patch and
+  # `feat:` is a minor — and `feat!:` / `fix!:` is a MAJOR. Because PRs are
+  # squash-merged with `squash_merge_commit_message=BLANK`, the PR title becomes
+  # the commit headline verbatim, so nothing downstream filters the marker: a
+  # title typed with a `!` cuts `3.0.0` on merge. docs/RELEASING.md has called
+  # this "the single most likely way to cut an unintended major" for a while;
+  # this job is that sentence turned into a gate.
+  #
+  # Policy (docs/VERSIONING.md § 2): a major means a rewrite from scratch, not a
+  # breaking change. Breaking changes ship in minors. A deliberate major goes
+  # through `"release-as": "3.0.0"` in release-please-config.json — which is how
+  # 1.0.0 and every forced version before it were cut — so there is no case where
+  # a `!` is the right tool, and therefore no bypass here.
+  #
+  # KNOWN COST, stated rather than discovered later: the `!` is also what routes
+  # an entry into the changelog's "⚠ BREAKING CHANGES" section, and rejecting it
+  # gives that up. A `BREAKING CHANGE:` footer is not a substitute — it lives in
+  # the commit body, which `BLANK` discards (docs/RELEASING.md). So a break has to
+  # be legible in the PR TITLE itself, because the title is the changelog entry:
+  # `feat: rename Foo to Bar (breaking)`.
+  breaking:
+    name: No breaking-change marker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject `!` in the PR title
+        # Through `env:`, never interpolated into the script. A PR title is
+        # attacker-controlled on a fork, and `${{ }}` inside `run:` would splice it
+        # straight into the shell.
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # Matches the conventional-commit breaking marker: `type!:` or
+          # `type(scope)!:`. A `!` anywhere else in the subject is fine.
+          if ! printf '%s' "${PR_TITLE}" | grep -qE '^[a-zA-Z]+(\([^)]*\))?!:'; then
+            echo "OK: no breaking-change marker."
+            exit 0
+          fi
+          {
+            echo "### Breaking-change marker rejected"
+            echo
+            echo "\`${PR_TITLE}\`"
+            echo
+            echo "The \`!\` cuts a **major version** on merge — the PR title becomes the commit"
+            echo "headline verbatim, and release-please reads it."
+            echo
+            echo "A major here means a rewrite from scratch, not a breaking change."
+            echo "Breaking changes ship in minors."
+            echo
+            echo "- **Shipping a breaking change?** Drop the \`!\` and make the break legible in"
+            echo "  the title, since the title *is* the changelog entry:"
+            echo "  \`feat: rename Foo to Bar (breaking)\`. A \`BREAKING CHANGE:\` footer will not"
+            echo "  work — the commit body is discarded by the squash merge."
+            echo "- **Genuinely cutting a major?** Use \`\"release-as\": \"3.0.0\"\` in"
+            echo "  release-please-config.json, then delete the key in the first PR after it"
+            echo "  publishes. See docs/RELEASING.md."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::error title=Breaking-change marker in PR title::The '!' cuts a major on merge. See the job summary."
+          exit 1

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -124,11 +124,19 @@ for a breaking change. Breaking changes ship in minors and are announced in the 
 where a consumer has to read them — see [VERSIONING.md § 3](VERSIONING.md#3-what-counts-as-breaking)
 for what counts as breaking, and § 5 for the deprecation cycle that softens it.
 
-> **The one way to cut a major by accident is a `!` in a PR title.** `feat!:` / `fix!:` still maps
-> to a major under the default strategy, and the squash merge means the PR title *is* the commit
-> headline, so nothing downstream filters it. `RELEASING.md` used to call this "the single most
-> likely way to cut an unintended major" and that has not changed. **Don't write the `!`.** Write
-> `feat:` and describe the break in the body and the changelog.
+> **The `!` is rejected by CI.** `feat!:` / `fix!:` still maps to a major under the default
+> strategy, and the squash merge means the PR title *is* the commit headline, so nothing downstream
+> filters it — a title typed with a `!` would cut a major on merge. The `No breaking-change marker`
+> job in [`pr-title.yml`](../.github/workflows/pr-title.yml) fails the PR instead. There is no
+> bypass, because a deliberate major goes through `release-as` rather than a marker.
+>
+> **Shipping a breaking change? Put the break in the title**, not the body. The title is the
+> changelog entry — `feat: rename Foo to Bar (breaking)`. A `BREAKING CHANGE:` footer does not work
+> here for the reason given above: the body is discarded by the squash.
+>
+> The cost of the gate, stated plainly: the `!` is also what routes an entry into the changelog's
+> "⚠ BREAKING CHANGES" section, so rejecting it gives that section up. Breaks are announced in the
+> entry text instead.
 
 **A deliberate major** goes through `"release-as": "3.0.0"` in the config, which is the same route
 `1.0.0` used. It is sticky — not consumed by the release it forces, so left in place every

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -46,8 +46,10 @@ Ordinary semver, with the major effectively frozen:
 | a new major | **basically never** | only a from-scratch rewrite |
 
 This is release-please's **default** strategy — there is deliberately no `versioning` key in the
-config. The mechanism, the `!`-in-a-PR-title hazard, and how a deliberate major is forced are in
-[RELEASING.md → Versioning after 2.0.0](RELEASING.md#versioning-after-200).
+config. The `!` that would otherwise cut a major is rejected by CI (the `No breaking-change marker`
+job in [`pr-title.yml`](../.github/workflows/pr-title.yml)), so the only route to one is a
+deliberate `release-as`. Mechanism and rationale: [RELEASING.md → Versioning after
+2.0.0](RELEASING.md#versioning-after-200).
 
 **A major no longer signals a breaking change; it signals a rewrite.** Breaking changes ship in
 minors. What the major used to promise now has to be read out of §§ 3–5 and the changelog: § 3


### PR DESCRIPTION
Refs #4772. Makes "majors basically never" mechanical instead of conventional.

## Why

The `!` is the only way this repo can cut a major by accident. Under the default versioning strategy `fix:` is a patch and `feat:` is a minor — but `feat!:` / `fix!:` is a **major**, and because PRs squash-merge with `squash_merge_commit_message=BLANK` the PR title becomes the commit headline verbatim. Nothing downstream filters the marker.

`docs/RELEASING.md` has called this *"the single most likely way to cut an unintended major"* for a while. This turns that sentence into a gate.

**No bypass, deliberately.** A major means a rewrite from scratch, not a breaking change, and a deliberate major goes through `release-as` — the route `1.0.0` used. There's no case where a `!` is the right tool, so there's nothing to opt out of.

## Security detail

The PR title reaches the script through `env:`, never interpolated into the `run:` body. A title is attacker-controlled on a fork, and `${{ github.event.pull_request.title }}` inside a run block would splice it straight into the shell. Asserted in the test plan.

## ⚠️ The cost, stated rather than discovered later

**The `!` is also what routes an entry into the changelog's "⚠ BREAKING CHANGES" section.** Rejecting it gives that section up.

A `BREAKING CHANGE:` footer is *not* a substitute — it lives in the commit body, which `BLANK` discards. So from here a break has to be legible in the **title**, because the title is the changelog entry:

```
feat: rename Foo to Bar (breaking)
```

If you'd rather keep the automatic breaking-changes section than have the gate, this PR is the wrong trade and I'd close it — the two can't both be had under the default strategy.

## Doc corrections

Two fixes to text I wrote in #5241:

- It said to *"describe the break in the body and the changelog"*. **The body is discarded by the squash**, so that was wrong. Corrected to say the break must be in the title.
- The cost above is now written down in both `RELEASING.md` and `VERSIONING.md` § 2, alongside a pointer to the new job.

## Test plan

Ran the exact regex against **real titles from this repository's history**, not invented ones:

| | Result |
|---|---|
| `feat!:` · `fix!:` · `feat(screen)!:` · `refactor(cli)!:` | **REJECT** ✅ |
| `feat: adopt minor-only versioning and cut 2.0.0` | allow |
| `fix(discovery): a Wear widget preview is a scratch canvas` | allow |
| `ci: stop the Maven publish guard from being able to strand a release` | allow |
| `docs: correct the versioning policy — patch for fixes, frozen major` | allow |
| `chore(main): release 2.0.0` · `chore(deps): move both preview-server pins to 3.9.0` | allow |
| `feat: add support for the ! operator` | allow |
| `fix: stop crashing on names ending in !` | allow |
| `feat(a!b): weird scope` | allow |

That last group matters: a `!` anywhere but marker position must not trip the gate, and doesn't.

Also:
- Both jobs parse as YAML (`lint`, `breaking`); asserted **no `${{ }}` appears inside any `run:` block** in the file.
- `docs/RELEASING.md` is a release-please `extra-files` target: 3 `x-release-please-start-version` / `-end` pairs before and after.
- `ci:` title, so it cuts no release — and, fittingly, this PR's own title passes the gate it adds.
- Attribution scan clean; branch is `agent/…`.

**Note on the existing concurrency design:** `pr-title.yml` gives `edited` events their own group precisely because `action-semantic-pull-request` validates the title frozen in its event payload. The new job reads the same payload field, so it inherits that protection rather than working around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2)_