### PR TITLE
test: pin the capture's non-linear sp-to-px font scale curve

### DIFF
--- a/data/remotecompose/connector/build.gradle.kts
+++ b/data/remotecompose/connector/build.gradle.kts
@@ -133,6 +133,7 @@ dependencies {
   // selecting `player = embedded` there falls back to the view player instead of dying.
   compileOnly(libs.rcplayer.embedded.android)
   testImplementation(libs.compose.remote.player.core)
+  testImplementation(libs.compose.remote.creation.compose)
   testImplementation(libs.compose.remote.core)
 
   testImplementation(libs.junit)

--- a/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/RemoteFontScaleCurveTest.kt
+++ b/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/RemoteFontScaleCurveTest.kt
@@ -1,0 +1,104 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.remote.creation.compose.capture.RemoteDensity
+import androidx.compose.remote.creation.compose.state.rf
+import androidx.compose.remote.creation.compose.state.rsp
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * `sp -> px` at capture is **non-linear**, and this pins the curve that makes it so.
+ *
+ * ## Why this is load-bearing for `composeai.render.rcDensity=host`
+ *
+ * Android does not scale text by multiplying: `FontScaleConverter` damps large text hard, so a
+ * headline barely moves while body text tracks the scale exactly. `RemoteTextUnit.toPx` reproduces
+ * that through `RemoteFontScaleConverter.NonLinear`, and — this is the part that matters — it does
+ * so on **both** of its branches:
+ *
+ * * every input constant ([RemoteCaptureDensity.FIXED]) folds the curve to a literal;
+ * * any input a variable ([RemoteCaptureDensity.HOST]) emits the same converter as a
+ *   `RemoteFloatExpression` over the player's own `FONT_SIZE`, evaluated at paint time.
+ *
+ * So a `Host` document is not "linear scaling deferred to the player" — it carries Android's curve
+ * with it. That is what makes the opt-in safe, and it is not obvious from the property name.
+ *
+ * ## What it means for a player
+ *
+ * The pixels a `Host` document resolves to **already carry the host's font scale**, damped. A
+ * player must draw them as they are; one that multiplies by `fontScale` a second time turns the
+ * 44sp row below from 50.4px into 100.8px — a 2x error on exactly the text the curve exists to
+ * protect. `rc-players`' `RcFontScaleRenderTest` pins a player doing that on one of its two text
+ * paths.
+ *
+ * Measured against the real converter rather than transcribed from AOSP's tables, so a version bump
+ * that re-cuts the curve fails here instead of silently changing every headline.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class RemoteFontScaleCurveTest {
+
+  /**
+   * Body text tracks the scale; headlines do not move at all until well past it.
+   *
+   * The two ends are the whole point: 12sp doubles exactly at 2.0, while 44sp is untouched through
+   * 1.5 and grows 15% at 2.0. Anything that "fixes" font scaling by multiplying would make both
+   * rows 2.0x and be wrong on one of them.
+   */
+  @Test
+  fun theCaptureCurveDampsLargeTextAndNotSmall() {
+    for ((size, expected) in EXPECTED) {
+      for ((fontScale, px) in expected) {
+        assertEquals(
+          "${size}sp at fontScale $fontScale",
+          px,
+          toPx(size, fontScale),
+          TOLERANCE,
+        )
+      }
+    }
+  }
+
+  /** A literal font size is unchanged at `fontScale = 1`, on every size the curve knots at. */
+  @Test
+  fun theCurveIsIdentityAtScaleOne() {
+    for (size in EXPECTED.keys) {
+      assertEquals("${size}sp at fontScale 1", size.toFloat(), toPx(size, 1f), TOLERANCE)
+    }
+  }
+
+  /** Density is a separate multiplier, so the curve is the same shape at any of them. */
+  @Test
+  fun densityMultipliesTheCurveRatherThanBendingIt() {
+    for (size in EXPECTED.keys) {
+      val atOne = toPx(size, FONT_SCALE_2X, density = 1f)
+      val atTwo = toPx(size, FONT_SCALE_2X, density = 2f)
+      assertEquals("${size}sp at density 2", atOne * 2f, atTwo, TOLERANCE)
+    }
+  }
+
+  /** The capture's own conversion, with both density and font scale constant. */
+  private fun toPx(sp: Int, fontScale: Float, density: Float = 1f): Float =
+    checkNotNull(sp.rsp.toPx(RemoteDensity(density.rf, fontScale.rf)).constantValueOrNull) {
+      "constant inputs should fold to a constant"
+    }
+
+  private companion object {
+    const val TOLERANCE = 0.05f
+    const val FONT_SCALE_2X = 2f
+
+    /** Measured off `RemoteFontScaleConverter.NonLinear` at density 1.0. */
+    val EXPECTED =
+      linkedMapOf(
+        12 to mapOf(1.15f to 13.8f, 1.3f to 15.6f, 1.5f to 18f, 2f to 24f),
+        16 to mapOf(1.15f to 18.1f, 1.3f to 20.2f, 1.5f to 23f, 2f to 28f),
+        24 to mapOf(1.15f to 25.2f, 1.3f to 26.4f, 1.5f to 28f, 2f to 36f),
+        30 to mapOf(1.15f to 30f, 1.3f to 30f, 1.5f to 30f, 2f to 38f),
+        44 to mapOf(1.15f to 44f, 1.3f to 44f, 1.5f to 44f, 2f to 50.4f),
+        57 to mapOf(1.15f to 57f, 1.3f to 57f, 1.5f to 57f, 2f to 61.914f),
+      )
+  }
+}


### PR DESCRIPTION
Android does not scale text by multiplying. `FontScaleConverter` damps large text hard, and `RemoteTextUnit.toPx` reproduces that through `RemoteFontScaleConverter.NonLinear`.

Measured against the real converter at density 1.0 — not transcribed from AOSP's tables:

| sp | fs=1.15 | fs=1.3 | fs=1.5 | fs=2.0 | |
| --- | --- | --- | --- | --- | --- |
| 12 | 13.8 | 15.6 | 18.0 | **24.0** | 2.00x |
| 16 | 18.1 | 20.2 | 23.0 | 28.0 | 1.75x |
| 24 | 25.2 | 26.4 | 28.0 | 36.0 | 1.50x |
| 30 | 30.0 | 30.0 | 30.0 | 38.0 | 1.27x |
| 44 | **44.0** | **44.0** | **44.0** | **50.4** | 1.15x |
| 57 | 57.0 | 57.0 | 57.0 | 61.9 | 1.09x |

A 44sp headline does not move at all until past fontScale 1.5 and grows 15% at 2.0, while 12sp body text doubles exactly.

## Why this is load-bearing for `composeai.render.rcDensity=host`

Not obvious from the property name: `RemoteTextUnit.toPx` applies that converter on **both** of its branches.

- Every input constant (`FIXED`) — folds the curve to a literal.
- Any input a variable (`HOST`) — emits the same converter as a `RemoteFloatExpression` over the player's own `FONT_SIZE`, evaluated at paint time.

So a `Host` document is not "linear scaling deferred to the player". It carries Android's curve with it, which is what makes the opt-in safe.

## What it means for a player

The pixels a `Host` document resolves to **already carry the damped scale**, so a player must draw them as they are. One that multiplies by `fontScale` a second time turns the 44sp row into 100.8px instead of 50.4 — a 2x error on exactly the text the curve exists to protect. [yschimke/rc-players#71](https://github.com/yschimke/rc-players/pull/71) pins a player doing precisely that on one of its two text paths (`cmp-wasm`; not the default served lane).

Pinning the curve here means a `remote-creation-compose` bump that re-cuts it fails this test instead of silently changing every headline in every published catalog.

## Test plan

- `./gradlew :data-remotecompose-connector:testDebugUnitTest --tests '*RemoteFontScaleCurveTest*' --rerun-tasks` — 3 tests, 0 failures, 0 skipped; verified it actually ran rather than reporting UP-TO-DATE.
- `./gradlew :data-remotecompose-connector:ktfmtFormatTest` before committing.
- Test-only change; no production code touched, so nothing here alters what any capture or player produces. Text-only evidence is correct.

`remote-creation-compose` gains a `testImplementation` alongside its existing `compileOnly` so the test can reach the converter; it stays out of the published AAR's metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mu5a7gLKePVTyjQ95zs3dX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mu5a7gLKePVTyjQ95zs3dX)_