### PR TITLE
docs: check a commit exists before reporting it for attribution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,12 +63,14 @@ still won't. Why the PR body matters and how a trailer reached `main` anyway:
 **Reviewers: run the detector before reporting an attribution finding.** This is
 the most-reported and least-real finding on this repo — 14 PRs drew a P1 "the
 author and committer are both `Codex`" comment over 2026-08-31/09-01 and not one
-was real. An agent reviewing its own or another agent's PR must not infer the
-commit identity from the fact that an agent wrote the code: the identity is
-whatever `git config user.email` held, and here that is the human. Check it, on
-the real range:
+was real, and the reports since have kept naming commits that are not objects in
+this repository at all. An agent reviewing its own or another agent's PR must not
+infer the commit identity from the fact that an agent wrote the code: the
+identity is whatever `git config user.email` held, and here that is the human.
+Check it, on the real range, starting with whether the commit exists:
 
 ```
+git cat-file -t <sha>          # a commit you are about to name must actually exist
 git log --format='%h %an <%ae> | %cn <%ce>' <base>..<head>
 .github/scripts/agent-attribution-scan.sh --range '<base>..<head>'
 ```


### PR DESCRIPTION
Companion to [yschimke/compose-preview-server#621](https://github.com/yschimke/compose-preview-server/pull/621), which adds the equivalent guidance to that repository.

## Why

The **Reviewers: run the detector before reporting an attribution finding** paragraph already tells an agent not to infer the commit identity from the fact that an agent wrote the code, and to run the scanner on the real range. That covers the failure mode it was written for.

The reports since have a different shape. They name a commit SHA that is not an object in the repository at all, so the identity check never gets a chance to run. Six such SHAs turned up overnight across pull requests in both repositories, none of which exists: `940973b`, `8e7b237`, `b1c9480`, `3ecc93fe`, `ab73e281`, `32737af`.

## What changed

The command sequence starts with `git cat-file -t <sha>`, and the surrounding sentence says that naming a non-existent commit is what the recent reports have been doing.

One paragraph in `AGENTS.md`. No script or behaviour changes.

## Test plan

`.github/scripts/agent-attribution-scan.sh --text-file AGENTS.md` passes on the edited file, which matters because the paragraph quotes the syntax the detector looks for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NT4AycZo6EPJnuwbuupLwR

---
_Generated by [Claude Code](https://claude.ai/code/session_01NT4AycZo6EPJnuwbuupLwR)_