### PR TITLE
feat: give data/ its own Maven version line, inert until wired

### DIFF
--- a/.github/scripts/maven-publish-needed.sh
+++ b/.github/scripts/maven-publish-needed.sh
@@ -61,6 +61,15 @@ HEAD_REF="HEAD"
 GITHUB_OUTPUT_MODE=0
 EXPLAIN=0
 PRINT_PATHS=0
+# Which train to answer for. `all` is every published module — the single-train question this
+# script has always answered, and still the default. `data` and `core` split the same set in two,
+# for the two version lines docs/design/RELEASE_TRAINS.md § 5 costs at -50.7%.
+#
+# The split is `data/*` against everything else, and it is that lopsided on purpose: 58 of the 94
+# modules live under `data/` and they move on a third of the releases, so separating them alone
+# buys 29.6 of the 40 percentage points any split has to offer. Costing for the three- and
+# five-way alternatives is in § 5; `scripts/release-train-costing.sh` reproduces it.
+TRAIN=all
 # The repository to inspect. Defaults to this checkout; the self-test points it at a fixture so
 # the logic can be exercised against histories this repository does not have.
 REPO="${SCRIPT_DIR}/../.."
@@ -72,6 +81,13 @@ while [ $# -gt 0 ]; do
     --github-output) GITHUB_OUTPUT_MODE=1; shift ;;
     --explain) EXPLAIN=1; shift ;;
     --print-paths) PRINT_PATHS=1; shift ;;
+    --train)
+      TRAIN="${2:?--train needs core|data|all}"
+      case "${TRAIN}" in
+        core|data|all) ;;
+        *) echo "unknown train: ${TRAIN} (expected core, data or all)" >&2; exit 2 ;;
+      esac
+      shift 2 ;;
     --repo) REPO="${2:?--repo needs a directory}"; shift 2 ;;
     *) echo "unknown argument: $1" >&2; exit 2 ;;
   esac
@@ -159,7 +175,19 @@ publishing_module_paths() {
   grep -rl --include=build.gradle.kts 'composeai\.maven-publishing' . 2>/dev/null |
     sed 's|^\./||; s|/build\.gradle\.kts$||' |
     grep -v '^build-logic$' |
-    sort -u
+    sort -u |
+    train_filter
+}
+
+# Restrict the enumeration to one train. Note what this does NOT touch: `shared_paths` is applied
+# to every train, because a change to `build-logic/` or the wrapper can move the bytes of every
+# module regardless of which line it versions on. Splitting the trains does not split that rule.
+train_filter() {
+  case "${TRAIN}" in
+    all) cat ;;
+    data) grep '^data/' || true ;;
+    core) grep -v '^data/' || true ;;
+  esac
 }
 
 watch_paths() {

--- a/.github/scripts/test-maven-publish-needed.sh
+++ b/.github/scripts/test-maven-publish-needed.sh
@@ -47,6 +47,7 @@ make_repo() {
   git -C "${dir}" config user.name Test
   mkdir -p "${dir}/data/focus/core/src/main/kotlin" \
     "${dir}/data/focus/core/src/test/kotlin" \
+    "${dir}/renderers/desktop/src/main/kotlin" \
     "${dir}/cli/src/main/kotlin" \
     "${dir}/build-logic" \
     "${dir}/gradle"
@@ -55,6 +56,16 @@ plugins { id("composeai.maven-publishing") }
 EOF
   echo 'fun a() = 1' > "${dir}/data/focus/core/src/main/kotlin/A.kt"
   echo 'fun t() = 1' > "${dir}/data/focus/core/src/test/kotlin/ATest.kt"
+  # A second publishing module, on the OTHER train. Without one the `--train` assertions below
+  # could not tell "this train did not change" from "this train has no modules".
+  cat > "${dir}/renderers/desktop/build.gradle.kts" <<'EOF'
+plugins { id("composeai.maven-publishing") }
+EOF
+  echo 'fun r() = 1' > "${dir}/renderers/desktop/src/main/kotlin/R.kt"
+  cat > "${dir}/renderers/desktop/gradle.lockfile" <<'EOF'
+com.example:lib:1.0.0=compileClasspath,runtimeClasspath
+empty=
+EOF
   # No publishing plugin: changes here must never force a publish.
   echo 'plugins { kotlin("jvm") }' > "${dir}/cli/build.gradle.kts"
   echo 'fun cli() = 1' > "${dir}/cli/src/main/kotlin/Cli.kt"
@@ -213,10 +224,56 @@ git -C "${UNREL}" commit -qm "orphan"
 git -C "${UNREL}" tag v2.0.0
 expect true "$(needed --repo "${UNREL}" --baseline v1.0.0 --head v2.0.0)" "no common history"
 
+echo "== --train answers per version line"
+# The two-train split (docs/design/RELEASE_TRAINS.md § 5): `data/*` versions separately from
+# everything else, so a release touching only one of them republishes only that one. These are the
+# assertions that make a skipped train safe — a wrong `false` here strands 58 artifacts exactly
+# the way a wrong `false` on the whole publish strands 94.
+TR="${tmp}/trains"
+make_repo "${TR}"
+
+echo 'fun a() = 2' > "${TR}/data/focus/core/src/main/kotlin/A.kt"
+git -C "${TR}" commit -aqm "data only"
+git -C "${TR}" tag v1.1.0
+expect true  "$(needed --repo "${TR}" --baseline v1.0.0 --head v1.1.0 --train data)" "data change -> data publishes"
+expect false "$(needed --repo "${TR}" --baseline v1.0.0 --head v1.1.0 --train core)" "data change -> core does not"
+expect true  "$(needed --repo "${TR}" --baseline v1.0.0 --head v1.1.0 --train all)"  "data change -> the single train still publishes"
+
+echo 'fun r() = 2' > "${TR}/renderers/desktop/src/main/kotlin/R.kt"
+git -C "${TR}" commit -aqm "core only"
+git -C "${TR}" tag v1.2.0
+expect false "$(needed --repo "${TR}" --baseline v1.1.0 --head v1.2.0 --train data)" "core change -> data does not"
+expect true  "$(needed --repo "${TR}" --baseline v1.1.0 --head v1.2.0 --train core)" "core change -> core publishes"
+
+# A shared build input is NOT split by the train filter: it can move the bytes of every module on
+# either line, so it publishes both. Getting this wrong is the quiet way a train goes stale.
+echo '// touched' >> "${TR}/build-logic/build.gradle.kts"
+git -C "${TR}" commit -aqm "shared input"
+git -C "${TR}" tag v1.3.0
+expect true "$(needed --repo "${TR}" --baseline v1.2.0 --head v1.3.0 --train data)" "shared input -> data publishes"
+expect true "$(needed --repo "${TR}" --baseline v1.2.0 --head v1.3.0 --train core)" "shared input -> core publishes"
+
+# The narrowings the whole-set guard makes still apply per train, rather than being lost when the
+# module set shrinks.
+echo 'fun t() = 2' > "${TR}/data/focus/core/src/test/kotlin/ATest.kt"
+git -C "${TR}" commit -aqm "data test only"
+git -C "${TR}" tag v1.4.0
+expect false "$(needed --repo "${TR}" --baseline v1.3.0 --head v1.4.0 --train data)" "data test source -> data does not publish"
+
+# An unknown train is a hard failure, never a silently empty module set: an empty set would look
+# like "this train did not change" and skip a publish that was needed.
+if "${SCRIPT}" --repo "${TR}" --baseline v1.3.0 --head v1.4.0 --train nonsense >/dev/null 2>&1; then
+  bad "--train nonsense was accepted"
+else
+  ok "--train nonsense is rejected"
+fi
+
 echo "== a tree with no publishing modules fails open"
 EMPTY="${tmp}/empty"
 make_repo "${EMPTY}"
-git -C "${EMPTY}" rm -rq data
+# Both trains' modules, not just `data` — the case under test is an enumeration that finds
+# nothing at all, and leaving the other train in place would make this assert something else.
+git -C "${EMPTY}" rm -rq data renderers
 git -C "${EMPTY}" commit -qm "drop publishing modules"
 git -C "${EMPTY}" tag v1.5.0
 expect true "$(needed --repo "${EMPTY}" --baseline v1.0.0 --head v1.5.0)" "no publishing modules found"

--- a/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiMavenPublishingPlugin.kt
+++ b/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiMavenPublishingPlugin.kt
@@ -43,9 +43,7 @@ class ComposeAiMavenPublishingPlugin : Plugin<Project> {
       )
 
     project.group = "ee.schimke.composeai"
-    project.version =
-      project.providers.environmentVariable("PLUGIN_VERSION").orNull
-        ?: project.nextPatchSnapshotVersion()
+    project.version = project.publishedVersion()
 
     project.configureAndroidLibraryPublication()
     project.configureDependencyLocking()
@@ -124,6 +122,49 @@ private fun Project.configureAndroidLibraryPublication() {
       )
     }
   }
+}
+
+/**
+ * Which of the two Maven version lines this module publishes on.
+ *
+ * Everything under `data/` versions separately from everything else. That split is lopsided on purpose: 58 of the
+ * 94 published modules live under `data/` and they change on roughly a third of releases, so
+ * giving them their own line stops the largest and slowest-moving block of artifacts being
+ * republished byte-identical on every release. Costed at −50.7% of module-publications in
+ * `docs/design/RELEASE_TRAINS.md` § 5, against −61.6% for a five-way split that needs three more
+ * version lines to get there.
+ *
+ * Derived from the module's directory rather than a list, for the same reason the guard enumerates
+ * modules from the build files: a list is a thing that goes stale silently, and here going stale
+ * means publishing a POM that names a sibling version which does not exist.
+ */
+internal fun Project.mavenTrain(): String =
+  if (projectDir.relativeTo(rootDir).invariantSeparatorsPath.startsWith("data/")) "data" else "core"
+
+/**
+ * The version this module publishes at.
+ *
+ * `core` takes `PLUGIN_VERSION` — the release tag — as it always has. `data` takes
+ * `DATA_LINE_VERSION` when the release sets it, which is the last version at which the data train
+ * actually changed. On a release where `data/` changed, the two are equal and this is a no-op; on
+ * one where it did not, the data modules keep the version they already have on Central and are not
+ * republished at all.
+ *
+ * Cross-train POMs come out right for free: a `core` module depending on `project(":data:…")` gets
+ * that project's `version`, so `renderer-desktop:2.9.0` names `data-focus-core:2.7.0` in its POM
+ * and Gradle resolves the artifact that genuinely exists.
+ *
+ * **`DATA_LINE_VERSION` is ignored unless `PLUGIN_VERSION` is set.** Outside a release both are
+ * absent and everything falls to the snapshot version; a stray `DATA_LINE_VERSION` in a developer
+ * shell must not silently version half the build differently from the other half.
+ */
+private fun Project.publishedVersion(): String {
+  val pluginVersion =
+    providers.environmentVariable("PLUGIN_VERSION").orNull?.takeIf { it.isNotBlank() }
+      ?: return nextPatchSnapshotVersion()
+  if (mavenTrain() != "data") return pluginVersion
+  return providers.environmentVariable("DATA_LINE_VERSION").orNull?.takeIf { it.isNotBlank() }
+    ?: pluginVersion
 }
 
 private fun Project.nextPatchSnapshotVersion(): String {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -307,3 +307,65 @@ tasks.register("functionalTestWithAndroidBundleDaemon") {
 // the second invocation sees the install up-to-date, so the only cost is dodging the race. The
 // functionalTest also self-checks the binary's presence past its opt-in gate and fails with a
 // useful message rather than a bare `NoClassDefFoundError`.
+
+// The Gradle task list `release.yml` runs to publish one Maven version line.
+//
+// Two version lines means the publish can no longer always be the root-level
+// `publishAndReleaseToMavenCentral` that fans out to everything: when one train is skipped, its
+// modules are already on Central at the version they carry, and Central refuses a version twice —
+// re-uploading them would fail the whole deployment, not just their part of it. So the skipped
+// train's tasks must not be in the invocation at all.
+//
+// Naming the tasks explicitly is not a different kind of publish. The root-level abbreviation just
+// selects `publishAndReleaseToMavenCentral` in every subproject that has one; listing a subset of
+// those same task paths in one invocation produces one deployment containing that subset.
+//
+// The list cannot be written down by hand. The guard enumerates modules by DIRECTORY (it works on
+// a git diff), Gradle addresses them by PROJECT PATH, and `settings.gradle.kts` deliberately
+// decouples the two — `:preview-data-api` lives in `api/preview-data-api`. A hand-kept mapping is
+// exactly the artefact that goes stale silently, and going stale here means either publishing a
+// module twice or dropping one out of a release.
+//
+// So Gradle prints the mapping it actually has. `mavenTrain()` in the publishing convention plugin
+// is the single definition of which train a module is on, shared with the version it publishes at,
+// so the task list and the version can never disagree about a module.
+//
+// Deliberately NOT wired into the release yet: this prints, and nothing consumes it.
+val printPublishTasks by
+  tasks.registering {
+    group = "publishing"
+    description =
+      "Print the publish task path for each module on a Maven train (-Ptrain=core|data|all)."
+    notCompatibleWithConfigurationCache("Inspects the project tree at execution time")
+    val requested = (project.findProperty("train") as String? ?: "all")
+    val rootDirPath = rootDir
+    val rows =
+      subprojects
+        .filter { it.plugins.hasPlugin("composeai.maven-publishing") }
+        .map { p ->
+          val dir = p.projectDir.relativeTo(rootDirPath).invariantSeparatorsPath
+          Triple(
+            if (dir.startsWith("data/")) "data" else "core",
+            "${p.path}:publishAndReleaseToMavenCentral",
+            dir,
+          )
+        }
+    doLast {
+      require(requested in setOf("core", "data", "all")) {
+        "unknown train '$requested' (expected core, data or all)"
+      }
+      // `gradle-plugin` is an includeBuild, so its four publishing modules are not `subprojects`
+      // of this build and the enumeration above cannot see them. They are addressed through the
+      // included build's own root task, which is what the release has always done — and they are
+      // all on the `core` train, being the plugin itself and its helpers. Emitted here rather
+      // than left for the caller to remember: a task list that silently omits the Gradle plugin
+      // is a release that publishes everything except the artifact consumers actually apply.
+      val all =
+        rows +
+          Triple("core", ":gradle-plugin:publishAndReleaseToMavenCentral", "gradle-plugin")
+      all
+        .filter { (train, _, _) -> requested == "all" || train == requested }
+        .sortedBy { (_, task, _) -> task }
+        .forEach { (train, task, dir) -> println("$train\t$task\t$dir") }
+    }
+  }

--- a/docs/design/RELEASE_TRAINS.md
+++ b/docs/design/RELEASE_TRAINS.md
@@ -360,9 +360,46 @@ module, exactly one always changed as a unit.
    `required-release-assets.sh` needed **no** change, contrary to the note this section used to
    carry: it lists only CLI assets, which a skipped publish still produces, so `finalize-release`
    and the draft sweeper are unaffected.
-4. **Split the trains** — a second version line for `data/`, with its own guard verdict and
-   manifest entry, and core POMs naming the data train's version rather than their own. Takes the
-   saving from `-21.1%` to `-50.7%`; § 5 costs why it is two lines and not five.
+4. **Split the trains** — a second version line for `data/`, with its own guard verdict, and core
+   POMs naming the data train's version rather than their own. Takes the saving from `-21.1%` to
+   `-50.7%`; § 5 costs why it is two lines and not five.
+
+   **4a. The mechanism** *(done, inert)* — three pieces, all verifiable without publishing
+   anything:
+
+   - `maven-publish-needed.sh --train core|data|all` answers the same question for one version
+     line. `all` remains the default, so the guard's current behaviour is untouched. Shared build
+     inputs are deliberately **not** split by the train filter: `build-logic/` or the wrapper can
+     move the bytes of every module on either line, so they publish both.
+   - `ComposeAiMavenPublishingPlugin` gives a module under `data/` the `DATA_LINE_VERSION` the
+     release sets, and everything else `PLUGIN_VERSION` as before. `mavenTrain()` derives the
+     train from the module's directory — one definition, shared with the task list below, so the
+     two can never disagree about a module. `DATA_LINE_VERSION` is ignored unless `PLUGIN_VERSION`
+     is also set, so a stray value in a developer shell cannot version half a build differently
+     from the other half.
+   - `./gradlew printPublishTasks -Ptrain=<train>` prints the publish task path for each module on
+     a train. Needed because the skipped train's tasks must be absent from the invocation entirely
+     — its modules are already on Central at the version they carry, and Central refuses a version
+     twice, so re-uploading them fails the whole deployment rather than just their part of it. The
+     list has to come from Gradle: the guard enumerates by directory, Gradle addresses by project
+     path, and `settings.gradle.kts` decouples the two (`:preview-data-api` lives in
+     `api/preview-data-api`). It also emits `:gradle-plugin:publishAndReleaseToMavenCentral`,
+     since that included build's four modules are not `subprojects` of this one and a task list
+     that silently omits them is a release publishing everything except the plugin consumers
+     apply.
+
+   **Cross-train POMs need no machinery at all.** A core module depending on `project(":data:…")`
+   picks up that project's `version`, so with `PLUGIN_VERSION=2.9.0 DATA_LINE_VERSION=2.7.0` the
+   generated `render-host` POM reads `2.9.0` for itself and `2.7.0` for `data-remotecompose-core`.
+   That is the whole of the "no train publishes a POM naming a sibling version that does not
+   exist" requirement, discharged by Gradle.
+
+   Inert today: nothing sets `DATA_LINE_VERSION`, nothing consumes `printPublishTasks`, and the
+   guard is still asked `--train all`.
+
+   **4b. Wire it into the release** — `release.yml` runs the guard once per train, resolves each
+   line's baseline, and publishes each train's task list only when its verdict says so. This is
+   where the `-50.7%` arrives, and it is the step that touches the irreversible path.
 
 Step 4 still needs the readiness marker and [`RELEASING.md`](../RELEASING.md) revisited in the
 same change: with two version lines there is no longer one Maven line for a release to name, so


### PR DESCRIPTION
Step **4a** of [`RELEASE_TRAINS.md` § 7](https://github.com/yschimke/compose-ai-tools/blob/main/docs/design/RELEASE_TRAINS.md) — the mechanism for the two-train split, landed while nothing uses it. Same pattern as step 2 before step 3: the seam goes in inert and verifiable, so wiring it into the release becomes a workflow change rather than a redesign of an irreversible path.

## Why data/

58 of the 94 published modules live under `data/`, and they change on about a third of releases. Giving them their own version line takes the guard's saving from **−21.1% to −50.7%** — 29.6 of the roughly 40 points any split has to offer, for *one* extra version line. #5247 costs the three- and five-way alternatives at +8.5 and +2.4 points respectively.

## Three pieces

**`maven-publish-needed.sh --train core|data|all`** answers the same question for one line. `all` stays the default, so the guard's current behaviour is untouched. Shared build inputs are deliberately **not** split by the filter — `build-logic/` or the wrapper can move the bytes of every module on either line, so they publish both. Nine new assertions pin the per-train verdicts, that one included.

**`ComposeAiMavenPublishingPlugin`** gives a module under `data/` the `DATA_LINE_VERSION` the release sets, and everything else `PLUGIN_VERSION` as before. `mavenTrain()` derives the train from the module's directory — one definition, shared with the task list below, so the two cannot disagree about a module. `DATA_LINE_VERSION` is ignored unless `PLUGIN_VERSION` is also set, so a stray value in a developer shell can't version half a build differently from the other half.

**`./gradlew printPublishTasks -Ptrain=<train>`** prints the publish task path per module. The skipped train's tasks have to be *absent from the invocation entirely*: its modules are already on Central at the version they carry, and Central refuses a version twice, so re-uploading them fails the whole deployment rather than just their part of it. The list must come from Gradle — the guard enumerates by **directory**, Gradle addresses by **project path**, and `settings.gradle.kts` decouples the two (`:preview-data-api` lives in `api/preview-data-api`). Naming tasks explicitly isn't a different kind of publish: the root-level abbreviation just selects the same task in every subproject.

It also emits `:gradle-plugin:publishAndReleaseToMavenCentral`. That caught a real gap — Gradle sees 90 publishing subprojects where the guard counts 94, because `gradle-plugin`'s four modules are an included build, not subprojects. A task list that silently omitted them would be a release publishing everything except the plugin consumers actually apply.

## Cross-train POMs need no machinery at all

A core module depending on `project(":data:…")` picks up that project's `version`. With `PLUGIN_VERSION=2.9.0 DATA_LINE_VERSION=2.7.0`, the generated `render-host` POM:

```xml
<artifactId>render-host</artifactId>
<version>2.9.0</version>
...
  <artifactId>daemon-core</artifactId>          <version>2.9.0</version>
  <artifactId>data-remotecompose-core</artifactId>  <version>2.7.0</version>
```

That discharges the "no train publishes a POM naming a sibling version that does not exist" requirement entirely, in Gradle, with no version rewriting.

## Test plan

- **`test-maven-publish-needed.sh` — 34 passed** (was 25). The fixture gained a second publishing module on the *other* train, without which the `--train` assertions couldn't distinguish "this train didn't change" from "this train has no modules". The existing no-publishing-modules case was updated to drop both trains, since its subject is an empty enumeration.
- **Both task lists dry-run clean**: 58 data tasks and 33 core tasks (32 subprojects + the included build), `--dry-run` `BUILD SUCCESSFUL` under `PLUGIN_VERSION=2.9.0 DATA_LINE_VERSION=2.7.0`. This is what proves the printed paths are real, resolvable tasks.
- **Four version cases verified through generated POMs**: both set → 2.9.0 / 2.7.0 as above; `PLUGIN_VERSION` only → all 2.9.0; `DATA_LINE_VERSION=""` → all 2.9.0 (blank treated as absent, same Actions-empty-string hazard as #5246); `DATA_LINE_VERSION` with no `PLUGIN_VERSION` → everything `2.0.1-SNAPSHOT`, i.e. the stray-value guard rail holds.
- Cross-checked the split against the guard: `--train data` enumerates exactly 58 modules, matching the costing.
- `test-maven-line-baseline.sh` 13 passed, `release-train-costing.sh` unchanged, `:cli:test` green, `ktfmtCheckAll` green.

One implementation note worth recording: `` `data/*` `` inside a KDoc broke the build, because **Kotlin block comments nest** — the `/*` opened a comment that swallowed the rest of the file, which surfaced as "unresolved reference" on functions defined below it.

Non-visual change; no render evidence applicable.

## What's inert, and what 4b does

Nothing sets `DATA_LINE_VERSION`, nothing consumes `printPublishTasks`, and the guard is still asked `--train all`. Step **4b** runs the guard once per train in `release.yml`, resolves each line's baseline, and publishes each train's task list only when its verdict says so — that's where the −50.7% arrives, and it's the step that touches the irreversible path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2)_