### PR TITLE
fix: don't read an absent recovery timestamp as midnight today

### DIFF
--- a/.github/scripts/sweep-stranded-releases.sh
+++ b/.github/scripts/sweep-stranded-releases.sh
@@ -62,9 +62,14 @@ CENTRAL_BASE_URL="${CENTRAL_BASE_URL:-https://repo1.maven.org/maven2}"
 now="$(date -u +%s)"
 exit_code=0
 
-minutes_since() { # <ISO-8601 timestamp> → whole minutes, or empty if unreadable
+minutes_since() { # <ISO-8601 timestamp> → whole minutes, or empty if absent or unreadable
   local epoch
-  epoch="$(date -u -d "${1:-}" +%s 2>/dev/null)" || return 0
+  # An empty argument is "no such timestamp", and it has to be rejected before `date` sees it:
+  # GNU `date -d ""` does not fail, it answers *midnight today*. So an absent `last_recovery`
+  # read as a recovery dispatched however many minutes we are past 00:00 UTC, and every sweep
+  # between midnight and the 6h cooldown refused to dispatch a rebuild it should have.
+  [[ -n "${1:-}" ]] || return 0
+  epoch="$(date -u -d "$1" +%s 2>/dev/null)" || return 0
   [[ -n "${epoch}" ]] && echo $(( (now - epoch) / 60 ))
 }
 


### PR DESCRIPTION
## The bug

`sweep-stranded-releases.sh`'s `minutes_since` handed its argument straight to `date -u -d`, including when that argument was the empty string. GNU `date` does not fail on an empty date — it answers **midnight today**:

```
$ date -u -d "" +%s; echo "rc=$?"
1788825600     # today 00:00:00Z
rc=0
```

So when no `release.yml` recovery run had ever been dispatched, `last_recovery` came back empty from the `// empty` jq filter, and `minutes_since` reported "minutes since midnight" rather than nothing.

Against the 6-hour `RECOVERY_COOLDOWN_MINUTES`, that reads as a recent recovery. Every sweep starting between 00:00 and 06:00 UTC therefore **declined to dispatch the rebuild a stranded draft needed**, and logged a warning naming a run that never happened:

```
::warning::a release.yml recovery run was dispatched 29m ago (< 360m); not dispatching another for v1.78.0.
```

That is a quarter of the day, and the sweep is scheduled — it runs precisely when nobody is watching it decline.

## The fix

An empty argument means "no such timestamp", and it has to be rejected before `date` sees it. One guard, with the reasoning beside it.

`minutes_since`'s other caller reads a draft's `created_at`, which is never empty in practice; if it ever were, the empty return is the existing "could not read the creation time; leaving it alone" path, which is the behaviour you want there too.

## How it was found

`test-sweep-stranded-releases.sh` already covers this — cases 5 and 6 pin exactly the dispatch this suppressed. They have been failing on `main` in any run started between 00:00 and 06:00 UTC, which is why it looks intermittent:

```
FAIL: a draft missing assets should dispatch release.yml
FAIL: the dispatch must name the stranded tag
2 sweep-stranded-releases.sh test(s) failed.
```

It surfaced as a red `Actions Script Tests` on an unrelated PR ([#5293](https://github.com/yschimke/compose-ai-tools/pull/5293)) that happened to run at 00:27 UTC. Reproduced on `origin/main` at the same hour with no other changes, so it is not that PR's.

## Test plan

- `./.github/scripts/test-sweep-stranded-releases.sh` at 00:30 UTC — **red before** (cases 5 and 6), **green after**: `sweep-stranded-releases.sh: all tests passed.`
- Same script on `origin/main` at the same hour — red, confirming the failure predates this branch.

Note the self-test is time-of-day dependent through this very bug, so a re-run after 06:00 UTC passes with or without the fix. The reproduction above was taken inside the window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TiJw44mgFLFjaf19Y7X1T

---
_Generated by [Claude Code](https://claude.ai/code/session_018TiJw44mgFLFjaf19Y7X1T)_