### PR TITLE
fix(ci): keep the root builder policy in all-module pre-flight validation

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -1914,8 +1914,16 @@ jobs:
           #
           # With no named module every discovered module is rendered, and one of them may have
           # neither file, so the root stays reachable and is checked.
+          #
+          # `ALL_MODULES` is the same question asked properly. It is true for `module: ''` AND for
+          # `modules: all`, and the second of those can carry a named module — so reading emptiness
+          # alone, a caller passing both got ownership decided by the one module it named while the
+          # job went on to render every discovered one. Any sibling with neither authored file falls
+          # back to the root, so a malformed root policy skipped this pre-flight entirely and was
+          # dropped after the render: the catalog published with no builder data, which is the exact
+          # silence this step exists to end.
           module_owns_itself=false
-          if [ -n "$MODULE" ] &&
+          if [ "${ALL_MODULES:-false}" = "false" ] && [ -n "$MODULE" ] &&
             { [ -f "$(to_dir "$MODULE")/ui-builder.policy.json" ] ||
               [ -f "$(to_dir "$MODULE")/catalog.spec.json" ]; }; then
             module_owns_itself=true
@@ -3221,8 +3229,16 @@ jobs:
           #
           # With no named module every discovered module is rendered, and one of them may have
           # neither file, so the root stays reachable and is checked.
+          #
+          # `ALL_MODULES` is the same question asked properly. It is true for `module: ''` AND for
+          # `modules: all`, and the second of those can carry a named module — so reading emptiness
+          # alone, a caller passing both got ownership decided by the one module it named while the
+          # job went on to render every discovered one. Any sibling with neither authored file falls
+          # back to the root, so a malformed root policy skipped this pre-flight entirely and was
+          # dropped after the render: the catalog published with no builder data, which is the exact
+          # silence this step exists to end.
           module_owns_itself=false
-          if [ -n "$MODULE" ] &&
+          if [ "${ALL_MODULES:-false}" = "false" ] && [ -n "$MODULE" ] &&
             { [ -f "$(to_dir "$MODULE")/ui-builder.policy.json" ] ||
               [ -f "$(to_dir "$MODULE")/catalog.spec.json" ]; }; then
             module_owns_itself=true

--- a/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/RemoteFontScaleCurveTest.kt
+++ b/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/RemoteFontScaleCurveTest.kt
@@ -4,6 +4,8 @@ import androidx.compose.remote.creation.compose.capture.RemoteDensity
 import androidx.compose.remote.creation.compose.state.rf
 import androidx.compose.remote.creation.compose.state.rsp
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -77,6 +79,35 @@ class RemoteFontScaleCurveTest {
       val atOne = toPx(size, FONT_SCALE_2X, density = 1f)
       val atTwo = toPx(size, FONT_SCALE_2X, density = 2f)
       assertEquals("${size}sp at density 2", atOne * 2f, atTwo, TOLERANCE)
+    }
+  }
+
+  /**
+   * The `Host` branch defers rather than folding — which is the branch `rcDensity=host` rides on.
+   *
+   * Every other case here supplies two literals, so `RemoteTextUnit.toPx` takes the
+   * constant-folding path and the assertions above never reach the variable one. That is the branch
+   * this file's header calls load-bearing: a regression that quietly folded `RemoteDensity.Host` to
+   * a literal would bake the capture host's own font scale into the document and ship it to every
+   * player, and every test above would still pass.
+   *
+   * What is checked is the difference in kind — the fixed branch answers a constant and the host
+   * branch answers an expression with no constant value, on the same sizes the curve knots at.
+   * Evaluating that expression needs a `RemoteContext` with the player's `FONT_SIZE` bound, which
+   * is a player's job rather than a capture's; `rc-players`' `RcFontScaleRenderTest` is where the
+   * resolved pixels are pinned, and the header says so.
+   */
+  @Test
+  fun theHostBranchEmitsAnExpressionInsteadOfFoldingTheCurve() {
+    for (size in EXPECTED.keys) {
+      assertNull(
+        "${size}sp against RemoteDensity.Host should stay an expression",
+        size.rsp.toPx(RemoteDensity.Host).constantValueOrNull,
+      )
+      assertNotNull(
+        "${size}sp against fixed inputs should fold",
+        size.rsp.toPx(RemoteDensity(1f.rf, 1f.rf)).constantValueOrNull,
+      )
     }
   }
 


### PR DESCRIPTION
Two unanswered Codex findings. A third from the same sweep, #5298's stale lockfiles, turned out to be **already fixed** on `main` — the version catalog and both `data/remotecompose/connector` and `runtimes/wear-preview` lockfiles agree at `rcplayers = 1.59.4` — so there is nothing to do for it.

## The root policy could skip its own pre-flight (#5314)

`ALL_MODULES` is `inputs.module == '' || inputs.modules == 'all'`. The second disjunct can carry a **named** module, and the block decided root-policy ownership from `[ -n "$MODULE" ]` alone:

```bash
module_owns_itself=false
if [ -n "$MODULE" ] && { module has a policy or a spec; }; then module_owns_itself=true; fi
if [ "$module_owns_itself" = "false" ] && [ -f root/ui-builder.policy.json ]; then check root; fi
```

So `module: app` + `modules: all` settled ownership from `app` while the job went on to render *every discovered module*. Any sibling with neither authored file falls back to the root through `authoredPair()`, so a malformed root policy skipped this check entirely and was silently dropped by discovery after the render — the catalog publishes with no builder data, which is the exact silence the step's own comment says it exists to end.

The block's comment reasoned about `MODULE` being empty ("with no named module every discovered module is rendered…"); the fix is to ask the question that actually matters, which is whether this render is scoped to one module. Both identical copies of the block are edited.

## The `RemoteDensity.Host` branch had no test (#5301)

`RemoteFontScaleCurveTest` passes two literals everywhere, so `RemoteTextUnit.toPx` takes the constant-folding path and `checkNotNull(...constantValueOrNull)` requires it to. The variable branch — the one the file's own header calls load-bearing for `composeai.render.rcDensity=host` — was never reached. A regression that quietly folded `RemoteDensity.Host` would bake the *capture host's* font scale into the document and ship it to every player, and all three existing tests would still pass.

The new case pins the difference in kind on each size the curve knots at: `RemoteDensity.Host` must answer an expression with no constant value, and fixed inputs must fold.

I deliberately stopped short of *evaluating* that expression here. Doing so needs a `RemoteContext` with the player's `FONT_SIZE` bound, which is a player's job rather than a capture's — and `rc-players`' `RcFontScaleRenderTest` is where the resolved pixels are already pinned, as this file's header says. Happy to go further if you'd rather the connector carried an evaluation harness of its own.

## Not fixed here, and it needs your call

The same review's remaining P2 (#5299) is a genuine cross-repo name collision, and both ways of resolving it are defensible, so I have not picked one. `androidx-embedded` is the **canonical** name here for the vendored player (`RemoteComposePlayerSelection`, with `embedded` as a historical alias), while in compose-preview-server `scripts/design-artifacts/render-rc-compare-html.mjs` gives lane id `embedded` to "AndroidX Embedded · vendored Android" and lane id `androidx-embedded` to "AndroidX Embedded · **androidx.dev**". Copying that column's name into `-PcomposePreview.rcPlayer=androidx-embedded` therefore renders the vendored player while the author believes they pinned upstream — invalidating exactly the comparison they were reproducing. Raised separately rather than folded in, since fixing it means renaming on one side or the other.

## Test plan

- `:data-remotecompose-connector:testDebugUnitTest --tests '*RemoteFontScaleCurveTest*'` — green, including the new host-branch case.
- `:data-remotecompose-connector:ktfmtFormatTest`.
- The workflow change is a shell condition inside a reusable workflow; both copies of the block are byte-identical and both were edited.

Text-only evidence: nothing here renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKaGa8Rtm7fRwkrwwiWJ3h

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKaGa8Rtm7fRwkrwwiWJ3h)_