### PR TITLE
fix: merge the duplicate env block that broke the v2.1.0 release

### DIFF
--- a/.github/scripts/check-workflow-yaml.sh
+++ b/.github/scripts/check-workflow-yaml.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Reject duplicate keys in workflow YAML.
+#
+# PyYAML's `safe_load` — and every "does this file parse?" check built on it — silently keeps the
+# LAST of a duplicated key and discards the rest. GitHub Actions does the opposite: it refuses the
+# whole file. So a workflow can pass local validation and still be rejected at parse time, and the
+# rejection is about as unhelpful as CI failures get: the calling run fails with ZERO jobs, no logs
+# and no annotation on the job that caused it.
+#
+# That is not hypothetical. A second `env:` on one step of `release.yml` shipped exactly that way:
+#
+#     Invalid workflow file: .github/workflows/release-please.yml#L187
+#     error parsing called workflow ... (Line: 310, Col: 9): 'env' is already defined
+#
+# It failed the v2.1.0 release. And the silent-discard behaviour made it worse than a parse error
+# would have been: the surviving `env:` was the second one, so the Maven Central credentials had
+# been dropped from the step. Had Actions been as permissive as PyYAML, the publish would have run
+# without them.
+#
+# Usage: check-workflow-yaml.sh [<file>...]     # defaults to .github/workflows/*.yml
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+if [ "$#" -gt 0 ]; then
+  files=("$@")
+else
+  mapfile -t files < <(find .github/workflows -maxdepth 1 -name '*.yml' -o -maxdepth 1 -name '*.yaml' | sort)
+fi
+
+python3 - "${files[@]}" <<'PY'
+import sys
+import yaml
+
+
+class DuplicateKeyError(Exception):
+    pass
+
+
+class StrictLoader(yaml.SafeLoader):
+    """A SafeLoader that refuses duplicate mapping keys, the way Actions does."""
+
+
+def _no_duplicates(loader, node, deep=False):
+    seen = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in seen:
+            mark = key_node.start_mark
+            raise DuplicateKeyError(
+                f"line {mark.line + 1}, column {mark.column + 1}: '{key}' is already defined"
+            )
+        seen[key] = True
+    return yaml.SafeLoader.construct_mapping(loader, node, deep)
+
+
+StrictLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _no_duplicates
+)
+
+failed = 0
+for path in sys.argv[1:]:
+    try:
+        with open(path) as handle:
+            yaml.load(handle, Loader=StrictLoader)
+    except DuplicateKeyError as exc:
+        print(f"::error file={path}::duplicate key — {exc}")
+        failed += 1
+    except yaml.YAMLError as exc:
+        print(f"::error file={path}::not valid YAML — {exc}")
+        failed += 1
+
+if failed:
+    print(f"\n{failed} workflow file(s) rejected.")
+    sys.exit(1)
+print(f"{len(sys.argv) - 1} workflow file(s) OK.")
+PY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1040,6 +1040,14 @@ jobs:
       # never exists and the plugin coordinate consumers resolve 404s. Every fail-open path is
       # pinned here, along with the module enumeration: if that ever stops matching, the guard
       # narrows to the shared build inputs and starts answering `false` for real changes.
+      # Workflow YAML that PyYAML accepts and GitHub Actions rejects. `safe_load` silently keeps
+      # the last of a duplicated key; Actions refuses the file — and the refusal surfaces as a run
+      # with ZERO jobs and no logs, on the calling workflow, which is close to undiagnosable from
+      # the Actions UI. A duplicate `env:` in release.yml failed the v2.1.0 release exactly that
+      # way, and the silent-discard behaviour had also dropped the Maven Central credentials from
+      # the step.
+      - name: Check workflow YAML
+        run: ./.github/scripts/check-workflow-yaml.sh
       - name: Run Maven publish guard tests
         run: ./.github/scripts/test-maven-publish-needed.sh
       # The baseline resolver the guard and the readiness gate share. They run in two SEPARATE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,7 +307,6 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-        env:
           CORE_NEEDED: ${{ needs.maven-publish-guard.outputs.core_needed }}
           DATA_NEEDED: ${{ needs.maven-publish-guard.outputs.data_needed }}
         run: |


### PR DESCRIPTION
**Releases are broken on `main` right now.** My #5251 left `release.yml`'s Maven Central publish step with two `env:` keys — the existing credentials block, and the `CORE_NEEDED` / `DATA_NEEDED` pair added for per-train gating.

```
Invalid workflow file: .github/workflows/release-please.yml#L187
error parsing called workflow
".github/workflows/release-please.yml"
-> "./.github/workflows/release.yml" (source branch with sha:57ae39ea9)
: (Line: 310, Col: 9): 'env' is already defined
```

Because `release.yml` is a *called* workflow, the rejection failed the whole v2.1.0 `release-please` run with **zero jobs, no logs, and nothing pointing at the cause**.

## Why it got through

Every "does this file parse?" check I ran used PyYAML's `safe_load`, which **silently keeps the last of a duplicated key** instead of erroring. Actions does the opposite and refuses the file.

The silent-discard behaviour also made the bug worse than a plain parse error: the block that survived was the *second* one, so the Maven Central credentials had been dropped from the step. Had Actions been as permissive as PyYAML, the publish would have run without them.

## The fix

One merged `env:` block carrying all four variables. The per-train gating logic is untouched — this is purely the YAML defect.

Plus `check-workflow-yaml.sh`, which models what Actions actually does: a `SafeLoader` subclass that refuses duplicate mapping keys, run over every workflow file. Wired into CI beside the other script tests.

## Test plan

- **Reproduced the failure and proved the checker catches it.** Run against the broken commit `57ae39ea9`:
  ```
  ::error file=...::duplicate key — line 310, column 9: 'env' is already defined
  1 workflow file(s) rejected.
  ```
  That is GitHub's own message — same line, same column, same wording — derived independently.
- Against the fixed tree: `40 workflow file(s) OK.`
- Confirmed all four variables survive the merge: `ORG_GRADLE_PROJECT_mavenCentralUsername`, `ORG_GRADLE_PROJECT_mavenCentralPassword`, `CORE_NEEDED`, `DATA_NEEDED`.

## One thing I checked and did *not* change

My first hypothesis was the folded `if:` I added, on the theory that a more-indented continuation line preserves a newline inside `${{ }}`. It does preserve the newline — but that is not the bug: four conditions already on `main` (`ci.yml`, `claude.yml`, `pr-body-syntax.yml`, `pr-commands.yml`) wrap the same way and run fine. I reverted that edit rather than ship a change justified by a wrong diagnosis.

Non-visual change; no render evidence applicable.

## Recovery for v2.1.0: nothing to undo

The run was rejected at parse time, so **no job ran at all** — including release-please's own. Verified: there is no `v2.1.0` tag (latest is `v2.0.0`), no draft release, and nothing reached Maven Central.

So there is no repair path to follow. Merging this restores `release.yml`, and the merge itself re-triggers `release-please`, which re-proposes the 2.1.0 release PR from the same commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2