### PR TITLE
feat: publish to Maven Central only when a published module changed

### DIFF
--- a/.github/scripts/maven-line-baseline.sh
+++ b/.github/scripts/maven-line-baseline.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# The version of this repository's Maven artifacts that is on Central *below* a given release.
+#
+# ONE resolver, TWO consumers in TWO SEPARATE WORKFLOW RUNS, and they must agree exactly:
+#   * `maven-publish-guard` in release.yml, which runs BEFORE the publish and decides whether
+#     this release needs one; and
+#   * `maven-readiness.yml`, which runs AFTER it (from release-please.yml, a different workflow
+#     run with no access to the first one's outputs) and has to know which coordinate to prove
+#     resolvable.
+#
+# That "before and after" is the whole reason this is a script and not two inline `sed`
+# expressions. Central's `<latest>` means different things at those two moments — it is
+# `v(N-1)` before the publish and `vN` after it — so a resolver built on it would have the two
+# jobs disagree about what happened on exactly the releases that DID publish, and the readiness
+# gate would then verify the wrong version. Selecting the greatest version **strictly below**
+# the release under consideration is stable across the publish: it is `v(N-1)` at both moments,
+# whether or not `vN` ever reaches Central.
+#
+# `renderer-desktop` is the sentinel coordinate. It is published on every Central publish this
+# repo does and it is the artifact the injected plugin resolves, so if it is absent at a version
+# then nothing else is there either. See `maven-publish-needed.sh` for the all-or-nothing rule
+# that makes one sentinel sufficient.
+#
+# Prints the bare version (no leading `v`) on stdout, or NOTHING when it cannot resolve one —
+# a network failure, an empty metadata document, or a first-ever release with nothing below it.
+# Exit status is 0 in both cases: "no baseline" is an answer, and every caller is required to
+# fail open on it (publish; verify the release's own version). A non-zero exit means the script
+# itself broke.
+#
+# Usage:
+#   maven-line-baseline.sh --below <version>              # query Central
+#   maven-line-baseline.sh --below <version> --metadata <file>   # read a maven-metadata.xml
+set -euo pipefail
+
+METADATA_URL="https://repo1.maven.org/maven2/ee/schimke/composeai/renderer-desktop/maven-metadata.xml"
+
+BELOW=""
+METADATA_FILE=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --below) BELOW="${2:?--below needs a version}"; shift 2 ;;
+    --metadata) METADATA_FILE="${2:?--metadata needs a path}"; shift 2 ;;
+    *) echo "maven-line-baseline.sh: unknown argument '$1'" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "${BELOW}" ] || { echo "maven-line-baseline.sh: --below is required" >&2; exit 2; }
+BELOW="${BELOW#v}"
+
+if [ -n "${METADATA_FILE}" ]; then
+  meta="$(cat "${METADATA_FILE}")"
+else
+  # `|| true`: a network failure must leave us with an empty document and print nothing, not
+  # abort the calling job. Fail-open is the caller's contract, and it can only honour it if it
+  # gets an answer back.
+  meta="$(curl -fsSL --max-time 30 "${METADATA_URL}" || true)"
+fi
+
+# One <version> element per line. `sed -n s///p` over the whole document rather than a parse:
+# Central writes this file, its shape is fixed, and adding an XML parser to a release-critical
+# path buys nothing.
+versions="$(printf '%s' "${meta}" | tr '<' '\n' | sed -n 's:^version>\(.*\)$:\1:p')"
+
+[ -n "${versions}" ] || exit 0
+
+# Keep only versions strictly below ${BELOW}. `sort -V` is the comparison — a string compare
+# puts 1.9.0 above 1.10.0, which would silently pick a baseline from six releases back.
+below_only=""
+while IFS= read -r v; do
+  [ -n "${v}" ] || continue
+  [ "${v}" != "${BELOW}" ] || continue
+  lower="$(printf '%s\n%s\n' "${v}" "${BELOW}" | sort -V | head -1)"
+  [ "${lower}" = "${v}" ] || continue
+  below_only="${below_only}${v}
+"
+done <<< "${versions}"
+
+[ -n "${below_only}" ] || exit 0
+
+printf '%s' "${below_only}" | sort -V | tail -1

--- a/.github/scripts/maven-publish-needed.sh
+++ b/.github/scripts/maven-publish-needed.sh
@@ -2,8 +2,9 @@
 # Does this release actually need a Maven Central publish?
 #
 # `release.yml`'s `publish-gradle-plugin` runs a root-level `publishAndReleaseToMavenCentral`,
-# which fans out to every subproject applying `composeai.maven-publishing` — 94 modules — on
-# every release, whether or not any of them changed. Measured over v1.57.0..v1.84.0 (38
+# which fans out to every subproject applying `composeai.maven-publishing` — 94 modules. It used
+# to do that on every release, whether or not any of them changed; this script is what that job's
+# `if:` now consults. Measured over v1.57.0..v1.84.0 (38
 # releases): 117 module-changes against 3,572 module publications, so 96.7% of what we upload
 # is a version-bumped rebuild of identical code. Six of those 38 releases changed no published
 # module at all. Maven Central meters file count, release size and release count per

--- a/.github/scripts/test-maven-line-baseline.sh
+++ b/.github/scripts/test-maven-line-baseline.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Self-test for maven-line-baseline.sh.
+#
+# Two jobs in two separate workflow runs — `maven-publish-guard` before the publish and
+# `maven-readiness.yml` after it — depend on this resolver returning the SAME answer at both
+# moments. The tests below pin that property directly (the "same answer before and after" case),
+# because the failure it prevents is silent: a readiness gate that proves the wrong version
+# resolvable reports a release consumable when its plugin coordinate does not exist.
+#
+# Fixtures are literal maven-metadata.xml documents, so nothing here touches the network.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+SCRIPT="$(pwd)/.github/scripts/maven-line-baseline.sh"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+pass=0
+fail=0
+ok() { echo "  ok: $*"; pass=$((pass + 1)); }
+bad() { echo "  FAIL: $*" >&2; fail=$((fail + 1)); }
+
+# Write a maven-metadata.xml carrying the given versions, and echo its path.
+metadata() {
+  local name="$1"; shift
+  local path="${tmp}/${name}.xml"
+  {
+    echo '<metadata>'
+    echo '  <groupId>ee.schimke.composeai</groupId>'
+    echo '  <artifactId>renderer-desktop</artifactId>'
+    echo '  <versioning>'
+    printf '    <latest>%s</latest>\n' "${!#}"
+    echo '    <versions>'
+    for v in "$@"; do printf '      <version>%s</version>\n' "${v}"; done
+    echo '    </versions>'
+    echo '  </versioning>'
+    echo '</metadata>'
+  } > "${path}"
+  printf '%s' "${path}"
+}
+
+# The resolver's answer, or the literal `error` when it exits non-zero.
+baseline() {
+  local out
+  if out="$("${SCRIPT}" "$@" 2>/dev/null)"; then printf '%s' "${out}"; else printf 'error'; fi
+}
+
+expect() {
+  local want="$1" got="$2" what="$3"
+  if [ "${got}" = "${want}" ]; then ok "${what} → '${got}'"; else bad "${what}: want '${want}', got '${got}'"; fi
+}
+
+echo "== picks the greatest version below the release =="
+meta="$(metadata simple 2.0.0 2.1.0 2.2.0)"
+expect "2.2.0" "$(baseline --below 2.3.0 --metadata "${meta}")" "2.3.0 over a line ending at 2.2.0"
+
+echo "== the release's own version is never its own baseline =="
+# The property the two consumers hang on: `--below 2.2.0` answers 2.1.0 whether or not 2.2.0 is
+# in the document, so the guard (before the publish) and the readiness gate (after it) agree.
+before="$(metadata before 2.0.0 2.1.0)"
+after="$(metadata after 2.0.0 2.1.0 2.2.0)"
+b1="$(baseline --below 2.2.0 --metadata "${before}")"
+b2="$(baseline --below 2.2.0 --metadata "${after}")"
+expect "2.1.0" "${b1}" "before the publish"
+expect "2.1.0" "${b2}" "after the publish"
+if [ "${b1}" = "${b2}" ]; then ok "same answer before and after the publish"; else bad "resolver disagrees across the publish: '${b1}' vs '${b2}'"; fi
+
+echo "== version ordering is numeric, not lexical =="
+# The bug this pins: a string compare ranks 1.9.0 above 1.10.0, so the baseline would jump
+# backwards past every release in between and the guard would diff against ancient history.
+meta="$(metadata ordering 1.8.0 1.9.0 1.10.0 1.11.0)"
+expect "1.11.0" "$(baseline --below 1.12.0 --metadata "${meta}")" "double-digit minor beats single-digit"
+expect "1.9.0" "$(baseline --below 1.10.0 --metadata "${meta}")" "below 1.10.0 is 1.9.0, not 1.8.0"
+
+echo "== versions above the release are ignored =="
+# Central carries every version ever published, including ones cut after the tag being verified
+# (a re-run of an old release's readiness gate, or a repair dispatch).
+meta="$(metadata newer 2.0.0 2.1.0 2.2.0 2.3.0)"
+expect "2.0.0" "$(baseline --below 2.1.0 --metadata "${meta}")" "a later line does not leak in"
+
+echo "== fail-open paths print nothing and exit 0 =="
+empty="${tmp}/empty.xml"; : > "${empty}"
+expect "" "$(baseline --below 2.0.0 --metadata "${empty}")" "empty metadata"
+meta="$(metadata first 2.0.0 2.1.0)"
+expect "" "$(baseline --below 2.0.0 --metadata "${meta}")" "nothing below the first release"
+expect "" "$(baseline --below 0.0.1 --metadata "${meta}")" "release older than the whole line"
+
+echo "== a leading v is accepted =="
+meta="$(metadata vprefix 2.0.0 2.1.0)"
+expect "2.1.0" "$(baseline --below v2.2.0 --metadata "${meta}")" "--below v2.2.0"
+
+echo "== argument errors are hard failures, not a silent empty baseline =="
+# A caller that fat-fingers a flag must see a broken script, not "no baseline" — the latter is
+# indistinguishable from a network failure and would quietly change the release's behaviour.
+expect "error" "$(baseline --metadata "${meta}")" "missing --below"
+expect "error" "$(baseline --below 2.2.0 --nonsense)" "unknown flag"
+
+echo
+echo "${pass} passed, ${fail} failed"
+[ "${fail}" -eq 0 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1042,6 +1042,13 @@ jobs:
       # narrows to the shared build inputs and starts answering `false` for real changes.
       - name: Run Maven publish guard tests
         run: ./.github/scripts/test-maven-publish-needed.sh
+      # The baseline resolver the guard and the readiness gate share. They run in two SEPARATE
+      # workflow runs, one before the Central publish and one after it, and a resolver that
+      # answered differently at those two moments would have the readiness gate prove the wrong
+      # version resolvable — attaching a "this release is usable" marker for a plugin coordinate
+      # that does not exist. That property is what these tests pin.
+      - name: Run Maven line baseline tests
+        run: ./.github/scripts/test-maven-line-baseline.sh
       - name: Run PR run reaper tests
         run: node --test .github/scripts/reap-pr-runs.test.mjs
       # The Figma reference column cuts a node out of a repo's committed page

--- a/.github/workflows/maven-readiness.yml
+++ b/.github/workflows/maven-readiness.yml
@@ -46,16 +46,77 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
+      # Which plugin version does THIS release's CLI actually ask Gradle for?
+      #
+      # Not necessarily its own any more. `maven-publish-guard` in release.yml skips the Central
+      # publish on a release where no published module changed, and the CLI built in that same
+      # run is baked to resolve the last version that IS on Central (MAVEN_LINE_VERSION — see
+      # cli/src/main/kotlin/ee/schimke/composeai/cli/Version.kt). Proving the release's own
+      # version resolvable would then poll for 55 minutes for artifacts that are never coming,
+      # and no marker would ever be attached — `latest` would freeze at the last publishing
+      # release and `compose-preview update` would stop offering anything.
+      #
+      # This reads the answer out of the shipped CLI rather than recomputing the guard's verdict
+      # here. Two reasons. It is ground truth about the artifact consumers will actually run, so
+      # it cannot drift from what the release did — a re-derivation in this separate workflow run
+      # could disagree with release.yml (its guard job is `continue-on-error`, so it may have
+      # published without ever writing a verdict), and disagreeing in the direction of "skipped"
+      # would attach a marker while the release's own artifacts were still propagating, which is
+      # exactly the #5051 failure this gate exists to prevent. And the tarball is a REQUIRED
+      # release asset, verified present by `finalize-release` before this job runs.
+      #
+      # Falling back to the release's own version is the conservative direction: on a skipped
+      # release it makes this job fail loudly with no marker attached (consumers keep the
+      # previous usable version) rather than pass with a wrong one.
+      - name: Resolve the plugin version this release's CLI asks Gradle for
+        id: line
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+          V="${TAG#v}"
+          dl="$RUNNER_TEMP/cli-dist"
+          mkdir -p "$dl"
+          plugin_v=""
+          if gh release download "$TAG" --dir "$dl" --pattern "compose-preview-${V}.tar.gz"; then
+            # Targeted extraction: the dist carries every renderer and daemon jar and runs to
+            # ~200 MB, and only the CLI's own jar holds cli-version.properties.
+            if tar -xzf "$dl/compose-preview-${V}.tar.gz" -C "$dl" \
+                 --wildcards "*/lib/compose-preview-*.jar" 2>/dev/null; then
+              jar="$(find "$dl" -name 'compose-preview-*.jar' -path '*/lib/*' | head -1)"
+              if [ -n "$jar" ]; then
+                plugin_v="$(unzip -p "$jar" ee/schimke/composeai/cli/cli-version.properties 2>/dev/null \
+                  | sed -n 's/^mavenLineVersion=//p' | head -1)"
+              fi
+            fi
+          fi
+          if [ -z "${plugin_v}" ]; then
+            echo "::warning::could not read mavenLineVersion from the shipped CLI — verifying ${V} itself."
+            plugin_v="${V}"
+          fi
+          rm -rf "$dl"
+          echo "plugin_version=${plugin_v}" >> "$GITHUB_OUTPUT"
+          if [ "${plugin_v}" = "${V}" ]; then
+            echo "This release published to Central; verifying ${V}."
+          else
+            echo "This release skipped the Central publish; its CLI resolves the plugin at ${plugin_v}."
+          fi
       - name: Resolve the released plugin from public Maven Central
         id: resolve
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+          # The version to prove resolvable — this release's own on a publishing release, the
+          # Maven line it points consumers at on one that skipped.
+          PLUGIN_V: ${{ steps.line.outputs.plugin_version }}
         run: |
           set -euo pipefail
           V="${TAG#v}"
           [[ "$V" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
             || { echo "::error::unexpected release version: $V"; exit 1; }
+          [[ "$PLUGIN_V" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+            || { echo "::error::unexpected plugin version: $PLUGIN_V"; exit 1; }
 
           smoke="$RUNNER_TEMP/compose-preview-maven-readiness"
           gradle_home="$RUNNER_TEMP/compose-preview-maven-readiness-gradle-home"
@@ -65,7 +126,7 @@ jobs:
           printf '%s\n' \
             'buildscript {' \
             '  repositories { mavenCentral() }' \
-            "  dependencies { classpath(\"ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:${V}\") }" \
+            "  dependencies { classpath(\"ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:${PLUGIN_V}\") }" \
             '}' \
             > "$smoke/build.gradle.kts"
 
@@ -83,25 +144,32 @@ jobs:
                 -p "$smoke" help --no-daemon --refresh-dependencies \
                 > "$smoke/gradle.log" 2>&1; then
               ready=1
-              echo "plugin ${V} resolved from public Maven Central on attempt ${attempt}."
+              echo "plugin ${PLUGIN_V} resolved from public Maven Central on attempt ${attempt}."
               # Consumed by the milestone comment below.
               {
                 echo "version=${V}"
+                echo "plugin_version=${PLUGIN_V}"
                 echo "attempts=${attempt}"
-                echo "plugin_coordinate=ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:${V}"
+                echo "plugin_coordinate=ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:${PLUGIN_V}"
               } >> "$GITHUB_OUTPUT"
               break
             fi
-            echo "plugin ${V} not fully resolvable from public Maven Central (attempt ${attempt}/${attempts_max})."
+            echo "plugin ${PLUGIN_V} not fully resolvable from public Maven Central (attempt ${attempt}/${attempts_max})."
             tail -n 30 "$smoke/gradle.log"
             sleep 30
           done
           [ "$ready" -eq 1 ] \
-            || { echo "::error::plugin ${V} was not resolvable after ${attempts_max} attempts (~55 minutes)"; exit 1; }
+            || { echo "::error::plugin ${PLUGIN_V} was not resolvable after ${attempts_max} attempts (~55 minutes)"; exit 1; }
 
+          # The marker is still named for the RELEASE version — `resolve-version.py` and the
+          # bootstrap installer look it up as `compose-preview-maven-ready-<release>.json`, and
+          # its presence is what makes `latest` mean "latest usable". `pluginVersion` is what the
+          # release's CLI resolves, which is the release's own version on a publishing release
+          # and an earlier one when the publish was skipped. Consumers that only need "is this
+          # release usable" can keep reading nothing but the filename.
           marker="$RUNNER_TEMP/compose-preview-maven-ready-${V}.json"
-          printf '{"version":"%s","verifiedAt":"%s"}\n' \
-            "$V" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$marker"
+          printf '{"version":"%s","pluginVersion":"%s","verifiedAt":"%s"}\n' \
+            "$V" "$PLUGIN_V" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$marker"
           gh release upload "$TAG" "$marker" --clobber
           echo "uploaded $(basename "$marker")."
 
@@ -122,6 +190,7 @@ jobs:
           MILESTONE_KEY: maven-published
           MILESTONE_TAG: ${{ inputs.tag }}
           V: ${{ steps.resolve.outputs.version }}
+          PLUGIN_V: ${{ steps.resolve.outputs.plugin_version }}
           ATTEMPTS: ${{ steps.resolve.outputs.attempts }}
           COORDINATE: ${{ steps.resolve.outputs.plugin_coordinate }}
           RELEASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ inputs.tag }}
@@ -131,8 +200,11 @@ jobs:
           # printf per line, not an indented heredoc — see the same note in preview-host-image.yml.
           md="$RUNNER_TEMP/maven-milestone.md"
           {
-            printf '### 📦 Artifacts on Maven Central — `%s` is resolvable\n\n' "${V}"
+            printf '### 📦 Artifacts on Maven Central — `%s` is resolvable\n\n' "${PLUGIN_V}"
             printf 'A clean Gradle project resolved the plugin classpath from `mavenCentral()` on attempt %s, so downstream builds can consume this release.\n\n' "${ATTEMPTS}"
+            if [ "${PLUGIN_V}" != "${V}" ]; then
+              printf 'This release **did not publish to Maven Central** — no published module changed since `%s`, so `maven-publish-guard` skipped the upload (see `docs/design/RELEASE_TRAINS.md`). Its CLI resolves the plugin at `%s`, which is what was verified above. Nothing downstream needs to change: `compose-preview` injects that version for you.\n\n' "${PLUGIN_V}" "${PLUGIN_V}"
+            fi
             printf -- '- **Verified coordinate** — `%s`\n' "${COORDINATE}"
             printf -- '- **Browse** — [central.sonatype.com](https://central.sonatype.com/search?namespace=ee.schimke.composeai)\n'
             printf -- '- **Readiness marker** — `compose-preview-maven-ready-%s.json` on [the release](%s), which is what lets `compose-preview update` offer this version\n' "${V}" "${RELEASE_URL}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,23 +59,22 @@ env:
   TAG_NAME: ${{ inputs.tag || github.ref_name }}
 
 jobs:
-  # REPORTING ONLY — nothing reads this job's output, and it must never be able to stop a release.
+  # Decides whether this release publishes to Maven Central at all, and — when it does not —
+  # which already-published version the CLI built in this same run resolves the plugin at.
   #
   # The root-level `publishAndReleaseToMavenCentral` below uploads all 94 publishing modules on
   # every release, whether or not one of them changed: over v1.57.0..v1.84.0 that was 3,572 module
-  # publications carrying 117 module-changes. This job runs the guard that decides whether a
-  # release needs a Central publish at all and writes the answer to the run summary, so the
-  # decision can be watched against real releases before it is allowed to act on one. Wiring it
-  # to `publish-gradle-plugin`'s `if:` is a deliberate second step, and it needs the CLI-side
-  # plugin-version pin to land first — see docs/design/RELEASE_TRAINS.md § Going live.
+  # publications carrying 117 module-changes, and six of those 38 releases changed no published
+  # module at all. Central meters file count, release size and release count per organisation.
+  # See docs/design/RELEASE_TRAINS.md.
   #
   # Its own job because the guard needs full history (`fetch-depth: 0`) and the publish job does
-  # not: deepening that checkout would slow the release for a step that only reports. It runs in
-  # parallel with everything else and has no dependents.
+  # not: deepening that checkout would slow every release down.
   #
-  # `continue-on-error` is the load-bearing line here, and "no dependents" is exactly why it was
-  # missed. Nothing needs this job's OUTPUT, but `release-please.yml` gates finalisation on the
-  # RESULT of the whole `release.yml` call:
+  # ## `continue-on-error` is still the load-bearing line, and it is not a leftover
+  #
+  # It was here when this job only reported, because `release-please.yml` gates finalisation on
+  # the RESULT of the whole `release.yml` call:
   #
   #     finalize-release:
   #       needs: [release-please, release]
@@ -84,14 +83,15 @@ jobs:
   # A workflow_call's result is the roll-up of every job inside it, so without this line a failure
   # here — a Maven Central blip while resolving the baseline, a git edge case — skips
   # `finalize-release` and leaves the GitHub Release a DRAFT: `/releases/latest` and every
-  # `latest/download/…` URL keep serving the previous version, with the new one published to Maven
-  # Central but invisible to installers. `release-draft-sweeper.yml` would recover it within the
-  # hour, which is a backstop, not a reason to allow it.
+  # `latest/download/…` URL keep serving the previous version. `release-draft-sweeper.yml` would
+  # recover it within the hour, which is a backstop, not a reason to allow it.
   #
-  # This is the same posture, for the same reason, as the release-milestone comment jobs described
-  # in docs/RELEASING.md: pure reporting that runs after a decision has been made must not be able
-  # to touch a publish that already succeeded. A red mark on this job in the run is the intended
-  # signal; a held release is not.
+  # That reasoning survives this job becoming a GATE, because the gate is one-directional: every
+  # consumer below tests `needed != 'false'`, so a job that dies without writing an answer
+  # publishes and builds the CLI at its own version, exactly as if this job did not exist. The
+  # only thing `continue-on-error` can now cost is an unnecessary publish. Removing it, so a
+  # crashed guard failed the release instead, would trade that for a stranded draft — the worse
+  # outcome by a wide margin, and the one this repository has been bitten by before.
   maven-publish-guard:
     continue-on-error: true
     runs-on: ubuntu-latest
@@ -100,6 +100,10 @@ jobs:
     outputs:
       needed: ${{ steps.guard.outputs.needed }}
       reason: ${{ steps.guard.outputs.reason }}
+      # The version of this repo's Maven artifacts a consumer of THIS release should resolve:
+      # the release's own version when it publishes, the last published version when it does not.
+      # Baked into the CLI by `build-applications` as MAVEN_LINE_VERSION.
+      maven_line: ${{ steps.line.outputs.maven_line }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -112,24 +116,19 @@ jobs:
       - name: Resolve the last Maven-published version
         # Central is the authority on what was actually published, which is exactly the baseline
         # the guard needs — and it stays correct once releases start skipping the publish, when
-        # "the previous tag" no longer means "the previous published version". `renderer-desktop`
-        # is the sentinel: it is published on every Central publish this repo does, and it is the
-        # coordinate the plugin injects, so if it is absent at a version nothing else is there
-        # either.
+        # "the previous tag" no longer means "the previous published version".
+        #
+        # Shared with `maven-readiness.yml`, which has to reach the same answer from a different
+        # workflow run AFTER the publish has happened; `maven-line-baseline.sh` explains why that
+        # forces "greatest version strictly below this release" rather than Central's `<latest>`.
         #
         # Failure to resolve leaves BASELINE empty, and the guard fails open on that.
         run: |
           set -uo pipefail
-          meta="$(curl -fsSL --max-time 30 \
-            https://repo1.maven.org/maven2/ee/schimke/composeai/renderer-desktop/maven-metadata.xml \
-            || true)"
-          latest="$(printf '%s' "${meta}" | sed -n 's:.*<latest>\(.*\)</latest>.*:\1:p' | head -1)"
-          if [ -z "${latest}" ]; then
-            latest="$(printf '%s' "${meta}" | sed -n 's:.*<version>\(.*\)</version>.*:\1:p' | tail -1)"
-          fi
+          latest="$(./.github/scripts/maven-line-baseline.sh --below "${TAG_NAME}")"
           if [ -n "${latest}" ] && git rev-parse --verify --quiet "v${latest}^{commit}" >/dev/null; then
             echo "BASELINE=v${latest}" >> "$GITHUB_ENV"
-            echo "Last published version on Central: ${latest}"
+            echo "Last published version below ${TAG_NAME}: ${latest}"
           else
             echo "BASELINE=" >> "$GITHUB_ENV"
             echo "Could not resolve a published baseline (got '${latest:-<none>}') — guard will fail open."
@@ -144,27 +143,56 @@ jobs:
             args=(--baseline "${BASELINE}" "${args[@]}")
           fi
           ./.github/scripts/maven-publish-needed.sh "${args[@]}"
+      - name: Resolve the Maven line this release's CLI resolves against
+        id: line
+        # The version consumers of this release get when the CLI asks Gradle for the plugin.
+        # Publishing → this release. Skipping → the baseline, which is the newest version that
+        # actually exists on Central.
+        #
+        # Only an EXPLICIT `false` skips: an empty `needed` (the guard job died before writing
+        # its output) lands here as "publish", matching the gate on `publish-gradle-plugin`. The
+        # two must agree — a CLI baked to resolve v(N-1) alongside a publish of vN is a silent
+        # downgrade for every consumer of this release.
+        env:
+          GUARD_NEEDED: ${{ steps.guard.outputs.needed }}
+        run: |
+          set -uo pipefail
+          if [ "${GUARD_NEEDED}" = "false" ] && [ -n "${BASELINE}" ]; then
+            line="${BASELINE#v}"
+          else
+            line="${TAG_NAME#v}"
+          fi
+          echo "maven_line=${line}" >> "$GITHUB_OUTPUT"
+          echo "CLI built by this release resolves the plugin at ${line}."
       - name: Report
         # Step outputs reach the shell through the environment, never through `${{ }}` inside the
         # script body — `reason` is free text and interpolating it would splice it into the shell.
         env:
           GUARD_NEEDED: ${{ steps.guard.outputs.needed }}
           GUARD_REASON: ${{ steps.guard.outputs.reason }}
+          MAVEN_LINE: ${{ steps.line.outputs.maven_line }}
         run: |
           {
-            echo "### Maven Central publish guard (reporting only)"
+            echo "### Maven Central publish guard"
             echo
             echo "| | |"
             echo "|---|---|"
-            echo "| Baseline (last published) | \`${BASELINE:-unresolved}\` |"
+            echo "| Baseline (last published below this release) | \`${BASELINE:-unresolved}\` |"
             echo "| This release | \`${TAG_NAME}\` |"
-            echo "| Publish needed | \`${GUARD_NEEDED}\` |"
+            echo "| Publish needed | \`${GUARD_NEEDED:-<no answer — publishing>}\` |"
             echo "| Reason | ${GUARD_REASON} |"
+            echo "| Maven line baked into the CLI | \`${MAVEN_LINE}\` |"
             echo
             if [ "${GUARD_NEEDED}" = "false" ]; then
-              echo "This release published 94 modules that no change could have altered."
+              echo "**Skipping the Central publish.** No published module differs from"
+              echo "\`${BASELINE}\`, so this release would have uploaded 94 modules that no change"
+              echo "could have altered. The CLI shipped by this release resolves the plugin at"
+              echo "\`${MAVEN_LINE}\`, which is on Central, so consumers are unaffected."
+            else
+              echo "Publishing to Central at \`${MAVEN_LINE}\`."
             fi
-            echo "Nothing was skipped — see \`docs/design/RELEASE_TRAINS.md\`."
+            echo
+            echo "See \`docs/design/RELEASE_TRAINS.md\`."
           } >> "$GITHUB_STEP_SUMMARY"
 
   # Run gradle publish AFTER the other builds succeed so we don't orphan a
@@ -195,7 +223,20 @@ jobs:
   publish-gradle-plugin:
     # Gate the irreversible Maven Central publish on every core application build. The bundle viewer
     # remains buildable from source, but its per-OS packages are no longer core release artifacts.
-    needs: [build-applications]
+    needs: [build-applications, maven-publish-guard]
+    # …and on the guard actually having something to publish. `!= 'false'` rather than
+    # `== 'true'`, deliberately: the guard is `continue-on-error`, so a job that crashed leaves
+    # this output empty, and an empty answer must publish. Only the guard's explicit `false` —
+    # written after it has diffed every published module against the last published version —
+    # skips. `maven-publish-needed.sh` fails open on every uncertainty for the same reason:
+    # publishing when we did not need to costs quota, while not publishing when we did strips a
+    # version out from under consumers with no way back, since Central refuses a version twice.
+    #
+    # `!cancelled()` first, so this does not hang on how a `continue-on-error` job reports itself
+    # to `needs`. A guard that failed must still let the publish through — the whole gate is
+    # "skip only on an explicit `false`" — and spelling that out here means the behaviour does not
+    # rest on a subtlety of Actions' job-result semantics.
+    if: ${{ !cancelled() && needs.maven-publish-guard.outputs.needed != 'false' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -255,6 +296,16 @@ jobs:
   # silently fell off the shallow upload glob in the `release` job (zero assets
   # shipped on v0.10.2–v0.10.5).
   build-applications:
+    # The guard decides the version this CLI resolves the Gradle plugin at, and that is baked
+    # into the binary at build time — so the CLI cannot be built before the verdict exists.
+    needs: [maven-publish-guard]
+    # …but it must never be blocked by one. This job produces every GitHub Release asset, and
+    # `finalize-release` holds the release as a draft until they are all attached, so a guard
+    # crash that stopped this job from running would strand the release over a question that
+    # only affects Maven Central. An absent verdict leaves MAVEN_LINE_VERSION empty, which the
+    # build reads as "use the CLI's own version" — and `publish-gradle-plugin` publishes on the
+    # same absence, so the two still agree.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -267,6 +318,18 @@ jobs:
         with:
           cache-read-only: 'true'
       - name: Build CLI distribution
+        # MAVEN_LINE_VERSION is what `generateCliVersionResource` bakes into
+        # `cli-version.properties`, and therefore the coordinate this CLI's auto-inject,
+        # `init-script` and `doctor` hand to Gradle. It equals the release version on every
+        # release that publishes; on one that does not, it names the last version that IS on
+        # Central, so a skipped publish never sends a consumer at a coordinate that 404s.
+        #
+        # Empty means "not set" as far as the build script is concerned (it falls back to the
+        # CLI's own version), which is the right behaviour if the guard job died without an
+        # answer — that path also publishes, so the two agree. See cli/build.gradle.kts and the
+        # MAVEN_LINE_VERSION KDoc in cli/src/main/kotlin/ee/schimke/composeai/cli/Version.kt.
+        env:
+          MAVEN_LINE_VERSION: ${{ needs.maven-publish-guard.outputs.maven_line }}
         run: |
           ./gradlew \
             :cli:distZip :cli:distTar \

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -980,8 +980,17 @@ val generateCliVersionResource =
     // publish: the release then sets MAVEN_LINE_VERSION to the last version that IS on Central, and
     // a CLI built at 2.5.0 keeps injecting the plugin at 2.4.0 rather than a coordinate that 404s.
     // See docs/design/RELEASE_TRAINS.md and `MAVEN_LINE_VERSION`.
+    //
+    // `takeIf { isNotBlank() }` is load-bearing, not defensive noise. release.yml passes this
+    // through as `env: MAVEN_LINE_VERSION: ${{ needs.maven-publish-guard.outputs.maven_line }}`,
+    // and an Actions expression that resolves to nothing sets the variable to the EMPTY STRING
+    // rather than leaving it unset — Gradle then reports it as present, and `orNull` alone would
+    // bake `mavenLineVersion=` into the properties file. Every consumer would ask Gradle for the
+    // plugin at version "". The guard is `continue-on-error`, so "no answer" is a path that can
+    // really happen, and it has to land on the CLI's own version.
     val mavenLineVersion =
-      project.providers.environmentVariable("MAVEN_LINE_VERSION").orNull ?: cliVersion
+      project.providers.environmentVariable("MAVEN_LINE_VERSION").orNull?.takeIf { it.isNotBlank() }
+        ?: cliVersion
     inputs.property("version", cliVersion)
     inputs.property("xrCompositeVersion", xrCompositeVersion)
     inputs.property("serveVersion", serveVersion)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PinCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PinCommand.kt
@@ -39,6 +39,14 @@ class PinCommand(
   private val args: List<String>,
   private val projectRoot: File? = findGradleProjectRoot(),
   private val cliVersion: String = BUNDLE_VERSION,
+  // What `--cli` actually writes. [MAVEN_LINE_VERSION], not [cliVersion]: the pin becomes
+  // `composePreview.version`, which every entrypoint hands to Gradle as a plugin coordinate, so
+  // it has to name a version that exists on Central. They differ only on a release whose Central
+  // publish `maven-publish-guard` skipped — and on such a release `--cli` writing [cliVersion]
+  // would produce a pin that resolves nothing. [cliVersion] stays the identity this command
+  // *reports* (`CLI:`, `cliVersion` in --json, the skew comparison), which is a different
+  // question. See the KDoc on MAVEN_LINE_VERSION.
+  private val mavenLineVersion: String = MAVEN_LINE_VERSION,
   private val fileSystem: FileSystem = SystemFileSystem,
   private val env: (String) -> String? = System::getenv,
   private val stdout: (String) -> Unit = ::println,
@@ -92,7 +100,7 @@ class PinCommand(
         report(root, json, warnSkew = false)
       }
       useCli || positional != null -> {
-        val version = (positional ?: cliVersion).trim().removePrefix("v")
+        val version = (positional ?: mavenLineVersion).trim().removePrefix("v")
         if (version.isEmpty()) {
           stderr("compose-preview pin: version must not be empty.")
           exitProcess(1)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/VersionPin.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/VersionPin.kt
@@ -375,6 +375,10 @@ internal fun warnOnCliSkew(
   cliVersion: String = BUNDLE_VERSION,
   stderr: (String) -> Unit = System.err::println,
   once: AtomicBoolean = cliSkewWarned,
+  // The version the "re-pin" remedy names. [MAVEN_LINE_VERSION], not [cliVersion]: a pin is a
+  // plugin coordinate, and advising someone to pin a version whose Central publish was skipped
+  // hands them a build that resolves nothing. The two differ only on such a release.
+  mavenLineVersion: String = MAVEN_LINE_VERSION,
 ) {
   if (pin == null || pin.version == cliVersion) return
   if (cliVersion.endsWith("-SNAPSHOT") || pin.version.endsWith("-SNAPSHOT")) return
@@ -390,7 +394,7 @@ internal fun warnOnCliSkew(
       else "") +
       "Injecting the pinned plugin version. Align the CLI with " +
       "`compose-preview update ${pin.version}`, or re-pin with " +
-      "`compose-preview pin $cliVersion`."
+      "`compose-preview pin $mavenLineVersion`."
   )
 }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PinCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PinCommandTest.kt
@@ -24,12 +24,20 @@ class PinCommandTest {
     val err = mutableListOf<String>()
   }
 
-  private fun run(args: List<String>, root: File, cliVersion: String = "1.1.0"): Sink {
+  private fun run(
+    args: List<String>,
+    root: File,
+    cliVersion: String = "1.1.0",
+    // Defaults to [cliVersion], which is the state on every release that publishes to Central.
+    // The tests that pass it separately are the ones covering a release that did not.
+    mavenLineVersion: String = cliVersion,
+  ): Sink {
     val sink = Sink()
     PinCommand(
         args = args,
         projectRoot = root,
         cliVersion = cliVersion,
+        mavenLineVersion = mavenLineVersion,
         env = { null },
         stdout = { sink.out += it },
         stderr = { sink.err += it },
@@ -51,6 +59,26 @@ class PinCommandTest {
     val root = tempDir()
     run(listOf("--cli"), root, cliVersion = "1.1.0")
     assertEquals("1.1.0", readGradlePropertiesPin(root))
+  }
+
+  @Test
+  fun `pin --cli writes the Maven line, not the CLI's own version`() {
+    // The distinction only exists on a release whose Central publish `maven-publish-guard`
+    // skipped: the CLI is 1.1.0 but no artifact was published at 1.1.0, so a pin naming it
+    // resolves nothing. What `--cli` means to a user — "make this project use my CLI" — is
+    // satisfied by the version that CLI actually injects, which is the Maven line.
+    val root = tempDir()
+    run(listOf("--cli"), root, cliVersion = "1.1.0", mavenLineVersion = "1.0.9")
+    assertEquals("1.0.9", readGradlePropertiesPin(root))
+  }
+
+  @Test
+  fun `an explicit version always wins over the Maven line`() {
+    // `--cli` is the only path that substitutes anything. A version the user typed is written
+    // verbatim, whether or not it is the one this CLI would have chosen.
+    val root = tempDir()
+    run(listOf("1.2.3"), root, cliVersion = "1.1.0", mavenLineVersion = "1.0.9")
+    assertEquals("1.2.3", readGradlePropertiesPin(root))
   }
 
   @Test

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -191,7 +191,7 @@ republishing the release.
 
 ### What the `release.yml` workflow does
 
-1. Publishes to **Maven Central** via the Central Portal:
+1. Publishes to **Maven Central** via the Central Portal — **when there is anything to publish**:
    - **Gradle plugin** — `ee.schimke.composeai:compose-preview-plugin`
    - **Android renderer AAR** — `ee.schimke.composeai:renderer-android`
    - **Preview annotations** — `ee.schimke.composeai:preview-annotations`
@@ -201,6 +201,37 @@ republishing the release.
    - **Data product connectors** — `ee.schimke.composeai:data-*-connector` artifacts used by daemon modules, including recomposition
 
    Maven Central is the only Maven coordinate source — we no longer mirror jars onto GitHub Packages. Consumers point Gradle at `mavenCentral()` and resolve every module from there.
+
+   **Not every release publishes.** `maven-publish-guard` diffs every module applying
+   `composeai.maven-publishing` — plus the shared inputs that change all of their bytes — against
+   the last version actually on Central, and `publish-gradle-plugin` is skipped when nothing
+   differs. Measured over `v1.57.0..v1.84.0`: 117 module-changes against 3,572 module
+   publications, and six of those 38 releases changed no published module at all. Central meters
+   file count, release size and release count per organisation, which is what this is for
+   ([`docs/design/RELEASE_TRAINS.md`](design/RELEASE_TRAINS.md), issue #4772).
+
+   It is **all-or-nothing** and it **fails open**: either every module publishes at this version
+   or none does, and every uncertainty — an unresolvable baseline, a shallow clone, an empty
+   module enumeration, a guard job that crashed — publishes. The asymmetry is total because the
+   mistakes are: publishing needlessly costs quota, while *not* publishing when we should have
+   cannot be repaired, since Central refuses a version twice.
+
+   **A release that skips the publish is still fully usable**, because the CLI it ships is baked
+   to resolve the plugin at the last version that *is* on Central rather than at its own
+   (`MAVEN_LINE_VERSION`; see
+   [`Version.kt`](../cli/src/main/kotlin/ee/schimke/composeai/cli/Version.kt)). Auto-inject,
+   `compose-preview init-script` and `doctor`'s recommendations all follow it. The job summary on
+   every release run names the verdict, the baseline it diffed against and the Maven line the CLI
+   was built with.
+
+   **A hand-written pin is the one thing that can still name a version that does not exist.**
+   `composePreview.version` in `gradle.properties`, `COMPOSE_PREVIEW_VERSION`, `--plugin-version`
+   and the catalog's `composePreviewCli` are all taken literally — that is the point of a pin —
+   so one naming a release that skipped the publish resolves nothing. `compose-preview pin --cli`
+   is safe: it writes the Maven line rather than the CLI's own version, for exactly this reason.
+   To pin by hand, read `pluginVersion` out of a release's
+   `compose-preview-maven-ready-<version>.json` marker, which records the version that release's
+   CLI resolves.
 2. Builds the **CLI** and the standalone **MCP server** as `.zip` / `.tar.gz` distributions:
    - `compose-preview-<ver>.{zip,tar.gz}` — the CLI; the tarball bundles the desktop renderer. It no longer bundles an MCP server: that module moved to yschimke/compose-preview-server (#5176), which attaches `compose-preview-mcp-<ver>.tar.gz` to its own releases, and `compose-preview mcp serve` fetches it on first use exactly as `serve` fetches the preview server.
    - `compose-preview-mcp-<ver>.{zip,tar.gz}` — the MCP server standalone for consumers who want to wire it into an MCP client without dragging the CLI in.

--- a/docs/design/RELEASE_TRAINS.md
+++ b/docs/design/RELEASE_TRAINS.md
@@ -76,10 +76,10 @@ predecessor.
 | Lever | Effect | Status |
 |---|---|---|
 | Batch the release cut (release train for the *CLI* line) | 44/week → ~7/week; ~6× on every metric | **Out of scope.** The cadence is wanted. |
-| Publish only when a published module changed | § 4 | **Implemented, reporting only** |
+| Publish only when a published module changed | § 4 | **Implemented and gating** |
 | Split the Maven publish into several trains | § 5 | Proposed |
 | Version each module independently | Largest, but contradicts `VERSIONING.md` § 3.1 | **Out of scope** |
-| Narrow the shared-input rule with dependency lock state | § 6 — ~97% of the remaining cost | **Locking implemented; guard not reading it yet** |
+| Narrow the shared-input rule with dependency lock state | § 6 — ~97% of the remaining cost | **Implemented** |
 
 Batching is by far the biggest lever and it is deliberately not taken: the release frequency is
 a product decision, not an accident. Everything below therefore reduces *artifacts per release*
@@ -89,15 +89,16 @@ rather than releases.
 
 [`.github/scripts/maven-publish-needed.sh`](../../.github/scripts/maven-publish-needed.sh)
 answers one question — *could any published artifact's bytes differ from the last
-Maven-published release?* — and the `maven-publish-guard` job in `release.yml` reports the
-answer on every release.
+Maven-published release?* — and the `maven-publish-guard` job in `release.yml` gates
+`publish-gradle-plugin` on the answer.
 
 It watches every module applying `composeai.maven-publishing` (enumerated from the build files,
 not a hand-kept list) plus the shared inputs that can change all of them: `build-logic/`, the
-version catalog, the wrapper, `settings.gradle.kts`, the root `build.gradle.kts`, and
-`gradle.properties` minus its release-please version block — that block moves
-`composeaiReleasedRuntimeVersion` on every single release, so watching it naively would hold
-the guard permanently open.
+wrapper, `settings.gradle.kts`, the root `build.gradle.kts`, and `gradle.properties` minus its
+release-please version block — that block moves `composeaiReleasedRuntimeVersion` on every
+single release, so watching it naively would hold the guard permanently open. Dependency
+movement arrives through each module's own committed `gradle.lockfile` rather than through the
+version catalog, which is § 6.
 
 **It is all-or-nothing, and it fails open.** Publishing a subset would leave
 `renderer-desktop:X` naming `data-focus-core:X` in its POM with no such artifact on Central, so
@@ -277,14 +278,59 @@ module, exactly one always changed as a unit.
    Still outstanding, and only needed once the two versions actually diverge: the CLI→Maven map on
    the release readiness marker (`compose-preview-maven-ready-<version>.json`). A project pin names
    a *CLI* release, and a CLI cannot know another release's Maven line offline.
-3. **Let the guard gate** — `publish-gradle-plugin` takes
-   `if: needs.maven-publish-guard.outputs.needed == 'true'`, and the release sets
-   `MAVEN_LINE_VERSION` from the guard's verdict: the new version when it publishes, the last
-   version that reached Central when it does not. Step 2 is what makes this safe; the `-15.8%`
-   arrives here.
+3. **Let the guard gate** *(done)* — `publish-gradle-plugin` takes
+   `if: needs.maven-publish-guard.outputs.needed != 'false'`, and `build-applications` bakes
+   `MAVEN_LINE_VERSION` from the guard's `maven_line` output: the new version when it publishes,
+   the last version that reached Central when it does not. Step 2 is what makes this safe; the
+   `-15.8%` arrives here.
+
+   `!= 'false'` rather than `== 'true'` because the guard job is `continue-on-error`: a job that
+   dies without writing an output must publish, not skip. Failing the job instead would strand
+   the release as a draft over a guard with no opinion. The same asymmetry runs through
+   `maven-publish-needed.sh`, which fails open on every uncertainty.
+
+   Three things had to move with it.
+
+   **The readiness gate had to learn which version to prove.**
+   [`maven-readiness.yml`](../../.github/workflows/maven-readiness.yml) resolved the release's own
+   version from Central and attached `compose-preview-maven-ready-<version>.json` on success. On a
+   release that skips the publish that version never appears, so it would poll for 55 minutes and
+   attach nothing — and since `resolve-version.py` gates `latest` on that marker, `latest` would
+   freeze at the last publishing release and `compose-preview update` would stop offering
+   anything. It now reads `mavenLineVersion` out of the CLI tarball already attached to the
+   release and proves *that* resolvable, keeping the marker's name (the release's version, which
+   is what consumers look up) and adding a `pluginVersion` field.
+
+   Reading the shipped artifact rather than recomputing the verdict is deliberate. A second
+   derivation, in a different workflow run, can disagree with what the release actually did —
+   the guard job is `continue-on-error`, so a release can publish without ever writing a verdict
+   — and disagreeing in the direction of "skipped" would attach a marker while the release's own
+   artifacts were still propagating. That is precisely the #5051 failure this gate exists to
+   prevent. The tarball is a required asset, verified present by `finalize-release` before this
+   job runs, and it is the thing consumers actually execute.
+
+   **`pin --cli` had to stop writing the CLI's own version.** A pin becomes
+   `composePreview.version`, which every entrypoint hands to Gradle as a plugin coordinate, so on
+   a skipped release `--cli` would have written a pin that resolves nothing. It writes
+   `MAVEN_LINE_VERSION` now, as does the "re-pin with…" remedy in `warnOnCliSkew`. A version the
+   user types is still written verbatim — that is what a pin is for — which leaves a
+   hand-written pin as the one remaining way to name a version that was never published. See
+   [`RELEASING.md`](../RELEASING.md).
+
+   **The baseline resolver had to become shared.** `maven-publish-guard` runs before the publish
+   and the readiness gate after it, in separate workflow runs, and Central's `<latest>` means
+   different things at those two moments. Both now call
+   [`maven-line-baseline.sh`](../../.github/scripts/maven-line-baseline.sh), which selects the
+   greatest version **strictly below** the release under consideration — stable across the
+   publish by construction. Pinned by `test-maven-line-baseline.sh` in CI.
+
+   `required-release-assets.sh` needed **no** change, contrary to the note this section used to
+   carry: it lists only CLI assets, which a skipped publish still produces, so `finalize-release`
+   and the draft sweeper are unaffected.
 4. **Split the trains** — five version lines, each with its own guard and manifest entry, and
    renderer POMs naming the library trains' own versions. The remaining `-30%`.
 
-Steps 3 and 4 each need `required-release-assets.sh`, the readiness marker and
-[`RELEASING.md`](../RELEASING.md) updated in the same change: a release that publishes nothing to
-Central must not wait for a Maven-readiness marker that will never appear.
+Step 4 still needs the readiness marker and [`RELEASING.md`](../RELEASING.md) revisited in the
+same change: with five version lines there is no longer one Maven line for a release to name, and
+the marker has to carry a version per train rather than the single `pluginVersion` it gained in
+step 3.


### PR DESCRIPTION
Step 3 of [`docs/design/RELEASE_TRAINS.md` § 7](https://github.com/yschimke/compose-ai-tools/blob/main/docs/design/RELEASE_TRAINS.md). `maven-publish-guard` has reported its verdict on every release since #5227 without acting on it; it now gates `publish-gradle-plugin`. This is where the **−15.8%** lands.

## The numbers

Over `v1.57.0..v1.84.0` (38 releases): **3,572 module publications carrying 117 module-changes**, and six of those releases changed no published module at all. Replaying the guard over the same windows gives 32 publishes and 6 skips — 3,572 → 3,008 module publications. Central meters file count, release size and release count per organisation (#4772).

## The gate

```yaml
if: ${{ !cancelled() && needs.maven-publish-guard.outputs.needed != 'false' }}
```

`!= 'false'`, not `== 'true'`. The guard job is `continue-on-error`, so a job that dies without writing an answer **publishes**, exactly as if it were not there — only its explicit `false` skips. Removing `continue-on-error` so a crashed guard failed the release instead would trade an unnecessary publish for a stranded draft, which is the worse outcome and one this repo has been bitten by. `!cancelled()` is there so none of this rests on a subtlety of how Actions reports a `continue-on-error` job to `needs`.

`build-applications` now depends on the guard (it bakes `MAVEN_LINE_VERSION` into the CLI) but carries `if: ${{ !cancelled() }}` so a guard crash can never stop the GitHub Release assets from being built.

## Three things had to move with it

**The readiness gate had to learn which version to prove.** `maven-readiness.yml` resolved the release's own version from Central. On a release that skips the publish that version never appears, so it would poll for 55 minutes and attach no marker — and `resolve-version.py` gates `latest` on that marker, so `latest` would freeze at the last publishing release and `compose-preview update` would stop offering anything. It now reads `mavenLineVersion` out of the CLI tarball **already attached to the release** and proves *that* resolvable, keeping the marker's name (the release's version, which is what consumers look up) and adding a `pluginVersion` field.

Reading the shipped artifact rather than recomputing the guard's verdict is deliberate. A second derivation, in a different workflow run, can disagree with what the release actually did — the guard job is `continue-on-error`, so a release can publish without ever writing a verdict — and disagreeing in the direction of "skipped" would attach a marker while the release's own artifacts were still propagating. That is precisely the #5051 failure this gate exists to prevent. The tarball is a required asset, verified present by `finalize-release` before this job runs, and it is what consumers actually execute.

**`pin --cli` had to stop writing the CLI's own version.** A pin becomes `composePreview.version`, which every entrypoint hands to Gradle as a plugin coordinate — so on a skipped release `--cli` would have written a pin that resolves nothing. It writes `MAVEN_LINE_VERSION` now, as does the "re-pin with…" remedy in `warnOnCliSkew`. A version the user *types* is still written verbatim (that is what a pin is for), which leaves a hand-written pin as the one remaining way to name a version that was never published; `RELEASING.md` says so and points at the marker's `pluginVersion` as the machine-readable answer. This is a site I missed in #5245's sweep — same coordinate-vs-identity rule.

**The baseline resolver had to become shared.** The guard runs *before* the publish and the readiness gate *after* it, in separate workflow runs, and Central's `<latest>` means different things at those two moments — so a resolver built on it would have the two disagree about exactly the releases that *did* publish. Both now call `maven-line-baseline.sh`, which selects the greatest version **strictly below** the release under consideration: stable across the publish by construction.

`required-release-assets.sh` needed **no** change, contrary to what § 7 used to claim — it lists only CLI assets, which a skipped publish still produces, so `finalize-release` and the draft sweeper are unaffected. § 7 corrected.

## A bug in #5245's seam, fixed here

`release.yml` passes the line through as `env: MAVEN_LINE_VERSION: ${{ … }}`, and **an Actions expression that resolves to nothing sets the variable to the empty string rather than leaving it unset** — Gradle reports that as present, so `orNull` alone baked `mavenLineVersion=` into the properties file and every consumer would have asked Gradle for the plugin at version `""`. Verified directly:

```
$ MAVEN_LINE_VERSION="" ./gradlew :cli:generateCliVersionResource   # before
mavenLineVersion=
```

Now `?.takeIf { it.isNotBlank() } ?: cliVersion`.

## Test plan

- **New**: `.github/scripts/test-maven-line-baseline.sh`, 13 assertions, wired into CI. Pins the property the whole design rests on — *same answer before and after the publish* — plus numeric-not-lexical ordering (a string compare ranks `1.9.0` above `1.10.0`), fail-open paths returning empty with exit 0, and argument errors being hard failures rather than a silent empty baseline.
- **Smoke-tested against live Central metadata**: `--below 2.0.1` → `2.0.0`, `--below 2.0.0` → `1.85.0`, `--below 1.84.0` → `1.83.0`.
- `test-maven-publish-needed.sh` — 25 passed.
- `./gradlew :cli:test` — 900 tests, green. `PinCommandTest` gained two cases: `--cli` writes the Maven line, and an explicit version still wins over it.
- `./gradlew ktfmtCheckAll` — green.
- All three touched workflows parse.
- Verified the properties resource for all three override states: unset → `2.0.1-SNAPSHOT`, `""` → `2.0.1-SNAPSHOT`, `1.99.0` → `1.99.0`.
- Verified the tarball extraction `maven-readiness` now performs against a real `:cli:distTar` build: `tar --wildcards '*/lib/compose-preview-*.jar'` then `unzip -p … cli-version.properties` returns `mavenLineVersion=2.0.1-SNAPSHOT`.

Non-visual change; no render evidence applicable.

## What to watch on the first releases

The first release to actually skip will be visible in the `maven-publish-guard` job summary, which now names the verdict, the baseline it diffed against and the Maven line baked into the CLI. The milestone comment on the release PR says explicitly when a release did not publish and which coordinate was verified instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2)_