### PR TITLE
fix: give the core train its own line version, not the release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,6 +287,21 @@ jobs:
         # Strip leading `v` from TAG_NAME, e.g. v0.1.0 → 0.1.0. $PLUGIN_VERSION
         # is inherited by every subsequent step in this job.
         run: echo "PLUGIN_VERSION=${TAG_NAME#v}" >> "$GITHUB_ENV"
+      - name: Derive the core line's version
+        # CORE_LINE_VERSION is what every core module publishes at, and — crucially — what DATA
+        # POMs name for those coordinates even when the core line is NOT publishing. The mirror of
+        # the step below, and it was missing: core took the raw tag whatever the guard said, so a
+        # data-only release stamped a never-uploaded version onto every core module and the data
+        # POMs pinned it. v2.2.1 shipped `data-remotecompose-connector:2.2.1` requiring
+        # `daemon-core:2.2.1` with core held at 2.2.0, which resolves for nobody
+        # (yschimke/wear-m3-catalog#350).
+        env:
+          GUARD_CORE_LINE: ${{ needs.maven-publish-guard.outputs.maven_line }}
+        run: |
+          set -uo pipefail
+          # Empty means the guard never answered, and everything publishes at this release's
+          # version — the same direction the `if:` above takes on an empty verdict.
+          echo "CORE_LINE_VERSION=${GUARD_CORE_LINE:-${TAG_NAME#v}}" >> "$GITHUB_ENV"
       - name: Derive the data line's version
         # DATA_LINE_VERSION is what every `data/*` module publishes at, and — crucially — what
         # CORE POMs name for those coordinates even when the data line is NOT publishing. Set it

--- a/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiMavenPublishingPlugin.kt
+++ b/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiMavenPublishingPlugin.kt
@@ -144,26 +144,34 @@ internal fun Project.mavenTrain(): String =
 /**
  * The version this module publishes at.
  *
- * `core` takes `PLUGIN_VERSION` — the release tag — as it always has. `data` takes
- * `DATA_LINE_VERSION` when the release sets it, which is the last version at which the data train
- * actually changed. On a release where `data/` changed, the two are equal and this is a no-op; on
- * one where it did not, the data modules keep the version they already have on Central and are not
- * republished at all.
+ * Each train takes **its own line's** version — `CORE_LINE_VERSION` / `DATA_LINE_VERSION` — which
+ * is the release tag when that train publishes and the last version it actually reached Central at
+ * when it does not. On a release where both trains change the three values are equal and this is a
+ * no-op; on a split release they are not, and a module must carry the version its own line
+ * publishes at rather than the tag's.
  *
- * Cross-train POMs come out right for free: a `core` module depending on `project(":data:…")` gets
- * that project's `version`, so `renderer-desktop:2.9.0` names `data-focus-core:2.7.0` in its POM
- * and Gradle resolves the artifact that genuinely exists.
+ * Cross-train POMs then come out right in **both** directions, because a module depending on
+ * `project(":…")` across the trains gets that project's `version`: `renderer-desktop:2.9.0` names
+ * `data-focus-core:2.7.0`, and `data-remotecompose-connector:2.9.0` names `daemon-core:2.7.0`.
  *
- * **`DATA_LINE_VERSION` is ignored unless `PLUGIN_VERSION` is set.** Outside a release both are
- * absent and everything falls to the snapshot version; a stray `DATA_LINE_VERSION` in a developer
- * shell must not silently version half the build differently from the other half.
+ * Only the first direction used to hold. `core` took `PLUGIN_VERSION` — the raw tag — whether or
+ * not the core train published, so on a data-only release every core module carried a version that
+ * was never uploaded, and the data POMs naming those coordinates pinned it. That shipped in v2.2.1:
+ * `data-remotecompose-connector:2.2.1` requires `daemon-core:2.2.1`, core having stayed at 2.2.0,
+ * so the data line resolved for nobody and consumers bumping to it went red at dependency
+ * resolution (yschimke/wear-m3-catalog#350). A skipped train has to stop stamping its tag onto the
+ * one that shipped.
+ *
+ * **Both line versions are ignored unless `PLUGIN_VERSION` is set.** Outside a release all three
+ * are absent and everything falls to the snapshot version; a stray `CORE_LINE_VERSION` in a
+ * developer shell must not silently version half the build differently from the other half.
  */
 private fun Project.publishedVersion(): String {
   val pluginVersion =
     providers.environmentVariable("PLUGIN_VERSION").orNull?.takeIf { it.isNotBlank() }
       ?: return nextPatchSnapshotVersion()
-  if (mavenTrain() != "data") return pluginVersion
-  return providers.environmentVariable("DATA_LINE_VERSION").orNull?.takeIf { it.isNotBlank() }
+  val lineVariable = if (mavenTrain() == "data") "DATA_LINE_VERSION" else "CORE_LINE_VERSION"
+  return providers.environmentVariable(lineVariable).orNull?.takeIf { it.isNotBlank() }
     ?: pluginVersion
 }
 

--- a/docs/design/RELEASE_TRAINS.md
+++ b/docs/design/RELEASE_TRAINS.md
@@ -371,12 +371,14 @@ module, exactly one always changed as a unit.
      line. `all` remains the default, so the guard's current behaviour is untouched. Shared build
      inputs are deliberately **not** split by the train filter: `build-logic/` or the wrapper can
      move the bytes of every module on either line, so they publish both.
-   - `ComposeAiMavenPublishingPlugin` gives a module under `data/` the `DATA_LINE_VERSION` the
-     release sets, and everything else `PLUGIN_VERSION` as before. `mavenTrain()` derives the
-     train from the module's directory — one definition, shared with the task list below, so the
-     two can never disagree about a module. `DATA_LINE_VERSION` is ignored unless `PLUGIN_VERSION`
-     is also set, so a stray value in a developer shell cannot version half a build differently
-     from the other half.
+   - `ComposeAiMavenPublishingPlugin` gives every module **its own line's** version — a module
+     under `data/` the `DATA_LINE_VERSION` the release sets, everything else the
+     `CORE_LINE_VERSION` — falling back to `PLUGIN_VERSION` when the release names neither (a
+     snapshot publishes both trains at one version). `mavenTrain()` derives the train from the
+     module's directory — one definition, shared with the task list below, so the two can never
+     disagree about a module. Both line versions are ignored unless `PLUGIN_VERSION` is also set,
+     so a stray value in a developer shell cannot version half a build differently from the other
+     half.
    - `./gradlew printPublishTasks -Ptrain=<train>` prints the publish task path for each module on
      a train. Needed because the skipped train's tasks must be absent from the invocation entirely
      — its modules are already on Central at the version they carry, and Central refuses a version
@@ -388,11 +390,22 @@ module, exactly one always changed as a unit.
      that silently omits them is a release publishing everything except the plugin consumers
      apply.
 
-   **Cross-train POMs need no machinery at all.** A core module depending on `project(":data:…")`
-   picks up that project's `version`, so with `PLUGIN_VERSION=2.9.0 DATA_LINE_VERSION=2.7.0` the
-   generated `render-host` POM reads `2.9.0` for itself and `2.7.0` for `data-remotecompose-core`.
-   That is the whole of the "no train publishes a POM naming a sibling version that does not
-   exist" requirement, discharged by Gradle.
+   **Cross-train POMs need no machinery at all** — *provided every train reads its own line's
+   version.* A module depending on `project(":…")` across the trains picks up that project's
+   `version`, so with `CORE_LINE_VERSION=2.9.0 DATA_LINE_VERSION=2.7.0` the generated `render-host`
+   POM reads `2.9.0` for itself and `2.7.0` for `data-remotecompose-core`. That is the whole of the
+   "no train publishes a POM naming a sibling version that does not exist" requirement, discharged
+   by Gradle.
+
+   The proviso is load-bearing and was missed the first time. Core took `PLUGIN_VERSION` — the raw
+   tag — rather than its own line's version, which is identical whenever core publishes and wrong
+   whenever it does not: on a data-only release every core module carried a version that was never
+   uploaded, and the data POMs naming those coordinates pinned it. v2.2.1 shipped
+   `data-remotecompose-connector:2.2.1` requiring `daemon-core:2.2.1` with core held at 2.2.0, so
+   the data line resolved for nobody and a consumer bumping to it went red at dependency resolution
+   ([wear-m3-catalog#350](https://github.com/yschimke/wear-m3-catalog/pull/350)). The symmetry is
+   the invariant: **a skipped train must not stamp its tag onto the one that shipped**, in either
+   direction.
 
    Inert today: nothing sets `DATA_LINE_VERSION`, nothing consumes `printPublishTasks`, and the
    guard is still asked `--train all`.
@@ -408,10 +421,13 @@ module, exactly one always changed as a unit.
    - **both lines publishing is byte-for-byte the command it has always run.** The generated task
      list is used only on a split release. Keeping the common path unchanged means the split
      cannot regress an ordinary release.
-   - `DATA_LINE_VERSION` is exported **unconditionally**, not only when data is skipped. It is
-     what core POMs name for `data-*` coordinates, so on a release where data does not publish it
-     is the only thing keeping `renderer-desktop`'s POM pointed at a version that exists. When
-     data does publish it equals `PLUGIN_VERSION` and setting it is a no-op.
+   - both `CORE_LINE_VERSION` and `DATA_LINE_VERSION` are exported **unconditionally**, not only
+     when their train is skipped. Each is what the *other* train's POMs name for that line's
+     coordinates, so on a release where one line does not publish it is the only thing keeping the
+     other's POMs pointed at a version that exists — `renderer-desktop` naming `data-*` one way,
+     `data-remotecompose-connector` naming `daemon-core` the other. When a line does publish, its
+     value equals `PLUGIN_VERSION` and setting it is a no-op. Exporting only the data half is what
+     let v2.2.1 publish a data line pinning a `daemon-core` that was never uploaded.
    - an empty task list is a hard failure. `./gradlew` with no tasks runs `help` and exits 0 —
      the v1.56.0 failure mode, a green job that published nothing — and the guard having said
      this line changed means an empty list is a broken enumeration, not an empty train.


### PR DESCRIPTION
## The defect

The two-train split gave `data/` a `DATA_LINE_VERSION` but left core on `PLUGIN_VERSION` — the raw tag — whether or not the core train published:

```kotlin
if (mavenTrain() != "data") return pluginVersion        // core: always the tag
return env("DATA_LINE_VERSION") ?: pluginVersion        // data: its own line
```

That is identical whenever core publishes and wrong whenever it does not. On a data-only release every core module still carries the tag, a version that was never uploaded — and because a module depending on `project(":…")` picks up that project's `version`, any **data** POM naming a core coordinate pins the phantom.

v2.2.1 shipped exactly that. The guard held core at 2.2.0 and moved data to 2.2.1, so:

```
Could not find ee.schimke.composeai:daemon-core:2.2.1.
  Required by: ... > ee.schimke.composeai:data-remotecompose-connector:2.2.1
```

The data line resolves for nobody. A consumer bumping to it goes red at dependency resolution rather than at anything that names the real problem — [wear-m3-catalog#350](https://github.com/yschimke/wear-m3-catalog/pull/350) is the repair on that side, and it had to exclude 2.2.1 by name in Renovate to stop it being re-proposed.

Nothing failed upstream when this shipped: every job in the release run succeeded, `verify-maven-readiness` included, because it resolves the plugin version *the CLI asks Gradle for* — 2.2.0 — and never exercises a data POM's core pins.

## The fix

Export `CORE_LINE_VERSION` from the guard's existing `maven_line` verdict — the mirror of the `DATA_LINE_VERSION` step already sitting beside it — and have the publishing plugin read whichever line a module is on:

```kotlin
val lineVariable = if (mavenTrain() == "data") "DATA_LINE_VERSION" else "CORE_LINE_VERSION"
return env(lineVariable) ?: pluginVersion
```

The `PLUGIN_VERSION` fallback is what keeps `snapshot.yml` correct: it sets only `PLUGIN_VERSION`, and a snapshot publishes both trains at one version.

No new guard output, no new plumbing — `core_line` was already computed and already surfaced as `maven_line` for the CLI's `MAVEN_LINE_VERSION` bake. It simply was never applied to the modules themselves.

The invariant is the symmetry, and `RELEASE_TRAINS.md` is corrected to say so: it claimed cross-train POMs come out right "for free", which held only core → data. **A skipped train must not stamp its tag onto the one that shipped, in either direction.**

## Test plan

**Reproduced the defect, then showed it fixed**, by reading the versions modules actually resolve to. The old behaviour is the new one with `CORE_LINE_VERSION` unset, so one binary demonstrates both:

```
$ PLUGIN_VERSION=2.2.1 DATA_LINE_VERSION=2.2.1 ./gradlew <module>:properties
  :daemon:core                       2.2.1     ← never published; what v2.2.1 pinned
  :data-remotecompose-connector      2.2.1
  :data-layoutinspector-connector    2.2.1

$ PLUGIN_VERSION=2.2.1 CORE_LINE_VERSION=2.2.0 DATA_LINE_VERSION=2.2.1 ./gradlew <module>:properties
  :daemon:core                       2.2.0     ← exists; what the data POMs will pin
  :data-remotecompose-connector      2.2.1
  :data-layoutinspector-connector    2.2.1
```

Also:

- `./gradlew ktfmtCheckAll help` — **BUILD SUCCESSFUL**, so `build-logic` compiles and the format gate is clean.
- `release.yml` re-parsed as valid YAML.

Non-visual: no rendered surface changes.

## Follow-up not in this PR

v2.2.1 is already published and cannot be repaired in place — Central refuses a version twice. The next release cuts a coherent pair, and `wear-m3-catalog` can drop its `!=2.2.1` Renovate exclusion then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHXPXkZtZ2w6KpLtjjDvd5

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHXPXkZtZ2w6KpLtjjDvd5)_