### PR TITLE
docs: require a GitHub-hosted origin for embedded images

### DIFF
--- a/.claude/skills/render-evidence/SKILL.md
+++ b/.claude/skills/render-evidence/SKILL.md
@@ -89,7 +89,10 @@ For the **before** side, render at the base commit (`git stash`, or a worktree a
 1. Commit the PNGs you intend to cite to your working branch and push.
 2. Embed them as markdown images whose URLs are **commit-SHA-pinned**
    `raw.githubusercontent.com` links to those pushed files — the same form the diff
-   bot uses.
+   bot uses. This is not just convention: a `![alt](url)` whose host is not a
+   GitHub origin has its `!` stripped before it reaches the API, silently, so a
+   deployment URL or a CDN link arrives as a bare link and the evidence is gone.
+   Committing and citing the raw URL is what makes the image survive.
 3. Write `![alt](url)` plainly and **leave any backticks that appear alone**. They
    are injected between the agent and GitHub, and the `PR Body Syntax` workflow
    repairs them in place. The three cases it does not cover — review comments,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,17 @@ examples are in [`docs/AGENT_GUIDE.md` → PR workflow](docs/AGENT_GUIDE.md#pr-w
   is not evidence. If a surface genuinely cannot be captured, say so and embed a
   renderable proxy or state how a human/CI verifies it. Text-only is correct for
   non-visual changes.
+- **Embed images only from a GitHub-hosted origin.** Claude Code on the web
+  silently rewrites `![alt](url)` to `[alt](url)` on the way to the API whenever
+  the destination is not a GitHub host, so the picture arrives as a bare link and
+  the call still succeeds. `raw.githubusercontent.com`,
+  `github.com/<owner>/<repo>/raw/<ref>/…`, `github.com/user-attachments/assets/…`
+  and the `user-images` / `private-user-images` / `avatars` / `objects` / `media`
+  / `gist` `.githubusercontent.com` hosts survive; everything else — a preview
+  deployment, a shields.io badge, `camo.githubusercontent.com` — does not. Applies
+  to issue bodies and comments as much as PR descriptions. The measured host list,
+  the upstream issue, and why it is not worth routing around are in
+  [`docs/AGENT_GUIDE.md` → PR workflow](docs/AGENT_GUIDE.md#pr-workflow).
 - **Write `![alt](url)` and leave the backticks alone if they appear.** They are
   injected between the agent and GitHub, not authored, and the
   [`PR Body Syntax`](.github/workflows/pr-body-syntax.yml) workflow repairs them

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -286,6 +286,44 @@ the preview pipeline, don't auto-merge — is stated once in
   and push to it instead of opening a duplicate. A *merged* or *closed* PR does not
   count — that is the [PR-state re-check](../AGENTS.md#re-check-pr-state-immediately-before-every-push).
 
+- **A non-GitHub host loses the `!`, and nothing tells you.** Claude Code on the
+  web rewrites `![alt](url)` to `[alt](url)` on the way to the API whenever the
+  destination is not a GitHub origin, so the image arrives as a plain link. The
+  API returns 201, the tool reports success, and the only way to notice is to read
+  the stored body back. Upstream this is
+  [anthropics/claude-code#89540](https://github.com/anthropics/claude-code/issues/89540)
+  (open, labelled `area:security`): an anti-exfiltration control — a rendered image
+  makes GitHub's camo fetch the URL server-side, which is a data channel — so the
+  answer is to write an allowed destination, not to defeat it.
+
+  Measured variant by variant on
+  [compose-preview-server#456](https://github.com/yschimke/compose-preview-server/issues/456):
+
+  | Kept as an image | Rewritten to a link |
+  | --- | --- |
+  | `raw.githubusercontent.com` (any repo, any ref) | any non-GitHub host — a preview deployment, `img.shields.io`, a CDN |
+  | `github.com/<owner>/<repo>/raw/<ref>/…` | `camo.githubusercontent.com` |
+  | `github.com/user-attachments/assets/…` | |
+  | `user-images` / `private-user-images` / `avatars` / `objects` / `media` / `gist` `.githubusercontent.com` | |
+
+  Three properties matter when you are trying to work out what happened to a body:
+
+  - **It is a blind regex, not a markdown pass.** It fires on `![…](…)` inside
+    inline code spans and inside fenced code blocks, in table cells, in
+    reference-style images (`![x][r]`), through a backslash escape, and on the
+    inner image of `[![x](u)](t)`. Documenting the syntax in a fenced block is
+    itself rewritten.
+  - **`<img>` is not an escape hatch.** An HTML image is entity-escaped *and*
+    wrapped in a code span.
+  - **It applies to issue bodies and issue comments too**, not just PR
+    descriptions.
+
+  So: commit the PNG and point at it with a commit-pinned
+  `raw.githubusercontent.com` URL, or upload the image into the body so GitHub
+  hosts it. Both forms already satisfy the evidence bar in
+  [root `AGENTS.md`](../AGENTS.md#pr-workflow), so nothing else about the workflow
+  changes.
+
 - **Those backticks are usually not yours.** A posted body often lands as
   ``![alt](`url`)`` — or its cousin with the closing run pushed past the `)` —
   which renders as literal text plus a stray code span, so the image never appears
@@ -313,8 +351,10 @@ the preview pipeline, don't auto-merge — is stated once in
   - **It only repairs destinations that still look like one.** `DEST_LOOKS_LIKE_TARGET`
     rejects anything not starting with a scheme, `.`, `#`, `/` or a path segment —
     so a destination wrapped in quotes, or one whose leading `!` was stripped
-    (making it a link rather than an image), falls through untouched. Rewrite the
-    body once by hand in that case.
+    (making it a link rather than an image), falls through untouched. A stripped
+    `!` is the host rewrite above, not this one, and re-adding the `!` by hand only
+    holds if the destination is a GitHub origin; otherwise the next write strips it
+    again. Fix the host, not the punctuation.
   - **It does not prove the picture rendered.** Check the published page, and
     remember `WebFetch` caches per URL for ~15 minutes: re-checking a body you just
     fixed can hand you the stale broken copy and send you chasing a bug you already


### PR DESCRIPTION
## What

Claude Code on the web rewrites `[alt](url)` to `[alt](url)` before the body reaches the GitHub API whenever the destination is not a GitHub origin. The API returns 201 and the tool reports success, so the only way to see it is to read the stored body back.

Three files, one rule:

- **`AGENTS.md`** — a short bullet in the PR workflow naming the surviving hosts and pointing at the guide. Kept tight for the 32 KiB first-turn budget; the file is 10.5 KiB after this.
- **`docs/AGENT_GUIDE.md`** — the detail, next to "Those backticks are usually not yours", since the two are easy to confuse and have different fixes. Also corrects the third case the `PR Body Syntax` net does not cover: a destination whose leading `!` was stripped is *this* rewrite, and re-adding the `!` by hand only holds if the host is a GitHub origin — otherwise the next write strips it again.
- **`.claude/skills/render-evidence/SKILL.md`** — step 2 already said commit-SHA-pinned `raw.githubusercontent.com`; it now says why that is load-bearing rather than convention.

## The measurement

Probed variant by variant on yschimke/compose-preview-server#456. Kept as images: `raw.githubusercontent.com`, `github.com/<o>/<r>/raw/<ref>/…`, `github.com/user-attachments/assets/…`, and the `user-images` / `private-user-images` / `avatars` / `objects` / `media` / `gist` `.githubusercontent.com` hosts. Stripped: everything else, `camo.githubusercontent.com` and `img.shields.io` included. The rewrite is a blind regex — it fires inside code spans, fenced blocks, table cells, reference-style images and through a backslash escape — and ``'&lt;img src=…&gt;'`` is entity-escaped into a code span. It applies to issue bodies and comments as well as PR descriptions.

Upstream: [anthropics/claude-code#89540](https://github.com/anthropics/claude-code/issues/89540), open, labelled `area:security`. It is an anti-exfiltration control, so the documented answer is to write an allowed destination rather than to route around it.

## Test plan

Docs only; no Kotlin, no TypeScript, no workflow behaviour changed, so `ktfmt` and the serve-web formatter have nothing to do.

- Both relative links added resolve: `docs/AGENT_GUIDE.md#pr-workflow` from the root, `../AGENTS.md#pr-workflow` from the guide.
- `.github/scripts/agent-attribution-scan.sh --range origin/main..HEAD` passes; author and committer are `Yuri Schimke <yuri@schimke.ee>`.

Sibling PRs carrying the same rule: yschimke/wear-m3-catalog#327 (plus the `preview.coo.ee` → `design-artifacts/*` URL mapping), yschimke/compose-preview-server#461, yschimke/rc-players#36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NERCXqX1x4gF3pbFSCFj2Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01NERCXqX1x4gF3pbFSCFj2Y)_