### PR TITLE
fix(ci): decide root-policy reachability from the modules being rendered

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -1912,23 +1912,40 @@ jobs:
           # was the fix; checking it unconditionally was the same fix left half-applied — the Gradle
           # side learned ownership and this pre-flight did not.
           #
-          # With no named module every discovered module is rendered, and one of them may have
-          # neither file, so the root stays reachable and is checked.
+          # The question is reachability, and only the set of modules being RENDERED can answer it.
           #
-          # `ALL_MODULES` is the same question asked properly. It is true for `module: ''` AND for
-          # `modules: all`, and the second of those can carry a named module — so reading emptiness
-          # alone, a caller passing both got ownership decided by the one module it named while the
-          # job went on to render every discovered one. Any sibling with neither authored file falls
-          # back to the root, so a malformed root policy skipped this pre-flight entirely and was
-          # dropped after the render: the catalog published with no builder data, which is the exact
-          # silence this step exists to end.
-          module_owns_itself=false
-          if [ "${ALL_MODULES:-false}" = "false" ] && [ -n "$MODULE" ] &&
+          # A single-module render asks it of that module. An all-module render cannot: `ALL_MODULES`
+          # is true for `module: ''` AND for `modules: all`, the second of which may still carry a
+          # named module, so deciding from `$MODULE` there let one module's ownership speak for a job
+          # that renders every discovered one — and a sibling with neither authored file falls back
+          # to a root that then skipped this check. Deciding instead that every all-module run
+          # reaches the root is the same mistake mirrored: where every discovered module owns its
+          # own files, nothing falls back, and validating the root turns another catalog's policy
+          # into a failure of a render that would never have read it.
+          #
+          # So an all-module run walks the discovery list and asks whether ANY module would fall
+          # back. Absent list, absent answer: the root stays checked, because being unable to prove
+          # nothing reads it is not proof that nothing does.
+          root_reachable=true
+          if [ "${ALL_MODULES:-false}" = "true" ]; then
+            if [ -f "$GITHUB_WORKSPACE/preview-module-sources.txt" ]; then
+              root_reachable=false
+              while IFS= read -r discovered_source; do
+                [ -n "$discovered_source" ] || continue
+                discovered_dir="${discovered_source%/}"
+                if [ ! -f "$discovered_dir/ui-builder.policy.json" ] &&
+                  [ ! -f "$discovered_dir/catalog.spec.json" ]; then
+                  root_reachable=true
+                  break
+                fi
+              done < "$GITHUB_WORKSPACE/preview-module-sources.txt"
+            fi
+          elif [ -n "$MODULE" ] &&
             { [ -f "$(to_dir "$MODULE")/ui-builder.policy.json" ] ||
               [ -f "$(to_dir "$MODULE")/catalog.spec.json" ]; }; then
-            module_owns_itself=true
+            root_reachable=false
           fi
-          if [ "$module_owns_itself" = "false" ] && [ -f "${RENDER_DIR:-.}/ui-builder.policy.json" ]; then
+          if [ "$root_reachable" = "true" ] && [ -f "${RENDER_DIR:-.}/ui-builder.policy.json" ]; then
             policy_candidates+=("${RENDER_DIR:-.}/ui-builder.policy.json")
           fi
           # `:-false` because only the all-modules render path defines ALL_MODULES, and this block
@@ -3227,23 +3244,40 @@ jobs:
           # was the fix; checking it unconditionally was the same fix left half-applied — the Gradle
           # side learned ownership and this pre-flight did not.
           #
-          # With no named module every discovered module is rendered, and one of them may have
-          # neither file, so the root stays reachable and is checked.
+          # The question is reachability, and only the set of modules being RENDERED can answer it.
           #
-          # `ALL_MODULES` is the same question asked properly. It is true for `module: ''` AND for
-          # `modules: all`, and the second of those can carry a named module — so reading emptiness
-          # alone, a caller passing both got ownership decided by the one module it named while the
-          # job went on to render every discovered one. Any sibling with neither authored file falls
-          # back to the root, so a malformed root policy skipped this pre-flight entirely and was
-          # dropped after the render: the catalog published with no builder data, which is the exact
-          # silence this step exists to end.
-          module_owns_itself=false
-          if [ "${ALL_MODULES:-false}" = "false" ] && [ -n "$MODULE" ] &&
+          # A single-module render asks it of that module. An all-module render cannot: `ALL_MODULES`
+          # is true for `module: ''` AND for `modules: all`, the second of which may still carry a
+          # named module, so deciding from `$MODULE` there let one module's ownership speak for a job
+          # that renders every discovered one — and a sibling with neither authored file falls back
+          # to a root that then skipped this check. Deciding instead that every all-module run
+          # reaches the root is the same mistake mirrored: where every discovered module owns its
+          # own files, nothing falls back, and validating the root turns another catalog's policy
+          # into a failure of a render that would never have read it.
+          #
+          # So an all-module run walks the discovery list and asks whether ANY module would fall
+          # back. Absent list, absent answer: the root stays checked, because being unable to prove
+          # nothing reads it is not proof that nothing does.
+          root_reachable=true
+          if [ "${ALL_MODULES:-false}" = "true" ]; then
+            if [ -f "$GITHUB_WORKSPACE/preview-module-sources.txt" ]; then
+              root_reachable=false
+              while IFS= read -r discovered_source; do
+                [ -n "$discovered_source" ] || continue
+                discovered_dir="${discovered_source%/}"
+                if [ ! -f "$discovered_dir/ui-builder.policy.json" ] &&
+                  [ ! -f "$discovered_dir/catalog.spec.json" ]; then
+                  root_reachable=true
+                  break
+                fi
+              done < "$GITHUB_WORKSPACE/preview-module-sources.txt"
+            fi
+          elif [ -n "$MODULE" ] &&
             { [ -f "$(to_dir "$MODULE")/ui-builder.policy.json" ] ||
               [ -f "$(to_dir "$MODULE")/catalog.spec.json" ]; }; then
-            module_owns_itself=true
+            root_reachable=false
           fi
-          if [ "$module_owns_itself" = "false" ] && [ -f "${RENDER_DIR:-.}/ui-builder.policy.json" ]; then
+          if [ "$root_reachable" = "true" ] && [ -f "${RENDER_DIR:-.}/ui-builder.policy.json" ]; then
             policy_candidates+=("${RENDER_DIR:-.}/ui-builder.policy.json")
           fi
           # `:-false` because only the all-modules render path defines ALL_MODULES, and this block


### PR DESCRIPTION
Follow-up to #5320. Codex reviewed that PR and landed a P2 on it just as it merged, and the finding is correct — my fix over-corrected. Fresh branch off `main` rather than commits on the merged one.

## What #5320 got right, and what it then broke

`ALL_MODULES` is `inputs.module == '' || inputs.modules == 'all'`. The second disjunct can carry a named module, so deciding root ownership from `[ -n "$MODULE" ]` let one named module speak for a job that renders *every discovered* module. A sibling with neither authored file falls back to the root through `authoredPair()`, so a malformed root policy skipped the pre-flight and was dropped after the render. That part stands.

But #5320 then treated **every** all-module run as reaching the root. Where every discovered module owns a local `ui-builder.policy.json` or `catalog.spec.json`, `authoredPair()` gives none of them the fallback — so validating the root now turns another catalog's policy into a failure of a render that would never have read it. Same mistake, mirrored.

## The question is reachability, not ownership

Reachability is a property of the set of modules being rendered, so that is what decides it:

- **all-module run** → walk `preview-module-sources.txt` and ask whether *any* discovered module would fall back. One that would makes the root reachable; none does not.
- **single-module run** → unchanged, ask it of that module.
- **no discovery list** → root stays checked. Being unable to prove nothing reads it is not proof that nothing does.

## Test plan

The block was extracted verbatim into a harness and run against a temp tree of three modules (`app` with a policy, `lib` with a spec, `bare` with neither):

| case | root checked? | |
| --- | --- | --- |
| single module, owns its files | no | |
| single module, owns nothing | yes | |
| all-modules, every discovered module owns its files, named module | **no** | the case this PR fixes |
| all-modules, every discovered module owns its files, no named module | **no** | |
| all-modules, one module falls back | yes | the case #5320 fixed |
| all-modules, no discovery list | yes | conservative |
| list with trailing slashes and a blank line | no | parsing |

All seven pass. The workflow still parses as YAML (`yaml.safe_load`, 5 jobs).

## The other comment on #5320

The P1 on that PR reported `9d6c89a…` as authored and committed by `Codex <codex@openai.com>`. That commit is not an object in this repository; the PR's only commit was `a836056`, authored and committed by `Yuri Schimke <yuri@schimke.ee>`, and `Reject agent attribution` was green on it — which is what let the PR merge at all. It is the false positive AGENTS.md names, and this time the scanner's own verdict is on the record as the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKaGa8Rtm7fRwkrwwiWJ3h

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKaGa8Rtm7fRwkrwwiWJ3h)_