### PR TITLE
fix: track rc-players 1.59.4 for the font-scale fix

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -446,7 +446,7 @@ composeai-preview-server-dist = "3.9.0"
 #
 # During the move these were briefly split across two refs, so that three unpublished coordinates
 # could not pin the five that were already on Central. That is over: one ref again.
-rcplayers = "1.59.3"
+rcplayers = "1.59.4"
 
 [libraries]
 


### PR DESCRIPTION
One-line version bump. It is the half of the font-scale chain this repository does not own.

## What 1.59.4 carries

[rc-players#61](https://github.com/yschimke/rc-players/pull/61) — `ID_FONT_SIZE` and `ID_DENSITY` were seeded into a store that `CoreDocument.initializeContext` discarded moments later (`loadFloat` writes into `mRemoteComposeState`; `initializeContext` ends by repointing that field at the document's freshly `reset()` store). A document reading either built-in got the store default however the render was configured — `0.0` on the JVM lane.

Nothing noticed for as long as it did because nothing read them: a `RemoteDensity.from(displayInfo)` capture folds density and font scale into constants, so `[27]` and `[33]` appear nowhere in its ops. #5296 made `composePreview.rcDensity=host` write documents whose text size is an expression over exactly those variables — which is what finally exposed the player bug. The two defects had been concealing each other.

## Evidence

The same `Host`-captured document through the patched player, only the font scale differing:

| | fontScale 1 | fontScale 2 |
| --- | --- | --- |
| PNG | 11067 bytes | 14180 bytes |

Text renders at roughly twice the size and the button reflows to wrap it. Against 1.59.3 the two are byte-identical. That is the first end-to-end confirmation that the capture → context → glyphs chain closes; both earlier fixes looked sufficient in isolation and neither was.

## What this does not do

**It does not change what `preview.coo.ee/remote-m3` serves.** The published catalog's documents are `fixed` captures baked before #5296, so their sp→px is already folded to constants and no player can move them. This bump makes the machinery correct; the URL responds only after a plugin release and a catalog re-bake ([wear-m3-catalog#369](https://github.com/yschimke/wear-m3-catalog/pull/369)).

It is also inert for every document that does not opt in, which is the safety case for taking it now. Measured on one preview captured both ways:

| document | references to `[27]` / `[33]` |
| --- | --- |
| baseline, `from(displayInfo)` | 0 |
| `rcDensity=host` | 17 |

The deployed lane is the one this fixes: the served page reports `data-rc-baked-player="cmp-android"`, which resolves to `third-party-rc-embedded-player` — the vendored AndroidX embedded player, and the artifact 1.59.4 patches.

## Test plan

- `:data-remotecompose-connector:compileDebugKotlin` and `:render-host:compileKotlin` against 1.59.4 — green, so the coordinates resolve and nothing in the bump breaks compilation.
- No source change beyond the catalog entry, so behaviour is whatever CI's render lanes report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mu5a7gLKePVTyjQ95zs3dX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mu5a7gLKePVTyjQ95zs3dX)_