### PR TITLE
docs: cost the train split, and land on two lines rather than five

### DIFF
--- a/docs/design/RELEASE_TRAINS.md
+++ b/docs/design/RELEASE_TRAINS.md
@@ -77,7 +77,7 @@ predecessor.
 |---|---|---|
 | Batch the release cut (release train for the *CLI* line) | 44/week → ~7/week; ~6× on every metric | **Out of scope.** The cadence is wanted. |
 | Publish only when a published module changed | § 4 | **Implemented and gating** |
-| Split the Maven publish into several trains | § 5 | Proposed |
+| Split the Maven publish into several trains | § 5 | Proposed — **two** lines, not five |
 | Version each module independently | Largest, but contradicts `VERSIONING.md` § 3.1 | **Out of scope** |
 | Narrow the shared-input rule with dependency lock state | § 6 — ~97% of the remaining cost | **Implemented** |
 
@@ -107,14 +107,19 @@ shallow clone, broken module enumeration — answers `needed=true`, because Cent
 accept a version twice: an unnecessary publish costs quota, a wrongly-skipped one is
 unrepairable.
 
-**Replayed over the same 38 windows: 32 publishes, 6 skips.**
+**Replayed over the same 38 windows: 30 publishes, 8 skips.**
 
 | | Module-publications | vs today |
 |---|---|---|
 | Today | 3,572 | — |
-| With the guard | 3,008 | **−15.8%** |
+| With the guard | 2,820 | **−21.1%** |
 
-Six releases in a week that publish nothing is worth having, and it is the whole of what a
+This is better than the −15.8% first measured here, and the difference is the lockfile rule in
+§ 6: dropping `gradle/libs.versions.toml` as a blanket shared input turned two more windows into
+skips. Re-measure after changing the guard — the number moved by a third without anyone touching
+the split.
+
+Eight releases in a week that publish nothing is worth having, and it is the whole of what a
 single train can give. The rest needs the split.
 
 ## 5. The train split
@@ -125,21 +130,53 @@ changes, or when a shared build input does):
 
 | Train | Modules | Publishes | Module-publications |
 |---|---|---|---|
-| **core** — `gradle-plugin*`, `renderers/*`, `render-host`, `render-matrix`, `render-session/*`, `daemon/*` | 17 | 30 / 38 | 510 |
-| **data** — `data/*` | 58 | 19 / 38 | 1,102 |
-| **runtimes** — `runtimes/*` | 10 | 16 / 38 | 160 |
-| **api** — `api/*` | 4 | 18 / 38 | 72 |
-| **misc** — `bundle/*`, `common/*`, `screen/model` | 5 | 19 / 38 | 95 |
-| | **94** | | **1,939** |
+| **core** — `gradle-plugin*`, `renderers/*`, `render-host`, `render-matrix`, `render-session/*`, `daemon/*` | 17 | 27 / 38 | 459 |
+| **data** — `data/*` | 58 | 13 / 38 | 754 |
+| **runtimes** — `runtimes/*` | 10 | 7 / 38 | 70 |
+| **api** — `api/*` | 4 | 10 / 38 | 40 |
+| **misc** — `bundle/*`, `common/*`, `screen/model` | 5 | 10 / 38 | 50 |
+| | **94** | | **1,373** |
+
+(Every count here is lower than when this table was first written, for the § 4 reason: the guard
+now reads committed lock state rather than treating the version catalog as a blanket shared
+input.)
 
 | | Module-publications | vs today |
 |---|---|---|
 | Today | 3,572 | — |
-| Guard, one train | 3,008 | −15.8% |
-| Guard, five trains | **1,939** | **−45.7%** |
+| Guard, one train | 2,820 | −21.1% |
+| Guard, five trains | **1,373** | **−61.6%** |
 
-The shape of the win is `data/`: 58 modules — 62% of everything we publish — moving on half the
-releases. It is the single largest block of artifacts and close to the slowest-changing.
+The shape of the win is `data/`: 58 modules — 62% of everything we publish — moving on a third of
+the releases. It is the single largest block of artifacts and close to the slowest-changing.
+
+### How many trains is worth it
+
+Five was the first grouping costed, not a conclusion, and costing the alternatives says it is the
+wrong shape. Reproduce with
+[`scripts/release-train-costing.sh`](../../scripts/release-train-costing.sh), which mirrors the
+guard's own rules (its one-train column reproduces the guard's replay exactly, 30/38):
+
+| Grouping | Module-publications | vs today | Marginal |
+|---|---|---|---|
+| 1 train — no split | 2,820 | −21.1% | — |
+| **2 trains — `data` \| rest** | **1,762** | **−50.7%** | **−29.6 pp** |
+| 3 trains — `core` \| `data` \| rest | 1,460 | −59.1% | −8.5 pp |
+| 5 trains — the table above | 1,373 | −61.6% | −2.4 pp |
+
+**One extra version line buys 29.6 points; the next three buy 10.9 between them.** Separating
+`data/` alone captures nearly three quarters of everything the split has to offer, because the
+win was never really about cadence matching — it is about 58 of the 94 modules being both the
+largest block and one of the slowest-moving. Splitting `core` off as well is defensible at
+−8.5 pp. `runtimes`, `api` and `misc` are 19 modules between them, and separating all three buys
+2.4 points for three more version lines, three more changelogs, three more tag streams and three
+more chances to publish a POM naming a sibling version that does not exist.
+
+**So: two trains, and revisit at three.** Not five.
+
+Each train stays internally all-or-nothing, so no train ever publishes a POM naming a sibling
+version that does not exist. This is **not** per-module versioning (`VERSIONING.md` § 3.1,
+explicitly out of scope): it is two version lines instead of one, each still a lockstep set.
 
 > **These groups are drawn from directory paths, and the paths do not match the dependency graph.**
 > `render-session` spans layers 0, 2, 3 and 5; `daemon` spans 0, 1 and 4; `data` spans 0, 1 and 2.
@@ -147,10 +184,6 @@ releases. It is the single largest block of artifacts and close to the slowest-c
 > path-based grouping, which makes this table a costing of one candidate rather than a
 > recommendation. Restructuring the directories to match the layers would buy about three
 > percentage points — see § 6's propagation numbers — and is not worth a 94-module reshuffle.
-
-Each train stays internally all-or-nothing, so no train ever publishes a POM naming a sibling
-version that does not exist. This is **not** per-module versioning (`VERSIONING.md` § 3.1,
-explicitly out of scope): it is five version lines instead of one, each still a lockstep set.
 
 ### Why a train can be skipped safely
 
@@ -282,7 +315,7 @@ module, exactly one always changed as a unit.
    `if: needs.maven-publish-guard.outputs.needed != 'false'`, and `build-applications` bakes
    `MAVEN_LINE_VERSION` from the guard's `maven_line` output: the new version when it publishes,
    the last version that reached Central when it does not. Step 2 is what makes this safe; the
-   `-15.8%` arrives here.
+   `-21.1%` arrives here.
 
    `!= 'false'` rather than `== 'true'` because the guard job is `continue-on-error`: a job that
    dies without writing an output must publish, not skip. Failing the job instead would strand
@@ -327,10 +360,21 @@ module, exactly one always changed as a unit.
    `required-release-assets.sh` needed **no** change, contrary to the note this section used to
    carry: it lists only CLI assets, which a skipped publish still produces, so `finalize-release`
    and the draft sweeper are unaffected.
-4. **Split the trains** — five version lines, each with its own guard and manifest entry, and
-   renderer POMs naming the library trains' own versions. The remaining `-30%`.
+4. **Split the trains** — a second version line for `data/`, with its own guard verdict and
+   manifest entry, and core POMs naming the data train's version rather than their own. Takes the
+   saving from `-21.1%` to `-50.7%`; § 5 costs why it is two lines and not five.
 
 Step 4 still needs the readiness marker and [`RELEASING.md`](../RELEASING.md) revisited in the
-same change: with five version lines there is no longer one Maven line for a release to name, and
-the marker has to carry a version per train rather than the single `pluginVersion` it gained in
-step 3.
+same change: with two version lines there is no longer one Maven line for a release to name, so
+the marker's single `pluginVersion` (gained in step 3) becomes a version per train. The CLI needs
+only the **core** line — that is the coordinate it injects — so `MAVEN_LINE_VERSION` keeps its
+meaning and the data line reaches consumers as a POM transitive of core, which is how it already
+reaches them today.
+
+The open question step 4 has to answer first, and the reason it is not a mechanical follow-on:
+**where the second version number lives and who bumps it.** Today one release-please invocation
+owns one version. Two lines means either a second release-please component with its own tag
+stream and changelog, or a data-train version derived from the release version and frozen when
+the guard says the train did not change. The second is much less machinery and keeps one tag per
+release; it costs a version number that is not monotonic per artifact, which `VERSIONING.md`
+would have to say out loud.

--- a/scripts/release-train-costing.sh
+++ b/scripts/release-train-costing.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# What would splitting the Maven publish into several version lines actually save?
+#
+# `maven-publish-needed.sh` decides whether a release publishes ALL 94 modules or none. A train
+# split replaces that one decision with several: each train publishes when one of its own modules
+# changed, so a release that touched only `data/` republishes 58 modules instead of 94, and one
+# that touched neither republishes nothing. This script replays candidate groupings over a range
+# of real release tags and prints what each would have cost.
+#
+# It exists because the grouping is a judgement call with a large, non-obvious answer. The five
+# trains originally proposed in docs/design/RELEASE_TRAINS.md § 5 turn out to be the wrong shape:
+# almost the entire saving comes from separating `data/` alone, and the last two version lines buy
+# under three percentage points between them. That is a conclusion nobody should have to take on
+# trust, so it is reproducible here.
+#
+# ## What it models, and where it is approximate
+#
+# It mirrors `maven-publish-needed.sh`'s rules: the same module enumeration (via `--print-paths`),
+# the same shared build inputs, the same test-source exclusion (copied verbatim, so it covers KMP
+# source sets like `src/jvmTest/` too), the same `gradle.properties`
+# release-please-block exclusion, and the same "a baseline advances only when a publish happens"
+# rule — so consecutive skippable releases coalesce into one span instead of each being compared
+# against its immediate predecessor.
+#
+# Two things it does NOT model, both of which make it OPTIMISTIC on historical ranges:
+#
+#   * Committed lock state did not exist before #5240, so a dependency bump in a historical window
+#     moves no `gradle.lockfile` and reads here as "nothing changed". Going forward the guard sees
+#     those; historically it cannot. Windows whose only change was `gradle/libs.versions.toml` are
+#     therefore counted as skips when some of them would really publish.
+#   * Cross-train propagation. A `core` module depending on a `data` module gets a POM naming the
+#     data train's version, so a data-only change does not force a core publish. § 6 measures
+#     propagation against the real dependency graph and finds it costs about three percentage
+#     points — small, but this script charges nothing for it.
+#
+# Treat the output as an upper bound on the saving and a sound comparison BETWEEN groupings, which
+# is the question it exists to answer.
+#
+# Usage:
+#   release-train-costing.sh [<tag-regex>]     # default: the v1.57.0..v1.84.0 window § 2 uses
+set -uo pipefail
+
+cd "$(dirname "$0")/.."
+
+TAG_PATTERN="${1:-^v1\.(5[7-9]|6[0-9]|7[0-9]|8[0-4])\.}"
+
+# Shared build inputs, from `shared_paths()` in maven-publish-needed.sh. A change to one of these
+# can alter every module's bytes, so it publishes every train.
+SHARED=(build-logic gradle/wrapper settings.gradle.kts build.gradle.kts)
+
+# The grouping under test. Paths, not the dependency graph — see § 5's note on why the two differ
+# and why closing that gap is not worth a 94-module reshuffle.
+train_of() {
+  case "$1" in
+    gradle-plugin*|renderers/*|render-host|render-matrix|render-session/*|daemon/*) echo core ;;
+    data/*) echo data ;;
+    runtimes/*) echo runtimes ;;
+    api/*) echo api ;;
+    *) echo misc ;;
+  esac
+}
+
+mapfile -t MODULES < <(
+  ./.github/scripts/maven-publish-needed.sh --print-paths |
+    grep -v -E '^(build-logic|gradle/wrapper|settings\.gradle\.kts|build\.gradle\.kts|gradle\.properties)$'
+)
+[ "${#MODULES[@]}" -gt 0 ] || { echo "no modules enumerated" >&2; exit 1; }
+
+mapfile -t TAGS < <(git tag | grep -E "${TAG_PATTERN}" | sort -V)
+[ "${#TAGS[@]}" -gt 1 ] || { echo "need at least two tags matching ${TAG_PATTERN}" >&2; exit 1; }
+
+# gradle.properties minus the release-please version block, which moves on EVERY release and would
+# otherwise report every window as changed.
+props_without_version_block() {
+  git show "${1}:gradle.properties" 2>/dev/null |
+    sed '/# x-release-please-start-version/,/# x-release-please-end/d'
+}
+
+# Did anything a train cares about change between two refs? Test sources are excluded: they are
+# compiled by `check`, never by `assemble`, so they reach neither the jar nor the sources jar.
+train_changed() {
+  local from="$1" to="$2"; shift 2
+  local diff
+  # Verbatim from maven-publish-needed.sh, and it has to be: a narrower pattern (one that misses
+  # KMP source sets like `src/jvmTest/`) makes this script report a publish the guard would skip,
+  # which shifts every column at once.
+  diff="$(git diff --name-only "${from}" "${to}" -- "${SHARED[@]}" "$@" 2>/dev/null |
+    grep -Ev '(^|/)src/[a-zA-Z]*[Tt]est[a-zA-Z]*/')"
+  [ -n "${diff}" ] && return 0
+  # A shared input, so it publishes every train.
+  [ "$(props_without_version_block "${from}")" != "$(props_without_version_block "${to}")" ]
+}
+
+WINDOWS=$(( ${#TAGS[@]} - 1 ))
+TODAY=$(( WINDOWS * ${#MODULES[@]} ))
+
+# One variant: each argument is a comma-separated set of train names forming one version line.
+run_variant() {
+  local label="$1"; shift
+  local -a groups=("$@")
+  local -A pubs prev size
+  local -A members   # group -> newline-separated module paths, built once
+  local g m tr
+
+  for g in "${groups[@]}"; do pubs[$g]=0; prev[$g]="${TAGS[0]}"; size[$g]=0; members[$g]=""; done
+  for m in "${MODULES[@]}"; do
+    tr="$(train_of "${m}")"
+    for g in "${groups[@]}"; do
+      if [[ ",${g}," == *",${tr},"* ]]; then
+        size[$g]=$(( size[$g] + 1 )); members[$g]+="${m}"$'\n'; break
+      fi
+    done
+  done
+
+  local t total=0
+  for t in "${TAGS[@]:1}"; do
+    for g in "${groups[@]}"; do
+      # `<<<` on a trailing-newline string yields a final EMPTY element, and an empty pathspec
+      # makes `git diff --` match nothing here while erroring into /dev/null — every train would
+      # read as unchanged and every grouping would score a perfect -100%.
+      local -a mods=(); mapfile -t -d $'\n' mods < <(printf '%s' "${members[$g]}")
+      if train_changed "${prev[$g]}" "${t}" "${mods[@]}"; then
+        pubs[$g]=$(( pubs[$g] + 1 )); prev[$g]="${t}"
+      fi
+    done
+  done
+  for g in "${groups[@]}"; do total=$(( total + pubs[$g] * size[$g] )); done
+
+  printf '| %-38s | %6s | %6s%% |' "${label}" "${total}" \
+    "$(awk -v a="${total}" -v b="${TODAY}" 'BEGIN{printf "%.1f", (a-b)*100/b}')"
+  for g in "${groups[@]}"; do printf ' %s %s/%s (%sm)' "${g}" "${pubs[$g]}" "${WINDOWS}" "${size[$g]}"; done
+  echo
+}
+
+echo "range      ${TAGS[0]}..${TAGS[-1]}  (${WINDOWS} windows, ${#MODULES[@]} published modules)"
+echo "today      ${TODAY} module-publications"
+echo
+printf '| %-38s | %6s | %7s | %s\n' "grouping" "m-pubs" "vs today" "per train"
+printf '|%s|%s|%s|%s\n' "----------------------------------------" "--------" "---------" "-----------"
+run_variant "1 train (no split)"          "core,data,runtimes,api,misc"
+run_variant "2 trains: data | rest"       "data" "core,runtimes,api,misc"
+run_variant "3 trains: core | data | rest" "core" "data" "runtimes,api,misc"
+run_variant "5 trains (§ 5's candidate)"  "core" "data" "runtimes" "api" "misc"


### PR DESCRIPTION
Re-measuring before building step 4 of [`RELEASE_TRAINS.md` § 7](https://github.com/yschimke/compose-ai-tools/blob/main/docs/design/RELEASE_TRAINS.md) changed what step 4 should be. Two findings, both of which move numbers this document has been asserting.

## The one-train guard is worth more than we recorded

Replaying `maven-publish-needed.sh` as merged over the same 38 windows: **30 publishes, 8 skips — 2,820 module-publications, −21.1%**, against the −15.8% written down when the guard was first costed.

The difference is the lockfile rule (#5243): dropping `gradle/libs.versions.toml` as a blanket shared input turned two more windows into skips. The number moved by a third without anyone touching the split — which is the argument for re-measuring after changing the guard, and the reason this PR exists at all.

## Five trains is the wrong shape

| Grouping | Module-publications | vs today | Marginal |
|---|---|---|---|
| 1 train — no split | 2,820 | −21.1% | — |
| **2 trains — `data` \| rest** | **1,762** | **−50.7%** | **−29.6 pp** |
| 3 trains — `core` \| `data` \| rest | 1,460 | −59.1% | −8.5 pp |
| 5 trains — § 5's original candidate | 1,373 | −61.6% | −2.4 pp |

**One extra version line buys 29.6 points; the next three buy 10.9 between them.**

Separating `data/` alone captures nearly three quarters of everything the split has to offer. The win was never really about matching cadences — it is that 58 of the 94 modules are simultaneously the largest block *and* one of the slowest-moving. Splitting `core` off as well is defensible at −8.5 pp. `runtimes`, `api` and `misc` are 19 modules between them, and separating all three buys 2.4 points in exchange for three more version lines, three more changelogs, three more tag streams, and three more chances to publish a POM naming a sibling version that does not exist — the failure § 4 calls worse than the one we are fixing.

**So: two trains, revisit at three.** § 5 and § 7 updated to say so; the levers table and every downstream figure follow.

## Reproducibility

`scripts/release-train-costing.sh` is the measurement, committed rather than pasted, because the conclusion contradicts what the document previously said and nobody should have to take that on trust.

It mirrors the guard's rules deliberately: module enumeration through `--print-paths`, the same shared inputs, the same `gradle.properties` release-please-block exclusion, the same "a baseline advances only when a publish happens" rule, and the test-source exclusion **copied verbatim**. That last one matters — my first version used a narrower pattern that missed KMP source sets like `src/jvmTest/`, which scored `v1.82.0` as a publish where the guard skips it and shifted every column. The fix is why **the script's one-train column now reproduces the guard's own replay exactly at 30/38**, which is what makes the other columns worth reading.

Its header states the two things it does not model, both of which make it optimistic on historical ranges:

- **Lock state did not exist before #5240**, so a dependency bump in a historical window moves no `gradle.lockfile` and reads as "nothing changed". Windows whose only change was the catalog are counted as skips when some would really publish.
- **Cross-train propagation is charged nothing.** § 6 measures propagation against the real dependency graph at about three percentage points.

Both bound the absolute saving, not the comparison between groupings, which is the question the script exists to answer.

## What step 4 still has to answer first

Recorded in § 7 rather than assumed away: **where the second version number lives and who bumps it.** Today one release-please invocation owns one version. Two lines means either a second release-please component with its own tag stream and changelog, or a data-train version derived from the release version and frozen when the guard says the train did not change. The second is far less machinery and keeps one tag per release, at the cost of a version number that is not monotonic per artifact — which `VERSIONING.md` would have to state out loud.

The CLI side is unaffected: it needs only the **core** line, since that is the coordinate it injects, so `MAVEN_LINE_VERSION` keeps its meaning and the data line reaches consumers as a POM transitive of core exactly as it does today.

## Test plan

- `./scripts/release-train-costing.sh` — output reproduces every figure in the tables above.
- Cross-checked against the guard itself: the single-train replay from `RELEASE_TRAINS.md` § 2's snippet gives 30 publishes / 8 skips, matching the script's one-train row. The one window that initially disagreed (`v1.82.0`) was traced to the exclusion-regex bug described above and fixed.
- Docs-only otherwise; no workflow, build or CLI behaviour changes.

Non-visual change; no render evidence applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2)_