### PR TITLE
fix(catalog): annotate each published render from its own semantics tree

### DIFF
--- a/scripts/design-artifacts/annotation-index.mjs
+++ b/scripts/design-artifacts/annotation-index.mjs
@@ -1,0 +1,128 @@
+/**
+ * Re-key a published catalog's **preview-side design annotations** to the render each one describes.
+ *
+ * `@design-parity/catalog-export` walks ONE semantics tree per component — the tree the candidate
+ * join kept after folding a function's renders together — and then writes that single layer under
+ * every sticker id the component publishes:
+ *
+ * ```js
+ * // Every ideal variant of a component shares its geometry, so the same layer
+ * // is correct for each id it renders under (light/dark, locales).
+ * ```
+ *
+ * That holds for a palette or a locale arm, which redraw one layout in other colours or words. It
+ * does not hold for a *content* variant. `Button/Filled`'s `icon` cell draws an icon, a primary and
+ * a secondary label where the default cell draws one centred label, so the component's layer names
+ * one text node at the default's coordinates while the render under it has two somewhere else — and
+ * the viewer's Typography layer duly drew the default's box over the variant's pixels
+ * (compose-preview-server#555). Every one of the 17 components on `remote-m3` published byte-
+ * identical layers across all of its previews, which is the fan-out rather than a coincidence.
+ *
+ * So each sticker's layer is rebuilt here from **its own** carried semantics tree, joined exactly
+ * the way {@link catalogTagIndex} joins the tag index and the figma-svg emit joins vectors: through
+ * the `previewId` `bridgeLivePreviewIds` stamps on each image. A render whose tree is in hand gets
+ * a layer measured on itself; one whose tree is not gets **no layer at all**, for the reason the
+ * tag index states in the same situation — an absent overlay degrades to "no redline", a wrong one
+ * asserts a spec the component does not have, and a reader cannot tell the second from the truth.
+ *
+ * A component where NOTHING resolved is left exactly as the export package wrote it: this pass
+ * corrects a fan-out it can see, and a catalog packed without `--with-semantics` has no better
+ * answer to offer than the one already published.
+ *
+ * Pure and I/O-free — no `@design-parity/*`, no filesystem — like `tag-index.mjs` and
+ * `catalog-priority.mjs`, so it unit-tests without an `npm ci`. The layer builder is injected
+ * (`treeAnnotations` from the export package) and the driver does the writing.
+ */
+
+import { catalogPreviewId } from "./live-preview.mjs";
+import { semanticsByIds } from "./tag-index.mjs";
+
+/** Schema token of the published `annotations/index.json`. Mirrors the export package's. */
+export const ANNOTATION_SCHEMA = "compose-preview-annotations/v1";
+
+/**
+ * The ids one image is published under: the **sticker id** a preview server routes on, plus the
+ * fully-qualified `previewId` the export package emits as an alias for a consumer holding that one.
+ * Both are rewritten together — leaving the alias behind would keep serving the fan-out under a key
+ * that resolves to the very same picture.
+ */
+function keysFor(image) {
+  const out = [catalogPreviewId(image.path)];
+  if (typeof image.previewId === "string" && image.previewId !== "") {
+    out.push(image.previewId);
+  }
+  return out.filter((key) => typeof key === "string" && key !== "");
+}
+
+/**
+ * Rebuild `published.previews` per render.
+ *
+ * @param {object} published the manifest `writeCatalog` wrote (`{schema, previews, references}`)
+ * @param {object} manifest the built `catalog.json`, AFTER `bridgeLivePreviewIds`
+ * @param {Array<object>} bundles the render bundles whose `previews/<id>.semantics.json` sidecars
+ *   carry the trees
+ * @param {Map<string,string>|undefined} semanticsIdByPath `resolveSemanticsIds` — the unfiltered
+ *   image-path → daemon-id resolution, covering images deliberately left without a live alias
+ * @param {(tree: object) => Array<object>} annotate builds one layer from one tree
+ * @returns {{manifest: object, measured: number, dropped: number, gaps: number, unresolved: number}}
+ *   `measured` renders given their own layer, `dropped` renders whose fanned-out layer was removed,
+ *   `gaps` renders with an id but no carried tree, `unresolved` components left as published.
+ */
+export function perRenderAnnotations(
+  published,
+  manifest,
+  bundles,
+  semanticsIdByPath,
+  annotate,
+) {
+  const treesById = semanticsByIds(bundles);
+  const previews = { ...(published?.previews ?? {}) };
+  let measured = 0;
+  let dropped = 0;
+  let gaps = 0;
+  let unresolved = 0;
+  for (const component of manifest?.components ?? []) {
+    const renders = (component?.images ?? [])
+      .filter((image) => typeof image?.path === "string")
+      .map((image) => {
+        // The live alias first (it alone reconstructs `@OverrideVariant` ids), then the unfiltered
+        // resolution — the same order and the same reason as the tag index's join.
+        const id = image.previewId ?? semanticsIdByPath?.get(image.path);
+        return { image, tree: id ? treesById.get(id) : undefined };
+      });
+    // Nothing to say about this component that the export package has not already said. Rewriting
+    // it from no trees at all would only delete the one layer a semantics-less catalog publishes.
+    if (!renders.some((render) => render.tree)) {
+      unresolved += 1;
+      continue;
+    }
+    for (const { image, tree } of renders) {
+      const keys = keysFor(image);
+      if (keys.length === 0) continue;
+      const layer = tree ? (annotate(tree) ?? []) : [];
+      if (layer.length === 0) {
+        // A render with no tree of its own, or one whose tree annotates to nothing. Either way the
+        // layer standing under these keys was measured on a SIBLING, so it goes.
+        const had = keys.filter((key) => key in previews);
+        for (const key of had) delete previews[key];
+        if (had.length > 0) dropped += 1;
+        if (!tree) gaps += 1;
+        continue;
+      }
+      for (const key of keys) previews[key] = layer;
+      measured += 1;
+    }
+  }
+  return {
+    manifest: {
+      ...published,
+      schema: published?.schema ?? ANNOTATION_SCHEMA,
+      previews,
+      references: published?.references ?? {},
+    },
+    measured,
+    dropped,
+    gaps,
+    unresolved,
+  };
+}

--- a/scripts/design-artifacts/annotation-index.test.mjs
+++ b/scripts/design-artifacts/annotation-index.test.mjs
@@ -1,0 +1,204 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { perRenderAnnotations } from "./annotation-index.mjs";
+
+/** A bundle carrying one `previews/<id>.semantics.json` sidecar per entry. */
+const bundleOf = (trees) => ({
+  previews: Object.keys(trees).map((id) => ({ id })),
+  entries: Object.fromEntries(
+    Object.entries(trees).map(([id, tree]) => [
+      `previews/${id}.semantics.json`,
+      new TextEncoder().encode(JSON.stringify(tree)),
+    ]),
+  ),
+});
+
+/** The layer builder, standing in for `treeAnnotations`: one annotation naming the tree's label. */
+const annotate = (tree) =>
+  tree.root.label
+    ? [
+        {
+          kind: "typography",
+          bounds: { x: 0, y: 0, width: 10, height: 10 },
+          label: tree.root.label,
+        },
+      ]
+    : [];
+
+const image = (path, previewId) => ({ path, ...(previewId ? { previewId } : {}) });
+
+const fannedOut = (keys, label) => ({
+  schema: "compose-preview-annotations/v1",
+  previews: Object.fromEntries(
+    keys.map((key) => [key, [{ kind: "typography", label }]]),
+  ),
+  references: { "figma:1": [{ kind: "layout", label: "pad 8px" }] },
+});
+
+// The bug: one component's layer written under every sticker it publishes, so a content variant
+// draws the default render's boxes (compose-preview-server#555).
+test("each render is annotated from its own carried tree", () => {
+  const published = fannedOut(
+    ["button__ideal__default__compact", "button__ideal__icon__compact"],
+    "default",
+  );
+  const manifest = {
+    components: [
+      {
+        componentId: "Button",
+        images: [
+          image("images/button/ideal__default__compact.png", "Fn_default"),
+          image("images/button/ideal__icon__compact.png", "Fn_VARIANT_icon"),
+        ],
+      },
+    ],
+  };
+  const bundle = bundleOf({
+    Fn_default: { root: { label: "one label" } },
+    Fn_VARIANT_icon: { root: { label: "icon + two labels" } },
+  });
+
+  const out = perRenderAnnotations(published, manifest, [bundle], undefined, annotate);
+
+  assert.equal(out.manifest.previews["button__ideal__default__compact"][0].label, "one label");
+  assert.equal(
+    out.manifest.previews["button__ideal__icon__compact"][0].label,
+    "icon + two labels",
+  );
+  assert.equal(out.measured, 2);
+});
+
+test("the fully-qualified previewId alias is rewritten with its sticker", () => {
+  const published = fannedOut(["button__ideal__icon__compact", "Fn_VARIANT_icon"], "default");
+  const manifest = {
+    components: [
+      {
+        componentId: "Button",
+        images: [image("images/button/ideal__icon__compact.png", "Fn_VARIANT_icon")],
+      },
+    ],
+  };
+  const bundle = bundleOf({ Fn_VARIANT_icon: { root: { label: "icon" } } });
+
+  const out = perRenderAnnotations(published, manifest, [bundle], undefined, annotate);
+
+  assert.equal(out.manifest.previews["Fn_VARIANT_icon"][0].label, "icon");
+  assert.equal(out.manifest.previews["button__ideal__icon__compact"][0].label, "icon");
+});
+
+// An absent overlay degrades to "no redline"; a sibling's overlay asserts a spec this render does
+// not have, and nothing on the page says which of the two you are looking at.
+test("a render with no carried tree loses the layer measured on its sibling", () => {
+  const published = fannedOut(
+    ["button__ideal__default__compact", "button__ideal__icon__compact"],
+    "default",
+  );
+  const manifest = {
+    components: [
+      {
+        componentId: "Button",
+        images: [
+          image("images/button/ideal__default__compact.png", "Fn_default"),
+          image("images/button/ideal__icon__compact.png", "Fn_VARIANT_icon"),
+        ],
+      },
+    ],
+  };
+  const bundle = bundleOf({ Fn_default: { root: { label: "one label" } } });
+
+  const out = perRenderAnnotations(published, manifest, [bundle], undefined, annotate);
+
+  assert.equal(out.manifest.previews["button__ideal__default__compact"][0].label, "one label");
+  assert.equal(out.manifest.previews["button__ideal__icon__compact"], undefined);
+  assert.equal(out.dropped, 1);
+  assert.equal(out.gaps, 1);
+});
+
+// A catalog packed without `--with-semantics` has nothing better to offer than what was published.
+test("a component that resolves no tree at all is left exactly as published", () => {
+  const published = fannedOut(
+    ["button__ideal__default__compact", "button__ideal__icon__compact"],
+    "default",
+  );
+  const manifest = {
+    components: [
+      {
+        componentId: "Button",
+        images: [
+          image("images/button/ideal__default__compact.png", "Fn_default"),
+          image("images/button/ideal__icon__compact.png", "Fn_VARIANT_icon"),
+        ],
+      },
+    ],
+  };
+
+  const out = perRenderAnnotations(published, manifest, [bundleOf({})], undefined, annotate);
+
+  assert.deepEqual(out.manifest.previews, published.previews);
+  assert.equal(out.unresolved, 1);
+  assert.equal(out.measured, 0);
+});
+
+// `bridgeLivePreviewIds` deliberately withholds a live alias from an image the Android-only
+// supplement overrode. Those pixels still have a tree; only their live lane is missing.
+test("an unbridged image resolves through the unfiltered semantics-id map", () => {
+  const published = fannedOut(["button__ideal__default__compact"], "default");
+  const manifest = {
+    components: [
+      {
+        componentId: "Button",
+        images: [image("images/button/ideal__default__compact.png")],
+      },
+    ],
+  };
+  const bundle = bundleOf({ Fn_default: { root: { label: "supplement" } } });
+
+  const out = perRenderAnnotations(
+    published,
+    manifest,
+    [bundle],
+    new Map([["images/button/ideal__default__compact.png", "Fn_default"]]),
+    annotate,
+  );
+
+  assert.equal(out.manifest.previews["button__ideal__default__compact"][0].label, "supplement");
+});
+
+test("the reference layer and schema are carried through untouched", () => {
+  const published = fannedOut(["button__ideal__default__compact"], "default");
+  const manifest = {
+    components: [
+      {
+        componentId: "Button",
+        images: [image("images/button/ideal__default__compact.png", "Fn_default")],
+      },
+    ],
+  };
+  const bundle = bundleOf({ Fn_default: { root: { label: "one label" } } });
+
+  const out = perRenderAnnotations(published, manifest, [bundle], undefined, annotate);
+
+  assert.deepEqual(out.manifest.references, published.references);
+  assert.equal(out.manifest.schema, "compose-preview-annotations/v1");
+});
+
+// The export package writes nothing when a component annotates to nothing, and a tree that
+// annotates to nothing must not resurrect a key.
+test("a tree that annotates to nothing publishes no key", () => {
+  const published = { schema: "compose-preview-annotations/v1", previews: {}, references: {} };
+  const manifest = {
+    components: [
+      {
+        componentId: "Button",
+        images: [image("images/button/ideal__default__compact.png", "Fn_default")],
+      },
+    ],
+  };
+  const bundle = bundleOf({ Fn_default: { root: {} } });
+
+  const out = perRenderAnnotations(published, manifest, [bundle], undefined, annotate);
+
+  assert.deepEqual(out.manifest.previews, {});
+  assert.equal(out.dropped, 0);
+});

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -42,7 +42,11 @@ import {
   catalogTokensFromBundle,
   themeTokenSetsFromBundle,
 } from "@design-parity/candidate";
-import { buildCatalog, writeCatalog } from "@design-parity/catalog-export";
+import {
+  buildCatalog,
+  treeAnnotations,
+  writeCatalog,
+} from "@design-parity/catalog-export";
 
 import {
   duplicateAxesFailure,
@@ -158,6 +162,7 @@ import {
   resolveSemanticsIds,
 } from "./bridge-live-preview-ids.mjs";
 import { catalogTagIndex } from "./tag-index.mjs";
+import { perRenderAnnotations } from "./annotation-index.mjs";
 import {
   catalogImagePath,
   derivationMismatches,
@@ -2263,6 +2268,65 @@ if (values["defer-figma-svg"]) {
           `to close the gap — an unindexed preview simply gets no element gate)`
         : ""),
   );
+}
+
+// The published design annotations (`annotations/index.json`), re-keyed to the render each layer
+// describes — same join as the tag index above, one file along.
+//
+// `writeCatalog` walks one semantics tree per COMPONENT and writes that layer under every sticker
+// the component publishes. Right for a palette or a locale arm; wrong for a content variant, whose
+// render has different text in different places — so the viewer's Typography layer drew the default
+// cell's boxes over `button-filled__ideal__icon__compact` (compose-preview-server#555). See
+// annotation-index.mjs for why an absent overlay beats a sibling's.
+//
+// Only the preview side is touched. The reference side is merged in later, by
+// `emit-design-references.mjs`, which reads this file back — so it must be written before that step
+// and must carry `references` through untouched.
+{
+  const file = join(outPath, "annotations", "index.json");
+  // Absent whenever `buildAnnotationManifest` had nothing to write (a catalog with no semantics at
+  // all): there is then no fan-out to correct, and this pass has no tree of its own to publish
+  // from either. Fail-soft like every other carried artifact — an unreadable manifest costs the
+  // correction, never the catalog.
+  const publishedAnnotations = await readFile(file, "utf8").then(
+    (text) => {
+      try {
+        return JSON.parse(text);
+      } catch {
+        return null;
+      }
+    },
+    () => null,
+  );
+  const layers = publishedAnnotations
+    ? perRenderAnnotations(
+        publishedAnnotations,
+        indexManifest,
+        allBundles,
+        resolveSemanticsIds(indexManifest, spec, allBundles),
+        treeAnnotations,
+      )
+    : null;
+  if (layers) {
+    await writeFile(
+      file,
+      `${JSON.stringify(layers.manifest, null, 2)}\n`,
+      "utf8",
+    );
+    console.log(
+      `[${spec.system}] design annotations: ${layers.measured} render(s) annotated from their ` +
+        `own semantics tree` +
+        (layers.dropped > 0
+          ? `, ${layers.dropped} carried a sibling render's layer and were cleared` +
+            (layers.gaps > 0
+              ? ` (${layers.gaps} of them for want of a tree — pack with --with-semantics)`
+              : "")
+          : "") +
+        (layers.unresolved > 0
+          ? `, ${layers.unresolved} component(s) resolved no tree and keep the exported layer`
+          : ""),
+    );
+  }
 }
 
 // Figma Code Connect manifest next to the figma-svg vectors: one mapping per component binding its


### PR DESCRIPTION
Fixes the published half of yschimke/compose-preview-server#555 — "typography for variants is shown for defaults".

## What was wrong

`@design-parity/catalog-export`'s `buildAnnotationManifest` walks **one** semantics tree per component and writes that layer under **every** sticker id the component publishes:

```js
// Every ideal variant of a component shares its geometry, so the same layer
// is correct for each id it renders under (light/dark, locales).
```

True for a palette or a locale arm. Not true for a content variant: `Button/Filled`'s `icon` cell draws an icon plus a primary *and* a secondary label where the default cell draws one centred label. So `annotations/index.json` named one text node at the default render's coordinates and keyed it onto the icon cell as well.

The preview server answers a `.annotations?layers=typography` request from those published bytes (`AnnotationKind.publishedLayersSuffice`), which is what the viewer's Typography checkbox sends — so `/remote-m3/p/button-filled__ideal__icon__compact?inspect=typography` drew one box, in the wrong place, from the wrong render. The unscoped daemon lane, which measures the frame on screen, reports the variant's two labels correctly; the two lanes disagreed.

Measured on the live delivery branch (`yschimke/wear-m3-catalog@design-artifacts/remote-m3`): all 17 components publish byte-identical layers across every one of their previews — the fan-out, not a coincidence.

```
$ curl -s '…/button-filled__ideal__icon__compact.annotations?layers=typography'   # published
  Primary label  15sp/18   {x:136, y:82,  w:182, h:36}          ← the DEFAULT render's box
$ curl -s '…/button-filled__ideal__icon__compact.annotations'                     # live daemon
  Primary label  15.0sp/18.0sp   {x:161, y:65,  w:182, h:36}
  Secondary label 13.0sp/16.0sp  {x:161, y:103, w:196, h:32}
```

## The fix

A new pass in `generate-design-catalog.mjs` rebuilds each sticker's layer from **its own** carried semantics tree, joined through the `previewId` `bridgeLivePreviewIds` stamps on every image — the same join the tag index (`tag-index.mjs`) and the per-variant figma-svg emit already use, so no third naming scheme. Each published catalog image already carries its own daemon id, `…FilledRemoteButton_…_VARIANT_icon` included, so the variant's tree is right there.

Two deliberate refusals, both borrowed verbatim from the tag index's reasoning:

- **A render whose tree is not in hand gets no layer at all**, rather than a sibling's. An absent overlay degrades to "no redline"; a wrong one asserts a spec the component does not have, and nothing on the page tells a reader which of the two they are looking at.
- **A component that resolves no tree at all is left exactly as the export package wrote it.** This pass corrects a fan-out it can see; a catalog packed without `--with-semantics` has no better answer to offer, and wiping its one published layer would be a regression.

Only the preview side is touched — the reference side is merged in afterwards by `emit-design-references.mjs`, which reads this file back, so `references` is carried through untouched and the write happens before that step.

`annotation-index.mjs` is pure and I/O-free like its siblings (no `@design-parity/*`, no filesystem — the layer builder is injected and the driver does the writing), so it unit-tests without an `npm ci`.

## Test plan

- `node --test scripts/design-artifacts/annotation-index.test.mjs` — 7 new cases: per-render layers, the `previewId` alias rewritten with its sticker, the sibling-layer drop, the untouched no-tree component, the unbridged-image resolution through `resolveSemanticsIds`, `references`/schema carried through, and a tree that annotates to nothing publishing no key.
- `node --test` across `scripts/design-artifacts/` — 1405 pass / 8 fail, and those same 8 fail on `main` in this sandbox (they need an `npm ci` for `@design-parity/*` / `playwright`).
- Not verifiable here without a render bundle: the end-to-end effect lands when `wear-m3-catalog` next publishes `design-artifacts/remote-m3` against a release carrying this. The server needs no change — its published lane simply stops being handed a layer measured on another render.

No pixels change, so there is no before/after render to embed; the artefact this touches is a JSON manifest, quoted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZwWPQ5T7vCx2VpYxqbEWS

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZwWPQ5T7vCx2VpYxqbEWS)_