### PR TITLE
fix(ci): treat an absent recovery timestamp as unknown, not as midnight

### DIFF
--- a/.github/scripts/sweep-stranded-releases.sh
+++ b/.github/scripts/sweep-stranded-releases.sh
@@ -62,9 +62,16 @@ CENTRAL_BASE_URL="${CENTRAL_BASE_URL:-https://repo1.maven.org/maven2}"
 now="$(date -u +%s)"
 exit_code=0
 
-minutes_since() { # <ISO-8601 timestamp> → whole minutes, or empty if unreadable
+minutes_since() { # <ISO-8601 timestamp> → whole minutes, or empty if absent/unreadable
   local epoch
-  epoch="$(date -u -d "${1:-}" +%s 2>/dev/null)" || return 0
+  # An EMPTY timestamp has to answer "unknown", not a number. GNU `date -u -d ""` does not fail —
+  # it reads the empty string as midnight today and exits 0 — so without this guard "no recovery
+  # run has ever been dispatched" came back as "dispatched <minutes since UTC midnight> ago". For
+  # the first RECOVERY_COOLDOWN_MINUTES of every UTC day that is inside the cooldown, so the
+  # sweeper declined to dispatch the rebuild it exists to dispatch, and its self-test failed for
+  # the same six hours daily.
+  [[ -n "${1:-}" ]] || return 0
+  epoch="$(date -u -d "$1" +%s 2>/dev/null)" || return 0
   [[ -n "${epoch}" ]] && echo $(( (now - epoch) / 60 ))
 }
 

--- a/.github/scripts/test-sweep-stranded-releases.sh
+++ b/.github/scripts/test-sweep-stranded-releases.sh
@@ -139,6 +139,12 @@ CURL_OK=false run central
 logged central "PATCH" && fail "a release whose plugin is not on Central must stay a draft"
 
 # 5. Assets missing means the build never finished — rebuild it for the tag rather than publish.
+#    No ${DISPATCHES} fixture is set, so this is also the "no recovery run has ever been
+#    dispatched" case, and it is the one that caught `date -u -d ""` reading an empty timestamp as
+#    midnight today rather than failing: the sweeper saw a phantom recovery <minutes since UTC
+#    midnight> old and sat inside its own cooldown. That made both assertions below — and the real
+#    sweeper — fail for the first RECOVERY_COOLDOWN_MINUTES of every UTC day. Keep this case
+#    fixture-less; its independence from the wall clock is the assertion.
 fixture "${ASSETS}" '[{"name":"compose-preview-1.78.0.zip"}]'
 run rebuild
 [[ $status -eq 0 ]] || fail "dispatching a rebuild should exit 0"


### PR DESCRIPTION
## The bug

`sweep-stranded-releases.sh`'s `minutes_since` passed its argument straight to `date -u -d`:

```bash
epoch="$(date -u -d "${1:-}" +%s 2>/dev/null)" || return 0
```

GNU `date -u -d ""` **does not fail.** It reads the empty string as midnight today and exits 0:

```console
$ date -u -d "" +%s
1788825600      # 2026-09-08T00:00:00Z
$ echo $?
0
```

So "no `release.yml` recovery run has ever been dispatched" — an empty `last_recovery`, which is also what a 404 on that query produces — came back as *"dispatched (minutes since UTC midnight) ago"*. `RECOVERY_COOLDOWN_MINUTES` is 360, so for the **first six hours of every UTC day** the sweeper concluded it was inside its own cooldown and declined to dispatch the rebuild it exists to dispatch.

## The visible symptom

`Actions Script Tests` is red on `main` right now, on these two:

```
FAIL: a draft missing assets should dispatch release.yml
FAIL: the dispatch must name the stranded tag
```

Those are case 5, which deliberately sets no `${DISPATCHES}` fixture. They have been failing on every PR raised between 00:00 and 06:00 UTC since the script was written, and passing the other eighteen hours — which is why it reads as intermittent rather than broken.

## The fix

Guard the empty case before `date` sees it. Case 5 already covers this; it just needed the wall clock out of the way to say so at every hour. A comment there records the trap, and that its independence from the clock is the assertion.

## Test plan

- `./.github/scripts/test-sweep-stranded-releases.sh` at 00:26 UTC — **before:** the two failures above; **after:** `sweep-stranded-releases.sh: all tests passed.`
- Both directions verified against the reproduction above (`date -u -d "" +%s` exiting 0).

Found while driving #5292, whose diff touches none of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAWxMuzo5hFagcDzxY4rUD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YAWxMuzo5hFagcDzxY4rUD)_