### PR TITLE
fix: stop the root build file being enumerated as a published module

### DIFF
--- a/.github/scripts/maven-publish-needed.sh
+++ b/.github/scripts/maven-publish-needed.sh
@@ -175,6 +175,17 @@ publishing_module_paths() {
   grep -rl --include=build.gradle.kts 'composeai\.maven-publishing' . 2>/dev/null |
     sed 's|^\./||; s|/build\.gradle\.kts$||' |
     grep -v '^build-logic$' |
+    # The ROOT build file, whose path the sed above leaves as the bare `build.gradle.kts`. It can
+    # never be a module, and it is already watched as a shared input — but this enumeration also
+    # feeds the "every published module must have lock state" check, and a root file obviously has
+    # no `gradle.lockfile`. Left in, it fails the guard open on every release forever, which is the
+    # safe direction and therefore the silent one: the publish decision simply stops happening.
+    #
+    # It got in because the guard finds modules by grepping for the plugin id, and the root build
+    # file came to contain that string in a task that lists publishing projects. `--print-paths`
+    # did not show it, because `watch_paths` sorts the shared inputs and the modules together and
+    # `build.gradle.kts` is in both — the duplicate collapsed and the count never moved.
+    grep -v '^build\.gradle\.kts$' |
     sort -u |
     train_filter
 }

--- a/.github/scripts/test-maven-publish-needed.sh
+++ b/.github/scripts/test-maven-publish-needed.sh
@@ -278,6 +278,35 @@ git -C "${EMPTY}" commit -qm "drop publishing modules"
 git -C "${EMPTY}" tag v1.5.0
 expect true "$(needed --repo "${EMPTY}" --baseline v1.0.0 --head v1.5.0)" "no publishing modules found"
 
+echo "== the root build file is never enumerated as a module"
+# Regression. The enumeration finds modules by grepping build files for the plugin id, so any
+# mention of that string in the ROOT build.gradle.kts made the root itself a "module" — and since
+# a root build file has no gradle.lockfile, the guard failed open on every release from then on.
+# Safe direction, and therefore the silent one: the publish decision just stops happening.
+#
+# `--print-paths` could not have caught it. `watch_paths` sorts the shared inputs and the modules
+# together, `build.gradle.kts` is in both, and the duplicate collapsed — the path count never
+# moved. So this asserts on the verdict, which is what actually broke.
+ROOTREF="${tmp}/rootref"
+make_repo "${ROOTREF}"
+cat > "${ROOTREF}/build.gradle.kts" <<'EOF'
+// A task that lists the publishing projects, mentioning the plugin id in passing.
+tasks.register("printPublishTasks") {
+  doLast { subprojects.filter { it.plugins.hasPlugin("composeai.maven-publishing") } }
+}
+EOF
+git -C "${ROOTREF}" add -A
+git -C "${ROOTREF}" commit -qm "root build file mentions the publishing plugin id"
+git -C "${ROOTREF}" tag v1.1.0
+# The root build file IS a shared input, so changing it publishes — that is not what is under
+# test. Take a second window where nothing changes at all: the guard must reach `false`, which it
+# cannot do while it believes there is a module with no lock state.
+echo '// unrelated' >> "${ROOTREF}/cli/src/main/kotlin/Cli.kt"
+git -C "${ROOTREF}" commit -aqm "cli only"
+git -C "${ROOTREF}" tag v1.2.0
+expect false "$(needed --repo "${ROOTREF}" --baseline v1.1.0 --head v1.2.0)" \
+  "root build file naming the plugin id does not become an unlocked module"
+
 echo "== --print-paths lists the real repository's watch set"
 paths="$("${SCRIPT}" --print-paths)"
 count="$(printf '%s\n' "${paths}" | wc -l | tr -d ' ')"


### PR DESCRIPTION
**The guard is currently disabled on `main`.** Found by running it against `main` before cutting a release:

```
$ .github/scripts/maven-publish-needed.sh --baseline v2.0.0 --head origin/main
needed=true
reason=1 published module(s) have no gradle.lockfile (e.g. build.gradle.kts)
```

## What happened

#5249 added `printPublishTasks` to the root `build.gradle.kts`, and its body names the plugin id:

```kotlin
.filter { it.plugins.hasPlugin("composeai.maven-publishing") }
```

The guard finds published modules by grepping build files for exactly that string, then strips the trailing `/build.gradle.kts` from each hit — which for the root file leaves the bare `build.gradle.kts`. The root of the repository became the 95th "published module".

A root build file has no `gradle.lockfile`, and any published module without lock state fails the guard **open**. So every release from #5249 onward would have published all 94 modules with that reason.

Safe — and that is exactly what made it dangerous. Failing open is silent: the −21.1% simply stops happening, no check goes red, and the next person to notice would be whoever eventually re-read a job summary.

## The fix

The root build file can never be a module, and it is already watched as a shared input. Exclude it from the enumeration the way `build-logic` already is.

## Why the existing tests didn't catch it, and what the new one asserts

`--print-paths` **could not** have caught this. `watch_paths` sorts the shared inputs and the modules together, `build.gradle.kts` is in both, and the duplicate collapsed — the path count stayed at 98 with the bug and 98 without it. That is why I didn't see it when I checked the counts while writing #5249.

So the regression test asserts on the **verdict**, which is what actually broke: a fixture whose root build file mentions the plugin id must still be able to reach `needed=false`.

## Test plan

- `test-maven-publish-needed.sh` — **35 passed** (was 34).
- **Verified the new test fails without the fix.** Reverting only the one `grep -v` line, keeping the test:
  ```
  FAIL: root build file naming the plugin id does not become an unlocked module -> true (want false)
  34 passed, 1 failed
  ```
  With the fix restored, 35/35.
- Guard against current `main` now answers on real evidence rather than the fail-open path, and the per-train split still resolves correctly:
  ```
  all   needed=true reason=97 file(s) changed under a published module or a shared build input
  core  needed=true reason=38 file(s) changed ...
  data  needed=true reason=61 file(s) changed ...
  ```
- Module counts unchanged at 98 / 40 / 62 for `all` / `core` / `data` — the fix removes a phantom, not a real module.

Non-visual change; no render evidence applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2)_