### PR TITLE
feat(cli): compose-preview design, a launcher for the server's design command

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
@@ -249,6 +249,26 @@ internal object CliFlagValidation {
             "--ui-builder-runtime-dir",
             "--ui-builder-state-dir",
           ),
+      // A launcher for the server's `design` command, so the flags are that command's. No
+      // selectors: this command names a design on a server rather than a preview in this project,
+      // so `--module` and friends would be noise it forwards for nobody. `--token` is listed
+      // because the server refuses it by name — a credential does not go on a command line — and
+      // that refusal is a better message than "unrecognised option".
+      "design" to
+        setOf(
+          "--format",
+          "--help",
+          "-h",
+          "--limit",
+          "--no-authorize",
+          "--out",
+          "-o",
+          "--revision",
+          "--server",
+          "--server-binary",
+          "--timeout",
+          "--token",
+        ),
       // The flags a preview server passes when it spawns the Gradle half of `serve`. Deliberately
       // narrow: this command is machine-facing, and every flag here is one the server has to know
       // to send. `--stdio` selects the transport; `--module` and `--variant` are the two selectors

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliRouter.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliRouter.kt
@@ -45,7 +45,10 @@ internal object CliRouter {
       // server spawns is still a command, and one that cannot be found is one nobody can debug.
       // `ui-builder` joins them because all three are the same binary: `serve` hosts it,
       // `build-host` is the Gradle half it spawns, and `ui-builder` launches its `ui` command.
-      "share" to listOf("serve", "ui-builder", "build-host", "share-preview"),
+      // `design` is the fourth face of that binary and the only one that does not serve: it talks
+      // to a server that is already up and writes a design's pixels or source to a file
+      // (yschimke/compose-preview-server#529).
+      "share" to listOf("serve", "ui-builder", "design", "build-host", "share-preview"),
       "setup" to listOf("update", "init-script", "pin", "auth"),
     )
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DesignCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DesignCommand.kt
@@ -1,0 +1,29 @@
+package ee.schimke.composeai.cli
+
+/**
+ * `compose-preview design` — the launcher for the preview server's `design` command.
+ *
+ * Fourth of the launchers, beside [ServeCommand], [BrowseCommand] and [UiBuilderCommand]: the
+ * server binary renders a UI-builder design, exports its generated source, or reads its document,
+ * and writes the result to a file
+ * ([yschimke/compose-preview-server#529](https://github.com/yschimke/compose-preview-server/issues/529)).
+ *
+ * It adds nothing of its own — no defaults, no flag rewriting — for the reason `ui-builder` adds
+ * nothing: the work needs the UI-builder renderer, the export executor and the asset store, all of
+ * which the layer rule places in that repository, and this side has no useful opinion about any of
+ * it. `--help` therefore reaches the server too, which is where the answer lives.
+ *
+ * **It is the one launcher whose target does not serve anything.** `design` runs against a server
+ * that is already up — `--server`, defaulting to a local one — and exits with a code that says
+ * whether the export was refused. [ServeCommand] already inherits IO and propagates the child's
+ * exit code, so a one-shot command needs nothing more from this side than the command word.
+ */
+class DesignCommand(private val args: List<String>) {
+  fun run() {
+    ServeCommand(args, serverCommand = SERVER_COMMAND).run()
+  }
+
+  internal companion object {
+    const val SERVER_COMMAND: String = "design"
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -27,6 +27,7 @@ internal val COMMANDS: Map<String, (List<String>) -> Unit> =
     "browse" to { a -> BrowseCommand(a).run() },
     "serve" to { a -> ServeCommand(a).run() },
     "ui-builder" to { a -> UiBuilderCommand(a).run() },
+    "design" to { a -> DesignCommand(a).run() },
     "build-host" to { a -> BuildHostCommand(a).run() },
     "share-preview" to { a -> SharePreviewCommand(a).run() },
     "bundle" to { a -> BundleCommand(a).run() },
@@ -142,7 +143,7 @@ private fun printUsage(full: Boolean = false) {
     Command groups (each command is also callable directly by its name):
       inspect   a11y · diff-semantics · devices · extensions · history · profile
       capture   render-matrix · record · bundle
-      share     serve · ui-builder · share-preview
+      share     serve · ui-builder · design · share-preview
       setup     update · init-script · pin · auth
     Run `compose-preview <group>` to list a group, or `help --all` for every command + flag.
 
@@ -216,6 +217,12 @@ private fun printFullUsage() {
       ui-builder       Build this project's previews and open the Compose UI builder against
                        them, so exported code calls your composables. Launches the preview
                        server's `ui` command; see `ui-builder --help` for its options.
+      design           Get a UI-builder design out of a running server: `design render <id>` for a
+                       PNG or SVG, `design export <id>` for the generated Kotlin, `design get` for
+                       the document, `design list` for what you can see. Launches the preview
+                       server's `design` command, which is a client rather than a server: it needs
+                       a `--server` that is already up, and exits non-zero when an export is
+                       refused, so it composes in CI. See `design --help`.
       share-preview    Share rendered previews (a markdown report + images, or a directory of
                        PNGs) somewhere openable. Picks the mechanism by what's available: a gist
                        when the GitHub CLI is installed + authenticated, otherwise a push to a

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/ServeLauncherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/ServeLauncherTest.kt
@@ -105,6 +105,42 @@ class ServeLauncherTest {
         .launchCommand("/opt/compose-preview-server"),
     )
   }
+
+  /**
+   * `design` is the one launcher whose target does not serve: the verb and the design id are the
+   * server's argv, forwarded untouched, and the exit code that comes back is what says whether an
+   * export was refused (yschimke/compose-preview-server#529).
+   */
+  @Test
+  fun `design launches the server's design command with the caller's argv`() {
+    assertEquals(
+      listOf("/opt/compose-preview-server", "design", "render", "my-widget", "--out", "cover.png"),
+      ServeCommand(
+          listOf("render", "my-widget", "--out", "cover.png"),
+          serverCommand = DesignCommand.SERVER_COMMAND,
+        )
+        .launchCommand("/opt/compose-preview-server"),
+    )
+  }
+
+  /** `--server-binary` is this side's own flag and is the only thing dropped on the way through. */
+  @Test
+  fun `design drops the launcher's own flag rather than forwarding it`() {
+    assertEquals(
+      listOf("/opt/from-flag", "design", "list", "--server", "https://preview.coo.ee"),
+      ServeCommand(
+          listOf(
+            "list",
+            ServerBinaryDiscovery.FLAG,
+            "/opt/from-flag",
+            "--server",
+            "https://preview.coo.ee",
+          ),
+          serverCommand = DesignCommand.SERVER_COMMAND,
+        )
+        .launchCommand("/opt/from-flag"),
+    )
+  }
 }
 
 class ServerBinaryDiscoveryTest {

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -134,7 +134,7 @@ The CLI ([cli/](../cli/src/main/kotlin/ee/schimke/composeai/cli/)) and VS Code e
 
 ### The launcher checks the JVM the server will run on
 
-`serve`, `browse`, `ui-builder` and `mcp serve` exec a start script, and a Gradle start script
+`serve`, `browse`, `ui-builder`, `design` and `mcp serve` exec a start script, and a Gradle start script
 resolves `java` from `JAVA_HOME`/`PATH` — it does **not** inherit the CLI's JVM. So the JVM that
 loads the server's classes is one neither repository picked, and on a host below the server's floor
 the user got an `UnsupportedClassVersionError` from a process they did not know existed:


### PR DESCRIPTION
The `:cli` half of [yschimke/compose-preview-server#529](https://github.com/yschimke/compose-preview-server/issues/529), whose server half is [yschimke/compose-preview-server#532](https://github.com/yschimke/compose-preview-server/pull/532).

```shell
compose-preview design list
compose-preview design render spotify-wear-widget -o cover.png
compose-preview design export spotify-wear-widget -o Widget.kt
compose-preview design get    spotify-wear-widget > design.json
```

Fourth launcher beside `serve`, `browse` and `ui-builder`, and — like `ui-builder` — it adds nothing of its own: no defaults, no flag rewriting. Rendering a design needs the UI-builder renderer, the export executor and the asset store, every one of which the layer rule in `docs/design/REPOSITORY_LAYERS.md` places in the server repository, and this side has no useful opinion about any of it. `--help` reaches the server too, which is where the answer lives.

It is the first launcher whose target does not serve: `design` talks to a host that is already up (`--server`) and exits with a code that says whether an export was refused. `ServeCommand` already inherits IO and propagates the child's exit code, so that needed nothing from this side but the command word.

Changed: the dispatch table, `CliRouter`'s `share` group, the per-command flag allowlist (`--server`, `--out`/`-o`, `--format`, `--revision`, `--limit`, `--no-authorize`, `--timeout`, plus `--token` so the server's own refusal — a credential does not go on a command line — is the message a caller gets), both help views, and the `ServerJavaPreflight` sentence in the agent guide that lists which commands exec a start script.

## Test plan

- `:cli:test --tests '*CliRouterTest' --tests '*ServeLauncherTest' --tests '*CliFlagsRegistryTest'` — green. The router tests are the ones that matter: they pin that `COMMANDS`, `CliRouter.KNOWN_FLAT` and `CliFlagValidation.BY_COMMAND` all agree on the command set, which is what a half-registered command fails. Two new launcher cases cover the forwarded argv and that `--server-binary` is dropped rather than forwarded.
- `:cli:ktfmtFormatMain :cli:ktfmtFormatTest` run and staged.

Not UI-affecting: text-only change to a CLI.

Note it needs a server release carrying the `design` command; against an older binary the launcher forwards a word the server answers `Unknown command 'design'` to, which is the same shape as any launcher running ahead of its target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8BZxzMbs9gWp2s87mUMup

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8BZxzMbs9gWp2s87mUMup)_