### PR TITLE
fix: carry the figma-svg font warning and refuse to publish boxes

### DIFF
--- a/.github/scripts/sweep-stranded-releases.sh
+++ b/.github/scripts/sweep-stranded-releases.sh
@@ -62,9 +62,16 @@ CENTRAL_BASE_URL="${CENTRAL_BASE_URL:-https://repo1.maven.org/maven2}"
 now="$(date -u +%s)"
 exit_code=0
 
-minutes_since() { # <ISO-8601 timestamp> → whole minutes, or empty if unreadable
+minutes_since() { # <ISO-8601 timestamp> → whole minutes, or empty if absent/unreadable
   local epoch
-  epoch="$(date -u -d "${1:-}" +%s 2>/dev/null)" || return 0
+  # An EMPTY timestamp has to answer "unknown", not a number. GNU `date -u -d ""` does not fail —
+  # it reads the empty string as midnight today and exits 0 — so without this guard "no recovery
+  # run has ever been dispatched" came back as "dispatched <minutes since UTC midnight> ago". For
+  # the first RECOVERY_COOLDOWN_MINUTES of every UTC day that is inside the cooldown, so the
+  # sweeper declined to dispatch the rebuild it exists to dispatch, and its self-test failed for
+  # the same six hours daily.
+  [[ -n "${1:-}" ]] || return 0
+  epoch="$(date -u -d "$1" +%s 2>/dev/null)" || return 0
   [[ -n "${epoch}" ]] && echo $(( (now - epoch) / 60 ))
 }
 

--- a/.github/scripts/test-sweep-stranded-releases.sh
+++ b/.github/scripts/test-sweep-stranded-releases.sh
@@ -139,6 +139,12 @@ CURL_OK=false run central
 logged central "PATCH" && fail "a release whose plugin is not on Central must stay a draft"
 
 # 5. Assets missing means the build never finished — rebuild it for the tag rather than publish.
+#    No ${DISPATCHES} fixture is set, so this is also the "no recovery run has ever been
+#    dispatched" case, and it is the one that caught `date -u -d ""` reading an empty timestamp as
+#    midnight today rather than failing: the sweeper saw a phantom recovery <minutes since UTC
+#    midnight> old and sat inside its own cooldown. That made both assertions below — and the real
+#    sweeper — fail for the first RECOVERY_COOLDOWN_MINUTES of every UTC day. Keep this case
+#    fixture-less; its independence from the wall clock is the assertion.
 fixture "${ASSETS}" '[{"name":"compose-preview-1.78.0.zip"}]'
 run rebuild
 [[ $status -eq 0 ]] || fail "dispatching a rebuild should exit 0"

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -487,11 +487,20 @@ jobs:
         run: ./gradlew ":${WASM_MODULE}:wasmCatalogDist" --quiet
 
       # The exporter gates on a complete render: `bundle pack --with-semantics`
-      # is best-effort (exits 0 even if the daemon failed or captured zero
-      # semantics), so the driver exits non-zero when any preview is missing or
-      # lacks semantics. With `set -e` that fails the job before the publish step,
-      # so a transient render failure can't force-push a degraded bundle over a
-      # good delivery branch.
+      # is best-effort about INFRASTRUCTURE (exits 0 even if the daemon failed or
+      # captured zero semantics), so the driver exits non-zero when any preview is
+      # missing or lacks semantics. With `set -e` that fails the job before the
+      # publish step, so a transient render failure can't force-push a degraded
+      # bundle over a good delivery branch.
+      #
+      # The pack itself is NOT best-effort about the artefact: it exits non-zero
+      # when a preview's figma-svg export lost a font family and exported its text
+      # as missing-glyph boxes, naming each one and its
+      # previews/<id>.figma-fonts.warnings.json. That gate is why a sheet of boxes
+      # can no longer publish and be found by eye days later; the export writes
+      # that sidecar only when it degrades, so a healthy catalog never sees it.
+      # `--allow-lost-font-families` on the pack steps above ships the boxes
+      # deliberately if a sheet has to go out while the export is fixed.
       - name: Generate importable catalog
         env:
           SYSTEM: ${{ matrix.system }}

--- a/bundle/format/api/bundle-format.api
+++ b/bundle/format/api/bundle-format.api
@@ -769,6 +769,7 @@ public final class ee/schimke/composeai/bundle/FigmaRasterScalingKt {
 }
 
 public final class ee/schimke/composeai/bundle/PreviewBundleFormatKt {
+	public static final field BUNDLE_FIGMA_FONT_WARNINGS_SUFFIX Ljava/lang/String;
 	public static final field BUNDLE_FIGMA_RASTER_DIR_SUFFIX Ljava/lang/String;
 	public static final field BUNDLE_FIGMA_SVG_SUFFIX Ljava/lang/String;
 	public static final field BUNDLE_FONTS_SUFFIX Ljava/lang/String;
@@ -780,6 +781,8 @@ public final class ee/schimke/composeai/bundle/PreviewBundleFormatKt {
 	public static synthetic fun addOrReplaceZipEntries$default ([BLjava/util/Map;Ljava/util/Set;ILjava/lang/Object;)[B
 	public static final fun embedWebIntoZip ([BLjava/util/Map;)[B
 	public static final fun getZIP_DOS_EPOCH_MS ()J
+	public static final fun injectFigmaFontWarningsIntoBundle (Ljava/io/File;Ljava/util/Map;Lokio/FileSystem;)I
+	public static synthetic fun injectFigmaFontWarningsIntoBundle$default (Ljava/io/File;Ljava/util/Map;Lokio/FileSystem;ILjava/lang/Object;)I
 	public static final fun injectFigmaRasterIntoBundle (Ljava/io/File;Ljava/util/Map;Lokio/FileSystem;I)I
 	public static synthetic fun injectFigmaRasterIntoBundle$default (Ljava/io/File;Ljava/util/Map;Lokio/FileSystem;IILjava/lang/Object;)I
 	public static final fun injectFigmaSvgIntoBundle (Ljava/io/File;Ljava/util/Map;Lokio/FileSystem;)I

--- a/bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/PreviewBundleFormat.kt
+++ b/bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/PreviewBundleFormat.kt
@@ -79,6 +79,20 @@ public const val BUNDLE_FIGMA_SVG_SUFFIX: String = ".figma.svg"
 public const val BUNDLE_FIGMA_RASTER_DIR_SUFFIX: String = ".figma-raster"
 
 /**
+ * Suffix for the `compose/figma-svg` export's font-warning sidecar, carried beside
+ * `previews/<id>.figma.svg`. The payload is the export's own `compose-figma-fonts.warnings.json` —
+ * which families the render drew that the SVG could not name, which it could, and the missing-glyph
+ * family it substituted.
+ *
+ * **Absent is the healthy state.** The export writes the sidecar only for a degraded preview, so an
+ * entry here means that sticker's text shipped as boxes. Carried because it previously went
+ * nowhere: the export wrote it into the render's data dir, nothing collected it, and a whole sheet
+ * published in missing-glyph boxes with the one artefact naming the lost face left behind on the
+ * build machine.
+ */
+public const val BUNDLE_FIGMA_FONT_WARNINGS_SUFFIX: String = ".figma-fonts.warnings.json"
+
+/**
  * Inject `previews/<id>.semantics.json` entries (id → `compose-semantics.json` bytes) into
  * [bundleFile]'s zip portion **in place**, preserving the leading PNG cover and every existing
  * entry. Re-injecting replaces any prior semantics entry for the same id, so a second
@@ -130,6 +144,20 @@ public fun injectFigmaSvgIntoBundle(
   figmaSvgById: Map<String, ByteArray>,
   fileSystem: FileSystem = SystemFileSystem,
 ): Int = injectSidecarsIntoBundle(bundleFile, figmaSvgById, BUNDLE_FIGMA_SVG_SUFFIX, fileSystem)
+
+/**
+ * Inject `previews/<id>.figma-fonts.warnings.json` entries (id →
+ * `compose-figma-fonts.warnings.json` bytes) into [bundleFile] — the font-warning sidecar the
+ * figma-svg export writes for a preview it had to draw in missing-glyph boxes. Only degraded
+ * previews have one, so this is normally a no-op. Same in-place, idempotent, byte-stable contract
+ * as [injectSemanticsIntoBundle]. Returns the number of entries written.
+ */
+public fun injectFigmaFontWarningsIntoBundle(
+  bundleFile: File,
+  warningsById: Map<String, ByteArray>,
+  fileSystem: FileSystem = SystemFileSystem,
+): Int =
+  injectSidecarsIntoBundle(bundleFile, warningsById, BUNDLE_FIGMA_FONT_WARNINGS_SUFFIX, fileSystem)
 
 /**
  * Inject a hybrid figma-svg's per-node raster crops ([figmaRasterById]: preview id → (crop filename

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.bundle.BUNDLE_FIGMA_FONT_WARNINGS_SUFFIX
 import ee.schimke.composeai.bundle.BUNDLE_FIGMA_RASTER_DIR_SUFFIX
 import ee.schimke.composeai.bundle.BUNDLE_FIGMA_SVG_SUFFIX
 import ee.schimke.composeai.bundle.BUNDLE_FONTS_SUFFIX
@@ -11,6 +12,7 @@ import ee.schimke.composeai.bundle.BundleReader
 import ee.schimke.composeai.bundle.WebEmbed
 import ee.schimke.composeai.bundle.embedWebIntoZip
 import ee.schimke.composeai.bundle.expandZipBytesSafely
+import ee.schimke.composeai.bundle.injectFigmaFontWarningsIntoBundle
 import ee.schimke.composeai.bundle.injectFigmaRasterIntoBundle
 import ee.schimke.composeai.bundle.injectFigmaSvgIntoBundle
 import ee.schimke.composeai.bundle.injectFontsIntoBundle
@@ -118,7 +120,7 @@ class BundleCommand(args: List<String>) : Command(args) {
       A <bundle> below is a local path OR an http(s)/file URL — URLs are downloaded first.
 
       Usage:
-        compose-preview bundle pack [--module <name>] [--id <preview>...] [-o <file.png>] [--no-render] [--with-semantics]
+        compose-preview bundle pack [--module <name>] [--id <preview>...] [-o <file.png>] [--no-render] [--with-semantics] [--allow-lost-font-families]
         compose-preview bundle pack --per-preview [--module <name>] [--id <preview>...] [-o <dir>]
         compose-preview bundle split   <sheet.png | URL> -o <dir> [--view-only | --shared-classpath-out <pool>] [--carriage-report <file.json>]
         compose-preview bundle inspect <bundle.png | URL>
@@ -212,14 +214,24 @@ class BundleCommand(args: List<String>) : Command(args) {
                             design-catalog export generates the in-browser tier's fonts.json, and the
                             layered compose/figma-svg export (editable vector) as
                             previews/<id>.figma.svg, shipped per sticker beside the raster PNG.
+                            A preview whose figma-svg export could not name a font family the
+                            render drew also carries the export's warning as
+                            previews/<id>.figma-fonts.warnings.json, and FAILS THE PACK — see
+                            --allow-lost-font-families.
                             Produced by a short-lived daemon render (no separate --with-extension
                             pass needed). Off by default; ignored with --no-render.
+        --allow-lost-font-families
+                            Pack anyway when a figma-svg export lost a font family. Such a preview
+                            exports its text as missing-glyph boxes, which is loud in the sticker
+                            and silent in the build log, so the pack refuses by default rather
+                            than let a sheet of boxes publish. Same posture as the render's
+                            -Dcomposeai.fonts.failOnFallback gate.
 
       Split flags (sheet → one bundle per preview):
         -o, --output <dir>  Directory to write <id>.png bundles into. Default: <sheet>-split/.
         --view-only         Drop the re-render classpath (classes/app.jar + libs/) from each output,
                             keeping the baked image + every sidecar (semantics / layout / figma.svg /
-                            overrides / catalog / fonts). Produces small (~tens of KB) addressable
+                            figma-fonts.warnings / overrides / catalog / fonts). Produces small (~tens of KB) addressable
                             stickers a viewer / detached reader opens, at the cost of live re-render.
                             Without it, each bundle carries the shared classpath and can re-render
                             (larger — the shared jars repeat per preview). A sheet packed
@@ -273,6 +285,17 @@ private class PackSubcommand(private val args: List<String>) {
   private val embedDeps: Boolean = "--embed-deps" in args
   private val includeDataExtensions: Boolean = "--include-data-extensions" in args
   private val withSemantics: Boolean = "--with-semantics" in args
+
+  /**
+   * Let a pack whose figma-svg export lost a font family succeed anyway.
+   *
+   * Off by default, and that default is the point. A lost family exports as missing-glyph boxes,
+   * which is loud in a rendered sticker and completely silent in a build log, so a degraded sheet
+   * published and sat in the catalog until somebody happened to look at one. Mirrors the render's
+   * own `-Dcomposeai.fonts.failOnFallback` gate, which fails a render that drew the wrong typeface
+   * for the same reason.
+   */
+  private val allowLostFontFamilies: Boolean = "--allow-lost-font-families" in args
   private val perPreview: Boolean = "--per-preview" in args
   private val verbose: Boolean = "--verbose" in args || "-v" in args
   private val progress: Boolean = verbose || "--progress" in args
@@ -464,7 +487,20 @@ private class PackSubcommand(private val args: List<String>) {
               } else null
 
             printPackSummary(resolvedOutput, meta)
-            semanticsLine?.let { println(it) }
+            semanticsLine?.let { println(it.summary) }
+            // A figma-svg export that lost a font family drew that preview's text as
+            // missing-glyph boxes. That is a defect in the artefact, not in the run that produced
+            // it, so it does not fall under the best-effort rule above: refuse the pack rather
+            // than let a sheet of boxes publish and be found by eye days later.
+            lostFontFamilyRefusal(
+                degradedPreviewIds = semanticsLine?.degradedPreviewIds.orEmpty(),
+                allowed = allowLostFontFamilies,
+                bundlePath = resolvedOutput.path,
+              )
+              ?.let {
+                System.err.println(it)
+                exitProcess(1)
+              }
           }
         }
       }
@@ -679,6 +715,18 @@ private class PackSubcommand(private val args: List<String>) {
   }
 
   /**
+   * What a `--with-semantics` pack carried: the stdout [summary] to print after the main pack
+   * summary, and the previews whose figma-svg export degraded to missing-glyph boxes.
+   *
+   * [degradedPreviewIds] is empty on a healthy sheet — the export writes its font-warning sidecar
+   * only when it could not name a family the render drew.
+   */
+  private data class PackedSemantics(
+    val summary: String,
+    val degradedPreviewIds: List<String> = emptyList(),
+  )
+
+  /**
    * Carry the per-preview semantics blob inside [bundleFile] (issue #1843). Drives a short-lived
    * daemon ([DaemonSemanticsFetcher]) to render the bundle's selected previews and read back each
    * one's `compose/semantics` tree (with resolved foreground/background colours), then injects them
@@ -687,15 +735,20 @@ private class PackSubcommand(private val args: List<String>) {
    *
    * Best-effort: any failure (missing descriptor, daemon open/render error, an unsupported backend)
    * warns to stderr and leaves the already-written bundle untouched rather than failing the pack —
-   * the cover PNG and every other entry are preserved and the polyglot stays valid. Returns the
-   * stdout summary line to print after the main pack summary, or null when nothing was carried.
+   * the cover PNG and every other entry are preserved and the polyglot stays valid. Returns what
+   * was carried, or null when nothing was.
+   *
+   * "Best-effort" covers *infrastructure* — a daemon that would not start says nothing about the
+   * bundle already on disk. It deliberately does not cover a figma-svg export that lost a font
+   * family, which is a statement about the artefact itself: those previews come back in
+   * [PackedSemantics.degradedPreviewIds] for the caller to refuse the pack over.
    */
   private fun packSemanticsBlob(
     target: PreviewModule,
     bundleFile: File,
     meta: BundleReader.Metadata,
     renderTimeout: Duration,
-  ): String? {
+  ): PackedSemantics? {
     val previewIds = meta.manifest.previewIds
     if (previewIds.isEmpty()) return null
     // The manifest's previewIds carry the sanitised in-bundle form; the daemon keys renders on the
@@ -782,6 +835,15 @@ private class PackSubcommand(private val args: List<String>) {
         // export copies the SVG onto the delivery branch. Empty for the common vector-only case.
         val figmaRasterWritten =
           injectFigmaRasterIntoBundle(bundleFile, outcome.figmaRasterById.keyedByBundleId())
+        // The export's font-warning sidecars. Written only for a preview drawn in missing-glyph
+        // boxes, so this is a no-op on a healthy sheet and the entries ARE the defect on a
+        // degraded one. Carried so the warning reaches the delivery branch (and the viewer) with
+        // the artefact it describes, instead of staying on the build machine as it used to.
+        val fontWarningsWritten =
+          injectFigmaFontWarningsIntoBundle(
+            bundleFile,
+            outcome.figmaFontWarningsById.keyedByBundleId(),
+          )
         val semanticsLine =
           "  semantics:     $written / $captureCount preview(s) carried as " +
             "previews/<id>$BUNDLE_SEMANTICS_SUFFIX" +
@@ -807,8 +869,16 @@ private class PackSubcommand(private val args: List<String>) {
               "\n  figma-raster:  $figmaRasterWritten crop(s) carried as " +
                 "previews/<id>$BUNDLE_FIGMA_RASTER_DIR_SUFFIX/<node>.png"
             )
+          if (fontWarningsWritten > 0)
+            append(
+              "\n  figma-fonts:   $fontWarningsWritten preview(s) DEGRADED — text exported as " +
+                "missing-glyph boxes, carried as previews/<id>$BUNDLE_FIGMA_FONT_WARNINGS_SUFFIX"
+            )
         }
-        return semanticsLine + extraLines
+        return PackedSemantics(
+          summary = semanticsLine + extraLines,
+          degradedPreviewIds = outcome.figmaFontWarningsById.keys.sorted(),
+        )
       }
       is DaemonSemanticsFetcher.Outcome.DescriptorMissing ->
         System.err.println(
@@ -1675,3 +1745,27 @@ private fun encodePreviewId(id: String): String =
       append(c)
     }
   }
+
+/**
+ * Why a `--with-semantics` pack must not publish, or null when it may.
+ *
+ * A figma-svg export that could not name a font family the render drew exports that preview's text
+ * as missing-glyph boxes. Nothing downstream distinguishes that from a deliberate rendering, which
+ * is how a whole sheet of boxes reached a live catalog and was found days later by eye — so the
+ * pack refuses by default and names both the previews and the sidecar that says which face was
+ * lost. [allowed] is the deliberate override.
+ */
+internal fun lostFontFamilyRefusal(
+  degradedPreviewIds: List<String>,
+  allowed: Boolean,
+  bundlePath: String,
+): String? {
+  if (degradedPreviewIds.isEmpty() || allowed) return null
+  return "bundle pack: ${degradedPreviewIds.size} preview(s) exported their text as " +
+    "missing-glyph boxes because the figma-svg export could not name a font family the render " +
+    "drew:\n" +
+    degradedPreviewIds.joinToString("\n") { "  - $it" } +
+    "\nEach carries previews/<id>$BUNDLE_FIGMA_FONT_WARNINGS_SUFFIX in $bundlePath naming the " +
+    "face that was lost. Fix the export, or pass --allow-lost-font-families to publish the boxes " +
+    "deliberately."
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSplit.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSplit.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.bundle.BUNDLE_FIGMA_FONT_WARNINGS_SUFFIX
 import ee.schimke.composeai.bundle.BUNDLE_FIGMA_RASTER_DIR_SUFFIX
 import ee.schimke.composeai.bundle.BUNDLE_FIGMA_SVG_SUFFIX
 import ee.schimke.composeai.bundle.BUNDLE_FONTS_SUFFIX
@@ -210,6 +211,10 @@ private val SPLIT_SIDECAR_SUFFIXES =
     BUNDLE_LAYOUT_SUFFIX,
     BUNDLE_FONTS_SUFFIX,
     BUNDLE_FIGMA_SVG_SUFFIX,
+    // Only present on a preview whose text exported as missing-glyph boxes. It must follow the
+    // sticker it describes: a split bundle is what the delivery branch serves, so dropping the
+    // warning here is what left the boxes unexplained in the viewer.
+    BUNDLE_FIGMA_FONT_WARNINGS_SUFFIX,
     ".overrides.json",
     ".catalog.json",
   )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
@@ -333,6 +333,7 @@ internal object CliFlagValidation {
             "--trust",
             "--view-only",
             "--with-semantics",
+            "--allow-lost-font-families",
           ),
       "mcp" to
         setOf(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.bundle.BUNDLE_FIGMA_SVG_SUFFIX
 import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.bundle.injectFigmaFontWarningsIntoBundle
 import ee.schimke.composeai.bundle.injectFigmaRasterIntoBundle
 import ee.schimke.composeai.bundle.injectFigmaSvgIntoBundle
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
@@ -2246,10 +2247,12 @@ class RenderCommand(args: List<String>) : Command(args) {
         )
       val svgById: Map<String, ByteArray>
       val rasterById: Map<String, Map<String, ByteArray>>
+      val fontWarningsById: Map<String, ByteArray>
       when (outcome) {
         is DaemonSemanticsFetcher.Outcome.Ok -> {
           svgById = outcome.figmaSvgById
           rasterById = outcome.figmaRasterById
+          fontWarningsById = outcome.figmaFontWarningsById
         }
         is DaemonSemanticsFetcher.Outcome.DescriptorMissing -> {
           System.err.println(
@@ -2268,8 +2271,19 @@ class RenderCommand(args: List<String>) : Command(args) {
       }
 
       totalWritten +=
-        if (bundle) injectSvgIntoModuleBundle(module, modulePath, svgById, rasterById)
+        if (bundle)
+          injectSvgIntoModuleBundle(module, modulePath, svgById, rasterById, fontWarningsById)
         else writeLooseSvgFiles(module, rows, svgById, rasterById)
+      // The export drew these previews' text as missing-glyph boxes because it could not name a
+      // family the render used. Say so on the way past — this command writes SVGs for a human to
+      // look at, and boxes are the one defect that reads as a rendering choice rather than a bug.
+      if (fontWarningsById.isNotEmpty()) {
+        System.err.println(
+          "render --format svg: ${fontWarningsById.size} preview(s) exported as missing-glyph " +
+            "boxes (a font family the render drew could not be named):"
+        )
+        for (id in fontWarningsById.keys.sorted()) System.err.println("  $id")
+      }
 
       val noSvg = rows.filter { it.id !in svgById }
       if (noSvg.isNotEmpty()) {
@@ -2326,6 +2340,7 @@ class RenderCommand(args: List<String>) : Command(args) {
     modulePath: String,
     svgById: Map<String, ByteArray>,
     rasterById: Map<String, Map<String, ByteArray>>,
+    fontWarningsById: Map<String, ByteArray>,
   ): Int {
     val bundleFile = module.projectDir.resolve("build/compose-previews/bundle.png")
     if (!bundleFile.isFile) {
@@ -2337,6 +2352,9 @@ class RenderCommand(args: List<String>) : Command(args) {
     }
     val svgWritten = injectFigmaSvgIntoBundle(bundleFile, svgById, fileSystem)
     val rasterWritten = injectFigmaRasterIntoBundle(bundleFile, rasterById, fileSystem)
+    // Only a degraded preview has one, so this is a no-op on a healthy module. Carried on the same
+    // trip as the SVG it explains — the two are useless apart.
+    injectFigmaFontWarningsIntoBundle(bundleFile, fontWarningsById, fileSystem)
     if (svgWritten > 0) {
       println(
         "Injected $svgWritten figma-svg" +

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcher.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.data.fonts.FigmaSvgFontWarningsSidecar
 import ee.schimke.composeai.data.fonts.FontsUsedDataProducer
 import ee.schimke.composeai.data.layoutinspector.ComposeFigmaSvgProduct
 import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsProduct
@@ -197,6 +198,7 @@ internal class DaemonSemanticsFetcher(
       val fontsById = LinkedHashMap<String, ByteArray>()
       val figmaSvgById = LinkedHashMap<String, ByteArray>()
       val figmaRasterById = LinkedHashMap<String, Map<String, ByteArray>>()
+      val figmaFontWarningsById = LinkedHashMap<String, ByteArray>()
       for (previewId in previewIds) {
         val file = sidecarFile(projectDir, previewId)
         if (file.isFile && file.length() > 0) {
@@ -239,6 +241,16 @@ internal class DaemonSemanticsFetcher(
               .orEmpty()
           if (crops.isNotEmpty()) figmaRasterById[previewId] = crops
         }
+        // The export's font-warning sidecar, written ONLY when it had to draw text as
+        // missing-glyph boxes because the render used a family it could not name. Collected
+        // unconditionally of the SVG above: a degraded preview is exactly the one whose warning
+        // has to travel, and it is the caller — not this fetcher — that decides whether a
+        // degraded catalog may publish.
+        val fontWarnings = figmaFontWarningsSidecarFile(projectDir, previewId)
+        if (fontWarnings.isFile && fontWarnings.length() > 0) {
+          figmaFontWarningsById[previewId] =
+            fileSystem.read(fontWarnings.path.toPath()) { readByteArray() }
+        }
       }
       Outcome.Ok(
         semanticsById = byId,
@@ -246,6 +258,7 @@ internal class DaemonSemanticsFetcher(
         fontsById = fontsById,
         figmaSvgById = figmaSvgById,
         figmaRasterById = figmaRasterById,
+        figmaFontWarningsById = figmaFontWarningsById,
       )
     }
   }
@@ -265,6 +278,9 @@ internal class DaemonSemanticsFetcher(
   private fun figmaRasterDir(projectDir: File, previewId: String): File =
     File(projectDir, "build/compose-previews/data/$previewId/${ComposeFigmaSvgProduct.RASTER_DIR}")
 
+  private fun figmaFontWarningsSidecarFile(projectDir: File, previewId: String): File =
+    File(projectDir, "build/compose-previews/data/$previewId/${FigmaSvgFontWarningsSidecar.FILE}")
+
   sealed interface Outcome {
     /**
      * Session opened and renders attempted. [semanticsById] holds one entry per preview whose
@@ -277,7 +293,9 @@ internal class DaemonSemanticsFetcher(
      * produced drawing layers. [figmaRasterById] holds, for each preview whose figma-svg is
      * **hybrid** (opaque Image/Icon/Canvas node), its `figma-raster/<node>.png` crops (filename →
      * bytes) so the SVG's `<image>` layers still resolve once carried; empty for a vector-only
-     * export.
+     * export. [figmaFontWarningsById] holds the export's font-warning sidecar for each preview it
+     * had to draw in missing-glyph boxes — **normally empty**, since a healthy export writes no
+     * sidecar, and an entry is the signal that this preview's text is wrong.
      */
     data class Ok(
       val semanticsById: Map<String, ByteArray>,
@@ -285,6 +303,7 @@ internal class DaemonSemanticsFetcher(
       val fontsById: Map<String, ByteArray> = emptyMap(),
       val figmaSvgById: Map<String, ByteArray> = emptyMap(),
       val figmaRasterById: Map<String, Map<String, ByteArray>> = emptyMap(),
+      val figmaFontWarningsById: Map<String, ByteArray> = emptyMap(),
     ) : Outcome
 
     data class DescriptorMissing(val expected: File) : Outcome

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSemanticsInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSemanticsInjectTest.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.bundle.BundleReader
 import ee.schimke.composeai.bundle.addOrReplaceZipEntries
+import ee.schimke.composeai.bundle.injectFigmaFontWarningsIntoBundle
 import ee.schimke.composeai.bundle.injectFigmaRasterIntoBundle
 import ee.schimke.composeai.bundle.injectFigmaSvgIntoBundle
 import ee.schimke.composeai.bundle.injectFontsIntoBundle
@@ -226,6 +227,54 @@ class BundleSemanticsInjectTest {
       names.getValue("previews/a.semantics.json").toString(Charsets.UTF_8),
     )
     assertEquals(svg, names.getValue("previews/a.figma.svg").toString(Charsets.UTF_8))
+  }
+
+  @Test
+  fun `carries the figma-svg font-warning sidecar beside the svg it explains`() {
+    // The export writes this file ONLY for a preview it had to draw as missing-glyph boxes, so an
+    // entry here is the defect. It used to be written into the render's data dir and collected by
+    // nobody, which is how a sheet of boxes published with the one artefact naming the lost face
+    // left behind on the build machine.
+    val cover = png(4, 8)
+    val svg = """<svg xmlns="http://www.w3.org/2000/svg"><g id="Box"/></svg>"""
+    val file =
+      polyglot(
+        cover,
+        linkedMapOf(
+          "bundle.json" to "{}".toByteArray(),
+          "previews/a.png" to cover,
+          "previews/a.figma.svg" to svg.toByteArray(),
+        ),
+      )
+
+    val warnings =
+      """{"unnamedRenderedFamilies":["Orbitron"],"namedFamilies":["Roboto"],""" +
+        """"tofuFamily":"ComposeAI Missing Font"}"""
+    val written = injectFigmaFontWarningsIntoBundle(file, mapOf("a" to warnings.toByteArray()))
+
+    assertEquals(1, written)
+    val names = entries(BundleReader.extractZipBytes(file))
+    assertEquals(svg, names.getValue("previews/a.figma.svg").toString(Charsets.UTF_8))
+    assertEquals(
+      warnings,
+      names.getValue("previews/a.figma-fonts.warnings.json").toString(Charsets.UTF_8),
+    )
+  }
+
+  @Test
+  fun `a healthy sheet carries no font-warning sidecar at all`() {
+    // Absence is the healthy signal, so "no entries" has to stay reachable: a reader treats the
+    // presence of one of these as "this sticker's text is wrong".
+    val cover = png(4, 8)
+    val file =
+      polyglot(cover, linkedMapOf("bundle.json" to "{}".toByteArray(), "previews/a.png" to cover))
+
+    assertEquals(0, injectFigmaFontWarningsIntoBundle(file, emptyMap()))
+    assertTrue(
+      entries(BundleReader.extractZipBytes(file)).keys.none {
+        it.endsWith(".figma-fonts.warnings.json")
+      }
+    )
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSplitTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSplitTest.kt
@@ -44,6 +44,8 @@ class BundleSplitTest {
         "previews/A.png" to "PNG-A".encodeToByteArray(),
         "previews/A.semantics.json" to """{"nodes":["a"]}""".encodeToByteArray(),
         "previews/A.figma.svg" to "<svg>A</svg>".encodeToByteArray(),
+        "previews/A.figma-fonts.warnings.json" to
+          """{"unnamedRenderedFamilies":["Orbitron"]}""".encodeToByteArray(),
         "previews/B.png" to "PNG-B".encodeToByteArray(),
         // C has NO baked image on purpose — it must be skipped.
         "previews/C.semantics.json" to """{"nodes":["c"]}""".encodeToByteArray(),
@@ -110,6 +112,9 @@ class BundleSplitTest {
     assertTrue("previews/A.png" in entries)
     assertTrue("previews/A.semantics.json" in entries)
     assertTrue("previews/A.figma.svg" in entries)
+    // The font-warning sidecar has to follow the sticker it explains: a split bundle is what the
+    // delivery branch serves, so dropping it here is what left the boxes unexplained downstream.
+    assertTrue("previews/A.figma-fonts.warnings.json" in entries)
     assertFalse("previews/B.png" in entries)
     // FULL keeps the shared re-render classpath.
     assertTrue("classes/app.jar" in entries)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/LostFontFamilyRefusalTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/LostFontFamilyRefusalTest.kt
@@ -1,0 +1,51 @@
+package ee.schimke.composeai.cli
+
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The gate that stopped a sheet of missing-glyph boxes from publishing again.
+ *
+ * A `compose/figma-svg` export that cannot name a font family the render drew falls back to boxes
+ * and writes `compose-figma-fonts.warnings.json` beside the SVG. For a year nothing read that file:
+ * it stayed in the render's data dir, the boxes published, and the defect was found by eye in a
+ * live catalog days later. The sidecar now travels with the sticker, and its presence refuses the
+ * pack.
+ */
+class LostFontFamilyRefusalTest {
+
+  @Test
+  fun `a healthy pack is not refused`() {
+    // No sidecar means no degraded preview — the export writes one only when it degrades.
+    assertNull(lostFontFamilyRefusal(emptyList(), allowed = false, bundlePath = "b.png"))
+  }
+
+  @Test
+  fun `a degraded pack is refused and names every preview and the sidecar`() {
+    val message =
+      lostFontFamilyRefusal(
+        listOf("AppCard_ideal", "Chip_default"),
+        allowed = false,
+        bundlePath = "out/wear-m3-bundle.png",
+      )
+
+    assertNotNull(message)
+    // The message has to carry what a publisher needs to act: how many, which, and where the
+    // machine-readable reason lives.
+    assertTrue(message.contains("2 preview(s)"), message)
+    assertTrue(message.contains("AppCard_ideal"), message)
+    assertTrue(message.contains("Chip_default"), message)
+    assertTrue(message.contains(".figma-fonts.warnings.json"), message)
+    assertTrue(message.contains("out/wear-m3-bundle.png"), message)
+    assertTrue(message.contains("--allow-lost-font-families"), message)
+  }
+
+  @Test
+  fun `the override publishes the boxes deliberately`() {
+    // Same posture as the render's own -Dcomposeai.fonts.failOnFallback: refusing is the default,
+    // and shipping the degraded artefact stays possible but has to be asked for.
+    assertNull(lostFontFamilyRefusal(listOf("AppCard_ideal"), allowed = true, bundlePath = "b.png"))
+  }
+}

--- a/data/fonts/core/src/main/kotlin/ee/schimke/composeai/data/fonts/FigmaSvgFontWarningsSidecar.kt
+++ b/data/fonts/core/src/main/kotlin/ee/schimke/composeai/data/fonts/FigmaSvgFontWarningsSidecar.kt
@@ -1,0 +1,20 @@
+package ee.schimke.composeai.data.fonts
+
+/**
+ * The `compose/figma-svg` export's font-warning sidecar, named once so the two ends agree.
+ *
+ * The export writes it beside `compose-figma.svg` whenever it drew text in missing-glyph boxes
+ * because the render used a family the export could not name; a healthy export leaves no file, so
+ * its **presence is the signal**. That made it worth exactly nothing for a year: the producer
+ * (`:data-layoutinspector-connector`) wrote it into the render's data dir, and no reader ever went
+ * looking, so a degraded sticker sheet published with the warning still sitting on the build
+ * machine's disk.
+ *
+ * The reader is `:cli`, which does not depend on the connector, so the name lives here — the one
+ * module both already depend on — rather than being spelled twice and drifting.
+ */
+public object FigmaSvgFontWarningsSidecar {
+
+  /** Filename written beside the SVG in the render's per-preview data dir. */
+  public const val FILE: String = "compose-figma-fonts.warnings.json"
+}

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeFigmaSvgDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeFigmaSvgDataProduct.kt
@@ -6,6 +6,7 @@ import ee.schimke.composeai.daemon.protocol.DataProductTransport
 import ee.schimke.composeai.daemon.protocol.FigmaSvgBackgroundMode
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.SamplingPolicy
+import ee.schimke.composeai.data.fonts.FigmaSvgFontWarningsSidecar
 import ee.schimke.composeai.data.layoutinspector.ComposeFigmaSvgProduct
 import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload
 import ee.schimke.composeai.data.layoutinspector.FigmaLayeredSvg
@@ -233,7 +234,7 @@ object ComposeFigmaSvgDataProducer {
   const val DEFAULT_EMBED_FAMILY: String = "Roboto"
 
   /** Sidecar naming the faces the render drew with that the export could not reproduce. */
-  const val FILE_FONT_WARNINGS: String = "compose-figma-fonts.warnings.json"
+  const val FILE_FONT_WARNINGS: String = FigmaSvgFontWarningsSidecar.FILE
 
   /** Every family named on a `<text>` or curved `<textPath>` run in [layer]'s subtree. */
   private fun capturedFamilies(layer: FigmaSvgLayer): Set<String> = buildSet {

--- a/render-host/api/render-host.api
+++ b/render-host/api/render-host.api
@@ -3936,8 +3936,8 @@ public final class ee/schimke/composeai/cli/serve/ServeParityIssuesStore {
 }
 
 public final class ee/schimke/composeai/cli/serve/ServePreview {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/util/List;Ljava/util/List;ZZZZLjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;IZJLjava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/CatalogRenderFailure;Ljava/util/List;Lee/schimke/composeai/cli/serve/ServeDeviceFrame;ZLjava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/util/List;Ljava/util/List;ZZZZLjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;IZJLjava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/CatalogRenderFailure;Ljava/util/List;Lee/schimke/composeai/cli/serve/ServeDeviceFrame;ZLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/util/List;Ljava/util/List;ZZZZLjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;IZJLjava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/CatalogRenderFailure;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/cli/serve/ServeDeviceFrame;ZLjava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/util/List;Ljava/util/List;ZZZZLjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;IZJLjava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/CatalogRenderFailure;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/cli/serve/ServeDeviceFrame;ZLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Z
 	public final fun component11 ()Ljava/lang/String;
@@ -3958,18 +3958,19 @@ public final class ee/schimke/composeai/cli/serve/ServePreview {
 	public final fun component25 ()Ljava/lang/String;
 	public final fun component26 ()Lee/schimke/composeai/cli/serve/CatalogRenderFailure;
 	public final fun component27 ()Ljava/util/List;
-	public final fun component28 ()Lee/schimke/composeai/cli/serve/ServeDeviceFrame;
-	public final fun component29 ()Z
+	public final fun component28 ()Ljava/util/List;
+	public final fun component29 ()Lee/schimke/composeai/cli/serve/ServeDeviceFrame;
 	public final fun component3 ()Ljava/util/List;
-	public final fun component30 ()Ljava/util/List;
+	public final fun component30 ()Z
+	public final fun component31 ()Ljava/util/List;
 	public final fun component4 ()Ljava/util/Set;
 	public final fun component5 ()Ljava/util/List;
 	public final fun component6 ()Ljava/util/List;
 	public final fun component7 ()Z
 	public final fun component8 ()Z
 	public final fun component9 ()Z
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/util/List;Ljava/util/List;ZZZZLjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;IZJLjava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/CatalogRenderFailure;Ljava/util/List;Lee/schimke/composeai/cli/serve/ServeDeviceFrame;ZLjava/util/List;)Lee/schimke/composeai/cli/serve/ServePreview;
-	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ServePreview;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/util/List;Ljava/util/List;ZZZZLjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;IZJLjava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/CatalogRenderFailure;Ljava/util/List;Lee/schimke/composeai/cli/serve/ServeDeviceFrame;ZLjava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServePreview;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/util/List;Ljava/util/List;ZZZZLjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;IZJLjava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/CatalogRenderFailure;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/cli/serve/ServeDeviceFrame;ZLjava/util/List;)Lee/schimke/composeai/cli/serve/ServePreview;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/serve/ServePreview;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/util/List;Ljava/util/List;ZZZZLjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;IZJLjava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/serve/CatalogRenderFailure;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/cli/serve/ServeDeviceFrame;ZLjava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/cli/serve/ServePreview;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBackgroundColor ()J
 	public final fun getBodyLine ()Ljava/lang/Integer;
@@ -3983,6 +3984,7 @@ public final class ee/schimke/composeai/cli/serve/ServePreview {
 	public final fun getGroup ()Ljava/lang/String;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getLabel ()Ljava/lang/String;
+	public final fun getLostFontFamilies ()Ljava/util/List;
 	public final fun getModes ()Ljava/util/List;
 	public final fun getMotion ()Ljava/util/List;
 	public final fun getOverrides ()Ljava/util/List;

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -287,6 +287,18 @@ public data class ServePreview(
   /** Published render failure for a catalog card that has no PNG. */
   val renderFailure: CatalogRenderFailure? = null,
   /**
+   * The font families the render drew that this preview's `compose/figma-svg` export could not
+   * name, so its text was exported as **missing-glyph boxes** rather than silently substituted.
+   * From the bundle's `previews/<id>.figma-fonts.warnings.json` sidecar; empty is the healthy
+   * state, because the export writes that sidecar only when it degrades.
+   *
+   * Carried so the viewer can say so on the sticker. The sidecar existed for a year and reached
+   * nobody — written into the render's data dir, collected by nothing — which is how a sheet of
+   * boxes published and was found by eye in a live catalog days later. A signal that stops one hop
+   * short of the reader is not a signal.
+   */
+  val lostFontFamilies: List<String> = emptyList(),
+  /**
    * Animated captures published for this preview. Empty for the overwhelming majority — a still is
    * the whole artifact for most components — so a viewer treats this as opt-in extra surface and
    * never as a replacement for the baked pixels.


### PR DESCRIPTION
## The fault

A `compose/figma-svg` export that cannot name a font family the render drew falls back to missing-glyph boxes, and records exactly what it lost in `compose-figma-fonts.warnings.json` beside the SVG.

**Nothing has ever read that file.** It is written into the render's data dir, and from there: not collected by `DaemonSemanticsFetcher`, not injected into the bundle, not published to `design-artifacts/<system>`, not served. So a sheet of boxes shipped to a live catalog and was found by eye a day later — with the one artefact naming the lost face still sitting on the build machine's disk.

The tofu itself was fixed by #5283. This is about the part that let it ship unnoticed, which is still true for the next one.

## Follow the signal to the end

**Collect and carry it.** The sidecar now travels the same route as every other per-preview sidecar — collected by `DaemonSemanticsFetcher`, injected as `previews/<id>.figma-fonts.warnings.json`, and split out alongside the sticker it explains, so it reaches the delivery branch beside the SVG it is about. Only a degraded preview has one, so this is a no-op on a healthy sheet, and an entry is itself the signal.

**Refuse to publish it.** `bundle pack --with-semantics` exits non-zero when any preview degraded, naming each one and pointing at the sidecar:

```
bundle pack: 2 preview(s) exported their text as missing-glyph boxes because the
figma-svg export could not name a font family the render drew:
  - AppCard_ideal
  - Chip_default
Each carries previews/<id>.figma-fonts.warnings.json in out/wear-m3-bundle.png
naming the face that was lost. Fix the export, or pass --allow-lost-font-families
to publish the boxes deliberately.
```

`design-artifacts.yml` runs exactly that command under `set -euo pipefail`, so this fails the job before the publish step.

**Hand it to the reader.** `ServePreview.lostFontFamilies` is where the server lands the sidecar's contents so the viewer can badge the sticker. The server reads the file and draws the badge — that half lives in `compose-preview-server` and is blocked on this releasing, since it compiles against a published `render-host`.

## Why the gate is at the pack, not the export

Throwing from `ComposeFigmaSvgDataProducer.writeSvg` looks like the obvious place and does nothing. Post-capture extensions are dispatched inside a `catch (t: Throwable)` in `RenderEngine` that logs and continues, deliberately — an extension failure must not strand the PNG the user came for. A gate there would print one more stderr line nobody reads, and the tofu SVG (already written) would publish regardless. The publish is where a gate actually stops something.

`--allow-lost-font-families` is the deliberate override, matching the render's own `-Dcomposeai.fonts.failOnFallback`, which is default-on and fails a render that drew the wrong typeface for exactly this reason.

## Note on the default

This is default-on by design, so **a catalog that currently degrades will now fail its publish instead of shipping boxes.** That is the intent; the escape hatch is one flag if a sheet needs to ship while the export is fixed.

## Also

The sidecar's filename moves to `:data-fonts-core` — the one module both the producer (`:data-layoutinspector-connector`) and the reader (`:cli`) already depend on — so it is spelled once rather than mirrored. `bundle-format` and `render-host` ABI dumps are regenerated for the new suffix, injector and field.

## Test plan

- `LostFontFamilyRefusalTest` — healthy pack not refused; degraded pack names every preview, the sidecar and the override; the override publishes deliberately.
- `BundleSemanticsInjectTest` — the sidecar lands beside the `.figma.svg` it explains without disturbing it; a healthy sheet carries none at all.
- `BundleSplitTest` — the sidecar follows its sticker through a split (the delivery branch serves split bundles, so dropping it there is what left the boxes unexplained downstream).
- `./gradlew :cli:test :bundle-format:test :data-fonts-core:test :data-layoutinspector-connector:test :render-host:test :bundle-format:checkKotlinAbi :render-host:checkKotlinAbi` — green.
- `./gradlew ktfmtCheckAll` — green.

Text-only change (CLI output, bundle entries, one DTO field); no rendered surface moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAWxMuzo5hFagcDzxY4rUD