### PR TITLE
fix(ui-builder): apply four fixes to the places they were left out of

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -1904,7 +1904,23 @@ jobs:
           # not the caller's. Checking only the spec-adjacent and module paths meant the policy
           # Gradle actually consumes could skip the pre-flight entirely and be dropped by discovery
           # after the render, which is the cost this step exists to avoid.
-          if [ -f "${RENDER_DIR:-.}/ui-builder.policy.json" ]; then
+          #
+          # Added only when this render can actually reach it, which is the OTHER half of
+          # `authoredPair()`: a module holding either authored file is describing itself and never
+          # falls back, so validating the root for it turned a policy belonging to a different
+          # catalog into a failure of a render that would never have read it. Checking the fallback
+          # was the fix; checking it unconditionally was the same fix left half-applied — the Gradle
+          # side learned ownership and this pre-flight did not.
+          #
+          # With no named module every discovered module is rendered, and one of them may have
+          # neither file, so the root stays reachable and is checked.
+          module_owns_itself=false
+          if [ -n "$MODULE" ] &&
+            { [ -f "$(to_dir "$MODULE")/ui-builder.policy.json" ] ||
+              [ -f "$(to_dir "$MODULE")/catalog.spec.json" ]; }; then
+            module_owns_itself=true
+          fi
+          if [ "$module_owns_itself" = "false" ] && [ -f "${RENDER_DIR:-.}/ui-builder.policy.json" ]; then
             policy_candidates+=("${RENDER_DIR:-.}/ui-builder.policy.json")
           fi
           # `:-false` because only the all-modules render path defines ALL_MODULES, and this block
@@ -3195,7 +3211,23 @@ jobs:
           # not the caller's. Checking only the spec-adjacent and module paths meant the policy
           # Gradle actually consumes could skip the pre-flight entirely and be dropped by discovery
           # after the render, which is the cost this step exists to avoid.
-          if [ -f "${RENDER_DIR:-.}/ui-builder.policy.json" ]; then
+          #
+          # Added only when this render can actually reach it, which is the OTHER half of
+          # `authoredPair()`: a module holding either authored file is describing itself and never
+          # falls back, so validating the root for it turned a policy belonging to a different
+          # catalog into a failure of a render that would never have read it. Checking the fallback
+          # was the fix; checking it unconditionally was the same fix left half-applied — the Gradle
+          # side learned ownership and this pre-flight did not.
+          #
+          # With no named module every discovered module is rendered, and one of them may have
+          # neither file, so the root stays reachable and is checked.
+          module_owns_itself=false
+          if [ -n "$MODULE" ] &&
+            { [ -f "$(to_dir "$MODULE")/ui-builder.policy.json" ] ||
+              [ -f "$(to_dir "$MODULE")/catalog.spec.json" ]; }; then
+            module_owns_itself=true
+          fi
+          if [ "$module_owns_itself" = "false" ] && [ -f "${RENDER_DIR:-.}/ui-builder.policy.json" ]; then
             policy_candidates+=("${RENDER_DIR:-.}/ui-builder.policy.json")
           fi
           # `:-false` because only the all-modules render path defines ALL_MODULES, and this block

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/StructuralTemplateTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/StructuralTemplateTest.kt
@@ -236,6 +236,23 @@ class StructuralTemplateTest {
   }
 
   @Test
+  fun `a comment inside a generic argument list is skipped`() {
+    // The fourth shape of this scan, and the one that shows the fix pattern was wrong: `commentEnd`
+    // exists precisely so a scanner does not read a comment as source, and three scanners consult
+    // it. `genericSpans` was written afterwards and never did, so a comment broke the scan at `/`
+    // exactly as `(` and `@` did before it.
+    val commented =
+      StructuralTemplate.holes("\${call(factory = emptyMap<String, /* result type */ Int>())}")
+        as StructuralTemplate.Result2.Ok
+    assertThat(commented.value)
+      .containsExactly(
+        StructuralTemplate.Hole.Call(
+          mapOf("factory" to "emptyMap<String, /* result type */ Int>()")
+        )
+      )
+  }
+
+  @Test
   fun `a less-than that is not a generic list is left alone`() {
     // The pre-scan may only ever un-split, so a comparison expression has to behave exactly as it
     // did before it existed — otherwise closing one false rejection would open another.

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogsTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogsTest.kt
@@ -313,6 +313,47 @@ class UiBuilderCatalogsTest {
   }
 
   @Test
+  fun `code strategy is an enum on the authoritative path too`() {
+    // The two checks beside this one compare the strategy with the templates and agree with each
+    // other about a MISSPELLED strategy: `templtes` with no templates satisfies neither, so the
+    // policy published a strategy no exporter implements with nothing said. The JavaScript
+    // pre-flight caught it and runs only in the two workflow render lanes — the same asymmetry as
+    // the builtin slot role, in the same file, found one round later.
+    val misspelled =
+      UiBuilderCatalogs.generate(
+        record(component("Card", builder = BuilderPolicy(id = "wear-m3/card", canvas = "p"))),
+        cover,
+        policy(code = UiBuilderCode(strategy = "templtes")),
+      )!!
+
+    val codes = misspelled.diagnostics.map { it.code to it.subject }
+    assertThat(codes).contains(UiBuilderCatalogs.Diagnostics.STRATEGY_UNKNOWN to "code.strategy")
+    // Not reported as the agreement failures, which are about a strategy the engine DOES know.
+    assertThat(codes.map { it.first })
+      .containsNoneOf(
+        UiBuilderCatalogs.Diagnostics.STRATEGY_WITHOUT_TEMPLATES,
+        UiBuilderCatalogs.Diagnostics.TEMPLATES_WITHOUT_STRATEGY,
+      )
+
+    for (known in listOf("record", "templates")) {
+      val fine =
+        UiBuilderCatalogs.generate(
+          record(component("Card", builder = BuilderPolicy(id = "wear-m3/card", canvas = "p"))),
+          cover,
+          policy(
+            code =
+              UiBuilderCode(
+                strategy = known,
+                templates = if (known == "templates") mapOf("screen-root" to "Box {}") else mapOf(),
+              )
+          ),
+        )!!
+      assertThat(fine.diagnostics.map { it.code })
+        .doesNotContain(UiBuilderCatalogs.Diagnostics.STRATEGY_UNKNOWN)
+    }
+  }
+
+  @Test
   fun `templates and the strategy have to agree`() {
     val declaredButUnused =
       UiBuilderCatalogs.generate(

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -706,9 +706,23 @@ abstract class BundlePreviewTask : DefaultTask() {
     // Only `builder` is merged. Everything else about the carried record is deliberately the
     // FILTERED view — its bindings name previews this bundle actually contains — and widening that
     // would put preview ids in `components.json` that its own `previews.json` does not have.
+    //
+    // The merged policy's own preview ids are remapped, for the same invariant. `declaredBy` and
+    // `conflicting` name PREVIEWS, and they come from the full record, so they are raw ids while
+    // everything else in this bundle has been through `bundleIds` — an `@Preview(name = "A B")` is
+    // `a_b` inside the bundle, and a collision makes it `a_b_1`. Carrying them unmapped put ids in
+    // `components.json` that its own `previews.json` does not have, which is precisely what the
+    // paragraph above says must not happen; a raw id is also not reconstructable from the outside
+    // once a suffix is involved. A preview the bundle did not select is dropped rather than guessed
+    // at: naming a preview that is not here is what made this wrong. (`ambiguousWith` is component
+    // ids and `traits` / `malformed` are not ids at all, so those five lists are the whole set and
+    // these two are the only ones to map.)
     val carriedRecord =
       ComponentRecords.from(filteredManifest).let { carried ->
-        val policyByComponent = fullRecord.components.associate { it.canonicalId to it.builder }
+        val policyByComponent =
+          fullRecord.components.associate {
+            it.canonicalId to remapPolicyPreviewIds(it.builder, bundleIds)
+          }
         carried.copy(
           components =
             carried.components.map {
@@ -2111,6 +2125,31 @@ private val SPATIAL_IMAGE_SUFFIXES = listOf(".png", ".jpg", ".jpeg", ".webp")
  * name and manifest so all id materialisations agree. A repeated raw id (same preview requested
  * twice) maps to the one bundle id, not a fresh disambiguated one.
  */
+/**
+ * A policy's own preview ids, rewritten into the bundle's namespace.
+ *
+ * [BuilderPolicy.declaredBy] and [BuilderPolicy.conflicting] name PREVIEWS, and the policy is
+ * merged in from the FULL record while everything else in the bundle has been through
+ * [assignBundleEntryIds]. Carried unmapped they are raw ids — an `@Preview(name = "A B")` is `a_b`
+ * inside the bundle, and a collision makes it `a_b_1` — so `components.json` named previews its own
+ * `previews.json` does not have, and a suffixed id cannot be reconstructed from the outside anyway.
+ *
+ * A preview this bundle did not select is DROPPED rather than guessed at, because naming a preview
+ * that is not here is the thing that was wrong. `ambiguousWith` holds component ids and `traits` /
+ * `malformed` are not ids, so of the policy's five lists these two are the whole set to map.
+ *
+ * Extracted rather than left inline so it can be tested: the bug was invisible because the merge
+ * sat in the middle of a task method nothing could call.
+ */
+internal fun remapPolicyPreviewIds(
+  policy: BuilderPolicy?,
+  bundleIds: Map<String, String>,
+): BuilderPolicy? =
+  policy?.copy(
+    declaredBy = policy.declaredBy.mapNotNull(bundleIds::get),
+    conflicting = policy.conflicting.mapNotNull(bundleIds::get),
+  )
+
 internal fun assignBundleEntryIds(rawIds: List<String>): Map<String, String> {
   val used = HashSet<String>()
   val result = LinkedHashMap<String, String>()

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/RemapPolicyPreviewIdsTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/RemapPolicyPreviewIdsTest.kt
@@ -1,0 +1,81 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.discovery.BuilderPolicy
+import org.junit.Test
+
+/**
+ * Pins [remapPolicyPreviewIds] — the half of the bundle's carried record that names PREVIEWS.
+ *
+ * The policy is merged in from the full record so that selecting one preview does not revert a
+ * component to defaults, but `declaredBy` and `conflicting` are preview ids and everything else in
+ * the bundle has been through [assignBundleEntryIds]. Carried unmapped, they put ids in
+ * `components.json` that the bundle's own `previews.json` does not have — the exact invariant the
+ * merge's own comment states, broken by the merge that comment describes.
+ */
+class RemapPolicyPreviewIdsTest {
+
+  private val bundleIds =
+    assignBundleEntryIds(listOf("pkg.Card_A B", "pkg.Card_A_B", "pkg.Card_Plain"))
+
+  @Test
+  fun `a sanitised preview id is carried in the bundle's namespace`() {
+    val remapped =
+      remapPolicyPreviewIds(BuilderPolicy(declaredBy = listOf("pkg.Card_A B")), bundleIds)!!
+
+    assertThat(remapped.declaredBy).containsExactly(bundleIds.getValue("pkg.Card_A B"))
+    assertThat(remapped.declaredBy.single()).doesNotContain(" ")
+  }
+
+  @Test
+  fun `a collision suffix is carried, not reconstructed`() {
+    // Two raw ids sanitise to the same form, so one gains a `_1` that nothing outside the bundle
+    // could derive. This is why the mapping is applied rather than the raw id being sanitised again
+    // at the point of use.
+    val second = bundleIds.getValue("pkg.Card_A_B")
+    val first = bundleIds.getValue("pkg.Card_A B")
+    assertThat(second).isNotEqualTo(first)
+
+    val remapped =
+      remapPolicyPreviewIds(BuilderPolicy(conflicting = listOf("pkg.Card_A_B")), bundleIds)!!
+    assertThat(remapped.conflicting).containsExactly(second)
+  }
+
+  @Test
+  fun `a preview the bundle did not select is dropped, not named raw`() {
+    // Naming a preview that is not in this bundle is what made the unmapped form wrong, so an
+    // unselected one is left out rather than carried through in either form.
+    val remapped =
+      remapPolicyPreviewIds(
+        BuilderPolicy(
+          declaredBy = listOf("pkg.Card_Plain", "pkg.Card_NotBundled"),
+          conflicting = listOf("pkg.Card_NotBundled"),
+        ),
+        bundleIds,
+      )!!
+
+    assertThat(remapped.declaredBy).containsExactly(bundleIds.getValue("pkg.Card_Plain"))
+    assertThat(remapped.conflicting).isEmpty()
+  }
+
+  @Test
+  fun `the rest of the policy is untouched and a null policy stays null`() {
+    // `ambiguousWith` is component ids and `traits` / `malformed` are not ids at all, so of the
+    // policy's five string lists only the two preview-id ones are mapped.
+    val policy =
+      BuilderPolicy(
+        id = "wear-m3/card",
+        canvas = "p",
+        traits = listOf("scrollable"),
+        ambiguousWith = listOf("pkg.OtherComponent"),
+        malformed = listOf("canvas"),
+        declaredBy = listOf("pkg.Card_Plain"),
+      )
+
+    val remapped = remapPolicyPreviewIds(policy, bundleIds)!!
+    assertThat(remapped)
+      .isEqualTo(policy.copy(declaredBy = listOf(bundleIds.getValue("pkg.Card_Plain"))))
+
+    assertThat(remapPolicyPreviewIds(null, bundleIds)).isNull()
+  }
+}

--- a/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/StructuralTemplate.kt
+++ b/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/StructuralTemplate.kt
@@ -352,6 +352,15 @@ object StructuralTemplate {
     val spans = mutableListOf<IntRange>()
     var index = 0
     while (index < text.length) {
+      // A comment is not source, here as everywhere else. `commentEnd` exists for exactly this and
+      // three other scanners consult it; this one was written afterwards and did not, so `/` ended
+      // the scan the way `(` and `@` did — the same bug a third time, from not applying the shared
+      // helper to a scanner added after it.
+      val skipped = commentEnd(text, index)
+      if (skipped >= 0) {
+        index = skipped
+        continue
+      }
       if (text[index] != '<' || index == 0 || !isTypeChar(text[index - 1])) {
         index++
         continue
@@ -361,7 +370,6 @@ object StructuralTemplate {
       var scan = index
       var end = -1
       while (scan < text.length) {
-        val ch = text[scan]
         // Everything a type argument list may hold, and nothing else. A quote or any other
         // character means the `<` was a comparison, and the attempt is abandoned rather than
         // guessed at.
@@ -377,6 +385,12 @@ object StructuralTemplate {
         // excluding `@` failed the identical way for the commoner input. It needs no depth of its
         // own — an annotation is a prefix, not a bracket — and admitting the character cannot widen
         // what the scan accepts as a list, because a `>` still has to close it at paren depth zero.
+        val commented = commentEnd(text, scan)
+        if (commented >= 0) {
+          scan = commented
+          continue
+        }
+        val ch = text[scan]
         if (!isTypeChar(ch) && ch !in "<>,?* -()@") break
         when {
           // `->` inside a function type argument: its `>` closes nothing.

--- a/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogs.kt
+++ b/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogs.kt
@@ -206,6 +206,7 @@ object UiBuilderCatalogs {
     const val STATE_CALLBACK_ARITY = "component.stateCallback.arity"
     const val BUILTIN_SHADOWS_RECORD = "policy.builtin.shadowsRecord"
     const val BUILTIN_SLOT_ROLE_UNKNOWN = "policy.builtin.slot.role.unknown"
+    const val STRATEGY_UNKNOWN = "policy.code.strategy.unknown"
   }
 
   /**
@@ -923,6 +924,23 @@ object UiBuilderCatalogs {
           }
         }
       }
+    }
+    // The two checks below compare the strategy with the templates, and they AGREE with each other
+    // about a misspelled one: `templtes` with no templates satisfies neither, so a strategy no
+    // exporter implements was published with nothing said. The schema admits exactly two words, and
+    // that is a fact about the strategy itself rather than about its agreement with anything, so it
+    // is asserted before either comparison — and here, where every consumer reaches it, not only in
+    // the pre-flight the two workflow render lanes run.
+    if (code.strategy !in UI_BUILDER_CODE_STRATEGIES) {
+      into +=
+        UiBuilderDiagnostic(
+          code = Diagnostics.STRATEGY_UNKNOWN,
+          subject = "code.strategy",
+          message =
+            "code.strategy is '${code.strategy}', which no exporter implements. It is " +
+              UI_BUILDER_CODE_STRATEGIES.sorted().joinToString(" or ") { "'$it'" } +
+              ".",
+        )
     }
     if (code.strategy == "templates" && code.templates.isEmpty()) {
       into +=

--- a/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/UiBuilderPolicy.kt
+++ b/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/UiBuilderPolicy.kt
@@ -43,6 +43,13 @@ val UI_BUILDER_STRUCTURAL_ROLES: Set<String> =
   setOf("screen-root", "list", "list-item", "overlay", "controlled", "decoration")
 
 /**
+ * How a catalog's designs are written as source. Closed, and stated here beside the role set for
+ * the same reason: a word outside it selects no exporter, and the failure surfaces at export rather
+ * than where somebody typed it.
+ */
+val UI_BUILDER_CODE_STRATEGIES: Set<String> = setOf("record", "templates")
+
+/**
  * The named holes each template role may use, and the whole reason a template can be checked when
  * the catalog is published rather than when somebody exports through it.
  *

--- a/scripts/design-artifacts/ui-builder-policy.mjs
+++ b/scripts/design-artifacts/ui-builder-policy.mjs
@@ -175,6 +175,16 @@ function validateTypedShapes(policy, errors) {
           );
         }
       }
+      // Not a string, and that is the point: the first cut of this sweep enumerated the string
+      // fields and left `properties` — a `List<JsonElement>` — out, which is the same "covers most
+      // of them" the sweep exists to replace. The list is derived from the model's declarations
+      // now, not from the fields that came to mind. The ELEMENTS stay unchecked: a property's shape
+      // is the preview server's, and only the array-ness is what the reader needs to deserialize.
+      if (builtin.properties !== undefined && !Array.isArray(builtin.properties)) {
+        errors.push(
+          `builtin ${JSON.stringify(id)} has a "properties" of ${JSON.stringify(builtin.properties)}; the reader decodes it as a list`,
+        );
+      }
     }
   }
   validateMenu(policy.menu, errors);

--- a/scripts/design-artifacts/ui-builder-policy.test.mjs
+++ b/scripts/design-artifacts/ui-builder-policy.test.mjs
@@ -279,3 +279,27 @@ test("every field the reader types is checked, not one per round", async () => {
   ordered.catalogId = "wear-m3";
   assert.deepEqual(validatePolicy(ordered).errors, []);
 });
+
+test("the sweep covers non-string typed fields too", async () => {
+  // The sweep above shipped enumerating STRING fields and handling `menu` beside them, which left
+  // `builtins.<id>.properties` — a `List<JsonElement>` — unchecked. A sweep that claims to cover
+  // every typed field and covers one kind of type is the thing it was written to replace, so this
+  // case is derived from the model's declarations rather than from the fields anyone remembered.
+  const scalar = wellFormed();
+  scalar.builtins = { "wear-m3/screen": { role: STRUCTURAL_ROLES[0], properties: "size" } };
+  const errors = validatePolicy(scalar).errors;
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /"properties"/);
+
+  const object = wellFormed();
+  object.builtins = { "wear-m3/screen": { role: STRUCTURAL_ROLES[0], properties: { size: 1 } } };
+  assert.equal(validatePolicy(object).errors.length, 1);
+
+  const listed = wellFormed();
+  listed.builtins = { "wear-m3/screen": { role: STRUCTURAL_ROLES[0], properties: [{ name: "size" }] } };
+  assert.deepEqual(validatePolicy(listed).errors, []);
+
+  const absent = wellFormed();
+  absent.builtins = { "wear-m3/screen": { role: STRUCTURAL_ROLES[0] } };
+  assert.deepEqual(validatePolicy(absent).errors, []);
+});


### PR DESCRIPTION
Follow-up to yschimke/compose-ai-tools#5312, which merged while this round was in flight. Five findings from the review of `091bcbd8`, and **four of them are the same defect as the fix they follow**: the change landed where the finding pointed and not in its siblings. That is worth saying plainly, because it is the pattern that produced most of the rounds on #5312 and every one of these was avoidable by asking "which siblings?" instead of "is this correct?".

## The four half-applied fixes

**The generic pre-scan now skips comments.** `commentEnd` exists so a scanner does not read a comment as source, and three scanners consult it. `genericSpans` was written afterwards and never did, so `emptyMap<String, /* result type */ Int>()` broke the scan at `/` and split one override into two — exactly as `(` and `@` did before it. Both of those were fixed by adding a character to an escape set rather than by asking which scanners the shared helper had missed, so the third shape was already waiting.

**The policy pre-flight's typed-field sweep now covers `properties`.** That sweep was written *one commit earlier* precisely so typed fields would stop being found one per round — and it enumerated the string fields, leaving `List<JsonElement>` out. A sweep that covers one kind of type is the thing it replaced. The list is derived from the model's declarations now, and the test asserts each field by name.

**`code.strategy` is validated as an enum in the generator.** The two checks beside it compare the strategy with the templates, and they *agree with each other* about a misspelled one: `templtes` with no templates satisfies neither, so a strategy no exporter implements was published in silence. Same asymmetry as the builtin slot role — caught by the JavaScript pre-flight, which runs only in the two workflow render lanes — in the same file, one round later.

**The render workflow checks the root policy only when the render can reach it.** `authoredPair()` learned that a module holding either authored file describes itself and never falls back to the root; this pre-flight did not, so an invalid policy belonging to a *different* catalog would fail a render that would never have read it. Fixed at both render paths.

## The fifth

**The bundle's carried policy remaps its preview ids.** `declaredBy` and `conflicting` name previews, and the policy is merged in from the full record while everything else in the bundle has been through `assignBundleEntryIds` — so an `@Preview(name = "A B")` is `a_b` inside the bundle, `a_b_1` after a collision, and `components.json` named previews its own `previews.json` does not have. That is the invariant stated in the merge's own comment, broken by the merge that comment describes. A preview the bundle did not select is dropped rather than guessed at.

Extracted to `remapPolicyPreviewIds` so it can be tested: the bug was invisible because the merge sat inside a task method nothing could call. Of `BuilderPolicy`'s five `List<String>` fields these two are the whole set that holds preview ids — `ambiguousWith` is component ids, `traits` and `malformed` are not ids.

## Not changed

The sixth finding was a P1 asking to recreate a commit with a human identity, citing `13a5bee0…` and then `…08ff125a`. Neither is an object in this repository. On those ranges the scanner exits **2** — "refusing to report clean" — and prints no identity, which is the one exit code meaning *no finding was produced*; every commit here is `Yuri Schimke <yuri@schimke.ee>` as author and committer, and `Reject agent attribution` is green.

## Known gap, not fixed here

The policy-candidate block is inline YAML duplicated at two render paths, and `.github/scripts/` has a `test-*.sh` for every *script* but nothing can reach this. That untestability is why it drifted from `authoredPair()` in the first place. Extracting it into a script with a test is the real fix; it is a refactor of two live render lanes and does not belong in a bug-fix PR, so it is flagged rather than done.

## Test plan

- `StructuralTemplateTest` — a comment inside a generic argument list. Written first and **confirmed failing** (`ClassCastException: Result2$Failed cannot be cast to Result2$Ok`) before the fix; the neighbouring case that a comparison expression is left alone still passes, which is the property that matters — the pre-scan may only ever un-split.
- `UiBuilderCatalogsTest` — a misspelled `code.strategy` reported, and neither agreement diagnostic raised for it; both known strategies clean. Verified the test fails without the fix (`48 tests completed, 1 failed`).
- `RemapPolicyPreviewIdsTest` — new. A sanitised id carried in the bundle namespace, a collision suffix carried rather than reconstructed, an unselected preview dropped, and the policy's other three lists untouched.
- `ui-builder-policy.test.mjs` — `properties` as a scalar and as an object rejected, as a list and absent accepted.
- The workflow's ownership decision exercised over all four cases (module with neither file, with a spec, with a policy, and the all-modules render) against a faithful harness; `check-workflow-yaml.sh` green on 40 files.
- `./gradlew ktfmtCheckAll`, `:preview-discovery:test`, `:test`, and `node --test scripts/design-artifacts/ui-builder-policy.test.mjs` (16) all green on this base.

Non-visual change; no renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01297vAqLHxgAc6XQuaQYCSe

---
_Generated by [Claude Code](https://claude.ai/code/session_01297vAqLHxgAc6XQuaQYCSe)_