### PR TITLE
ci: give the integration job the retry script it invokes

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -775,6 +775,28 @@ jobs:
           #   # The other matrix entries stay on the workflow-default 17.
           #   java_version: "21"
     steps:
+      # This job checks out CONSUMERS, never this repository — `$GITHUB_WORKSPACE`
+      # holds `external/<consumer>` plus downloaded artifacts and nothing of ours.
+      # So the `retry-gradle-repository.sh` wrapper the Gradle steps below invoke
+      # was simply absent: `No such file or directory`, exit 127, on every cell of
+      # every PR since it was introduced (#5276). The leg is a REQUIRED check and
+      # the workflow has no push-to-`main` lane, so nothing caught it at merge.
+      #
+      # Fetched into `tools/` rather than the workspace root deliberately. A root
+      # checkout would put this repo's `settings.gradle.kts` above the consumer's
+      # own build, and Gradle walks upward for one — the consumers are the whole
+      # point of this job, so nothing of ours belongs in their parent directory.
+      # Non-cone sparse checkout keeps it to the scripts alone: no root files, no
+      # build wiring, ~4 paths on disk.
+      - name: Checkout compose-ai-tools scripts
+        if: ${{ env.CELL_ACTIVE == '1' }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: tools
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
       - name: Checkout ${{ matrix.repo }}
         if: ${{ env.CELL_ACTIVE == '1' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1054,7 +1076,7 @@ jobs:
           # other cell in the same run was green. The wrapper retries ONLY on
           # "Could not GET '<url>'" + a 403/429/5xx status, so a real build break
           # still fails on the first attempt.
-          "$GITHUB_WORKSPACE/.github/scripts/retry-gradle-repository.sh" \
+          "$GITHUB_WORKSPACE/tools/.github/scripts/retry-gradle-repository.sh" \
             ./gradlew --init-script "$COMPOSE_AI_INIT_SCRIPT" composePreviewDiscover \
             ${{ matrix.extra_gradle_args }} \
             --stacktrace
@@ -1070,7 +1092,7 @@ jobs:
           # Tooling API and drives composePreviewDiscover under the hood, so this
           # exercises the CLI binary's end-to-end pipeline (not just the
           # Gradle path used by the other matrix entries).
-          "$GITHUB_WORKSPACE/.github/scripts/retry-gradle-repository.sh" \
+          "$GITHUB_WORKSPACE/tools/.github/scripts/retry-gradle-repository.sh" \
             compose-preview list --module "${{ matrix.module }}"
 
       - name: Verify previews.json was produced
@@ -1108,7 +1130,7 @@ jobs:
           # invocation. This is the step that exercises renderer-android AAR
           # resolution from mavenLocal — the artifact path external consumers
           # hit at runtime.
-          "$GITHUB_WORKSPACE/.github/scripts/retry-gradle-repository.sh" \
+          "$GITHUB_WORKSPACE/tools/.github/scripts/retry-gradle-repository.sh" \
             ./gradlew --init-script "$COMPOSE_AI_INIT_SCRIPT" composePreviewRender \
             ${{ matrix.extra_gradle_args }} \
             --stacktrace
@@ -1123,7 +1145,7 @@ jobs:
           # `compose-preview render` drives composePreviewRender end-to-end via
           # the Tooling API, including renderer-android AAR resolution from
           # the mavenLocal snapshot we seeded earlier.
-          "$GITHUB_WORKSPACE/.github/scripts/retry-gradle-repository.sh" \
+          "$GITHUB_WORKSPACE/tools/.github/scripts/retry-gradle-repository.sh" \
             compose-preview render --module "${{ matrix.module }}"
 
       - name: Verify PNGs were produced
@@ -1165,7 +1187,7 @@ jobs:
           # runtime on the :renderer-xr render configuration and writes
           # renders/<preview>/scene.json plus a <testTag>.png texture per
           # SpatialPanel.
-          "$GITHUB_WORKSPACE/.github/scripts/retry-gradle-repository.sh" \
+          "$GITHUB_WORKSPACE/tools/.github/scripts/retry-gradle-repository.sh" \
             ./gradlew --init-script "$COMPOSE_AI_INIT_SCRIPT" composePreviewRenderXr \
             ${{ matrix.extra_gradle_args }} \
             --stacktrace
@@ -1380,7 +1402,7 @@ jobs:
         run: |
           # Writes <module>/build/compose-previews/daemon-launch.json (the JSON the
           # VS Code extension reads to spawn the daemon JVM directly).
-          "$GITHUB_WORKSPACE/.github/scripts/retry-gradle-repository.sh" \
+          "$GITHUB_WORKSPACE/tools/.github/scripts/retry-gradle-repository.sh" \
             ./gradlew --init-script "$COMPOSE_AI_INIT_SCRIPT" composePreviewDaemonStart \
             ${{ matrix.extra_gradle_args }} \
             --stacktrace
@@ -1780,7 +1802,7 @@ jobs:
           # resolution from the mavenLocal snapshot seeded earlier. This is
           # the "oldest AGP × Kotlin together" floor-coverage cell (Gradle
           # 8.13 + AGP 8.13.0 + Kotlin 2.0.21 + JDK 17 + compose-bom 2026.05.00).
-          "$GITHUB_WORKSPACE/.github/scripts/retry-gradle-repository.sh" \
+          "$GITHUB_WORKSPACE/tools/.github/scripts/retry-gradle-repository.sh" \
             ./gradlew --init-script "$COMPOSE_AI_INIT_SCRIPT" composePreviewRender \
             --no-configuration-cache --stacktrace
 


### PR DESCRIPTION
## The failure

```
.../compose-ai-tools/.github/scripts/retry-gradle-repository.sh: No such file or directory
##[error]Process completed with exit code 127.
```

The `integration` matrix job checks out **consumers, never this repository**. Its first step fetches `${{ matrix.repo }}` into `external/` (`integration.yml:778`), and the only other checkout is the optional secondary — so `$GITHUB_WORKSPACE` holds the consumer's tree plus downloaded artifacts and nothing of ours. The wrapper the Gradle steps invoke, added by #5276, has never been on disk there.

The script is not the problem: it is committed at mode `100755` and present on every branch. Only its location is wrong for this job.

## Blast radius

Deterministic, and on every cell of every PR since #5276 merged. `wear-os-samples (ComposeStarter)` is a **required** status check on `pull_request`, and this workflow deliberately has no push-to-`main` lane, so nothing ran it at merge time and the break landed unobserved.

Observed on two unrelated heads, which is what rules out any particular PR as the cause:

| PR | head | diff |
| --- | --- | --- |
| #5283 | `2c252cf` | four Kotlin files, no CI |
| #5282 | `2b289be` | release-please version bumps + changelog |

Neither can make a script disappear.

## The fix

Fetch `.github/scripts` into `tools/` and point the seven call sites at it.

**Not the workspace root**, deliberately. A root checkout would put this repo's `settings.gradle.kts` in the consumer's parent directory, and Gradle walks upward looking for one — the consumers building cleanly is the entire purpose of this job, so nothing of ours belongs above them. Non-cone sparse checkout keeps it to the scripts alone: no root files, no build wiring.

`daemon-harness.yml` invokes the same script by relative path and is untouched; that job does check this repository out, which is why it never saw this.

## Test plan

CI is the test — the `wear-os-samples (ComposeStarter)` leg on this PR is the thing that has been failing, so it going green *is* the verification, and it exercises the changed path on the first of the seven call sites.

Locally:

- `.github/scripts/check-workflow-yaml.sh` → `40 workflow file(s) OK.`
- all 7 call sites rewritten, verified by count; no `$GITHUB_WORKSPACE/.github/scripts/` reference remains in `integration.yml`

Note the new step carries the same `if: ${{ env.CELL_ACTIVE == '1' }}` guard as the checkout beside it, so a skipped cell stays skipped and the scope gate's re-emitted green legs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHXPXkZtZ2w6KpLtjjDvd5

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHXPXkZtZ2w6KpLtjjDvd5)_