### PR TITLE
fix: scope a family's resolved font file to the preview that drew it

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/FontsRecorderExtension.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/FontsRecorderExtension.kt
@@ -40,9 +40,16 @@ class FontsRecorderExtension(context: Context? = null) :
 
   @Composable
   override fun Around(context: ExtensionComposeContext, content: @Composable () -> Unit) {
-    // Each preview's SVG export must see only its own faces, so clear the shared buffer as this
+    // Each preview's SVG export must see only its own faces, so clear the shared buffers as this
     // preview starts composing rather than after it renders.
+    //
+    // Both, not just the recorded families. Which FILE a family resolved to is as much a
+    // per-preview fact as which families were drawn: a specimen declaring font-variation axes
+    // resolves the family's variable file where a sticker declaring none resolves a static
+    // instance, and left process-wide the first of those was embedded into every preview that
+    // followed it in the same catalog run.
     FigmaSvgRenderedFonts.begin()
+    FigmaResourceFonts.beginPreview()
     val baseFontResolver = LocalFontFamilyResolver.current
     CompositionLocalProvider(
       LocalFontFamilyResolver provides recordingFontFamilyResolver(baseFontResolver, recorder),

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/FigmaResourceFonts.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/FigmaResourceFonts.kt
@@ -31,6 +31,34 @@ object FigmaResourceFonts {
   private val paths = ConcurrentHashMap<String, String>()
 
   /**
+   * Family-keyed registrations, scoped to the preview that made them.
+   *
+   * A `res/font/<resId>` handle names one concrete face and resolves to the same bytes for the life
+   * of the render JVM, so [paths] keeps those for the process. A FAMILY does not: which file
+   * `Roboto Flex` resolved to is a fact about one render, and the catalog's own documents disagree
+   * about it — a typography specimen declaring `wght`/`wdth` axes resolves the family's VARIABLE
+   * file, while a sticker that declares no axes resolves a static per-weight instance.
+   *
+   * Held process-wide, the specimen's registration outlived it and every later preview in the same
+   * catalog run embedded the variable file instead of the one it drew: 1.6 MB of `gvar` for a
+   * document that varies nothing, in an SVG that came to 4.4 MB. The recorder publishes during the
+   * render and the export reads at post-capture, so the window is a preview — the same window
+   * [FigmaSvgRenderedFonts] is already scoped to, and for the same reason.
+   */
+  private val previewPaths = ConcurrentHashMap<String, String>()
+
+  /**
+   * Drop the family-keyed registrations of the preview that just ended.
+   *
+   * Called as each preview starts composing, beside [FigmaSvgRenderedFonts.begin]. Resource-id
+   * registrations are deliberately kept: those are process facts, and re-extracting them per
+   * preview would cost a whole-catalog render the same work over and over for no gain.
+   */
+  fun beginPreview() {
+    previewPaths.clear()
+  }
+
+  /**
    * The captured identity for an Android font resource — matching what
    * `ComposeSemanticsDataProducer` writes into `typography.fontFamily` for a `ResourceFont`.
    */
@@ -57,7 +85,7 @@ object FigmaResourceFonts {
    */
   fun register(identity: String, weight: Int, italic: Boolean, path: String) {
     if (identity.isBlank() || path.isBlank()) return
-    paths[key(identity, weight, italic)] = path
+    previewPaths[key(identity, weight, italic)] = path
   }
 
   /** The registered file for [identity], or null when nothing recovered that face. */
@@ -69,7 +97,7 @@ object FigmaResourceFonts {
    * (`res/font/<resId>`) resolving through the same lookup.
    */
   fun pathFor(identity: String, weight: Int, italic: Boolean): String? =
-    paths[key(identity, weight, italic)] ?: paths[identity]
+    previewPaths[key(identity, weight, italic)] ?: paths[identity]
 
   /**
    * The CSS/Figma family declared inside one font file, or null when [bytes] are not a readable
@@ -113,6 +141,7 @@ object FigmaResourceFonts {
   /** Drop every registration. Tests only — production accumulates for the process's life. */
   fun clear() {
     paths.clear()
+    previewPaths.clear()
   }
 
   private const val NAME_ID_TYPOGRAPHIC_FAMILY = 16

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/FigmaResourceFontsScopeTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/FigmaResourceFontsScopeTest.kt
@@ -1,0 +1,70 @@
+package ee.schimke.composeai.daemon
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Which file a FAMILY resolved to is a fact about one render, not about the process.
+ *
+ * `remote-m3` proves it within a single catalog: a typography specimen declaring `wght`/`wdth` axes
+ * resolves Roboto Flex's variable file, while a sticker declaring no axes resolves a static
+ * per-weight instance. Held process-wide the specimen's registration outlived it, and every later
+ * preview embedded the variable file it never drew — 1.6 MB of `gvar` for a document that varies
+ * nothing.
+ *
+ * A `res/font/<resId>` handle is the opposite case and must survive: it names one concrete face
+ * whose bytes do not change for the life of the render JVM, and re-extracting it per preview would
+ * cost a whole-catalog render the same work repeatedly.
+ */
+class FigmaResourceFontsScopeTest {
+
+  @Before fun reset() = FigmaResourceFonts.clear()
+
+  @After fun cleanup() = FigmaResourceFonts.clear()
+
+  @Test
+  fun `a family's file does not outlive the preview that resolved it`() {
+    FigmaResourceFonts.register("Roboto Flex", 550, false, "/cache/roboto-flex-variable.ttf")
+    assertEquals(
+      "/cache/roboto-flex-variable.ttf",
+      FigmaResourceFonts.pathFor("Roboto Flex", 550, false),
+    )
+
+    FigmaResourceFonts.beginPreview()
+
+    assertNull(
+      "the next preview must not inherit the previous one's file",
+      FigmaResourceFonts.pathFor("Roboto Flex", 550, false),
+    )
+  }
+
+  @Test
+  fun `the preview that draws it wins over one that drew it before`() {
+    FigmaResourceFonts.register("Roboto Flex", 550, false, "/cache/roboto-flex-variable.ttf")
+    FigmaResourceFonts.beginPreview()
+    FigmaResourceFonts.register("Roboto Flex", 550, false, "/cache/roboto-flex-550.ttf")
+
+    assertEquals(
+      "/cache/roboto-flex-550.ttf",
+      FigmaResourceFonts.pathFor("Roboto Flex", 550, false),
+    )
+  }
+
+  @Test
+  fun `a resource face survives, because its bytes are a process fact`() {
+    val identity = FigmaResourceFonts.identityFor(2131296256)
+    FigmaResourceFonts.register(identity, "/extracted/montserrat_medium.ttf")
+
+    FigmaResourceFonts.beginPreview()
+
+    assertEquals("/extracted/montserrat_medium.ttf", FigmaResourceFonts.pathFor(identity))
+    assertEquals(
+      "and stays reachable through the weight-qualified lookup",
+      "/extracted/montserrat_medium.ttf",
+      FigmaResourceFonts.pathFor(identity, 500, false),
+    )
+  }
+}


### PR DESCRIPTION
Follow-up to #5283 and #5289, and the reason `remote-m3`'s SVGs are 4.4 MB.

## A family's file is not a process fact

`FigmaResourceFonts` holds every registration for the life of the render JVM. That is right for a `res/font/<resId>` handle — it names one concrete face whose bytes do not change — and wrong for a **family**, because which file `Roboto Flex` resolved to is a fact about one render.

`remote-m3` disagrees with itself about exactly that inside a single catalog run:

- a **typography specimen** declares `wght`/`wdth` axes → `GoogleFontFamilies` takes its variable branch → the family resolves to `roboto-flex-variable.ttf`
- a **sticker** declares no axes → the static branch → a per-weight instance

Held process-wide, the specimen's registration outlives it, and every preview rendered afterwards embeds the variable file **it never drew**. That is where the 1.6 MB of `gvar` in a document that varies nothing comes from, and why one comparison SVG weighs 4.4 MB — 99.9% of it font bytes, the same blob twice.

Corroborating detail: `GoogleFontFiles.cached` can only ever return a static per-weight file (`GoogleFontKey(family, weight, italic).fileName()`), so nothing on the downloadable path explains a variable file appearing in a no-axes document. The registry does.

## The fix

Scope the family-keyed registrations to the preview, along the line the class already draws between its two `register` overloads:

| overload | names | scope |
| --- | --- | --- |
| `register(identity, path)` | a per-face handle — `res/font/<resId>` | process (unchanged) |
| `register(identity, weight, italic, path)` | a **family** | **per preview** |

`FontsRecorderExtension.Around` already clears `FigmaSvgRenderedFonts` as each preview starts composing, with the comment *"Each preview's SVG export must see only its own faces"*. The file registry needed the same window and did not have it; it is now cleared beside it.

Keeping resource ids process-wide is deliberate, not an oversight I preserved: re-extracting them per preview would cost a whole-catalog render the same work over and over, which is why the accumulation exists.

## Why this rather than instancing the variable face

Instancing would shrink the embedded face from 322 KB to ~35 KB, but it means applying `gvar` deltas with tuple regions, intermediate tuples and IUP — real font engineering, easy to get subtly wrong, and producing plausible-looking wrong glyphs when it is. This gets the same result for every document that declares no axes by embedding the file the render already resolved, with no glyph maths at all. Instancing stays available for documents that genuinely vary an axis, where #5289's `gvar` subsetting is the current floor.

## Test plan

Three cases in a new `FigmaResourceFontsScopeTest`, of which **one fails without the change**:

```
FigmaResourceFontsScopeTest > a family's file does not outlive the preview that resolved it FAILED
tests=3 failures=1
```

The other two are guards that pass either way and must keep passing: a later preview's file wins over an earlier one's, and a `res/font/` registration **survives** `beginPreview()` — including through the weight-qualified lookup, which falls back to it.

Verified green:

```
:data-layoutinspector-connector:test        41 classes, 233 tests, 0 failures
:daemon:android:testDebugUnitTest           78 classes, 340 tests, 0 failures
ktfmtCheck (both changed modules)           BUILD SUCCESSFUL
```

The android suite matters here because the one-line change outside the connector is in `FontsRecorderExtension`, and `FigmaSvgRemoteComposeFontEmbedTest` + `RenderEngineTest` exercise that recorder end to end.

**Not verified by me:** that this actually shrinks the published SVGs. That needs a release and a catalog re-render, and the mechanism above is inferred from the code and the artifacts rather than observed in a daemon run — the same standing caveat as #5279 records. Expect ~322 KB per face after #5289 ships, and a static instance's ~35 KB after this one, for documents with no axes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHXPXkZtZ2w6KpLtjjDvd5

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHXPXkZtZ2w6KpLtjjDvd5)_