### PR TITLE
build: extend ktfmtCheckAll into the gradle-plugin included build's subprojects

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,17 +40,34 @@ plugins {
 val ktfmtProjectPaths =
   providers.systemProperty("composeai.ktfmtProjectPaths").get().split(",")
 
+// The `gradle-plugin` included build is a multi-project build of its own, and Gradle's task-name
+// matching does not reach into it either — `includedBuild(...).task(":ktfmtCheck")` addresses that
+// build's ROOT project alone. Its subprojects (`:preview-discovery`, `:daemon-launch-builder`,
+// `:gradle-plugin-config`) each carry their own ktfmt, so they travel the same closure-free
+// system-property channel, gathered in `gradle-plugin/settings.gradle.kts`. The root is depended on
+// explicitly below; this list holds only the subprojects, so `:$path:task` is always well-formed.
+val gradlePluginKtfmtProjectPaths =
+  providers
+    .systemProperty("composeai.gradlePluginKtfmtProjectPaths")
+    .get()
+    .split(",")
+    .filter { it.isNotEmpty() }
+
 tasks.register("ktfmtCheckAll") {
   group = "verification"
   description = "Runs ktfmtCheck across this build and the gradle-plugin included build."
-  dependsOn(gradle.includedBuild("gradle-plugin").task(":ktfmtCheck"))
+  val gradlePlugin = gradle.includedBuild("gradle-plugin")
+  dependsOn(gradlePlugin.task(":ktfmtCheck"))
+  gradlePluginKtfmtProjectPaths.forEach { dependsOn(gradlePlugin.task("$it:ktfmtCheck")) }
   ktfmtProjectPaths.forEach { dependsOn("$it:ktfmtCheck") }
 }
 
 tasks.register("ktfmtFormatAll") {
   group = "formatting"
   description = "Runs ktfmtFormat across this build and the gradle-plugin included build."
-  dependsOn(gradle.includedBuild("gradle-plugin").task(":ktfmtFormat"))
+  val gradlePlugin = gradle.includedBuild("gradle-plugin")
+  dependsOn(gradlePlugin.task(":ktfmtFormat"))
+  gradlePluginKtfmtProjectPaths.forEach { dependsOn(gradlePlugin.task("$it:ktfmtFormat")) }
   ktfmtProjectPaths.forEach { dependsOn("$it:ktfmtFormat") }
 }
 

--- a/docs/build-scripts/SETTINGS.md
+++ b/docs/build-scripts/SETTINGS.md
@@ -304,6 +304,29 @@ Two exclusions:
   because a build-logic plugin on the root classpath leaks to every subproject and
   collides with their versioned plugin aliases.
 
+### The `gradle-plugin` included build does the same, for itself
+
+`gradle-plugin` is a build of its own, so neither Gradle's task-name matching nor
+the list above reaches into it. `gradle.includedBuild("gradle-plugin")
+.task(":ktfmtCheck")` addresses **only that build's root project** — for a long
+time that was the whole gate for the included build, and its three subprojects
+(`:preview-discovery`, `:daemon-launch-builder`, `:gradle-plugin-config`) each
+carry their own ktfmt while nothing invoked it. Unformatted files under
+`gradle-plugin/preview-discovery/src/**` reached `main` that way.
+
+So `gradle-plugin/settings.gradle.kts` gathers its own project paths the same
+closure-free way, into `composeai.gradlePluginKtfmtProjectPaths`, and the
+aggregates add one `includedBuild("gradle-plugin").task(":<path>:ktfmtCheck")`
+edge per path. A task reference by path is an ordinary lazy task-graph edge and
+never touches the sibling `Project` at configuration time, so it stays IP-clean;
+the property is read back through the same configuration-cache-tracked
+`providers.systemProperty(...)`.
+
+The differences from the outer build's list are both about the root project:
+that build's root **does** carry ktfmt (it is a real plugin module, not a
+container), and the outer build already depends on its `:ktfmtCheck` explicitly —
+so the gathered list holds subprojects only, and the two edges do not duplicate.
+
 ## Modules that used to be here
 
 <a id="extractions"></a>

--- a/gradle-plugin/gradle-plugin-config/build.gradle.kts
+++ b/gradle-plugin/gradle-plugin-config/build.gradle.kts
@@ -63,18 +63,19 @@ dependencies {
 // which the runtime plugin owns — both jars can share a buildscript classpath, so the resource
 // paths
 // must not collide). Read back by `ConfigPluginVersion`.
-val generateConfigPluginVersionResource = tasks.register("generateConfigPluginVersionResource") {
-  val outputDir = layout.buildDirectory.dir("generated/config-plugin-version-resource")
-  val pluginVersion = project.version.toString()
-  inputs.property("version", pluginVersion)
-  outputs.dir(outputDir)
-  doLast {
-    val file =
-      outputDir.get().file("ee/schimke/composeai/plugin/config-plugin-version.properties").asFile
-    file.parentFile.mkdirs()
-    file.writeText("version=$pluginVersion\n")
+val generateConfigPluginVersionResource =
+  tasks.register("generateConfigPluginVersionResource") {
+    val outputDir = layout.buildDirectory.dir("generated/config-plugin-version-resource")
+    val pluginVersion = project.version.toString()
+    inputs.property("version", pluginVersion)
+    outputs.dir(outputDir)
+    doLast {
+      val file =
+        outputDir.get().file("ee/schimke/composeai/plugin/config-plugin-version.properties").asFile
+      file.parentFile.mkdirs()
+      file.writeText("version=$pluginVersion\n")
+    }
   }
-}
 
 sourceSets.main.get().resources.srcDir(generateConfigPluginVersionResource)
 

--- a/gradle-plugin/preview-discovery/build.gradle.kts
+++ b/gradle-plugin/preview-discovery/build.gradle.kts
@@ -33,9 +33,11 @@ ktfmt { googleStyle() }
 // are **shared source**, not a copy: they live in `screen/model/src/commonMain`, and this module
 // compiles them from there.
 //
-// They have to be in two places at once and cannot be. The browser UI builder needs to generate code
+// They have to be in two places at once and cannot be. The browser UI builder needs to generate
+// code
 // with no server, which means a `wasmJs` target; this module is `kotlin("jvm")` inside a
-// `kotlin-dsl` plugin build pinned to Gradle's embedded Kotlin, where adding Kotlin Multiplatform is
+// `kotlin-dsl` plugin build pinned to Gradle's embedded Kotlin, where adding Kotlin Multiplatform
+// is
 // a fight over the toolchain rather than a configuration. And the dependency cannot run the other
 // way — an included build cannot depend on a project of the build that includes it.
 //
@@ -43,7 +45,9 @@ ktfmt { googleStyle() }
 // `preview-discovery` jar is unchanged: it still carries these classes, compiled from the same
 // files the `:screen-model` KMP module compiles for `wasmJs`. The alternative was a mirror, and the
 // `serve-wasm` fork is this repository's own evidence for what mirrors cost.
-sourceSets.named("main") { kotlin.srcDir(rootDir.resolve("../screen/generator/src/commonMain/kotlin")) }
+sourceSets.named("main") {
+  kotlin.srcDir(rootDir.resolve("../screen/generator/src/commonMain/kotlin"))
+}
 
 dependencies {
   api(libs.kotlinx.serialization.json)

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComposableSignatureTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComposableSignatureTest.kt
@@ -311,8 +311,7 @@ class ComposableSignatureTest {
     val content = parametersOf("scopeDslComponent").single()
 
     assertThat(content.composableSlot).isFalse()
-    assertThat(content.scopeDslReceiver)
-      .isEqualTo("ee.schimke.composeai.discovery.TestListScope")
+    assertThat(content.scopeDslReceiver).isEqualTo("ee.schimke.composeai.discovery.TestListScope")
   }
 
   @Test

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
@@ -278,7 +278,8 @@ class ScreenGeneratorTest {
       ScreenGenerator.generate(
         screen(),
         catalog(card, text),
-        preview = ScreenGenerator.Preview(devices = listOf("id:pixel_6\", showBackground = evil()")),
+        preview =
+          ScreenGenerator.Preview(devices = listOf("id:pixel_6\", showBackground = evil()")),
       )
 
     assertThat(refused).isInstanceOf(ScreenGenerator.Result.Refused::class.java)

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenValueVocabularyTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenValueVocabularyTest.kt
@@ -140,8 +140,7 @@ class ScreenValueVocabularyTest {
     // the theme once per coloured node, so this is most of what a generated file says.
     assertThat(result.source).contains("color = MaterialTheme.colorScheme.primary")
     assertThat(result.source).contains("import androidx.compose.material3.MaterialTheme")
-    assertThat(result.source)
-      .doesNotContain("androidx.compose.material3.MaterialTheme.colorScheme")
+    assertThat(result.source).doesNotContain("androidx.compose.material3.MaterialTheme.colorScheme")
   }
 
   @Test
@@ -214,7 +213,8 @@ class ScreenValueVocabularyTest {
       )
     assertThat(result.source).contains("color = ColorDefaults.brand()")
     assertThat(result.source).contains("import androidx.compose.material3.ColorDefaults")
-    assertThat(result.source).doesNotContain("import androidx.compose.material3.ColorDefaults.brand")
+    assertThat(result.source)
+      .doesNotContain("import androidx.compose.material3.ColorDefaults.brand")
   }
 
   @Test
@@ -330,7 +330,8 @@ class ScreenValueVocabularyTest {
         catalog(text, column),
       )
     assertThat(result.source).contains("modifier = Modifier.weight(1.0f)")
-    assertThat(result.source).doesNotContain("import androidx.compose.foundation.layout.ColumnScope")
+    assertThat(result.source)
+      .doesNotContain("import androidx.compose.foundation.layout.ColumnScope")
   }
 
   @Test
@@ -558,8 +559,7 @@ class ScreenValueVocabularyTest {
         ),
         catalog(text),
       )
-    assertThat(result.source)
-      .contains("color = Color(4284960932L, 2.0)")
+    assertThat(result.source).contains("color = Color(4284960932L, 2.0)")
   }
 
   @Test
@@ -1421,8 +1421,7 @@ class ScreenValueVocabularyTest {
       )
         as ScreenGenerator.Result.Emitted
 
-    assertThat(result.source)
-      .contains("val tintInitial = MaterialTheme.colorScheme.primary")
+    assertThat(result.source).contains("val tintInitial = MaterialTheme.colorScheme.primary")
     assertThat(result.source)
       .contains("mutableStateOf<androidx.compose.ui.graphics.Color>(tintInitial)")
   }
@@ -1499,8 +1498,7 @@ class ScreenValueVocabularyTest {
       )
         as ScreenGenerator.Result.Emitted
 
-    assertThat(result.source)
-      .contains("val tintInitial_ = MaterialTheme.colorScheme.primary")
+    assertThat(result.source).contains("val tintInitial_ = MaterialTheme.colorScheme.primary")
   }
 
   @Test
@@ -1612,6 +1610,7 @@ class ScreenValueVocabularyTest {
 
     assertThat(reasons.single()).contains("has no `onLongPress`")
   }
+
   private companion object {
     const val COLUMN_SCOPE = "androidx.compose.foundation.layout.ColumnScope"
     const val ROW_SCOPE = "androidx.compose.foundation.layout.RowScope"
@@ -1650,7 +1649,9 @@ class ScreenValueVocabularyTest {
     // The check that makes the kind worth having. Every zero-argument function type in the library
     // is a `kotlin.Function0`, so a value held only to the parameter's own `typeFqn` is held to
     // almost nothing — and `progress = { "" }` compiles in this generator's head and nowhere else.
-    assertThat(refusal(indicatorNode(ScreenValue.Lambda(ScreenValue.Text("hi"))), catalog(indicator)))
+    assertThat(
+        refusal(indicatorNode(ScreenValue.Lambda(ScreenValue.Text("hi"))), catalog(indicator))
+      )
       .containsExactly("`LinearProgressIndicator`.`progress` is kotlin.Float, which Text is not")
   }
 
@@ -1665,7 +1666,9 @@ class ScreenValueVocabularyTest {
           catalog(indicator),
         )
       )
-      .containsExactly("`LinearProgressIndicator`.`progress` is kotlin.Float, which Fractional is not")
+      .containsExactly(
+        "`LinearProgressIndicator`.`progress` is kotlin.Float, which Fractional is not"
+      )
   }
 
   @Test
@@ -1702,7 +1705,9 @@ class ScreenValueVocabularyTest {
 
   @Test
   fun `a lambda is refused on a parameter that is not a function type at all`() {
-    assertThat(refusal(textNode("text" to ScreenValue.Lambda(ScreenValue.Text("hi"))), catalog(text)))
+    assertThat(
+        refusal(textNode("text" to ScreenValue.Lambda(ScreenValue.Text("hi"))), catalog(text))
+      )
       .containsExactly(
         "`Text`.`text` is `String`, which a `{ … }` returning a value does not satisfy"
       )

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/SignatureFixtures.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/SignatureFixtures.kt
@@ -25,16 +25,13 @@ class TestRowScope
  * The shape `LazyColumn` has: a receiver lambda that is **not** `@Composable`, whose children are
  * declared through members of the receiver rather than composed into it.
  */
-@Suppress("unused", "UNUSED_PARAMETER")
-fun scopeDslComponent(content: TestListScope.() -> Unit) {}
+@Suppress("unused", "UNUSED_PARAMETER") fun scopeDslComponent(content: TestListScope.() -> Unit) {}
 
 /** An ordinary callback, to prove the signal is about the receiver and not about being a lambda. */
-@Suppress("unused", "UNUSED_PARAMETER")
-fun callbackComponent(onValueChange: (String) -> Unit) {}
+@Suppress("unused", "UNUSED_PARAMETER") fun callbackComponent(onValueChange: (String) -> Unit) {}
 
 /** The shape a determinate progress indicator has: a lambda returning a value. */
-@Suppress("unused", "UNUSED_PARAMETER")
-fun valueReturningLambdaComponent(progress: () -> Float) {}
+@Suppress("unused", "UNUSED_PARAMETER") fun valueReturningLambdaComponent(progress: () -> Float) {}
 
 /** The same return type behind an argument, which a bare `{ … }` must not be accepted for. */
 @Suppress("unused", "UNUSED_PARAMETER")

--- a/gradle-plugin/settings.gradle.kts
+++ b/gradle-plugin/settings.gradle.kts
@@ -22,3 +22,21 @@ include(":preview-discovery")
 include(":daemon-launch-builder")
 
 include(":gradle-plugin-config")
+
+// Project paths in THIS included build that carry ktfmt, handed to the outer build's
+// `ktfmtCheckAll` / `ktfmtFormatAll` aggregate tasks through a system property — the same
+// closure-free channel the outer build's own `settings.gradle.kts` uses, for the same Isolated
+// Projects reason. docs/build-scripts/SETTINGS.md#ktfmt-project-paths
+//
+// Only subprojects are listed. This build's ROOT project applies ktfmt too, but the outer build
+// depends on `:ktfmtCheck` explicitly, so including it here would duplicate that edge.
+val ktfmtProjectPaths = buildList {
+  fun visit(descriptor: org.gradle.api.initialization.ProjectDescriptor) {
+    // Mirrors the outer build: only projects with a build script apply ktfmt.
+    if (descriptor.buildFile.exists()) add(descriptor.path)
+    descriptor.children.forEach(::visit)
+  }
+  rootProject.children.forEach(::visit)
+}
+
+System.setProperty("composeai.gradlePluginKtfmtProjectPaths", ktfmtProjectPaths.joinToString(","))


### PR DESCRIPTION
## The gap

`.github/workflows/format.yml` runs `./gradlew ktfmtCheckAll`, and that aggregate reached the `gradle-plugin` included build through exactly one edge:

```kotlin
dependsOn(gradle.includedBuild("gradle-plugin").task(":ktfmtCheck"))
```

`includedBuild(...).task(":ktfmtCheck")` addresses that build's **root project** alone. `gradle-plugin/settings.gradle.kts` also declares `:preview-discovery`, `:daemon-launch-builder` and `:gradle-plugin-config`, each of which applies ktfmt and owns its own `ktfmtCheck*` tasks — and nothing in CI ever invoked them. `ktfmtProjectPaths` covers only the outer build, because it is gathered from the outer build's settings.

So files under `gradle-plugin/*/src/**` could be committed unformatted and nothing noticed. That was the whole gate for those sources.

## The fix

`gradle-plugin/settings.gradle.kts` now gathers its own ktfmt-carrying project paths into `composeai.gradlePluginKtfmtProjectPaths`, mirroring the existing mechanism the outer build uses for its siblings, and `ktfmtCheckAll` / `ktfmtFormatAll` add one `includedBuild("gradle-plugin").task(":<path>:ktfmtCheck")` edge per path.

It stays IP-clean and configuration-cache-clean for the same reasons the existing channel does, as the comment above `ktfmtProjectPaths` records:

- Depending on a task **by path** is an ordinary lazy task-graph edge; it never touches the sibling `Project` object at configuration time.
- The channel is closure-free — a system property read back through a configuration-cache-tracked `providers.systemProperty(...)`, not a `gradle.lifecycle.beforeProject` closure that Isolated Projects cannot serialize.

One difference from the outer build's list, noted in both comments: the included build's root project **does** carry ktfmt (it is a real plugin module, not a container), and the aggregates already depend on its `:ktfmtCheck` explicitly — so the gathered list holds subprojects only and the two edges do not duplicate.

`docs/build-scripts/SETTINGS.md#ktfmt-project-paths` gains a subsection for the included build.

## Formatting fallout

Second commit, kept separate so the wiring diff stays readable — pure `./gradlew ktfmtFormatAll` output, no behaviour change:

- `preview-discovery/src/test/.../ComposableSignatureTest.kt`
- `preview-discovery/src/test/.../ScreenGeneratorTest.kt`
- `preview-discovery/src/test/.../ScreenValueVocabularyTest.kt`
- `preview-discovery/src/test/.../SignatureFixtures.kt`

Turning the gate on also surfaced two build scripts that `ktfmtCheckScripts` now covers for the first time, beyond the four sources reported: `gradle-plugin/preview-discovery/build.gradle.kts` and `gradle-plugin/gradle-plugin-config/build.gradle.kts`.

## Verification

A gate that cannot fail is the thing being fixed, so this was confirmed both ways rather than assumed.

1. **Before**, on `main`: `./gradlew --no-configuration-cache -p gradle-plugin :preview-discovery:ktfmtCheckTest` failed on the four committed files above, while `./gradlew ktfmtCheckAll` passed.
2. **The gate can fail.** With the fix in place and the tree otherwise clean, appending a deliberately misformatted declaration to `preview-discovery/src/test/.../SignatureFixtures.kt`:

   ```
   Execution failed for task ':gradle-plugin:preview-discovery:ktfmtCheckTest'
   > [ktfmt] Found 1 files that are not properly formatted:
     src/test/kotlin/ee/schimke/composeai/discovery/SignatureFixtures.kt
   ```
3. **It was genuinely invisible before.** With that same misformatted file still on disk, restoring only the two pre-fix build files (`git checkout <base> -- build.gradle.kts gradle-plugin/settings.gradle.kts`) makes `./gradlew ktfmtCheckAll` report `BUILD SUCCESSFUL`.
4. **It passes once formatted.** On the final tree `./gradlew ktfmtCheckAll` is `BUILD SUCCESSFUL`, with `Configuration cache entry stored` / `reused` and no configuration-cache problems (`org.gradle.configuration-cache.problems=fail` is on).
5. The task graph now contains `:gradle-plugin:preview-discovery:ktfmtCheck*`, `:gradle-plugin:daemon-launch-builder:ktfmtCheck*` and `:gradle-plugin:gradle-plugin-config:ktfmtCheck*` alongside the root's, confirmed via `--dry-run`.
6. Also exercised the risky path for a system-property channel — stored configuration-cache entry replayed on a **fresh daemon** (`./gradlew --stop` first): `Configuration cache entry reused`, `BUILD SUCCESSFUL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QgFVdfoUm8mNqxpYz5eRZ

---
_Generated by [Claude Code](https://claude.ai/code/session_018QgFVdfoUm8mNqxpYz5eRZ)_