### PR TITLE
feat(screen): draw a generated screen on the devices its design named

### DIFF
--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
@@ -204,6 +204,110 @@ class ScreenGeneratorTest {
     assertThat(source.indexOf("fun HomeScreen()")).isLessThan(source.indexOf("@PreviewScreenSizes"))
   }
 
+  @Test
+  fun `named devices become one Preview each, on one wrapper`() {
+    val source =
+      generated(
+          screen(),
+          catalog(card, text),
+          ScreenGenerator.Preview(
+            widthDp = 411,
+            heightDp = 914,
+            fontScale = 1.3,
+            darkMode = true,
+            devices = listOf("id:pixel_6", "id:pixel_fold"),
+          ),
+        )
+        .source
+
+    assertThat(source).contains("private fun HomeScreenDevicesPreview() {")
+    assertThat(source).contains("device = \"id:pixel_6\",")
+    assertThat(source).contains("device = \"id:pixel_fold\",")
+    // The design's own frame stays on its own wrapper: the device supplies width, height and
+    // density, so a widthDp beside it would override the very thing being varied.
+    val fanOut = source.substringAfter("private fun HomeScreenDevicesPreview")
+    assertThat(fanOut).doesNotContain("widthDp")
+    assertThat(fanOut).doesNotContain("fontScale")
+    val devices = source.substringAfter("@Composable\nprivate fun HomeScreenPreview")
+    assertThat(source.indexOf("fun HomeScreen()"))
+      .isLessThan(source.indexOf("HomeScreenDevicesPreview"))
+    assertThat(devices).isNotEmpty()
+  }
+
+  /**
+   * The named set is the design's answer and the multipreview is androidx's, so they are two
+   * questions rather than two spellings of one: a screen claiming a foldable and nothing else gets
+   * a foldable and nothing else.
+   */
+  @Test
+  fun `devices and the reference-size fan-out are independent`() {
+    val source =
+      generated(
+          screen(),
+          catalog(card, text),
+          ScreenGenerator.Preview(devices = listOf("id:pixel_fold"), screenSizes = false),
+        )
+        .source
+
+    assertThat(source).contains("device = \"id:pixel_fold\",")
+    assertThat(source).doesNotContain("PreviewScreenSizes")
+  }
+
+  /** Two identical previews are not two answers. */
+  @Test
+  fun `a repeated device is emitted once`() {
+    val source =
+      generated(
+          screen(),
+          catalog(card, text),
+          ScreenGenerator.Preview(devices = listOf("id:pixel_6", "id:pixel_6")),
+        )
+        .source
+
+    assertThat(source.split("device = \"id:pixel_6\",")).hasSize(2)
+  }
+
+  /**
+   * A shape check rather than a catalog: which ids exist is the tooling's question, and a list here
+   * would go stale and refuse devices that work. What it does settle is that the value cannot close
+   * the string literal and continue in code.
+   */
+  @Test
+  fun `a device that would escape its string literal is refused by name`() {
+    val refused =
+      ScreenGenerator.generate(
+        screen(),
+        catalog(card, text),
+        preview = ScreenGenerator.Preview(devices = listOf("id:pixel_6\", showBackground = evil()")),
+      )
+
+    assertThat(refused).isInstanceOf(ScreenGenerator.Result.Refused::class.java)
+    assertThat((refused as ScreenGenerator.Result.Refused).reasons.single())
+      .contains("is not a device specifier")
+  }
+
+  @Test
+  fun `a component the device wrapper would shadow is qualified instead`() {
+    val clashing =
+      component(
+        "HomeScreenDevicesPreview",
+        "androidx.compose.material3.HomeScreenDevicesPreview",
+        emptyList(),
+      )
+    val document = ScreenDocument(name = "HomeScreen", root = ScreenNode(clashing.canonicalId))
+
+    val source =
+      generated(
+          document,
+          catalog(clashing),
+          ScreenGenerator.Preview(devices = listOf("id:pixel_6")),
+        )
+        .source
+
+    assertThat(source).doesNotContain("import androidx.compose.material3.HomeScreenDevicesPreview")
+    assertThat(source).contains("androidx.compose.material3.HomeScreenDevicesPreview()")
+  }
+
   /** The fan-out is the caller's second question, not a thing every preview drags along. */
   @Test
   fun `a preview without the fan-out names neither the annotation nor the wrapper`() {

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ScreenGeneratorCompileFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ScreenGeneratorCompileFunctionalTest.kt
@@ -253,6 +253,11 @@ class ScreenGeneratorCompileFunctionalTest {
         screen,
         components,
         expressionPackages = setOf("androidx.compose"),
+        // The device fan-out rides on this case rather than getting its own project, because what
+        // it needs proving is exactly what this test already provides: that the Kotlin compiler
+        // accepts what was emitted. `@Preview` is repeatable, and "repeatable" is a claim about a
+        // real annotation on a real classpath — a string assertion cannot check it.
+        preview = ScreenGenerator.Preview(devices = listOf("id:pixel_6", "id:pixel_fold")),
       )
     val emitted =
       assertWithMessage(
@@ -285,6 +290,10 @@ class ScreenGeneratorCompileFunctionalTest {
     // library; `ComposableSignatureTest` covers the same trap on fixtures.
     assertThat(emitted.requiredOptIns).isEmpty()
     assertThat(emitted.source).doesNotContain("@OptIn")
+    // Two stacked `@Preview`s on one wrapper, which the compile below is the real check on.
+    assertThat(emitted.source).contains("""device = "id:pixel_6"""")
+    assertThat(emitted.source).contains("""device = "id:pixel_fold"""")
+    assertThat(emitted.source).contains("private fun HomeScreenDevicesPreview() {")
 
     val generated = File(projectDir, "src/main/kotlin/generated")
     generated.mkdirs()

--- a/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -151,6 +151,26 @@ object ScreenGenerator {
      * handed five.
      */
     val screenSizes: Boolean = false,
+    /**
+     * Device ids to draw the screen at, one `@Preview(device = …)` each, beside the design's own
+     * frame.
+     *
+     * These are what a *design* named rather than what the platform ships, which is the whole
+     * difference between this and [screenSizes]. `@PreviewScreenSizes` answers "does it still look
+     * right at the reference sizes?" and is androidx's to maintain; this answers "does it look
+     * right on the devices this screen claims to work on?", which only the design knows. A screen
+     * claiming a foldable and nothing else should get a foldable and nothing else, and the
+     * multipreview cannot express that.
+     *
+     * Ids, not geometry: `id:pixel_6` is what `@Preview.device` resolves against the tooling's own
+     * catalog, so a list here cannot describe a frame no renderer produces. A width and height
+     * would be a second copy of that catalog, free to disagree with it.
+     *
+     * Empty by default, and empty means the design's own frame alone — what every caller before
+     * this field asked for. Order is kept and repeats are dropped: two identical previews are not
+     * two answers.
+     */
+    val devices: List<String> = emptyList(),
   )
 
   private const val INDENT = "    "
@@ -251,7 +271,11 @@ object ScreenGenerator {
             // The fan-out spends two more names on the same terms, and only when it is emitted.
             (preview?.screenSizes != true ||
               (it.symbol.name != PREVIEW_SCREEN_SIZES_SIMPLE_NAME &&
-                it.symbol.name != screenSizesPreviewFunctionName(document.name)))
+                it.symbol.name != screenSizesPreviewFunctionName(document.name))) &&
+            // The device fan-out spends one more name, on the same terms. It reuses the `Preview`
+            // annotation already reserved above, so only the wrapper is new.
+            (preview?.devices.isNullOrEmpty() ||
+              it.symbol.name != devicesPreviewFunctionName(document.name))
         }
         .map { it.canonicalId }
         .toSet()
@@ -471,6 +495,11 @@ object ScreenGenerator {
         if (preview.screenSizes) {
           appendLine()
           append(screenSizesPreviewFunction(document.name))
+        }
+        val devices = preview.devices.distinct()
+        if (devices.isNotEmpty()) {
+          appendLine()
+          append(devicesPreviewFunction(document.name, devices))
         }
       }
     }
@@ -1513,11 +1542,17 @@ object ScreenGenerator {
 
   private const val PREVIEW_SCREEN_SIZES_SIMPLE_NAME = "PreviewScreenSizes"
 
+  /** Names the device fan-out's wrapper, e.g. `HomeScreenDevicesPreview`. */
+  private const val DEVICES_SIMPLE_NAME = "Devices"
+
   /** The wrapper's name, needed before it is emitted so a component cannot be shadowed by it. */
   private fun previewFunctionName(screenName: String) = "$screenName$PREVIEW_SIMPLE_NAME"
 
   private fun screenSizesPreviewFunctionName(screenName: String) =
     "$screenName$PREVIEW_SCREEN_SIZES_SIMPLE_NAME$PREVIEW_SIMPLE_NAME"
+
+  private fun devicesPreviewFunctionName(screenName: String) =
+    "$screenName$DEVICES_SIMPLE_NAME$PREVIEW_SIMPLE_NAME"
 
   /**
    * A language tag this generator is willing to put inside a string literal.
@@ -1531,6 +1566,18 @@ object ScreenGenerator {
    */
   private val LANGUAGE_TAG = Regex("[A-Za-z0-9]+(?:[-_][A-Za-z0-9]+)*")
 
+  /**
+   * A device specifier this generator is willing to put inside a string literal.
+   *
+   * Deliberately a shape check and not a catalog. `@Preview.device` takes both `id:pixel_6` and the
+   * `spec:width=411dp,height=891dp,dpi=420` form, and which ids exist is the *tooling's* question,
+   * answered by whichever Android Studio or render lane resolves the string — a list here would go
+   * stale against it and refuse devices that work. What this can settle is that the value is a
+   * device specifier at all rather than something that closes the literal and continues in code, so
+   * a quote, a backslash or a newline is refused by name.
+   */
+  private val DEVICE_SPEC = Regex("[A-Za-z0-9_.:=,%/+-]+")
+
   /** Every problem with [preview], so a caller fixes them in one pass rather than one per run. */
   private fun previewRefusals(preview: Preview): List<String> = buildList {
     preview.widthDp?.let { if (it <= 0) add("preview widthDp must be positive, not $it") }
@@ -1543,6 +1590,9 @@ object ScreenGenerator {
     }
     preview.locale?.let {
       if (!LANGUAGE_TAG.matches(it)) add("preview locale `$it` is not a language tag")
+    }
+    preview.devices.forEach {
+      if (!DEVICE_SPEC.matches(it)) add("preview device `$it` is not a device specifier")
     }
   }
 
@@ -1593,6 +1643,31 @@ object ScreenGenerator {
    * theme and type scale stay on [previewFunction], where they describe one picture the author
    * actually approved.
    */
+  /**
+   * The device fan-out: one `@Preview(device = …)` per id the design named, on one wrapper.
+   *
+   * Stacked annotations rather than a function each, because `@Preview` is repeatable and N
+   * wrappers calling one screen would be N identical bodies differing only in an annotation.
+   *
+   * It carries none of the design's frame, for [screenSizesPreviewFunction]'s reason exactly: the
+   * device supplies its own width, height and density, and a `widthDp` beside it would override the
+   * thing being varied. `name` is the id itself — the generator has no label for a device and
+   * inventing one would be a second catalog — so each picture is identifiable by what asked for it.
+   */
+  private fun devicesPreviewFunction(screenName: String, devices: List<String>): String =
+    buildString {
+      devices.forEach {
+        appendLine("@$PREVIEW_SIMPLE_NAME(")
+        appendLine("${INDENT}name = \"$it\",")
+        appendLine("${INDENT}device = \"$it\",")
+        appendLine(")")
+      }
+      appendLine("@Composable")
+      appendLine("private fun ${devicesPreviewFunctionName(screenName)}() {")
+      appendLine("$INDENT$screenName()")
+      appendLine("}")
+    }
+
   private fun screenSizesPreviewFunction(screenName: String): String = buildString {
     appendLine("@$PREVIEW_SCREEN_SIZES_SIMPLE_NAME")
     appendLine("@Composable")


### PR DESCRIPTION
`Preview.screenSizes` emits `@PreviewScreenSizes`, the platform's reference sizes. That answers "does it still look right at the sizes androidx tracks?" and cannot answer "does it look right on the devices this screen claims to work on?" — a different question, and only the design knows it. A screen claiming a foldable and nothing else should get a foldable and nothing else; the multipreview would hand it five.

`Preview.devices` takes the ids a design named and emits one `@Preview(device = …)` each. It is independent of `screenSizes`: the two are different questions, not two spellings of one.

## What it emits

```kotlin
@Preview(
    widthDp = 411,
    heightDp = 914,
    fontScale = 1.3f,
    showBackground = true,
    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
)
@Composable
private fun HomeScreenPreview() {
    HomeScreen()
}

@Preview(
    name = "id:pixel_6",
    device = "id:pixel_6",
)
@Preview(
    name = "id:pixel_fold",
    device = "id:pixel_fold",
)
@Composable
private fun HomeScreenDevicesPreview() {
    HomeScreen()
}
```

## Decisions worth naming

- **Stacked annotations, one wrapper.** `@Preview` is repeatable, and a wrapper apiece would be N identical bodies differing only in an annotation.
- **No frame fields on the fan-out**, for the reason the reference-size wrapper already gives: the device supplies its own width, height and density, so a `widthDp` beside it would override the axis being varied and a `fontScale` would apply to all of them. The design's own frame stays on its own wrapper, where it describes one picture its author approved.
- **`name` is the id itself.** The generator has no label for a device, and inventing one would be a second catalog to disagree with the tooling's.
- **Validated by shape, not against a list.** Which ids exist is the tooling's question, and both `id:pixel_6` and the `spec:width=411dp,height=891dp` form are legal — a catalog here would go stale and refuse devices that work. What the check does settle is that a value cannot close the string literal and continue in code.
- **Repeats dropped, order kept.** Two identical previews are not two answers.

## Test plan

- `ScreenGeneratorTest`: the emitted shape, independence from `screenSizes`, a repeated id emitted once, a device that would escape its literal refused by name, and the wrapper's own name reserved against a component that would shadow it.
- That the emitted Kotlin **compiles** is the real claim here, and a string assertion cannot make it — "repeatable" is a property of a real annotation on a real classpath. The fan-out therefore rides on `ScreenGeneratorCompileFunctionalTest`, which writes the generated file into a project and runs `compileKotlin` against a real Compose classpath. Green.
- `:gradle-plugin:preview-discovery:test` and `:screen-model:jvmTest` green; `ktfmtFormat` run.

## Follow-on

This is the upstream half. The compose-preview-server picker that stores the set ([compose-preview-server#465](https://github.com/yschimke/compose-preview-server/pull/465)) can only read it once this ships in a release, since that build resolves published coordinates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9bqpc2okyZebUgQiYjMn4

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9bqpc2okyZebUgQiYjMn4)_