### PR TITLE
ci: retry external-consumer Gradle runs on a transient repository 403

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1043,7 +1043,19 @@ jobs:
           # Unqualified task name runs composePreviewDiscover in every subproject
           # the init script applied the plugin to (i.e. every Android /
           # Compose-multiplatform module).
-          ./gradlew --init-script "$COMPOSE_AI_INIT_SCRIPT" composePreviewDiscover \
+          #
+          # Wrapped in retry-gradle-repository.sh: these cells clone a consumer
+          # whose Gradle home starts cold ("Entry not restored: no match found"),
+          # so the very first task resolves the consumer's whole buildscript graph
+          # from repo.maven.apache.org / plugins.gradle.org in one burst. A shared
+          # runner IP that is already near Central's threshold gets 403 Forbidden
+          # for artifacts that plainly exist — the cadence cell died that way in
+          # run 34122295656 on ~67 coordinates including jsr305 3.0.2, while every
+          # other cell in the same run was green. The wrapper retries ONLY on
+          # "Could not GET '<url>'" + a 403/429/5xx status, so a real build break
+          # still fails on the first attempt.
+          "$GITHUB_WORKSPACE/.github/scripts/retry-gradle-repository.sh" \
+            ./gradlew --init-script "$COMPOSE_AI_INIT_SCRIPT" composePreviewDiscover \
             ${{ matrix.extra_gradle_args }} \
             --stacktrace
 
@@ -1058,7 +1070,8 @@ jobs:
           # Tooling API and drives composePreviewDiscover under the hood, so this
           # exercises the CLI binary's end-to-end pipeline (not just the
           # Gradle path used by the other matrix entries).
-          compose-preview list --module "${{ matrix.module }}"
+          "$GITHUB_WORKSPACE/.github/scripts/retry-gradle-repository.sh" \
+            compose-preview list --module "${{ matrix.module }}"
 
       - name: Verify previews.json was produced
         # Skip the assertion on cells whose discovery was skipped above, else it
@@ -1095,7 +1108,8 @@ jobs:
           # invocation. This is the step that exercises renderer-android AAR
           # resolution from mavenLocal — the artifact path external consumers
           # hit at runtime.
-          ./gradlew --init-script "$COMPOSE_AI_INIT_SCRIPT" composePreviewRender \
+          "$GITHUB_WORKSPACE/.github/scripts/retry-gradle-repository.sh" \
+            ./gradlew --init-script "$COMPOSE_AI_INIT_SCRIPT" composePreviewRender \
             ${{ matrix.extra_gradle_args }} \
             --stacktrace
 
@@ -1109,7 +1123,8 @@ jobs:
           # `compose-preview render` drives composePreviewRender end-to-end via
           # the Tooling API, including renderer-android AAR resolution from
           # the mavenLocal snapshot we seeded earlier.
-          compose-preview render --module "${{ matrix.module }}"
+          "$GITHUB_WORKSPACE/.github/scripts/retry-gradle-repository.sh" \
+            compose-preview render --module "${{ matrix.module }}"
 
       - name: Verify PNGs were produced
         if: ${{ matrix.render && env.CELL_ACTIVE == '1' }}
@@ -1150,7 +1165,8 @@ jobs:
           # runtime on the :renderer-xr render configuration and writes
           # renders/<preview>/scene.json plus a <testTag>.png texture per
           # SpatialPanel.
-          ./gradlew --init-script "$COMPOSE_AI_INIT_SCRIPT" composePreviewRenderXr \
+          "$GITHUB_WORKSPACE/.github/scripts/retry-gradle-repository.sh" \
+            ./gradlew --init-script "$COMPOSE_AI_INIT_SCRIPT" composePreviewRenderXr \
             ${{ matrix.extra_gradle_args }} \
             --stacktrace
 
@@ -1364,7 +1380,8 @@ jobs:
         run: |
           # Writes <module>/build/compose-previews/daemon-launch.json (the JSON the
           # VS Code extension reads to spawn the daemon JVM directly).
-          ./gradlew --init-script "$COMPOSE_AI_INIT_SCRIPT" composePreviewDaemonStart \
+          "$GITHUB_WORKSPACE/.github/scripts/retry-gradle-repository.sh" \
+            ./gradlew --init-script "$COMPOSE_AI_INIT_SCRIPT" composePreviewDaemonStart \
             ${{ matrix.extra_gradle_args }} \
             --stacktrace
 
@@ -1763,7 +1780,8 @@ jobs:
           # resolution from the mavenLocal snapshot seeded earlier. This is
           # the "oldest AGP × Kotlin together" floor-coverage cell (Gradle
           # 8.13 + AGP 8.13.0 + Kotlin 2.0.21 + JDK 17 + compose-bom 2026.05.00).
-          ./gradlew --init-script "$COMPOSE_AI_INIT_SCRIPT" composePreviewRender \
+          "$GITHUB_WORKSPACE/.github/scripts/retry-gradle-repository.sh" \
+            ./gradlew --init-script "$COMPOSE_AI_INIT_SCRIPT" composePreviewRender \
             --no-configuration-cache --stacktrace
 
       - name: Verify previews.json was produced


### PR DESCRIPTION
Closes #5272.

## What broke

The nightly `Integration` run [34122295656](https://github.com/yschimke/compose-ai-tools/actions/runs/34122295656) failed only in the **cadence (:composeApp)** cell, on `composePreviewDiscover`, after 34s. The log is ~67 `ModuleVersionResolveException`s and every single one bottoms out in the same thing:

```
Caused by: HttpErrorStatusCodeException: Could not GET
  'https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.pom'.
  Received status code 403 from server: Forbidden
```

All of it while resolving `buildscript of root project 'Cadence' > com.android.application.gradle.plugin:9.3.2 > com.android.tools.build:gradle:9.3.2 > …` — jsr305 3.0.2, gson 2.11.0, kotlin-stdlib 2.4.0, asm 9.10.1 / asm-util 9.9 / asm-commons 9.9, jdom2 2.0.6.

## Why it is not upstream drift

The issue template's default explanation (the consumer bumped AGP/Kotlin/the BOM) does not hold here:

- **Every one of those coordinates exists and serves today.** `jsr305-3.0.2.pom`, `asm-9.10.1.pom`, `kotlin-stdlib-2.4.0.pom`, `asm-util-9.9.pom` all return `200` from `repo.maven.apache.org`. A missing artifact would be a 404 anyway, not a 403.
- **Nothing else in the run was red.** agp8-min, nowinandroid, adaptive-apps-samples, both wear-os-samples cells, meshcore-mobile, androidify and homeassistant-remotecompose were all green at the same minute, on the same runner fleet.
- **Nothing in this repository or in `yschimke/cadence` changed to cause it** — the failure is in the consumer's own buildscript classpath, upstream of any plugin code.

What *is* specific to these cells: the Gradle home starts cold — the job reported `Entry not restored: no match found` — so the first task resolves the consumer's entire dependency graph from Central in one burst. A shared GitHub runner IP already near Central's threshold gets 403 Forbidden back, for artifacts that plainly exist. That is a transient throttle, not a regression.

## The fix

`.github/scripts/retry-gradle-repository.sh` already exists for precisely this failure shape, with a comment that names Central 403/429 on shared runner IPs. It was only wired into `daemon-harness.yml` and never reached the external-consumer matrix. This PR wraps the steps in `integration.yml` that resolve a consumer's dependencies:

- `Discover previews via Gradle` (the step that failed)
- `Render previews via Gradle`, `Render XR subspace previews`, `Emit daemon launch descriptor`
- the two `compose-preview list` / `compose-preview render` CLI equivalents
- `Phase 3 — composePreviewRender must PASS at renderer floor` (agp8-min)

**Deliberately not wrapped:** `Phase 1 — composePreviewRender must FAIL on the too-old BOM`. That step asserts a *non-zero* exit, so a retry wrapper there would be reasoning about the wrong exit code.

The wrapper retries only when the output carries both `Could not GET '<url>'` and `Received status code 403|429|5xx`; anything else exits on the first attempt, so this is not a blanket flaky-build retry. Defaults are 3 attempts with 15s/30s backoff.

## Test plan

- `yaml.safe_load` on the edited workflow — parses.
- Drove `retry-gradle-repository.sh` against a stub that emits the cadence log's exact two lines and then succeeds: it retried and exited 0, forwarding `--init-script x composePreviewDiscover --stacktrace` unchanged.
- Drove it against a stub emitting `e: Unresolved reference: Foo` — exited 1 immediately, no retry.
- Probed the five failing coordinates against `repo.maven.apache.org`: all `200`, confirming the 403 was throttling rather than a missing or moved artifact.

Non-visual change (CI workflow only), so no render evidence applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQH3rgtLuUXpFQC5U94f4x

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQH3rgtLuUXpFQC5U94f4x)_