### PR TITLE
fix: name a family-less text run the family the render recorded

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/FontResolverRecorder.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/FontResolverRecorder.kt
@@ -49,6 +49,16 @@ class FontResolverRecorder(private val context: Context? = null) {
     // exporter uses, so the rendered-font audit compares `Roboto` with `Roboto` rather than a cache
     // filename with `Roboto` and falsely switches the whole document to tofu (issue #4935).
     val fileFamily = matched?.let(::recoverFileFontFamily)
+    // Publish the file under that family as well. The export reaches a face through
+    // [FigmaResourceFonts] by NAME, and a text run that states no family is looked up under the
+    // family this recorder published — so without this the export knows which face was drawn but
+    // not where its bytes are, and re-fetches a woff2 by name instead of embedding the ones the
+    // render used. Same contract as [recoverDownloadableFont] below, for the file-backed shape.
+    if (fileFamily != null && matched != null) {
+      fileFor(matched)?.let {
+        FigmaResourceFonts.register(fileFamily, weight, style == "italic", it.absolutePath)
+      }
+    }
     val displayName = matched?.let { displayFamilyName(fontLabel(it)) }
     // A downloadable `Font(GoogleFont("Lato"), …)` resolved to a real TTF in the renderer's font
     // cache for the PNG. Publish that file so the figma-svg export embeds the same bytes rather

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeFigmaSvgDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeFigmaSvgDataProduct.kt
@@ -158,7 +158,22 @@ object ComposeFigmaSvgDataProducer {
         deviceBackground = background,
         backgroundMode = mode,
       )
-    val fonts = fontResolver?.let { resolveFonts(model, it, fileSystem) }
+    // The face the render actually drew for text that states no family of its own. The export used
+    // to hardcode [DEFAULT_EMBED_FAMILY] here and then compare that guess against what the render
+    // recorded — manufacturing its own mismatch and boxing the whole document whenever the two
+    // differed. When the render drew exactly ONE family, that is by construction what the
+    // family-less runs drew, so it is the answer rather than something to guess at.
+    //
+    // A singleton is the whole of the claim. Two or more recorded families means some run drew one
+    // and some another, and nothing here can say which is which — the guard is then right to fire.
+    // The recorded name is already the clean CSS family (`Roboto Flex`): it is read out of the
+    // face's own bytes by `FigmaResourceFonts.familyName`, never from the document, so a player's
+    // resolution namespace (`google:` / `device:`) cannot leak into a `font-family`.
+    val recordedFamily = FigmaSvgRenderedFonts.singleRenderedFamily()
+    val defaultFamily = recordedFamily ?: DEFAULT_EMBED_FAMILY
+    val fonts = fontResolver?.let {
+      resolveFonts(model, it, fileSystem, recordedFamily, defaultFamily)
+    }
     // Everything this export can put a real name to: the faces it embedded, the captured→emitted
     // family map, and the families named straight on a `<text>` when nothing was embedded.
     val named = buildSet {
@@ -198,7 +213,7 @@ object ComposeFigmaSvgDataProducer {
         else ->
           FigmaLayeredSvg.render(
             model,
-            FigmaLayeredSvg.Options(defaultFontFamily = DEFAULT_EMBED_FAMILY),
+            FigmaLayeredSvg.Options(defaultFontFamily = defaultFamily),
             fonts.faces,
             fonts.familyOverrides,
           )
@@ -309,11 +324,17 @@ object ComposeFigmaSvgDataProducer {
     model: FigmaSvgModel,
     resolver: FigmaFontResolver,
     fileSystem: FileSystem,
+    recordedFamily: String?,
+    defaultFamily: String,
   ): FontPlan {
     val faces = LinkedHashMap<String, FigmaSvgFontFace>()
     val overrides = HashMap<String, String>()
     fun add(captured: String?, weight: Int, italic: Boolean, codePoints: Set<Int>) {
-      val fontPath = captured?.let { fontFilePath(it, weight, italic, fileSystem) }
+      // A family-less run looks the face up under [recordedFamily] — the render published its file
+      // there — so it embeds the exact bytes that were drawn rather than re-fetching a woff2 by
+      // name, which is the same reason the captured-family path consults the registry (#2906).
+      val lookupFamily = captured ?: recordedFamily
+      val fontPath = lookupFamily?.let { fontFilePath(it, weight, italic, fileSystem) }
       if (fontPath != null) {
         // Subset to a stable base charset (printable ASCII) plus whatever this face actually draws,
         // so every Latin sticker asks for the *same* subset — computed once, cached process-wide,
@@ -358,12 +379,14 @@ object ComposeFigmaSvgDataProducer {
                 .also { fontFaceCache[cacheKey] = it }
             }
         faces["${face.family}|$weight|$italic|${face.format}"] = face
-        overrides[captured] = face.family
+        if (captured != null) overrides[captured] = face.family
         return
       }
       // A meaningful generic (serif/monospace) maps to a concrete embeddable family; a bare
       // cursive/fantasy has none, so skip embedding and let the text fall back to the generic.
-      val name = FigmaLayeredSvg.embedFamily(captured, DEFAULT_EMBED_FAMILY) ?: return
+      val name =
+        if (captured == null) defaultFamily
+        else FigmaLayeredSvg.embedFamily(captured, DEFAULT_EMBED_FAMILY) ?: return
       val bytes = resolver.woff2(name, weight, italic)
       if (bytes == null) {
         // Fail loud: embedding was asked for (a resolver is present) but this concrete face didn't

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/FigmaSvgRenderedFonts.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/FigmaSvgRenderedFonts.kt
@@ -59,6 +59,21 @@ object FigmaSvgRenderedFonts {
   fun snapshot(): Set<String> = synchronized(families) { families.toSet() }
 
   /**
+   * The one family this preview drew with, or null when it drew none or several.
+   *
+   * What the `compose/figma-svg` export names a text run that states no family of its own. Exactly
+   * one recorded family means every run drew that face, so it is a fact rather than a guess — and
+   * guessing is what boxed whole documents: the export hardcoded its own default, compared that
+   * against this record, found them different and concluded a face had been lost.
+   *
+   * Null on two or more, deliberately. Several families means some run drew one and some another,
+   * the export cannot tell which from a family-less node, and the audit firing is then correct. It
+   * is also null on none, which is the stock-Material case the recorder stays quiet about.
+   */
+  fun singleRenderedFamily(): String? =
+    snapshot().singleOrNull()?.trim()?.takeIf { it.isNotEmpty() }
+
+  /**
    * The families the render drew with that [named] does not account for — the faces the export is
    * about to misrepresent. Compared case-insensitively because a family reaches the two sides by
    * different routes (a declared `GoogleFont` name vs a name read out of font bytes).

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/FigmaSvgTofuFallbackTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/FigmaSvgTofuFallbackTest.kt
@@ -229,4 +229,75 @@ class FigmaSvgTofuFallbackTest {
         .contains(TofuFont.FAMILY),
     )
   }
+
+  @Test
+  fun `a family-less run is named the one family the render recorded`() {
+    // The `remote-m3` shape: the document declares `google:Roboto Flex`, the embedded player
+    // resolves it to a file, the capture cannot name that file's face — and the export used to
+    // fill the gap with its own hardcoded default, then box the document for disagreeing with the
+    // record it had in hand all along.
+    FigmaSvgRenderedFonts.record("Roboto Flex")
+    val resolver = FigmaFontResolver { family, weight, italic ->
+      if (family == "Roboto Flex" && weight == 500 && !italic) byteArrayOf(1, 2, 3) else null
+    }
+
+    ComposeFigmaSvgDataProducer.writeSvg(
+      rootDir = dir,
+      previewId = "recorded-default",
+      layout = layout(),
+      semantics = payload(),
+      fontResolver = resolver,
+    )
+
+    val svg =
+      dir.resolve("recorded-default").resolve(ComposeFigmaSvgDataProducer.FILE_SVG).readText()
+    assertTrue("the recorded face must be named, got:\n$svg", svg.contains("Roboto Flex"))
+    assertFalse("nothing was lost, so no boxes", svg.contains(TofuFont.FAMILY))
+    assertFalse(
+      "the hardcoded default must not stand in for a face the render named",
+      svg.contains("font-family=\"${ComposeFigmaSvgDataProducer.DEFAULT_EMBED_FAMILY},"),
+    )
+    assertFalse("nothing was lost, so no warning", warnings("recorded-default").exists())
+  }
+
+  @Test
+  fun `two recorded families leave a family-less run to the guard`() {
+    // Ambiguous by construction: some run drew Karla and some drew Orbitron, and a node carrying
+    // no family cannot say which. Guessing either would be the original defect with a new default,
+    // so the export must keep boxing rather than pick.
+    FigmaSvgRenderedFonts.record("Karla")
+    FigmaSvgRenderedFonts.record("Orbitron")
+    val resolver = FigmaFontResolver { _, _, _ -> byteArrayOf(1, 2, 3) }
+
+    ComposeFigmaSvgDataProducer.writeSvg(
+      rootDir = dir,
+      previewId = "ambiguous",
+      layout = layout(),
+      semantics = payload(),
+      fontResolver = resolver,
+    )
+
+    val svg = dir.resolve("ambiguous").resolve(ComposeFigmaSvgDataProducer.FILE_SVG).readText()
+    assertTrue("an unresolvable family-less run must still box", svg.contains(TofuFont.FAMILY))
+    assertTrue("and must still say what it lost", warnings("ambiguous").exists())
+  }
+
+  @Test
+  fun `a recorded face the resolver cannot supply still boxes`() {
+    // Naming a face the SVG carries no `@font-face` for is the wrong-and-plausible failure the
+    // guard exists to prevent, so the default only applies when the face can actually be embedded.
+    FigmaSvgRenderedFonts.record("Orbitron")
+    val resolver = FigmaFontResolver { _, _, _ -> null }
+
+    ComposeFigmaSvgDataProducer.writeSvg(
+      rootDir = dir,
+      previewId = "unembeddable",
+      layout = layout(),
+      semantics = payload(),
+      fontResolver = resolver,
+    )
+
+    val svg = dir.resolve("unembeddable").resolve(ComposeFigmaSvgDataProducer.FILE_SVG).readText()
+    assertTrue("a face that cannot be embedded must still box", svg.contains(TofuFont.FAMILY))
+  }
 }


### PR DESCRIPTION
Closes part of #5279.

## The export manufactured its own mismatch

For a text run that states no family, `resolveFonts` filled the gap with a hardcoded constant:

```kotlin
val name = FigmaLayeredSvg.embedFamily(captured, DEFAULT_EMBED_FAMILY) ?: return   // "Roboto"
```

…and then, a few lines earlier in the same function, compared that guess against what the render had recorded:

```kotlin
val unnamed = FigmaSvgRenderedFonts.unnamedIn(named)   // ["Roboto Flex"]
```

`Roboto Flex` vs `Roboto`, disagreement, boxes. The answer was in hand three lines before the guess was made.

## What this does

When the render drew exactly **one** family, that is by construction what the family-less runs drew. Use it — for the `<text>`, for the `@font-face`, and as the key the bytes are looked up under.

The two ways it deliberately declines to help are as important as the case it fixes, and both have tests:

- **Two or more recorded families** → `singleRenderedFamily()` returns null and nothing changes. Some run drew one and some another; a family-less node cannot say which, and picking either would be the original defect wearing a new default. The guard is right to fire.
- **A face the resolver cannot supply** → still boxes. Naming a family the SVG carries no `@font-face` for is exactly the wrong-and-plausible failure the boxes exist to prevent, so the default only applies when the face can actually be embedded.

The recorder half publishes the resolved file under that family, so the export embeds the bytes the render drew rather than re-fetching a woff2 by name — the contract `recoverDownloadableFont` already has for downloadable faces, extended to the file-backed shape.

## Why the recorder's name and not the document's

The `.rc` is captured and published alongside the SVG, and it names the family outright — so reading it is the obvious alternative. Two reasons this doesn't:

1. **The namespace.** The document says `google:Roboto Flex`. `google:` is a *player resolution* namespace (`device:` is its sibling), not a CSS family. Emitting it would produce a `font-family` meaningless to CSS and Figma, and would send the `?mode=web` rewrite after a Google Fonts family that does not exist — the shape #3024 fixed for `Montserrat+Medium`. What the recorder holds is read out of the face's own bytes by `FigmaResourceFonts.familyName`, so it is already the clean `Roboto Flex` and no namespace can leak. Measured: `RobotoFlex.ttf` has no nameID 16 and nameID 1 `Roboto Flex`.
2. **No new seam.** The capture walks Compose text nodes, not the document, so routing the document's name to it means a new contract between `rc-embedded-player` and this repo. This change is entirely inside the export.

The document stays the right escalation for the case this declines: with several families recorded, it is the only thing that can say which run drew which. That is worth doing when something needs it, and it would need the `google:`/`device:` strip that `GoogleFontFamilies.googleFamilyName()` already implements.

## Test plan

Three cases added to `FigmaSvgTofuFallbackTest` (9 tests, was 6):

| test | asserts |
| --- | --- |
| `a family-less run is named the one family the render recorded` | the `remote-m3` shape — names `Roboto Flex`, no boxes, no warning sidecar |
| `two recorded families leave a family-less run to the guard` | still boxes, still warns |
| `a recorded face the resolver cannot supply still boxes` | the default never outruns what can be embedded |

**Reproduced first.** With `recordedFamily` forced to null (the old behaviour):

```
FigmaSvgTofuFallbackTest > a family-less run is named the one family the render recorded FAILED
tests=9 failures=1
```

…and with the change, `tests=9 failures=0`. The two guard-preserving tests pass either way, which is the point — they pin behaviour this must not change.

Full run, all green in 12m56s:

```
./gradlew :data-layoutinspector-connector:test :daemon:android:testDebugUnitTest ktfmtCheckAll
BUILD SUCCESSFUL
```

`:daemon:android:testDebugUnitTest` covers `FigmaSvgRemoteComposeFontEmbedTest` and `RenderEngineTest`, so the downloadable-font path and the existing tofu behaviour are unchanged.

Non-visual: no rendered surface changes in this diff. Whether it clears the `remote-m3` wall is still unmeasured for the reasons #5279 records — that needs a published release and a catalog re-render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHXPXkZtZ2w6KpLtjjDvd5

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHXPXkZtZ2w6KpLtjjDvd5)_