### PR TITLE
fix: pin published preview-runtimes to the line that actually published

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -323,6 +323,9 @@ jobs:
       # (inlined) bundle.
       - name: Wait for released preview-runtimes on Maven Central
         if: ${{ matrix.wasmModule != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           version="$(grep -oP '(?<=^composeaiReleasedRuntimeVersion=).*' gradle.properties || true)"
@@ -330,21 +333,65 @@ jobs:
             echo "::error title=Released runtime version missing::gradle.properties has no composeaiReleasedRuntimeVersion, so the catalog cannot resolve its published preview runtimes." >&2
             exit 1
           fi
+          data_version="$version"
+
+          # `composeaiReleasedRuntimeVersion` is bumped by release-please when the release PR is
+          # CUT — before `maven-publish-guard` decides whether that version publishes at all. On a
+          # release where a Maven line did not change, the guard skips its publish and the runtimes
+          # on that line stay at their previous version, so this property names something that will
+          # never appear on Central and the poll below would burn 60 minutes and then fail.
+          #
+          # The release records what it actually did, per line, in the readiness marker it attaches
+          # once Central has resolved. Prefer that over the property. Probing Central directly is
+          # NOT an alternative: a 404 cannot distinguish "this line was skipped" from "not
+          # propagated yet", which is the same race that made the marker the right answer for the
+          # plugin version. See docs/design/RELEASE_TRAINS.md § 7.
+          #
+          # Falls through to the property when there is no marker — an older release, or a regen
+          # running before readiness finished — which is exactly the previous behaviour.
+          # `release_version` is fixed before the lines are resolved: it names the marker's file
+          # and the tag it hangs off, and both `version` and `data_version` are reassigned below.
+          release_version="$version"
+          marker_name="compose-preview-maven-ready-${release_version}.json"
+          marker_dir="$RUNNER_TEMP/maven-ready"
+          mkdir -p "$marker_dir"
+          # `--dir` only, no `-O`: the two are mutually exclusive in `gh release download`.
+          if gh release download "v${release_version}" --dir "$marker_dir" \
+               --pattern "$marker_name" 2>/dev/null && [ -s "$marker_dir/$marker_name" ]; then
+            m_core="$(sed -n 's/.*"pluginVersion":"\([^"]*\)".*/\1/p' "$marker_dir/$marker_name" | head -1)"
+            m_data="$(sed -n 's/.*"dataVersion":"\([^"]*\)".*/\1/p' "$marker_dir/$marker_name" | head -1)"
+            # Each field is taken only when present. A marker written before `dataVersion` existed
+            # still pins the core line correctly and leaves data on the property.
+            [ -n "$m_core" ] && version="$m_core"
+            [ -n "$m_data" ] && data_version="$m_data"
+            echo "Readiness marker for v${release_version}: core=${m_core:-<absent>} data=${m_data:-<absent>}."
+          else
+            echo "No readiness marker for v${release_version} — using composeaiReleasedRuntimeVersion for both lines."
+          fi
+
+          # Hand the resolved lines to the render. The catalog samples substitute the two runtimes
+          # at these properties, and they are separate because the runtimes are on separate lines.
+          {
+            echo "ORG_GRADLE_PROJECT_composeaiReleasedRuntimeVersion=${version}"
+            echo "ORG_GRADLE_PROJECT_composeaiReleasedDataRuntimeVersion=${data_version}"
+          } >> "$GITHUB_ENV"
+
           base="https://repo1.maven.org/maven2/ee/schimke/composeai"
-          echo "Waiting for preview-runtimes $version on Maven Central (up to 60 minutes)…"
+          echo "Waiting for preview-runtimes core=$version data=$data_version on Maven Central (up to 60 minutes)…"
           last_status=""
           for i in $(seq 1 60); do
             ok=1
             statuses=()
-            for a in data-preview-overrides-runtime slot-preview-runtime; do
+            for entry in "data-preview-overrides-runtime:$data_version" "slot-preview-runtime:$version"; do
+              a="${entry%%:*}"; v="${entry##*:}"
               code="$(curl -s -o /dev/null -w '%{http_code}' \
-                "$base/$a/$version/$a-$version.pom" || true)"
-              statuses+=("$a=HTTP ${code:-000}")
+                "$base/$a/$v/$a-$v.pom" || true)"
+              statuses+=("$a@$v=HTTP ${code:-000}")
               [ "$code" = "200" ] || ok=0
             done
             last_status=$(IFS=,; echo "${statuses[*]}")
             if [ "$ok" = 1 ]; then
-              echo "✓ preview-runtimes $version available (attempt $i)."
+              echo "✓ preview-runtimes core=$version data=$data_version available (attempt $i)."
               exit 0
             fi
             if [ "$i" -eq 1 ] || [ $((i % 5)) -eq 0 ]; then
@@ -352,7 +399,7 @@ jobs:
             fi
             sleep 60
           done
-          echo "::error title=Preview runtimes unavailable::Version $version did not fully appear on Maven Central after 60 minutes. Last response: $last_status" >&2
+          echo "::error title=Preview runtimes unavailable::core=$version data=$data_version did not fully appear on Maven Central after 60 minutes. Last response: $last_status" >&2
           exit 1
 
       - name: Render catalog bundle

--- a/.github/workflows/maven-readiness.yml
+++ b/.github/workflows/maven-readiness.yml
@@ -79,6 +79,7 @@ jobs:
           dl="$RUNNER_TEMP/cli-dist"
           mkdir -p "$dl"
           plugin_v=""
+          data_v=""
           if gh release download "$TAG" --dir "$dl" --pattern "compose-preview-${V}.tar.gz"; then
             # Targeted extraction: the dist carries every renderer and daemon jar and runs to
             # ~200 MB, and only the CLI's own jar holds cli-version.properties.
@@ -86,8 +87,9 @@ jobs:
                  --wildcards "*/lib/compose-preview-*.jar" 2>/dev/null; then
               jar="$(find "$dl" -name 'compose-preview-*.jar' -path '*/lib/*' | head -1)"
               if [ -n "$jar" ]; then
-                plugin_v="$(unzip -p "$jar" ee/schimke/composeai/cli/cli-version.properties 2>/dev/null \
-                  | sed -n 's/^mavenLineVersion=//p' | head -1)"
+                props="$(unzip -p "$jar" ee/schimke/composeai/cli/cli-version.properties 2>/dev/null)"
+                plugin_v="$(printf '%s' "$props" | sed -n 's/^mavenLineVersion=//p' | head -1)"
+                data_v="$(printf '%s' "$props" | sed -n 's/^dataLineVersion=//p' | head -1)"
               fi
             fi
           fi
@@ -95,8 +97,12 @@ jobs:
             echo "::warning::could not read mavenLineVersion from the shipped CLI — verifying ${V} itself."
             plugin_v="${V}"
           fi
+          # The data line falls back to the plugin line, which is what it equals on every release
+          # that publishes both trains — and on an older CLI built before this key existed.
+          [ -n "${data_v}" ] || data_v="${plugin_v}"
           rm -rf "$dl"
           echo "plugin_version=${plugin_v}" >> "$GITHUB_OUTPUT"
+          echo "data_version=${data_v}" >> "$GITHUB_OUTPUT"
           if [ "${plugin_v}" = "${V}" ]; then
             echo "This release published to Central; verifying ${V}."
           else
@@ -110,6 +116,7 @@ jobs:
           # The version to prove resolvable — this release's own on a publishing release, the
           # Maven line it points consumers at on one that skipped.
           PLUGIN_V: ${{ steps.line.outputs.plugin_version }}
+          DATA_V: ${{ steps.line.outputs.data_version }}
         run: |
           set -euo pipefail
           V="${TAG#v}"
@@ -149,6 +156,7 @@ jobs:
               {
                 echo "version=${V}"
                 echo "plugin_version=${PLUGIN_V}"
+                echo "data_version=${DATA_V}"
                 echo "attempts=${attempt}"
                 echo "plugin_coordinate=ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:${PLUGIN_V}"
               } >> "$GITHUB_OUTPUT"
@@ -168,8 +176,8 @@ jobs:
           # and an earlier one when the publish was skipped. Consumers that only need "is this
           # release usable" can keep reading nothing but the filename.
           marker="$RUNNER_TEMP/compose-preview-maven-ready-${V}.json"
-          printf '{"version":"%s","pluginVersion":"%s","verifiedAt":"%s"}\n' \
-            "$V" "$PLUGIN_V" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$marker"
+          printf '{"version":"%s","pluginVersion":"%s","dataVersion":"%s","verifiedAt":"%s"}\n' \
+            "$V" "$PLUGIN_V" "$DATA_V" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$marker"
           gh release upload "$TAG" "$marker" --clobber
           echo "uploaded $(basename "$marker")."
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -411,6 +411,11 @@ jobs:
         # MAVEN_LINE_VERSION KDoc in cli/src/main/kotlin/ee/schimke/composeai/cli/Version.kt.
         env:
           MAVEN_LINE_VERSION: ${{ needs.maven-publish-guard.outputs.maven_line }}
+          # Recorded alongside it, for the release chain rather than the CLI runtime — see the
+          # comment on `dataLineVersion` in cli/build.gradle.kts. `design-artifacts.yml` pins
+          # `data-preview-overrides-runtime` to this, and it cannot derive it by probing Central
+          # without confusing a skipped data train with an unpropagated one.
+          DATA_LINE_VERSION: ${{ needs.maven-publish-guard.outputs.data_line }}
         run: |
           ./gradlew \
             :cli:distZip :cli:distTar \

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -991,10 +991,24 @@ val generateCliVersionResource =
     val mavenLineVersion =
       project.providers.environmentVariable("MAVEN_LINE_VERSION").orNull?.takeIf { it.isNotBlank() }
         ?: cliVersion
+    // The data train's version, recorded for the RELEASE CHAIN rather than for the CLI runtime:
+    // nothing in the CLI resolves a `data-*` coordinate directly (they arrive as POM transitives of
+    // core), so there is no `DATA_LINE_VERSION` constant in Version.kt to match this.
+    //
+    // It is here because this properties file is the one artifact that durably records what a
+    // release decided about each Maven line, and `maven-readiness.yml` already reads it out of the
+    // shipped tarball. `design-artifacts.yml` needs the data line to pin `data-preview-overrides-
+    // runtime`, and deriving it by probing Central cannot distinguish "this release skipped the
+    // data train" from "Central has not propagated yet" — the same race that made reading this
+    // file the right answer for the plugin version. See docs/design/RELEASE_TRAINS.md § 7.
+    val dataLineVersion =
+      project.providers.environmentVariable("DATA_LINE_VERSION").orNull?.takeIf { it.isNotBlank() }
+        ?: cliVersion
     inputs.property("version", cliVersion)
     inputs.property("xrCompositeVersion", xrCompositeVersion)
     inputs.property("serveVersion", serveVersion)
     inputs.property("mavenLineVersion", mavenLineVersion)
+    inputs.property("dataLineVersion", dataLineVersion)
     outputs.dir(outputDir)
     doLast {
       val file = outputDir.get().file("ee/schimke/composeai/cli/cli-version.properties").asFile
@@ -1003,7 +1017,8 @@ val generateCliVersionResource =
         "version=$cliVersion\n" +
           "xrCompositeVersion=$xrCompositeVersion\n" +
           "serveVersion=$serveVersion\n" +
-          "mavenLineVersion=$mavenLineVersion\n"
+          "mavenLineVersion=$mavenLineVersion\n" +
+          "dataLineVersion=$dataLineVersion\n"
       )
     }
   }

--- a/docs/design/RELEASE_TRAINS.md
+++ b/docs/design/RELEASE_TRAINS.md
@@ -422,9 +422,40 @@ module, exactly one always changed as a unit.
    version can never disagree — a POM naming `v(N-1)` beside a publish of `vN`, or the reverse, is
    a coordinate no consumer can resolve.
 
-   `maven-readiness.yml` needed no change. It reads `mavenLineVersion` from the shipped CLI, which
-   is the **core** line, and resolves the plugin classpath — whose `data-*` transitives are named
-   by the core POMs at a version that is on Central by construction.
+   `maven-readiness.yml` needed no change to *gate* correctly. It reads `mavenLineVersion` from
+   the shipped CLI, which is the **core** line, and resolves the plugin classpath — whose `data-*`
+   transitives are named by the core POMs at a version that is on Central by construction.
+
+   **4c. The published-runtime pin** *(done)* — one consumer did break, and it would have broken
+   on the very first skipped release.
+
+   `design-artifacts.yml` pins the catalog's two preview runtimes to released coordinates and
+   polls Central for them for up to 60 minutes before rendering, deliberately failing loudly
+   rather than rendering an unpinned bundle. It took the version from
+   `composeaiReleasedRuntimeVersion`, which release-please bumps when the release PR is **cut** —
+   before the guard has decided anything. On a release where a line does not publish, that
+   property names a version that never appears, so the poll would burn an hour and fail.
+
+   Worse, one version cannot answer the question at all: `slot-preview-runtime` lives under
+   `runtimes/` (core) and `data-preview-overrides-runtime` under `data/` (data), so a release that
+   publishes only core leaves them on *different* versions.
+
+   The fix records both lines and reads them back:
+
+   - `generateCliVersionResource` bakes `dataLineVersion` beside `mavenLineVersion`. It is there
+     for the release chain, not the CLI runtime — nothing in the CLI resolves a `data-*`
+     coordinate directly — but this properties file is the one artifact that durably records what
+     a release decided per line.
+   - `maven-readiness.yml` reads both out of the shipped tarball and writes them into the marker:
+     `{"version":…,"pluginVersion":…,"dataVersion":…}`.
+   - `design-artifacts.yml` reads the marker and exports
+     `ORG_GRADLE_PROJECT_composeaiReleased{,Data}RuntimeVersion`, then waits for *those*.
+   - Both catalog samples substitute the data runtime at its own property, defaulting to the core
+     one — so a local build and any release that publishes both trains behave exactly as before.
+
+   **Probing Central is not an alternative**, and that is the crux: a 404 cannot distinguish "this
+   line was skipped" from "not propagated yet". It is the same race that made reading the shipped
+   artifact the right answer for the plugin version in 4b, and the same answer applies.
 
    One consequence worth knowing: a release where **data publishes but core does not** uploads
    `data-*` artifacts that no published POM references yet. They are picked up by the next core

--- a/samples/design-catalog-m3-shared/build.gradle.kts
+++ b/samples/design-catalog-m3-shared/build.gradle.kts
@@ -149,10 +149,21 @@ if (useReleasedRuntimes) {
         "composeaiUseReleasedRuntimes is set but composeaiReleasedRuntimeVersion is missing from " +
           "gradle.properties"
       )
+  // The two runtimes below are on DIFFERENT Maven version lines: `slot-preview-runtime` lives
+  // under `runtimes/` (the core line) and `data-preview-overrides-runtime` under `data/` (the data
+  // line). `maven-publish-guard` publishes those lines independently, so a release that changed
+  // only core leaves the data runtime at an earlier version and one substitution version cannot
+  // name both. Defaults to the core version, which is what they are equal to on every release that
+  // publishes both trains — so nothing changes for a local build or an ordinary release.
+  // docs/design/RELEASE_TRAINS.md § 5.
+  val dataVersion =
+    providers.gradleProperty("composeaiReleasedDataRuntimeVersion").orNull?.takeIf {
+      it.isNotBlank()
+    } ?: version
   configurations.all {
     resolutionStrategy.dependencySubstitution {
       substitute(project(":data-preview-overrides-runtime"))
-        .using(module("ee.schimke.composeai:data-preview-overrides-runtime:$version"))
+        .using(module("ee.schimke.composeai:data-preview-overrides-runtime:$dataVersion"))
         .because("published previews reference released preview-runtimes (see :design-catalog-m3)")
       substitute(project(":slot-preview-runtime"))
         .using(module("ee.schimke.composeai:slot-preview-runtime:$version"))

--- a/samples/design-catalog-m3/build.gradle.kts
+++ b/samples/design-catalog-m3/build.gradle.kts
@@ -89,14 +89,24 @@ if (providers.gradleProperty("composeaiUseReleasedRuntimes").orNull.toBoolean())
         "composeaiUseReleasedRuntimes is set but composeaiReleasedRuntimeVersion is missing from " +
           "gradle.properties"
       )
+  // `data-preview-overrides-runtime` is on the DATA Maven line and `slot-preview-runtime` on the
+  // core one, and `maven-publish-guard` publishes those lines independently — so a release that
+  // changed only core leaves the data runtime at an earlier version. Defaults to the core version,
+  // which is what they are equal to whenever both trains publish. Kept in lockstep with
+  // `:samples:design-catalog-m3-shared` by hand, as the note there says.
+  val dataVersion =
+    providers.gradleProperty("composeaiReleasedDataRuntimeVersion").orNull?.takeIf {
+      it.isNotBlank()
+    } ?: version
   logger.lifecycle(
-    ":samples:design-catalog-m3: pinning preview-runtime deps to released $version for the " +
-      "published bundle (new runtime APIs must be released before a published preview can use them)."
+    ":samples:design-catalog-m3: pinning preview-runtime deps to released core $version / data " +
+      "$dataVersion for the published bundle (new runtime APIs must be released before a " +
+      "published preview can use them)."
   )
   configurations.all {
     resolutionStrategy.dependencySubstitution {
       substitute(project(":data-preview-overrides-runtime"))
-        .using(module("ee.schimke.composeai:data-preview-overrides-runtime:$version"))
+        .using(module("ee.schimke.composeai:data-preview-overrides-runtime:$dataVersion"))
         .because("published previews reference released preview-runtimes (see build note)")
       substitute(project(":slot-preview-runtime"))
         .using(module("ee.schimke.composeai:slot-preview-runtime:$version"))


### PR DESCRIPTION
**`design-artifacts.yml` would have failed on the first skipped release — and taken an hour to do it.** Step **4c** of [`RELEASE_TRAINS.md` § 7](https://github.com/yschimke/compose-ai-tools/blob/main/docs/design/RELEASE_TRAINS.md), found while checking whether it was safe to cut a release from current `main`.

## The bug

`design-artifacts.yml` pins the catalog's two preview runtimes to released coordinates and polls Central for them for **up to 60 minutes**, deliberately failing loudly rather than rendering an unpinned bundle. It took the version from `composeaiReleasedRuntimeVersion` — which release-please bumps when the release PR is **cut**, before `maven-publish-guard` has decided anything.

On a release where a Maven line doesn't change, the guard skips its publish and those artifacts never appear at the new version. The poll burns an hour, then fails.

This is not hypothetical: a release from current `main` would be exactly that case, since only #5252 has landed and it touched nothing published:

```
core  needed=false   no published module, shared build input or build-toolchain pin changed since v2.1.0
data  needed=false   (same)
```

**And one version can't answer the question anyway.** The two runtimes are on *different* trains:

| Artifact | Directory | Train |
|---|---|---|
| `slot-preview-runtime` | `runtimes/slots` | core |
| `data-preview-overrides-runtime` | `data/preview-overrides/runtime` | data |

So a release publishing only core leaves them at different versions, which a single substitution version cannot express.

## The fix — record both lines, read them back

- `generateCliVersionResource` bakes `dataLineVersion` beside `mavenLineVersion`. It's for the release chain, not the CLI runtime (nothing in the CLI resolves a `data-*` coordinate directly — they arrive as POM transitives of core), but this properties file is the one artifact that durably records what a release decided per line, and `maven-readiness` already reads it out of the shipped tarball.
- `release.yml` passes `DATA_LINE_VERSION` to `build-applications`, from a guard output it already computes.
- `maven-readiness.yml` reads both keys and writes them into the marker: `{"version":…,"pluginVersion":…,"dataVersion":…}`. Data falls back to the plugin line, so a marker from an older CLI still parses.
- `design-artifacts.yml` reads the marker and exports `ORG_GRADLE_PROJECT_composeaiReleased{,Data}RuntimeVersion`, then waits for *those* coordinates.
- Both catalog samples substitute the data runtime at its own property, defaulting to the core one — so local builds and any release publishing both trains behave exactly as before.

**Probing Central instead is not an alternative, and that's the crux:** a 404 cannot distinguish "this line was skipped" from "not propagated yet". Same race that made reading the shipped artifact the right answer for the plugin version in 4b; same answer here.

## Test plan

- **Verified the override mechanism actually works** — this was the load-bearing assumption, since Gradle's precedence between `gradle.properties` and `ORG_GRADLE_PROJECT_*` decides whether any of this has an effect:
  ```
  $ grep composeaiReleasedRuntimeVersion gradle.properties   → 2.1.0
  $ ORG_GRADLE_PROJECT_composeaiReleasedRuntimeVersion=9.9.9 ./gradlew -q properties
    composeaiReleasedRuntimeVersion: 9.9.9
  ```
- **Verified the baked properties** under a simulated split: `PLUGIN_VERSION=2.2.0 DATA_LINE_VERSION=2.1.0` produces `mavenLineVersion=2.2.0` / `dataLineVersion=2.1.0`.
- **Verified marker parsing against both shapes**, including the real v2.1.0 marker that predates `dataVersion` — it yields `core=2.1.0 data=<absent>` and correctly leaves the data line on the property, i.e. graceful degradation rather than an empty coordinate.
- Confirmed both runtimes' trains and that both are on Central at 2.1.0 (HTTP 200).
- `bash -n` on the rewritten wait step (extracted from the YAML); `gh release download` uses `--dir` alone, since `--dir` and `-O` are mutually exclusive.
- `check-workflow-yaml.sh` 40 files OK, `ktfmtCheckAll` green, `:cli:test` green, guard tests 35, baseline tests 17.

Non-visual change; no render evidence applicable.

## After this merges

A release from `main` becomes the **first genuine skip**: 0 module-publications instead of 94, the CLI shipping at 2.1.1 while resolving the plugin at 2.1.0, the marker recording both lines, and the design map publishing to npm through the normal release-please chain (closing the gap left by v2.1.0's manual recovery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2)_