### PR TITLE
fix: let Create Release Tag use a token that can create a ref

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -47,7 +47,23 @@ jobs:
     permissions:
       contents: write # create the tag ref
     env:
-      GH_TOKEN: ${{ github.token }}
+      # `RELEASE_TAG_TOKEN` when it exists, else the default token.
+      #
+      # The default token was refused outright on 2026-09-06 — `POST /git/refs` answered
+      # `Resource not accessible by integration (HTTP 403)` — while a release was stranded and this
+      # workflow was the documented way out. That is worth knowing precisely, because none of the
+      # usual explanations fit: the job declares `contents: write`, the repository's only ruleset
+      # targets the default BRANCH (no tag rules, no bypass list), and `release.yml`'s `release`
+      # job wrote contents with the same token forty minutes earlier. Whatever refuses ref creation
+      # here is not visible from inside the workflow.
+      #
+      # So this escape hatch no longer depends on being able to explain it: give it a token that
+      # can create a ref and it works. A fine-grained PAT or GitHub App installation token with
+      # `contents: write` is enough. Same pattern, and the same reason, as `LOCKFILE_REGEN_TOKEN`
+      # in dependency-locks.yml — a job whose whole purpose is unblocking a stuck state must not be
+      # the thing that is stuck.
+      GH_TOKEN: ${{ secrets.RELEASE_TAG_TOKEN || github.token }}
+      USING_PAT: ${{ secrets.RELEASE_TAG_TOKEN != '' }}
       GH_REPO: ${{ github.repository }}
       # Referenced only via these env vars in the script below — never
       # interpolated into the run block — so a crafted input can't inject shell.
@@ -74,7 +90,30 @@ jobs:
             exit 0
           fi
 
-          gh api --method POST "repos/${GH_REPO}/git/refs" \
-            -f ref="refs/tags/${TAG}" -f sha="${full_sha}"
+          echo "Creating refs/tags/${TAG} at ${full_sha} (token: $([ "${USING_PAT}" = "true" ] && echo RELEASE_TAG_TOKEN || echo GITHUB_TOKEN))."
+
+          # Capture the response rather than letting `set -e` kill the step on a bare API error:
+          # a stranded release is exactly when someone needs to know WHY this did not work, and
+          # `gh`'s one-line message on its own sent a person hunting through repository settings.
+          if ! out="$(gh api --method POST "repos/${GH_REPO}/git/refs" \
+                -f ref="refs/tags/${TAG}" -f sha="${full_sha}" 2>&1)"; then
+            echo "${out}"
+            if printf '%s' "${out}" | grep -q 'Resource not accessible by integration'; then
+              {
+                echo "::error title=Cannot create the tag ref::The token was refused ref creation (HTTP 403)."
+                echo "The job requests \`contents: write\`, so this is a repository or account"
+                echo "restriction on the default GITHUB_TOKEN rather than a bug in this workflow."
+                echo "Two ways out, in order of preference:"
+                echo "  1. Add a \`RELEASE_TAG_TOKEN\` secret — a fine-grained PAT or GitHub App"
+                echo "     installation token with \`contents: write\` on this repository. This"
+                echo "     workflow prefers it automatically and needs no further change."
+                echo "  2. Create the tag by hand:"
+                echo "       git tag ${TAG} ${full_sha} && git push origin ${TAG}"
+                echo "Then run \`release.yml\` (workflow_dispatch, tag=${TAG}) FROM \`main\` to build"
+                echo "and publish — dispatching from main uses main's workflow while building the tag."
+              } >&2
+            fi
+            exit 1
+          fi
           echo "created tag ${TAG} at ${full_sha}."
           echo "note: this did NOT trigger release.yml (token-created ref) — build/publish separately if you want artifacts."

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -158,6 +158,16 @@ number that falls out of a PR title.
 
 ## Fallback paths
 
+> **If `Create Release Tag` fails with `Resource not accessible by integration (HTTP 403)`**, the
+> default `GITHUB_TOKEN` is being refused ref creation. That is not a bug in the workflow — the job
+> requests `contents: write`, the repository's only ruleset targets the default *branch* with no tag
+> rules, and `release.yml` writes contents with the same token. Set a **`RELEASE_TAG_TOKEN`** secret
+> (fine-grained PAT or GitHub App installation token, `contents: write` on this repository) and the
+> workflow uses it automatically. Without one, create the tag by hand
+> (`git tag vX.Y.Z <sha> && git push origin vX.Y.Z`) and then dispatch `release.yml` **from `main`**
+> with that tag — dispatching from `main` runs main's workflow while building the tag's contents.
+> This happened on v2.1.0.
+
 **First, check whether the sweeper already has it.** A release left as a draft is picked up hourly by [`release-draft-sweeper.yml`](../.github/workflows/release-draft-sweeper.yml), which tags, rebuilds or publishes it as needed — Actions → **Release Draft Sweeper** → **Run workflow** runs it on demand, with a `dry_run` option that reports what it would do and touches nothing. It deliberately declines two things: publishing a release whose required assets are missing or whose plugin is not on Maven Central yet, and tagging a draft whose target is a branch rather than a commit (use **Create Release Tag** at the release PR's merge commit for that). Everything below is the manual version of the same levers.
 
 If the automatic chain ever leaves a release half-published (e.g. Maven Central rejected an upload, CLI build failed), you can re-run the build/publish against an existing tag without touching release-please:


### PR DESCRIPTION
The escape hatch for a stranded release failed *while a release was stranded*. Dispatching it for `v2.1.0` answered:

```
POST repos/yschimke/compose-ai-tools/git/refs
gh: Resource not accessible by integration (HTTP 403)
```

## What I ruled out

I could not reproduce the cause from outside, and each obvious explanation is contradicted by evidence:

| Hypothesis | Evidence against |
|---|---|
| Workflow doesn't request write | Job declares `permissions: contents: write` |
| A ruleset protects `v*` tags | The repo's **only** ruleset targets the default *branch* — rules `deletion`, `non_fast_forward`, `pull_request`, `required_status_checks`; no tag conditions, `bypass_actors: null`. Legacy tag-protection endpoint returns nothing. |
| Default workflow permissions are read-only | `release.yml`'s `release` job (`contents: write`, same `GITHUB_TOKEN`) created the Release and uploaded assets 40 minutes later |
| The identical call never works | `release-please.yml` has byte-identical code and has created every tag up to `v2.0.0` |

So whatever refuses ref creation isn't visible from inside the workflow, and I can't change it from here either.

## The fix: stop depending on explaining it

The workflow now prefers a **`RELEASE_TAG_TOKEN`** secret when present — a fine-grained PAT or GitHub App installation token with `contents: write` — falling back to `github.token`. Same pattern and same reasoning as `LOCKFILE_REGEN_TOKEN` in `dependency-locks.yml`: *a job whose whole purpose is unblocking a stuck state must not itself be the thing that is stuck.*

And when it still can't create the ref, it says something useful instead of a one-line `gh` error. On a 403 it prints which token it used, that the restriction is a repository/account setting rather than this workflow, and the two ways out:

1. add the secret; or
2. create the tag by hand, then dispatch `release.yml` **from `main`** with that tag.

That second detail is what took longest to work out while the release was down: dispatching from `main` runs main's workflow while building the tag's contents, which is what let v2.1.0 publish at all after the tag was created manually.

The API response is captured rather than left to `set -e`, so a *different* failure — a 422 for an already-existing ref, say — still exits non-zero without falsely claiming a permissions problem.

## Test plan

- **Verified the diagnosis branch fires on the real error text** and only on it:
  - fed the verbatim `Resource not accessible by integration (HTTP 403)` output → diagnosis printed, with `TAG` and the resolved SHA correctly interpolated into the suggested `git tag` command;
  - fed `Reference already exists (HTTP 422)` → falls through to a plain `exit 1`, no permissions claim.
- `bash -n` on the step body extracted from the YAML.
- `check-workflow-yaml.sh` — 40 files OK (this is the checker added in #5252, which is what would have caught that PR's duplicate `env:`; note this PR adds two keys to an existing `env:` block rather than a second one).
- `secrets.RELEASE_TAG_TOKEN || github.token` degrades correctly when the secret is absent — that's the current state, so the workflow behaves exactly as before except for the improved error.

Docs-wise, `RELEASING.md`'s fallback section records the same, since that's where someone looks when a release is stranded.

Non-visual change; no render evidence applicable.

## What you still need to decide

Adding `RELEASE_TAG_TOKEN` is a repo-settings action I can't take. Until it exists this PR changes nothing operationally — it just makes the next failure self-explaining instead of costing an hour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDdkQ4Ch9VwYPJav4dbED2)_