### PR TITLE
test(cli): widen the semantics inactivity test's stall margin

### DIFF
--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcherTest.kt
@@ -296,21 +296,29 @@ class DaemonSemanticsFetcherTest {
   fun `render timeout is an inactivity window, not a batch-wide budget`() {
     // Issue #2948: a wide catalog (a component library fanning out across many themes) renders far
     // more previews than fit inside a single `--timeout`, yet each individual render still lands
-    // quickly. The daemon here completes one render every 20ms across 15 previews (~300ms total),
-    // well past the 150ms window — but never idle for that long. Every semantics sidecar must still
-    // be collected: the old batch-wide budget cut the batch off mid-flight and silently dropped
+    // quickly. The daemon here completes one render every 20ms across 100 previews (~2s total),
+    // well past the 1s window — but never idle for that long. Every semantics sidecar must still be
+    // collected: the old batch-wide budget cut the batch off mid-flight and silently dropped
     // roughly a third of the catalog's semantics.
+    //
+    // Two numbers carry the test and they are independent. Total elapsed must exceed the window —
+    // that is the property, and it is why this test cannot be made cheap by simply widening the
+    // window. The stagger must sit far *below* the window — that is the margin, and 150ms against
+    // a 20ms stagger was not enough of it: the wait below trips on a single scheduling stall or GC
+    // pause longer than one window, and a CI runner encoding shader GIFs while it renders stalls a
+    // thread past 150ms routinely. At 1s the same stall has to be ~50x the stagger to fail. Retune
+    // both together if this ever gets too slow; do not close the gap between them.
     val projectDir = newTempFolder("semantics-inactivity")
     writeDescriptor(projectDir)
 
-    val ids = (1..15).map { "Preview$it" }
+    val ids = (1..100).map { "Preview$it" }
     val produced = ids.associateWith { """{"root":{"nodeId":"$it","boundsInRoot":"0,0,4,8"}}""" }
     val logs = mutableListOf<String>()
     val fetcher =
       DaemonSemanticsFetcher(
         factory = FakeFactory(produced = produced, staggerMs = 20),
         onLog = { logs += it },
-        renderTimeout = 150.milliseconds,
+        renderTimeout = 1.seconds,
       )
 
     val outcome = fetcher.fetch(projectDir = projectDir, moduleName = "sample", previewIds = ids)


### PR DESCRIPTION
## Summary

`DaemonSemanticsFetcherTest > render timeout is an inactivity window, not a batch-wide budget` pins issue #2948: `renderTimeout` resets on every completed render, so a catalog whose full render outlasts the window still finishes. Good property, worth keeping — but the margin was too thin to survive a loaded runner.

It drove the property with 15 previews at a 20ms stagger against a 150ms window: the batch ran ~300ms, past the budget, with no single gap over 20ms. That is only **7.5x headroom on one gap**, and the assertion trips on a *single* scheduling stall or GC pause longer than the window. 150ms is ordinary on shared hardware — it failed `Module Unit Tests` on an unrelated PR (#5312) while the same job was concurrently encoding four 40-frame shader GIFs and drawing 79 render captures, and passed on every local run.

This scales both numbers instead of loosening the assertion: **100 previews at the same 20ms stagger against a 1s window**. Total elapsed becomes ~2s against a 1s budget, so the batch still runs well past the window and the property under test is unchanged — but a stall now has to exceed 1s rather than 150ms to fail.

The test is not skipped, disabled, `@Ignore`d or quarantined, and no production code changed.

### On the virtual-clock alternative

The obvious "real" fix is to drive this off an injectable time source so it is deterministic and instant. I looked at it and deliberately did not take it, because here it would make the test *weaker* at the exact thing it exists to catch.

`DaemonSemanticsFetcher` has **no clock**. Its wait loop is a single `progress.poll(renderTimeout, MILLISECONDS)` on a `LinkedBlockingQueue`, with one token offered per terminal event — the inactivity semantics are structural, not measured. So there is nothing to virtualize on the production side; all the wall-clock dependence lives in the test's `FakeSession.Thread.sleep(staggerMs)` and in `poll`'s real timeout. Removing it means injecting a gate over the blocking rendezvous, and that costs two things:

- A batch-wide budget reintroduced with its own `System.nanoTime()` deadline — which is the shape of the #2948 regression — would **evade** a virtual gate entirely, since near-zero real time elapses and the budget never trips. The wall-clock version catches it precisely because real time passes.
- Driving emission synchronously from inside `awaitProgress` runs the notification listener on the fetcher's own thread, losing the cross-thread rendezvous that is the reason this code needs a blocking queue at all.

A seam that a broken implementation can walk around is worse than a slow test, so the wall clock stays. Both numbers are load-bearing and independent — elapsed must stay *above* the window (that is the property), the stagger far *below* it (that is the margin) — and the comment now records which is which so a future retune scales them together rather than closing the gap.

## Test plan

- `./gradlew :cli:test --tests '*DaemonSemanticsFetcherTest*'` — **13/13 pass**. The changed case runs 2.07s (was ~0.3s); the class totals 2.26s.
- **Still a check, not just a green light:** temporarily reintroduced a batch-wide deadline in `DaemonSemanticsFetcher`'s wait loop (compute `deadlineNanos` once, poll the shrinking remainder). Result: `13 tests completed, 1 failed` — this case and only this case. Production file restored; the diff is test-only.
- `./gradlew :cli:test` — full suite green, **907 tests, 0 failures, 0 errors**, 70.6s. Suite cost of this change is ~1.8s.
- **Stress check against the actual failure mode:** reran the case 4 consecutive times with the CPU 2x oversubscribed (8 spinners on 4 cores). 4/4 pass, 2.14s / 2.25s / 2.20s / 2.14s — gaps stayed near 20ms even under saturation.
- `./gradlew :cli:ktfmtFormatTest` run before committing.

Non-visual change, so no render evidence — nothing user-facing moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6eFx9QagQN9brXxxbyn3a

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6eFx9QagQN9brXxxbyn3a)_