### PR TITLE
ci: read dependency lock state instead of the version catalog

### DIFF
--- a/.github/scripts/maven-publish-needed.sh
+++ b/.github/scripts/maven-publish-needed.sh
@@ -29,8 +29,13 @@
 #
 # Any file under a module that applies `composeai.maven-publishing` (enumerated from the working
 # tree, so a newly added module is picked up as its own change), plus the shared inputs that
-# change the bytes or the POM of every one of them: `build-logic/`, the version catalog, the
-# wrapper, `settings.gradle.kts` and the root `build.gradle.kts`.
+# change the bytes or the POM of every one of them: `build-logic/`, the wrapper,
+# `settings.gradle.kts` and the root `build.gradle.kts`.
+#
+# A module's committed `gradle.lockfile` lives inside that module, so DEPENDENCY movement is
+# caught by the same rule that catches source changes. The version catalog is therefore no longer
+# a blanket shared input — only its build-toolchain half is checked separately. See
+# `toolchain_fingerprint`.
 #
 # `gradle.properties` is watched with ONE exclusion: the `x-release-please-start-version` block.
 # Release-please rewrites `composeaiReleasedRuntimeVersion` there on every single release (see
@@ -78,10 +83,67 @@ cd "${REPO}"
 shared_paths() {
   printf '%s\n' \
     'build-logic' \
-    'gradle/libs.versions.toml' \
     'gradle/wrapper' \
     'settings.gradle.kts' \
     'build.gradle.kts'
+}
+
+# `gradle/libs.versions.toml` is deliberately NOT in that list any more.
+#
+# It used to be, and it was the single most expensive rule here: any catalog edit dirtied all 94
+# modules, because a path diff cannot tell which of them actually resolve the bumped coordinate.
+# Over v1.57.0..v1.84.0 that rule was ~97% of the publishing this guard could not eliminate.
+#
+# Committed lock state answers that exactly. Each module's `gradle.lockfile` lives INSIDE the
+# module directory, which is already watched, so a catalog bump that moves a module's resolved
+# classpath shows up as a change to that module and needs no special handling. A bump that moves
+# nothing any published module resolves — a test-only dependency, something only the CLI uses —
+# leaves every lockfile untouched, and now correctly publishes nothing.
+#
+# That leaves one hole, which `toolchain_fingerprint` below closes: the BUILD TOOLCHAIN. AGP, the
+# Compose compiler and friends are `[plugins]` entries, they change the bytecode we publish, and
+# they do not necessarily appear on any module's compile or runtime classpath — so no lockfile
+# moves when they do. Measured over the same window, 13 release windows touched the catalog and 1
+# of them was a toolchain move: rare, but a wrongly skipped publish is unrepairable, so it is
+# checked rather than hoped about.
+
+# The `[plugins]` block plus the `[versions]` entries those plugins reference, for one git ref.
+# Anything else in the catalog is a library and is covered by lock state.
+#
+# Two awk passes rather than one because `[versions]` is declared above `[plugins]`, so the refs
+# are not known on first read. Empty output for a ref that has no catalog at all is fine — the
+# caller compares two of these and only cares whether they differ.
+toolchain_fingerprint() {
+  local ref="$1" catalog
+  catalog="$(git show "${ref}:gradle/libs.versions.toml" 2>/dev/null)" || return 1
+  local refs
+  refs="$(printf '%s\n' "${catalog}" | awk '
+    /^\[/        { section = $0; next }
+    section == "[plugins]" && match($0, /version\.ref[ \t]*=[ \t]*"[^"]+"/) {
+      # Strip the key and the quotes off the matched fragment with anchored subs. NOT
+      # `gsub(/.*"/, ...)`: `.*` is greedy, so it eats through the closing quote and yields an
+      # empty ref — which silently reduced this fingerprint to the [plugins] text alone, so an
+      # `agp` or `kotlin` version bump moved nothing and the guard would have skipped a publish
+      # it needed. That is the one direction this script must never fail in.
+      s = substr($0, RSTART, RLENGTH)
+      sub(/^version\.ref[ \t]*=[ \t]*"/, "", s)
+      sub(/"$/, "", s)
+      print s
+    }')"
+  {
+    printf '%s\n' "${catalog}" | awk '
+      /^\[/ { section = $0; next }
+      # Comment lines are skipped: a `#` line in TOML is inert, and this repository comments
+      # heavily enough that including them would force a 94-module publish for a prose edit.
+      section == "[plugins]" && NF && $0 !~ /^[ \t]*#/ { print "plugin " $0 }'
+    printf '%s\n' "${catalog}" | awk -v refs="${refs}" '
+      BEGIN { n = split(refs, a, "\n"); for (i = 1; i <= n; i++) if (a[i] != "") want[a[i]] = 1 }
+      /^\[/ { section = $0; next }
+      section == "[versions]" && match($0, /^[ \t]*[A-Za-z0-9_.-]+[ \t]*=/) {
+        key = $0; sub(/[ \t]*=.*/, "", key); gsub(/^[ \t]+/, "", key)
+        if (key in want) print "version " key " " $0
+      }'
+  } | sort
 }
 
 # Every module that publishes, derived from the build files themselves rather than a hand-kept
@@ -138,6 +200,16 @@ git merge-base "${BASELINE}" "${HEAD_REF}" >/dev/null 2>&1 ||
 mapfile -t MODULES < <(publishing_module_paths)
 [ "${#MODULES[@]}" -gt 0 ] || emit true "found no modules applying composeai.maven-publishing"
 
+# Dependency movement is now read from committed lock state, so a published module WITHOUT a
+# lockfile is a module whose dependencies we cannot see. Its source changes are still caught, but a
+# catalog bump that moved only its classpath would look like nothing at all — the one direction
+# this script must never fail in. So: any module missing lock state, and the whole thing fails open.
+mapfile -t UNLOCKED < <(
+  for m in "${MODULES[@]}"; do [ -f "${m}/gradle.lockfile" ] || printf '%s\n' "${m}"; done
+)
+[ "${#UNLOCKED[@]}" -eq 0 ] ||
+  emit true "${#UNLOCKED[@]} published module(s) have no gradle.lockfile (e.g. ${UNLOCKED[0]})"
+
 mapfile -t WATCHED < <(watch_paths)
 
 # `--` and the explicit pathspec list keep this to the watched set; everything else in the diff
@@ -193,4 +265,14 @@ if [ "${gradle_properties_changed}" = 1 ]; then
   emit true "gradle.properties changed outside the release-please version block"
 fi
 
-emit false "no published module or shared build input changed since ${BASELINE}"
+# The build toolchain, which lock state cannot see. See the comment on `toolchain_fingerprint`.
+# A failure to read either catalog fails open rather than silently comparing nothing.
+tc_baseline="$(toolchain_fingerprint "${BASELINE}")" ||
+  emit true "could not read the version catalog at ${BASELINE}"
+tc_head="$(toolchain_fingerprint "${HEAD_REF}")" ||
+  emit true "could not read the version catalog at ${HEAD_REF}"
+if [ "${tc_baseline}" != "${tc_head}" ]; then
+  emit true "the build toolchain moved ([plugins], or a version they reference)"
+fi
+
+emit false "no published module, shared build input or build-toolchain pin changed since ${BASELINE}"

--- a/.github/scripts/test-maven-publish-needed.sh
+++ b/.github/scripts/test-maven-publish-needed.sh
@@ -59,7 +59,26 @@ EOF
   echo 'plugins { kotlin("jvm") }' > "${dir}/cli/build.gradle.kts"
   echo 'fun cli() = 1' > "${dir}/cli/src/main/kotlin/Cli.kt"
   echo '// build logic' > "${dir}/build-logic/build.gradle.kts"
-  echo '[versions]' > "${dir}/gradle/libs.versions.toml"
+  # Lock state for the publishing module. Without it the guard fails open on every case (a
+  # published module with no lockfile is a module whose dependencies it cannot see), so this is
+  # what makes the rest of these assertions meaningful rather than vacuously true.
+  cat > "${dir}/data/focus/core/gradle.lockfile" <<'EOF'
+com.example:lib:1.0.0=compileClasspath,runtimeClasspath
+empty=
+EOF
+  # A catalog with both halves: a library entry (covered by lock state) and a plugin entry whose
+  # version.ref points into [versions] (covered by the toolchain fingerprint).
+  cat > "${dir}/gradle/libs.versions.toml" <<'EOF'
+[versions]
+somelib = "1.0.0"
+agp = "9.0.0"
+
+[libraries]
+somelib = { module = "com.example:lib", version.ref = "somelib" }
+
+[plugins]
+android-library = { id = "com.android.library", version.ref = "agp" }
+EOF
   echo 'rootProject.name = "fixture"' > "${dir}/settings.gradle.kts"
   echo '// root' > "${dir}/build.gradle.kts"
   cat > "${dir}/gradle.properties" <<'EOF'
@@ -113,7 +132,12 @@ release "${R}" 1.4.0
 expect false "$(needed --repo "${R}" --baseline v1.3.0 --head v1.4.0)" "published test source changed"
 
 echo "== each shared build input forces a publish on its own"
-for f in build-logic/build.gradle.kts gradle/libs.versions.toml settings.gradle.kts build.gradle.kts; do
+# `gradle/libs.versions.toml` is deliberately NOT in this list any more — it stopped being a
+# blanket shared input when lock state took over the library half. Leaving it here would have
+# kept passing for the wrong reason: appending a line puts it inside the trailing [plugins]
+# section, so the toolchain fingerprint trips and the assertion goes green while asserting an
+# invariant that no longer holds. The catalog's two halves are covered by their own cases below.
+for f in build-logic/build.gradle.kts settings.gradle.kts build.gradle.kts; do
   base="$(git -C "${R}" describe --tags --abbrev=0)"
   echo "// touched $(date +%s%N)" >> "${R}/${f}"
   git -C "${R}" add -A
@@ -133,6 +157,45 @@ echo "== the baseline advancing only on a publish is the caller's job, but a mul
 expect false "$(needed --repo "${R}" --baseline v1.0.0 --head v1.2.0)" "span of two skippable releases"
 # ...and a span that contains the module change says yes, so nothing is lost by coalescing.
 expect true "$(needed --repo "${R}" --baseline v1.0.0 --head v1.3.0)" "span containing a real change"
+
+echo "== a LIBRARY-only catalog bump that moves no lockfile does not need a publish"
+# The headline change: this used to force all 94 modules because the catalog was a blanket
+# shared input. Lock state is what makes it answerable.
+base="$(git -C "${R}" rev-parse HEAD)"
+sed -i.bak 's/^somelib = "1.0.0"/somelib = "1.1.0"/' "${R}/gradle/libs.versions.toml"
+rm -f "${R}/gradle/libs.versions.toml.bak"
+git -C "${R}" add -A && git -C "${R}" commit -qm "chore(deps): bump somelib"
+expect false "$(needed --repo "${R}" --baseline "${base}" --head HEAD)" "library-only catalog bump, no lockfile movement"
+
+echo "== the same bump DOES need a publish once it moves a module's lock state"
+base="$(git -C "${R}" rev-parse HEAD)"
+sed -i.bak 's/^com.example:lib:1.0.0=/com.example:lib:1.1.0=/' "${R}/data/focus/core/gradle.lockfile"
+rm -f "${R}/data/focus/core/gradle.lockfile.bak"
+git -C "${R}" add -A && git -C "${R}" commit -qm "chore(deps): regenerate lockfiles"
+expect true "$(needed --repo "${R}" --baseline "${base}" --head HEAD)" "lockfile moved"
+
+echo "== a TOOLCHAIN bump needs a publish even though no lockfile moves"
+# AGP and friends change the bytecode we publish but need not appear on any module's classpath,
+# so lock state cannot see them. This is the hole the fingerprint closes.
+base="$(git -C "${R}" rev-parse HEAD)"
+sed -i.bak 's/^agp = "9.0.0"/agp = "9.1.0"/' "${R}/gradle/libs.versions.toml"
+rm -f "${R}/gradle/libs.versions.toml.bak"
+git -C "${R}" add -A && git -C "${R}" commit -qm "chore(deps): bump agp"
+expect true "$(needed --repo "${R}" --baseline "${base}" --head HEAD)" "plugin-referenced version moved"
+
+echo "== a comment-only edit inside [plugins] does not need a publish"
+base="$(git -C "${R}" rev-parse HEAD)"
+printf '\n# a prose note about the plugins above\n' >> "${R}/gradle/libs.versions.toml"
+git -C "${R}" add -A && git -C "${R}" commit -qm "docs: comment the catalog"
+expect false "$(needed --repo "${R}" --baseline "${base}" --head HEAD)" "comment-only catalog edit"
+
+echo "== a published module with NO lock state fails open"
+NOLOCK="${tmp}/nolock"
+make_repo "${NOLOCK}"
+git -C "${NOLOCK}" rm -q "data/focus/core/gradle.lockfile"
+git -C "${NOLOCK}" commit -qm "chore: drop lock state"
+git -C "${NOLOCK}" tag v1.9.0
+expect true "$(needed --repo "${NOLOCK}" --baseline v1.0.0 --head v1.9.0)" "module without a lockfile"
 
 echo "== fail-open paths"
 expect true "$(needed --repo "${R}")" "no baseline"

--- a/docs/design/RELEASE_TRAINS.md
+++ b/docs/design/RELEASE_TRAINS.md
@@ -1,7 +1,7 @@
 # Release trains
 
 **Status: measurement + proposal.** The guard in § 4 is implemented and running in reporting mode.
-The dependency lock state in § 6 is implemented; the guard does not read it yet. The train split in
+The dependency lock state in § 6 is implemented and the guard now reads it. The train split in
 § 5 is not built, and § 6's graph-based measurement supersedes its grouping. Issue
 [#4772](https://github.com/yschimke/compose-ai-tools/issues/4772).
 
@@ -213,6 +213,18 @@ diffs that file instead of guessing from the catalog.
 
 `LockMode.DEFAULT`, not `STRICT`: DEFAULT does not fail a locked configuration that has no lock
 state, which is what makes the mechanism safe to land before a single lockfile exists.
+
+**The guard now reads that lock state instead of the catalog.** `gradle/libs.versions.toml` is no
+longer a blanket shared input: a module's `gradle.lockfile` lives inside the module directory, which
+is already watched, so dependency movement is caught by the same rule that catches source changes. A
+bump that moves nothing any published module resolves now correctly publishes nothing.
+
+One hole had to be closed separately. The build **toolchain** — AGP, the Compose compiler, Kotlin —
+lives in the catalog's `[plugins]` block, changes the bytecode we publish, and need not appear on any
+module's classpath, so no lockfile moves when it does. `toolchain_fingerprint` compares that block
+plus the `[versions]` entries those plugins reference. Over the same 38 windows the toolchain moved
+exactly once (AGP 9.3.2 → 9.4.0 at v1.62.2 → v1.63.0) against 13 windows that touched the catalog —
+so 12 of 13 catalog changes stop forcing a publish, and the one that must still force one, does.
 
 Keeping the files current is [`dependency-locks.yml`](../../.github/workflows/dependency-locks.yml).
 Renovate cannot do it — `postUpgradeTasks` needs a self-hosted Renovate with the command


### PR DESCRIPTION
Refs #4772. This is the ~97% the whole lockfile exercise was for.

## The rule being replaced

Any change to `gradle/libs.versions.toml` dirtied **all 94** published modules, because a path diff can't tell which of them resolve the bumped coordinate. Over v1.57.0..v1.84.0: 16 of 38 windows forced all 94 via a shared input, and **13 of those touched only the catalog**.

## The replacement is almost nothing

A module's `gradle.lockfile` lives *inside* the module directory, which the guard already watches. So dependency movement is caught by the same rule that catches source changes, and the catalog is simply **removed** from the blanket shared-input list. A bump that moves nothing any published module resolves now publishes nothing.

## Two things I added rather than assumed

**1. The build toolchain is invisible to lock state.** AGP, the Compose compiler and Kotlin are `[plugins]` entries — they change the bytecode we publish and need not appear on any module's compile or runtime classpath, so no lockfile moves when they do.

`toolchain_fingerprint` compares the `[plugins]` block plus the `[versions]` entries those plugins reference. Replayed over the same window it moves **exactly once** — AGP `9.3.2 → 9.4.0` at v1.62.2 → v1.63.0 — against 13 windows that touched the catalog. So 12 of 13 catalog changes stop forcing a publish, and the one that must still force one, does.

TOML comments are excluded: a `#` line is inert, and this repo comments heavily enough that including them would force a 94-module publish for a prose edit.

**2. A published module with no lockfile fails the whole thing open.** Its source changes are still caught, but a bump that moved only its classpath would look like nothing at all — the one direction this script must never fail in.

## ⚠️ A bug I introduced and caught, in the direction that matters

The first version extracted plugin `version.ref`s with:

```awk
gsub(/.*"|"$/, "", s)
```

`.*"` is **greedy** — it eats through the closing quote and yields an *empty* ref. That silently reduced the fingerprint to the `[plugins]` **text** alone, so `agp = "9.4.0"` → `"9.5.0"` moved nothing and the guard would have skipped a publish it needed.

I found it because a sanity check printed `plugin version.refs:` as empty. Anchored `sub()`s now, and the AGP window above is the regression evidence: with the bug, zero toolchain moves across 39 windows; fixed, exactly the one real move.

This is the third bug of this shape in this workstream — silent, and biased toward skipping. That's why the fail-open discipline is written into the script rather than left to care.

## A test that was passing for the wrong reason

The shared-input loop still listed `gradle/libs.versions.toml` and stayed green only because appending a line lands inside the trailing `[plugins]` section, tripping the new fingerprint. It asserted an invariant that no longer holds, so the catalog's two halves get their own cases instead.

## Test plan

**25 assertions, up from 21**, all passing. New cases:

| Case | Expected |
|---|---|
| Library-only catalog bump, no lockfile movement | `false` ← the headline change |
| The same bump once lock state moves | `true` |
| Toolchain bump, no lockfile movement | `true` |
| Comment-only edit inside `[plugins]` | `false` |
| Published module with no lock state | `true` (fails open) |

Also verified against the real repository, not just fixtures:
- `toolchain_fingerprint` on `main` yields 13 `plugin` + 8 `version` lines, including `agp = "9.4.0"` and `kotlin = "2.4.10"`.
- Stable across a known library-only window (v1.76.0 → v1.77.0, which bumped okio and playwright).
- Moves across exactly one window in 39 — the AGP bump.
- `--print-paths` now lists 98 rather than 99 (the catalog is gone from the watch set).

**The guard is still reporting-only**, so this changes no publishing behaviour yet — it changes what the run summary reports. That's deliberate: the realized saving becomes observable from the guard's own output before anything acts on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2)_