### PR TITLE
ci: make the snapshot publish manual-only

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,13 +1,19 @@
 name: Publish snapshot
 
 # Publish a -SNAPSHOT build to the Maven Central snapshots repo
-# (https://central.sonatype.com/repository/maven-snapshots/) on every push to
-# main. The vanniktech plugin routes `-SNAPSHOT` versions to that URL
-# automatically; snapshots are unsigned.
+# (https://central.sonatype.com/repository/maven-snapshots/). The vanniktech
+# plugin routes `-SNAPSHOT` versions to that URL automatically; snapshots are
+# unsigned.
+#
+# DISABLED on pushes to main: the `push` trigger is intentionally removed, so
+# nothing publishes automatically. The workflow is manual-only — run it from
+# the Actions tab against whatever ref you want a snapshot of. Restore the
+# trigger by re-adding:
+#
+#   push:
+#     branches: [main]
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
     inputs:
       suffix:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -239,9 +239,10 @@ exist.
 
 ## Testing a downstream project against a `-SNAPSHOT`
 
-Every push to `main` publishes `<next-patch>-SNAPSHOT` to Central
-snapshots. For PR testing, run the **Publish snapshot** workflow
-manually from the branch — it produces a branch-qualified version
+Snapshots are published on demand only — the **Publish snapshot**
+workflow is manual, with no push-to-`main` trigger. Run it from `main`
+for `<next-patch>-SNAPSHOT`, or from your branch for PR testing, where
+it produces a branch-qualified version
 (`<next-patch>-<branch-name>-<short-sha>-SNAPSHOT`) that won't collide
 with `main`. See [RELEASING.md § Snapshots](RELEASING.md#snapshots) for
 the full recipe and consumer-side `pluginManagement` block.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -349,9 +349,11 @@ the same way the extension's own release stamps its version, so nothing in the t
 
 ## Snapshots
 
-Every push to `main` triggers `snapshot.yml`, which computes the next
-patch-SNAPSHOT version from `git describe` (e.g. last tag `v0.3.3` →
-`0.3.4-SNAPSHOT`) and publishes to the Central snapshots repository:
+`snapshot.yml` is **manual-only** — the push-to-`main` trigger is disabled,
+so no snapshot is published automatically. Run **Publish snapshot** from the
+Actions tab against the ref you want. It computes the next patch-SNAPSHOT
+version from `git describe` (e.g. last tag `v0.3.3` → `0.3.4-SNAPSHOT`) and
+publishes to the Central snapshots repository:
 
 ```
 https://central.sonatype.com/repository/maven-snapshots/
@@ -360,9 +362,9 @@ https://central.sonatype.com/repository/maven-snapshots/
 Snapshots are unsigned, so they only need `MAVEN_CENTRAL_USERNAME` /
 `MAVEN_CENTRAL_PASSWORD`.
 
-For pre-merge testing, run **Publish snapshot** manually from the branch
-you want to test. Branch/manual runs publish the same Maven artifacts
-with a branch-qualified version by default:
+For pre-merge testing, run it from the branch you want to test. Branch
+runs publish the same Maven artifacts with a branch-qualified version by
+default:
 
 ```
 <next-patch>-<branch-name>-<short-sha>-SNAPSHOT


### PR DESCRIPTION
## Summary

Disables the automatic snapshot publish. `snapshot.yml` no longer runs on pushes to `main`; the `workflow_dispatch` entry point is kept, so a `-SNAPSHOT` can still be published on demand from any ref (including branch-qualified coordinates for PR testing).

- `.github/workflows/snapshot.yml` — drop the `push: branches: [main]` trigger. The header comment records that this is deliberate and shows the exact block to re-add to restore it. Jobs, the shared version computation and the publish step are untouched.
- `docs/RELEASING.md` § Snapshots and `docs/DEVELOPMENT.md` — no longer claim every push to `main` publishes a snapshot; both now describe the workflow as manual.

Nothing else references the `push` trigger: `scripts/snapshot-version.sh` still handles both the plain next-patch case and the ref+SHA suffix case, and `release.yml` only cites `snapshot.yml` in a comment.

## Test plan

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/snapshot.yml'))"` — parses.
- Non-visual change (CI configuration and docs only), so no render evidence applies.
- Behavioural check after merge: a push to `main` no longer queues a **Publish snapshot** run, and dispatching the workflow manually still does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Xxv57Dfm6N5kpxbrDKoth

---
_Generated by [Claude Code](https://claude.ai/code/session_019Xxv57Dfm6N5kpxbrDKoth)_