### PR TITLE
feat: resolve the Gradle plugin at a separate Maven-line version

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -970,15 +970,31 @@ val generateCliVersionResource =
     // wire-drift tests compile against; this names the release an installed CLI downloads, and a
     // server-only release moves one without the other.
     val serveVersion = libs.versions.composeai.preview.server.dist.get()
+    // The version of THIS repository's Maven artifacts the CLI should ask Gradle for — the plugin
+    // coordinate it auto-injects, and the coordinate `doctor` recommends. Deliberately a separate
+    // value from `cliVersion`, for the same reason `serveVersion` is: what the CLI IS and what it
+    // RESOLVES stop being the same number the moment a release does not publish to Central.
+    //
+    // Today they are identical, because every release publishes and nothing sets the override, so
+    // this is inert. It becomes load-bearing when `maven-publish-guard` is allowed to skip a
+    // publish: the release then sets MAVEN_LINE_VERSION to the last version that IS on Central, and
+    // a CLI built at 2.5.0 keeps injecting the plugin at 2.4.0 rather than a coordinate that 404s.
+    // See docs/design/RELEASE_TRAINS.md and `MAVEN_LINE_VERSION`.
+    val mavenLineVersion =
+      project.providers.environmentVariable("MAVEN_LINE_VERSION").orNull ?: cliVersion
     inputs.property("version", cliVersion)
     inputs.property("xrCompositeVersion", xrCompositeVersion)
     inputs.property("serveVersion", serveVersion)
+    inputs.property("mavenLineVersion", mavenLineVersion)
     outputs.dir(outputDir)
     doLast {
       val file = outputDir.get().file("ee/schimke/composeai/cli/cli-version.properties").asFile
       file.parentFile.mkdirs()
       file.writeText(
-        "version=$cliVersion\nxrCompositeVersion=$xrCompositeVersion\nserveVersion=$serveVersion\n"
+        "version=$cliVersion\n" +
+          "xrCompositeVersion=$xrCompositeVersion\n" +
+          "serveVersion=$serveVersion\n" +
+          "mavenLineVersion=$mavenLineVersion\n"
       )
     }
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
@@ -633,11 +633,12 @@ internal val ISOLATED_PROJECTS_OFF_ARGS: List<String> =
  *
  * The injected plugin version is the **project's version pin** when it has one —
  * `--plugin-version`, `COMPOSE_PREVIEW_VERSION`, `gradle.properties`' `composePreview.version`, or
- * the catalog's `[versions] composePreviewCli` (see [resolveVersionPin]) — and this CLI's own
- * [BUNDLE_VERSION] otherwise. That is what makes a pin mean the same thing here as it does in VS
- * Code and in the `install` / `apply` actions (issue #3738). Callers that already know the version
- * they want (the `init-script` command's `--plugin-version`, tests) pass [pluginVersion] explicitly
- * and no project lookup happens.
+ * the catalog's `[versions] composePreviewCli` (see [resolveVersionPin]) — and this CLI's
+ * [MAVEN_LINE_VERSION] otherwise (the Maven line it resolves against, which is [BUNDLE_VERSION]
+ * unless a release skipped publishing). That is what makes a pin mean the same thing here as it
+ * does in VS Code and in the `install` / `apply` actions (issue #3738). Callers that already know
+ * the version they want (the `init-script` command's `--plugin-version`, tests) pass
+ * [pluginVersion] explicitly and no project lookup happens.
  *
  * Opt-out (any one of these disables auto-inject):
  * - `--no-auto-inject` in [args],

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -1076,11 +1076,16 @@ abstract class Command(
     resolveVersionPin(findProjectRoot(), args)
   }
 
-  /** The compose-preview plugin version this run injects — the pin when there is one, else ours. */
+  /**
+   * The compose-preview plugin version this run injects — the pin when there is one, else the Maven
+   * line this CLI resolves against. Must agree with what [autoInjectInitScriptArgs] actually
+   * injects (it defaults through [resolvePluginVersion], same fallback), or the diagnosis in
+   * [buildFailureAdvice] would name a different coordinate than the one that failed.
+   */
   protected val injectedPluginVersion: String
-    get() = resolvedPin?.version ?: BUNDLE_VERSION
+    get() = resolvedPin?.version ?: MAVEN_LINE_VERSION
 
-  /** Where [injectedPluginVersion] came from, or null when it is simply the CLI's own version. */
+  /** Where [injectedPluginVersion] came from, or null when it is simply the default line. */
   protected val injectedPluginVersionSource: String?
     get() = resolvedPin?.source?.display
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -97,11 +97,13 @@ class DoctorCommand(
   /**
    * Version the CLI suggests in remediation messages ("install version X"). Comes from
    * `--plugin-version`, else the project's version pin once [checkVersionPin] has read it, else the
-   * CLI's compiled-in default. Distinct from [appliedPluginVersion], which is what the project
-   * actually has on its classpath — a project can be pinned to one version and still have another
-   * applied, which is exactly the state the pin check exists to surface.
+   * CLI's compiled-in Maven-line default. Distinct from [appliedPluginVersion], which is what the
+   * project actually has on its classpath — a project can be pinned to one version and still have
+   * another applied, which is exactly the state the pin check exists to surface.
    */
-  private var recommendedPluginVersion = args.flagValue("--plugin-version") ?: BUNDLE_VERSION
+  // [MAVEN_LINE_VERSION], not [BUNDLE_VERSION]: doctor prints this into snippets a user pastes
+  // into a build, so it has to name a version Gradle can actually resolve.
+  private var recommendedPluginVersion = args.flagValue("--plugin-version") ?: MAVEN_LINE_VERSION
 
   /**
    * `--variant <name>` forwarded as `-PcomposePreview.variant=<name>` on the Gradle connection,
@@ -473,7 +475,10 @@ class DoctorCommand(
     // that should print the generic "check wrapper/cache access" line when the real cause is that
     // the plugin version this project asks for isn't published yet (issue #5034).
     val pin = resolveVersionPin(projectDir, args, fileSystem = fileSystem)
-    val pluginVersion = pin?.version ?: BUNDLE_VERSION
+    // [MAVEN_LINE_VERSION], not [BUNDLE_VERSION]. This feeds `pluginResolutionGuidance`, whose
+    // whole job is diagnosing "the plugin version this project asks for is not published"
+    // (#5034) — so it must be the version that IS published, not the CLI's own.
+    val pluginVersion = pin?.version ?: MAVEN_LINE_VERSION
     val pluginVersionSource = pin?.source?.display
     val diagnosePublicationRace = { text: String ->
       pluginResolutionGuidance(text, pluginVersion, pluginVersionSource)
@@ -712,7 +717,7 @@ class DoctorCommand(
                 commands =
                   listOf(
                     "# bump the plugin to match the CLI:",
-                    "compose-preview init-script --plugin-version $BUNDLE_VERSION",
+                    "compose-preview init-script --plugin-version $MAVEN_LINE_VERSION",
                     "# …or update the CLI to match the plugin (see install.sh):",
                     "compose-preview update",
                   ),

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/InitScriptCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/InitScriptCommand.kt
@@ -19,7 +19,7 @@ import okio.FileSystem
  *
  * The version baked into the script follows the same precedence as every other entrypoint:
  * `--plugin-version`, then the project's pin (`COMPOSE_PREVIEW_VERSION`, `gradle.properties`,
- * version catalog — see [resolveVersionPin]), then this CLI's [BUNDLE_VERSION]. So a `./gradlew
+ * version catalog — see [resolveVersionPin]), then this CLI's [MAVEN_LINE_VERSION]. So a `./gradlew
  * --init-script "$(compose-preview init-script --path)"` invocation applies the same plugin version
  * a bare `compose-preview render` would.
  */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Version.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Version.kt
@@ -50,6 +50,36 @@ internal val XR_COMPOSITE_VERSION: String by lazy { cliVersionProperty("xrCompos
  */
 internal val SERVE_VERSION: String by lazy { cliVersionProperty("serveVersion") }
 
+/**
+ * Version of THIS repository's Maven artifacts the CLI resolves — the Gradle plugin it
+ * auto-injects, and the coordinate `doctor` recommends putting in a build.
+ *
+ * Deliberately NOT [BUNDLE_VERSION], and the subtle one of the four. The others name other people's
+ * release lines; this names *ours*, and it exists because what the CLI **is** and what the CLI
+ * **resolves** stop being the same number the moment a release does not publish to Central.
+ *
+ * `maven-publish-guard` in release.yml measures that most releases change no published module —
+ * across v1.57.0..v1.84.0, 117 module-changes against 3,572 module publications. Skipping those
+ * publishes is the point of docs/design/RELEASE_TRAINS.md. But a skipped publish means the version
+ * a CLI was built at has no artifacts at all, so injecting the plugin at [BUNDLE_VERSION] would
+ * hand every consumer `Could not find ee.schimke.composeai:renderer-desktop:<version>` — and that
+ * is the one failure Central cannot be asked to repair afterwards, since it refuses to accept a
+ * version twice.
+ *
+ * So the CLI carries the last version that IS on Central, baked in by `generateCliVersionResource`
+ * from the `MAVEN_LINE_VERSION` override the release sets.
+ *
+ * **Today this equals [BUNDLE_VERSION] and nothing sets that override**, because every release
+ * still publishes and the guard only reports. The seam is landed while it is a no-op so that
+ * letting the guard gate becomes a change to one workflow rather than a redesign of version
+ * resolution.
+ *
+ * Not solved here, and not needed until the two versions actually diverge: a project pin
+ * (`composePreview.version`) names a *CLI* release, and a CLI cannot know another release's Maven
+ * line offline. That needs the release readiness marker to carry the mapping — RELEASE_TRAINS.md.
+ */
+internal val MAVEN_LINE_VERSION: String by lazy { cliVersionProperty("mavenLineVersion") }
+
 /** Read one key from the build-time-generated `cli-version.properties`. */
 private fun cliVersionProperty(key: String): String {
   val props = Properties()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/VersionPin.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/VersionPin.kt
@@ -404,7 +404,10 @@ internal fun resolvePluginVersion(
   args: List<String> = emptyList(),
   env: (String) -> String? = System::getenv,
   fileSystem: FileSystem = SystemFileSystem,
-  fallback: String = BUNDLE_VERSION,
+  // [MAVEN_LINE_VERSION], not [BUNDLE_VERSION]: this value becomes a Gradle coordinate, so it has
+  // to name a version that exists on Maven Central rather than the version this CLI happens to be.
+  // Identical today; see the KDoc on MAVEN_LINE_VERSION for when and why they diverge.
+  fallback: String = MAVEN_LINE_VERSION,
   stderr: (String) -> Unit = System.err::println,
 ): String {
   val pin = resolveVersionPin(projectRoot, args, env, fileSystem)

--- a/docs/design/RELEASE_TRAINS.md
+++ b/docs/design/RELEASE_TRAINS.md
@@ -259,13 +259,29 @@ module, exactly one always changed as a unit.
 
 1. **Report only** *(done)* — the `maven-publish-guard` job records its verdict on every release
    and gates nothing. Watch it against real releases; a wrong `false` here costs nothing.
-2. **Bake the plugin-version pin** — `pluginVersion` into `cli-version.properties`, the
-   `resolvePluginVersion` fallback reading it, and the CLI→Maven map on the release marker.
-   Nothing skips yet, so the pin still equals the release version and the change is a no-op in
-   production.
+2. **Bake the plugin-version pin** *(done, inert)* — `generateCliVersionResource` writes a
+   `mavenLineVersion` key into `cli-version.properties` from a `MAVEN_LINE_VERSION` environment
+   override, defaulting to the CLI's own version; `MAVEN_LINE_VERSION` in `Version.kt` reads it;
+   and every site that turns a version into a **Gradle coordinate** now reads that rather than
+   `BUNDLE_VERSION` — the `resolvePluginVersion` fallback (so auto-inject and `init-script`
+   follow), `Commands.injectedPluginVersion`, and doctor's `recommendedPluginVersion`,
+   `pluginResolutionGuidance` input and `--plugin-version` snippet. Sites that state an
+   **identity** or measure **skew** — `compose-preview --version`, the update check,
+   `versionsIncompatible(applied, BUNDLE_VERSION)`, the build-host handshake — deliberately keep
+   `BUNDLE_VERSION`: they are about which CLI this is, not about what Gradle can resolve.
+
+   Nothing sets the override and every release still publishes, so today the two values are equal
+   and this is a no-op in production. That is the point: the seam lands while it is inert, so
+   step 3 is a workflow change rather than a redesign.
+
+   Still outstanding, and only needed once the two versions actually diverge: the CLI→Maven map on
+   the release readiness marker (`compose-preview-maven-ready-<version>.json`). A project pin names
+   a *CLI* release, and a CLI cannot know another release's Maven line offline.
 3. **Let the guard gate** — `publish-gradle-plugin` takes
-   `if: needs.maven-publish-guard.outputs.needed == 'true'`. Step 2 is what makes this safe; the
-   `-15.8%` arrives here.
+   `if: needs.maven-publish-guard.outputs.needed == 'true'`, and the release sets
+   `MAVEN_LINE_VERSION` from the guard's verdict: the new version when it publishes, the last
+   version that reached Central when it does not. Step 2 is what makes this safe; the `-15.8%`
+   arrives here.
 4. **Split the trains** — five version lines, each with its own guard and manifest entry, and
    renderer POMs naming the library trains' own versions. The remaining `-30%`.
 


### PR DESCRIPTION
Step 2 of [`docs/design/RELEASE_TRAINS.md` § 7](../blob/main/docs/design/RELEASE_TRAINS.md). Inert in production today — it lands the seam that step 3 needs.

## Why

The CLI injects the compose-preview Gradle plugin at its own `BUNDLE_VERSION`. That is only correct while **every** release publishes to Maven Central — which is exactly what `maven-publish-guard` (#5227) exists to stop. Measured across `v1.57.0..v1.84.0`: 117 module-changes against 3,572 module publications, so most releases publish artifacts byte-identical to the previous ones.

The moment a release skips publishing, a CLI built at that version has **no artifacts at all**, and injecting `BUNDLE_VERSION` hands every consumer `Could not find ee.schimke.composeai:renderer-desktop:<version>`. Central refuses a version twice, so that one cannot be repaired after the fact — it has to be impossible by construction, before the guard is allowed to gate anything.

## What

Splits what the CLI **is** from what the CLI **resolves**, the same way `XR_COMPOSITE_VERSION` and `SERVE_VERSION` already split off other repositories' release lines.

- `generateCliVersionResource` writes a `mavenLineVersion` key into `cli-version.properties`, from a `MAVEN_LINE_VERSION` environment override, defaulting to the CLI's own version.
- `MAVEN_LINE_VERSION` in `Version.kt` reads it.
- Every site that turns a version into a **Gradle coordinate** now reads it instead of `BUNDLE_VERSION`:
  - the `resolvePluginVersion` fallback — which covers auto-inject and `init-script` through their existing default,
  - `Commands.injectedPluginVersion` (a parallel path; it has to agree with what auto-inject really injects, or `buildFailureAdvice` would name a different coordinate than the one that failed),
  - doctor's `recommendedPluginVersion`, its `pluginResolutionGuidance` input (#5034 — whose whole job is diagnosing "this version is not published", so it must name the version that *is*), and its `--plugin-version` remediation snippet.

Sites that state an **identity** or measure **skew** keep `BUNDLE_VERSION` deliberately, and the KDoc says so: `compose-preview --version`, the update check against the latest GitHub tag, `versionsIncompatible(applied, BUNDLE_VERSION)`, the pin-skew report, the build-host handshake. Those answer "which CLI is this", not "what can Gradle resolve".

**Nothing sets the override and every release still publishes**, so today `MAVEN_LINE_VERSION == BUNDLE_VERSION` and behaviour is unchanged. That is intentional: landing the seam while it is a no-op makes letting the guard gate a change to one workflow rather than a redesign of version resolution.

Still outstanding, and only needed once the two actually diverge: the CLI→Maven map on the release readiness marker. A project pin names a *CLI* release, and a CLI cannot know another release's Maven line offline. Noted in § 7.

## Test plan

- `./gradlew :cli:test` — green.
- `./gradlew :cli:ktfmtFormatMain :cli:ktfmtFormatTest` run and staged.
- Verified both branches of the new build input:
  ```
  $ cat cli/build/.../cli-version.properties
  version=2.0.1-SNAPSHOT
  xrCompositeVersion=2.0.0
  serveVersion=3.9.0
  mavenLineVersion=2.0.1-SNAPSHOT      # default == cliVersion

  $ MAVEN_LINE_VERSION=2.0.0 ./gradlew :cli:generateCliVersionResource
  mavenLineVersion=2.0.0               # override takes, and re-runs the task
  ```
  The second run re-executing confirms `inputs.property("mavenLineVersion", …)` tracks the override rather than serving a stale up-to-date result.

Non-visual change; no render evidence applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2)_