### PR TITLE
ci: wait for released runtimes before building the CLI, and retry the snapshot publish

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -237,82 +237,6 @@ jobs:
       - uses: ./.github/actions/buildfetch-cache
         with:
           ro-token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
-      - uses: ./.github/actions/install-cli
-
-      # `compose-m3` is now a Compose Multiplatform (desktop) catalog, so its
-      # render goes through the Skiko desktop daemon (CPU raster) instead of
-      # Robolectric. Skiko's native lib links libGL.so.1, so Mesa's software GL
-      # must be present (same deps ci.yml installs for desktop renders; the Wear /
-      # Remote Android rows don't need them, but the packages are harmless there).
-      - name: Install desktop (Skiko) render deps
-        run: |
-          scripts/install-linux-font-fallbacks.sh \
-            xvfb libgl1 libglx-mesa0 libgl1-mesa-dri libfreetype6 libfontconfig1
-
-      # The export engine lives in the (private) design-parity repo, but its
-      # building blocks are published to npm. The driver
-      # (scripts/design-artifacts/) pins @design-parity/candidate +
-      # @design-parity/catalog-export, so we install them from npm rather than
-      # cloning design-parity: the workflow's GITHUB_TOKEN is scoped to this repo
-      # only and can't read the private design-parity repo, and a public-npm
-      # install needs no cross-repo secret.
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 22
-      - name: Install export engine (pinned npm packages)
-        working-directory: scripts/design-artifacts
-        run: npm ci --no-audit --no-fund --loglevel=warn
-
-      # Fast, build-free pre-flight: resolve every spec `preview` against the
-      # @Preview functions the module actually declares BEFORE the ~90-minute
-      # render. A mistyped/renamed `preview` fails here in seconds instead of as a
-      # late "missing" entry that trips the completeness gate at the end. Structural
-      # errors (duplicate componentId, malformed variant) fail here too. Uses only
-      # node built-ins (no npm deps). Coverage warnings don't fail the job.
-      - name: Validate catalog spec
-        id: validate-spec
-        run: |
-          set -euo pipefail
-          node scripts/design-artifacts/validate-catalog-spec.mjs --spec "${{ matrix.spec }}" \
-            --render-filter-out "$GITHUB_WORKSPACE/render-filter.txt" \
-            --deferred-modes-out "$GITHUB_WORKSPACE/deferred-modes.txt"
-          # Render priority (issue #2950): the `--preview` patterns that render just the
-          # entries this spec still needs baked. EMPTY unless the spec marks entries
-          # `priority: "deferred"` — no catalog here does today, so the render set is
-          # unchanged. Consumed by the render step below.
-          echo "render-filter=$(cat "$GITHUB_WORKSPACE/render-filter.txt")" >> "$GITHUB_OUTPUT"
-          # Gate for the per-mode exclusion step below (issue #2966): that one needs discovered
-          # preview ids, so it costs an extra Gradle invocation and only runs when a mode is
-          # actually deferred.
-          echo "deferred-modes=$(cat "$GITHUB_WORKSPACE/deferred-modes.txt")" >> "$GITHUB_OUTPUT"
-
-      # Per-mode render exclusions (issue #2966). `modePriority` thins the palette fan-out INSIDE one
-      # `@Preview` function, so it can't be named as function patterns like the entry-level filter
-      # above — it needs the discovered ids (`FilledButton_Dark`). `compose-preview list --json` runs
-      # `composePreviewDiscover` for them; the compile it does is shared with the render below, so the
-      # extra invocation costs discovery rather than a second build. Skipped when nothing is deferred.
-      - name: Derive per-mode render exclusions
-        id: mode-filter
-        if: ${{ steps.validate-spec.outputs.deferred-modes != '' }}
-        run: |
-          set -euo pipefail
-          compose-preview list --json --module "${{ matrix.module }}" \
-            > "$GITHUB_WORKSPACE/discovered-previews.json"
-          node scripts/design-artifacts/deferred-preview-ids.mjs \
-            --spec "${{ matrix.spec }}" \
-            --previews "$GITHUB_WORKSPACE/discovered-previews.json" \
-            --out "$GITHUB_WORKSPACE/mode-filter.txt" \
-            --anchored-out "$GITHUB_WORKSPACE/mode-filter-cli.txt" \
-            --rows-out "$GITHUB_WORKSPACE/mode-filter-rows.txt"
-          # The ANCHORED file. `--exclude-preview-id` matches a plain pattern by equality OR
-          # substring, and ids are hierarchical, so deferring `Switch_Dark` unanchored also defers
-          # `Switch_Dark_VARIANT_off` — never deferred by the spec, and missing from the sheet with
-          # nothing pointing back at this step (#3559).
-          echo "exclude-ids=$(cat "$GITHUB_WORKSPACE/mode-filter-cli.txt")" >> "$GITHUB_OUTPUT"
-          # Modes that carry no discovered id are a @PreviewParameter row axis — skipped by label
-          # inside the render instead, since discovery never sees those rows.
-          echo "exclude-rows=$(cat "$GITHUB_WORKSPACE/mode-filter-rows.txt")" >> "$GITHUB_OUTPUT"
-
       # Published previews pin their preview-runtimes to a RELEASED version
       # (`composeaiReleasedRuntimeVersion`, bumped by release-please on each release). Sonatype →
       # Maven Central propagation lags a release, so a regen kicked right after a release (or by the
@@ -321,6 +245,14 @@ jobs:
       # release makes Central" work reliably. Only the CMP tier substitutes released runtimes, so
       # only it needs the gate; a bounded poll fails loudly rather than rendering an unpinned
       # (inlined) bundle.
+      #
+      # AHEAD OF `install-cli`, not just ahead of the render. `:cli:installDist` configures the
+      # whole build, and the wasm sample's `wasmJsCompileClasspath` resolves the SAME pinned
+      # runtimes, so a regen kicked before Central caught up died in the CLI build with
+      # "Could not find ee.schimke.composeai:slot-preview-runtime:<version>" long before this gate
+      # ran (run 34108903408, v2.1.1). The step also exports the resolved versions through
+      # $GITHUB_ENV, so every Gradle invocation after it — the CLI build included — pins to the
+      # lines the readiness marker actually names.
       - name: Wait for released preview-runtimes on Maven Central
         if: ${{ matrix.wasmModule != '' }}
         env:
@@ -401,6 +333,83 @@ jobs:
           done
           echo "::error title=Preview runtimes unavailable::core=$version data=$data_version did not fully appear on Maven Central after 60 minutes. Last response: $last_status" >&2
           exit 1
+
+      - uses: ./.github/actions/install-cli
+
+      # `compose-m3` is now a Compose Multiplatform (desktop) catalog, so its
+      # render goes through the Skiko desktop daemon (CPU raster) instead of
+      # Robolectric. Skiko's native lib links libGL.so.1, so Mesa's software GL
+      # must be present (same deps ci.yml installs for desktop renders; the Wear /
+      # Remote Android rows don't need them, but the packages are harmless there).
+      - name: Install desktop (Skiko) render deps
+        run: |
+          scripts/install-linux-font-fallbacks.sh \
+            xvfb libgl1 libglx-mesa0 libgl1-mesa-dri libfreetype6 libfontconfig1
+
+      # The export engine lives in the (private) design-parity repo, but its
+      # building blocks are published to npm. The driver
+      # (scripts/design-artifacts/) pins @design-parity/candidate +
+      # @design-parity/catalog-export, so we install them from npm rather than
+      # cloning design-parity: the workflow's GITHUB_TOKEN is scoped to this repo
+      # only and can't read the private design-parity repo, and a public-npm
+      # install needs no cross-repo secret.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+      - name: Install export engine (pinned npm packages)
+        working-directory: scripts/design-artifacts
+        run: npm ci --no-audit --no-fund --loglevel=warn
+
+      # Fast, build-free pre-flight: resolve every spec `preview` against the
+      # @Preview functions the module actually declares BEFORE the ~90-minute
+      # render. A mistyped/renamed `preview` fails here in seconds instead of as a
+      # late "missing" entry that trips the completeness gate at the end. Structural
+      # errors (duplicate componentId, malformed variant) fail here too. Uses only
+      # node built-ins (no npm deps). Coverage warnings don't fail the job.
+      - name: Validate catalog spec
+        id: validate-spec
+        run: |
+          set -euo pipefail
+          node scripts/design-artifacts/validate-catalog-spec.mjs --spec "${{ matrix.spec }}" \
+            --render-filter-out "$GITHUB_WORKSPACE/render-filter.txt" \
+            --deferred-modes-out "$GITHUB_WORKSPACE/deferred-modes.txt"
+          # Render priority (issue #2950): the `--preview` patterns that render just the
+          # entries this spec still needs baked. EMPTY unless the spec marks entries
+          # `priority: "deferred"` — no catalog here does today, so the render set is
+          # unchanged. Consumed by the render step below.
+          echo "render-filter=$(cat "$GITHUB_WORKSPACE/render-filter.txt")" >> "$GITHUB_OUTPUT"
+          # Gate for the per-mode exclusion step below (issue #2966): that one needs discovered
+          # preview ids, so it costs an extra Gradle invocation and only runs when a mode is
+          # actually deferred.
+          echo "deferred-modes=$(cat "$GITHUB_WORKSPACE/deferred-modes.txt")" >> "$GITHUB_OUTPUT"
+
+      # Per-mode render exclusions (issue #2966). `modePriority` thins the palette fan-out INSIDE one
+      # `@Preview` function, so it can't be named as function patterns like the entry-level filter
+      # above — it needs the discovered ids (`FilledButton_Dark`). `compose-preview list --json` runs
+      # `composePreviewDiscover` for them; the compile it does is shared with the render below, so the
+      # extra invocation costs discovery rather than a second build. Skipped when nothing is deferred.
+      - name: Derive per-mode render exclusions
+        id: mode-filter
+        if: ${{ steps.validate-spec.outputs.deferred-modes != '' }}
+        run: |
+          set -euo pipefail
+          compose-preview list --json --module "${{ matrix.module }}" \
+            > "$GITHUB_WORKSPACE/discovered-previews.json"
+          node scripts/design-artifacts/deferred-preview-ids.mjs \
+            --spec "${{ matrix.spec }}" \
+            --previews "$GITHUB_WORKSPACE/discovered-previews.json" \
+            --out "$GITHUB_WORKSPACE/mode-filter.txt" \
+            --anchored-out "$GITHUB_WORKSPACE/mode-filter-cli.txt" \
+            --rows-out "$GITHUB_WORKSPACE/mode-filter-rows.txt"
+          # The ANCHORED file. `--exclude-preview-id` matches a plain pattern by equality OR
+          # substring, and ids are hierarchical, so deferring `Switch_Dark` unanchored also defers
+          # `Switch_Dark_VARIANT_off` — never deferred by the spec, and missing from the sheet with
+          # nothing pointing back at this step (#3559).
+          echo "exclude-ids=$(cat "$GITHUB_WORKSPACE/mode-filter-cli.txt")" >> "$GITHUB_OUTPUT"
+          # Modes that carry no discovered id are a @PreviewParameter row axis — skipped by label
+          # inside the render instead, since discovery never sees those rows.
+          echo "exclude-rows=$(cat "$GITHUB_WORKSPACE/mode-filter-rows.txt")" >> "$GITHUB_OUTPUT"
+
 
       - name: Render catalog bundle
         env:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -72,7 +72,24 @@ jobs:
           # publish list that previously drifted out of sync (PR #724 added
           # `:data-a11y-hierarchy-android` here but missed adding it to this list, leaving
           # consumers' `renderer-android` POM resolution broken at snapshot time).
-          ./gradlew :gradle-plugin:publishToMavenCentral publishToMavenCentral
+          #
+          # RETRIED ONCE, and with a longer socket timeout than Gradle's 30s default. The upload is
+          # hundreds of POMs and jars over one connection to Sonatype, and a single "Read timed out"
+          # partway through fails the whole task and reds main for a reason that has nothing to do
+          # with the tree (runs 34106995040 and 34109570587). Re-publishing a -SNAPSHOT coordinate
+          # is idempotent — snapshots are overwritable by definition — so a retry costs time and
+          # nothing else. Two attempts, then the failure is real.
+          set -euo pipefail
+          publish() {
+            ./gradlew :gradle-plugin:publishToMavenCentral publishToMavenCentral \
+              -Dorg.gradle.internal.http.socketTimeout=120000 \
+              -Dorg.gradle.internal.http.connectionTimeout=60000
+          }
+          publish || {
+            echo "::warning title=Snapshot publish retry::The first publish attempt failed; retrying once before failing the job."
+            sleep 30
+            publish
+          }
           # Note: `--no-configuration-cache` is incompatible with
           # `org.gradle.unsafe.isolated-projects=true` set in gradle.properties
           # (Gradle fails with "Configuration Cache cannot be disabled when


### PR DESCRIPTION
## Summary

Two red mains today, both release/network timing rather than anything wrong with the tree.

**`Design Artifacts` — the Central gate ran too late.** The `compose-m3` job failed in `install-cli` with:

```
Could not determine the dependencies of task ':samples:design-catalog-m3-shared:compileKotlinWasmJs'.
> Could not find ee.schimke.composeai:slot-preview-runtime:2.1.1.
```

([run 34108903408](https://github.com/yschimke/compose-ai-tools/actions/runs/34108903408), kicked ~20 min after v2.1.1 was cut). The workflow already has a step whose whole job is to prevent this — "Wait for released preview-runtimes on Maven Central" — but it sat at step 11, five steps *after* `install-cli`. `:cli:installDist` configures the whole build, and the wasm sample's `wasmJsCompileClasspath` resolves the same pinned coordinates, so the build died before the gate ever ran.

This moves the gate ahead of `install-cli`. It has no dependency on anything the CLI build produces (it reads `gradle.properties` and the release's readiness marker), and it exports the resolved lines through `$GITHUB_ENV` — so the CLI build now pins to the versions the marker actually names, rather than to `composeaiReleasedRuntimeVersion` on its own.

**`Publish snapshot` — a single read timeout kills the whole upload.** Two failures today ([34106995040](https://github.com/yschimke/compose-ai-tools/actions/runs/34106995040), [34109570587](https://github.com/yschimke/compose-ai-tools/actions/runs/34109570587)), both `> Read timed out` against Sonatype partway through publishing hundreds of POMs and jars. Raised the socket timeout past Gradle's 30s default and added one retry; republishing a `-SNAPSHOT` coordinate is idempotent by definition, so the retry costs time and nothing else.

## Test plan

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/design-artifacts.yml'))"` — parses.
- The moved block is byte-identical to what was there; only its position in the step list changed (now between `buildfetch-cache` and `install-cli`). Nothing between the old and new positions writes state it reads.
- The retry wrapper is a shell function around the existing `./gradlew` line plus two `-D` timeout properties — no task-list change.
- Both paths are exercised by the next release-triggered `Design Artifacts` run and the next push to `main`.

## Note

`slot-preview-runtime` 2.1.1 and 2.2.0 are still 404 on Central as of this writing, so the very next post-release regen is the real test of the reordering — it should now sit in the poll instead of failing in the CLI build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013G32hRkKneW52wLdtRv9uU

---
_Generated by [Claude Code](https://claude.ai/code/session_013G32hRkKneW52wLdtRv9uU)_