### PR TITLE
fix(plugin): keep build outputs out of the ui-builder template tree

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -744,8 +744,8 @@ internal object ComposePreviewTasks {
       // whole project: `templates` entries are branch-relative paths like
       // `ui-builder/designs/wear-list.json`, so this is the tree they resolve inside.
       uiBuilderTemplateCandidates.from(
-        project.layout.projectDirectory.dir("ui-builder"),
-        project.rootProject.layout.projectDirectory.dir("ui-builder"),
+        uiBuilderTemplateTree(project.layout.projectDirectory.dir("ui-builder")),
+        uiBuilderTemplateTree(project.rootProject.layout.projectDirectory.dir("ui-builder")),
       )
       uiBuilderTemplateRoots.from(
         project.layout.projectDirectory,
@@ -1851,8 +1851,8 @@ internal object ComposePreviewTasks {
       // whole project: `templates` entries are branch-relative paths like
       // `ui-builder/designs/wear-list.json`, so this is the tree they resolve inside.
       uiBuilderTemplateCandidates.from(
-        project.layout.projectDirectory.dir("ui-builder"),
-        project.rootProject.layout.projectDirectory.dir("ui-builder"),
+        uiBuilderTemplateTree(project.layout.projectDirectory.dir("ui-builder")),
+        uiBuilderTemplateTree(project.rootProject.layout.projectDirectory.dir("ui-builder")),
       )
       uiBuilderTemplateRoots.from(
         project.layout.projectDirectory,
@@ -2597,4 +2597,28 @@ internal object ComposePreviewTasks {
       return dir == relDir && leaf.startsWith(prefix) && leaf.endsWith(ext)
     }
   }
+
+  /**
+   * The authored designs under a `ui-builder/` directory, and nothing a build wrote.
+   *
+   * `ui-builder` is a *conventional* directory name, and in a repository that also has a Gradle
+   * module called `ui-builder` — compose-preview-server does — the two are the same path. Handing
+   * the whole directory to an `@InputFiles` property then snapshots that module's `build/` output
+   * as well, and Gradle refuses the build outright: `composePreviewDiscover` and
+   * `composePreviewBundle` are consuming `build/wasmDist` and `build/tmp/…/package.json` from tasks
+   * they do not depend on, which is an *"uses this output of task … without declaring an explicit
+   * or implicit dependency"* validation failure rather than a warning.
+   *
+   * A template is an authored JSON design, so restricting the tree to JSON files loses none of
+   * them, and excluding `build` directories removes every generated file that made the directory
+   * ambiguous. (Spelled as a glob in the code below rather than here: a `json` glob contains the
+   * two characters that end a KDoc block.) The roots stay the project directories
+   * ([DiscoverPreviewsTask.uiBuilderTemplateRoots]), so a branch-relative `templates` path still
+   * resolves exactly as it did.
+   */
+  private fun uiBuilderTemplateTree(dir: Directory) =
+    dir.asFileTree.matching {
+      include("**/*.json")
+      exclude("**/build/**")
+    }
 }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/UiBuilderTemplateCandidatesTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/UiBuilderTemplateCandidatesTest.kt
@@ -1,0 +1,79 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import org.gradle.api.DefaultTask
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * The `ui-builder/` template tree is authored designs, never a build directory.
+ *
+ * `ui-builder` is a *conventional* directory name for template designs. In a repository that also
+ * has a Gradle module called `ui-builder` — compose-preview-server does — they are the same path,
+ * so handing the whole directory to an `@InputFiles` property snapshotted that module's `build/`
+ * output too. Gradle does not warn about that, it fails the build: `composePreviewDiscover` and
+ * `composePreviewBundle` end up consuming `build/wasmDist` and
+ * `build/tmp/wasmJsPublicPackageJson/package.json` from tasks they do not depend on, which is an
+ * *"uses this output of task … without declaring an explicit or implicit dependency"* validation
+ * error. Every job in that repository's CI went red on the 2.4.0 bump.
+ */
+class UiBuilderTemplateCandidatesTest {
+
+  @get:Rule val tmp = TemporaryFolder()
+
+  @Test
+  fun `a build directory under ui-builder is not an input`() {
+    val root = tmp.root
+    val design = File(root, "ui-builder/designs/wear-list.json").withText("{}")
+    // What a co-located Gradle module writes: the two paths that actually broke
+    // compose-preview-server, plus a non-JSON one.
+    val wasmDist = File(root, "ui-builder/build/wasmDist/index.html").withText("<html></html>")
+    val packageJson =
+      File(root, "ui-builder/build/tmp/wasmJsPublicPackageJson/package.json").withText("{}")
+    val nestedBuild = File(root, "ui-builder/designs/build/generated.json").withText("{}")
+
+    val discover = discoverTask(root)
+    val files = discover.uiBuilderTemplateCandidates.files
+
+    assertThat(files).contains(design)
+    assertThat(files).doesNotContain(wasmDist)
+    assertThat(files).doesNotContain(packageJson)
+    assertThat(files).doesNotContain(nestedBuild)
+  }
+
+  @Test
+  fun `the authored designs are still found`() {
+    val root = tmp.root
+    val top = File(root, "ui-builder/designs/wear-list.json").withText("{}")
+    val nested = File(root, "ui-builder/designs/wear/list.json").withText("{}")
+    // Not a design, and never was one — the tree is JSON.
+    File(root, "ui-builder/designs/README.md").withText("# designs")
+
+    val discover = discoverTask(root)
+
+    assertThat(discover.uiBuilderTemplateCandidates.files).containsExactly(top, nested)
+  }
+
+  private fun discoverTask(root: File): DiscoverPreviewsTask {
+    val project = ProjectBuilder.builder().withProjectDir(root).build()
+    project.extensions.create("composePreview", PreviewExtension::class.java)
+    project.configurations.create("runtimeClasspath") {
+      isCanBeResolved = true
+      isCanBeConsumed = false
+    }
+    ComposePreviewTasks.registerDesktopTasks(
+      project,
+      project.extensions.getByType(PreviewExtension::class.java),
+    )
+    project.tasks.register("compileKotlin", DefaultTask::class.java)
+    return project.tasks.named("composePreviewDiscover", DiscoverPreviewsTask::class.java).get()
+  }
+
+  private fun File.withText(text: String): File = apply {
+    parentFile.mkdirs()
+    writeText(text)
+  }
+}


### PR DESCRIPTION
**This unblocks compose-preview-server, whose CI has been red on every commit since the 2.4.0 bump landed there.**

## What broke

`ui-builder` is a *conventional* directory name for template designs. In a repository that also has a Gradle module called `ui-builder` — compose-preview-server does — the two are the same path, so

```kotlin
uiBuilderTemplateCandidates.from(
  project.layout.projectDirectory.dir("ui-builder"),
  project.rootProject.layout.projectDirectory.dir("ui-builder"),
)
```

snapshotted that module's entire `build/` directory as an `@InputFiles` input.

Gradle does not warn about that — it fails the build. `composePreviewDiscover` and `composePreviewBundle` end up consuming `build/wasmDist` and `build/tmp/wasmJsPublicPackageJson/package.json` from tasks they do not depend on:

```
Gradle detected a problem with the following location: '…/ui-builder/build/wasmDist'
  Task ':ui-builder:composePreviewDiscover' uses this output of task ':ui-builder:wasmFrontendDist'
  without declaring an explicit or implicit dependency.
```

## Blast radius

compose-preview-server's `gradle` and `visual-harness` jobs both went red on [its 2.4.0 bump](https://github.com/yschimke/compose-preview-server/pull/616) (CI run 1605) and have been red on every commit since. Run 1604, immediately before, had only an unrelated `serve-web` bundle-budget failure — so this is the change that took those two jobs down.

## The fix

A template is an authored JSON design, so restricting the tree to JSON files loses none of them, and excluding `build` directories removes the generated files that made the directory ambiguous.

The template **roots** are deliberately untouched — they are still the project directories — so a branch-relative `templates` path resolves exactly as before. Only what gets *snapshotted* changes.

## Test plan

- **`UiBuilderTemplateCandidatesTest`** (new): `ui-builder/build/wasmDist/index.html`, `ui-builder/build/tmp/wasmJsPublicPackageJson/package.json` and a nested `designs/build/generated.json` are all excluded; authored designs at the top level and nested under `designs/` are still found; a README is not. I confirmed it fails without the fix — and the failure message is the diagnosis: unfixed, the collection resolves to the bare `ui-builder` *directory*, which is precisely why everything beneath it was snapshotted.
- **Verified end to end against compose-preview-server.** On its `main` at 2.4.0, `./gradlew :ui-builder:composePreviewDiscover :ui-builder:wasmFrontendDist` fails naming `ui-builder/build/wasmDist`. With this branch published to mavenLocal and consumed from there, the same command is `BUILD SUCCESSFUL`. (Those local edits to compose-preview-server were reverted; that checkout is clean.)
- `:gradle-plugin:test` for the neighbouring discover/bundle wiring tests, and ktfmt.

## After this merges

compose-preview-server needs the resulting release picked up before its CI can go green. Its other main failure — `serve-web`, "spatial viewer 183832 / 182000 bytes OVER" from the `three` 0.186.0 bump — is separate and lives in that repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKaGa8Rtm7fRwkrwwiWJ3h

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKaGa8Rtm7fRwkrwwiWJ3h)_