### PR TITLE
fix(serve): stop the theme cache file-name memo growing on unpersistable keys

### DIFF
--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
@@ -1015,21 +1015,35 @@ public class ThemeCacheStore(
      * `MessageDigest.getInstance` provider lookup — one snapshot pass, per `/status` load, with no
      * cache between them (yschimke/compose-ai-tools#5322).
      *
-     * Bounded the same way [present], [dirtyNames] and [adopted] are: one entry per cache key this
-     * generation is asked about, which is one per themed render in one catalog. Nothing reaches
-     * this with unbounded keys — every caller walks a catalog's own renders.
+     * **Only names this generation actually holds are remembered**, which is what bounds the map.
+     * The read path forwards WHATEVER key a request produces: `CatalogThemeCache.get` asks
+     * [wasAdopted] and [get] about ad-hoc override renders — widths, locales, devices, knob values
+     * — that `CatalogThemeCache.put` then declines to persist precisely because a visitor can mint
+     * them indefinitely. Memoizing on the way in would have grown the heap on exactly the keys the
+     * disk budget refuses, so the insert is gated on membership instead: an unpersistable key never
+     * matches [present] or [adopted], pays its digest, and is forgotten. What is left is a subset
+     * of the names on disk, bounded by `--theme-cache-max-bytes` like [present], [dirtyNames] and
+     * [adopted].
+     *
+     * The gate costs a re-hash per lookup for a configured target not yet written. That set drains
+     * to nothing as the optimizer completes, and the steady state #5322 is about — a full
+     * generation being walked per `/status` — is entirely names in [present].
      */
     private val fileNames = ConcurrentHashMap<String, String>()
 
-    private fun fileName(cacheKey: String): String =
-      fileNames.computeIfAbsent(cacheKey) { key ->
-        // `HexFormat` rather than `"%02x".format(byte)`: the latter parsed a two-character format
-        // string through `java.util.Formatter` once per digest byte, which is 32 parses per name
-        // and was where the profiler's samples actually landed. Byte-for-byte the same string —
-        // `Formatter` renders a negative `Byte` under `%x` as the value plus 2^8, which is the
-        // unsigned hex `formatHex` writes — so names already on disk still resolve.
-        HEX.formatHex(MessageDigest.getInstance("SHA-256").digest(key.toByteArray()))
+    private fun fileName(cacheKey: String): String {
+      fileNames[cacheKey]?.let {
+        return it
       }
+      // `HexFormat` rather than `"%02x".format(byte)`: the latter parsed a two-character format
+      // string through `java.util.Formatter` once per digest byte, which is 32 parses per name and
+      // was where the profiler's samples actually landed. Byte-for-byte the same string —
+      // `Formatter` renders a negative `Byte` under `%x` as the value plus 2^8, which is the
+      // unsigned hex `formatHex` writes — so names already on disk still resolve.
+      val name = HEX.formatHex(MessageDigest.getInstance("SHA-256").digest(cacheKey.toByteArray()))
+      if (name in present || name in adopted) fileNames[cacheKey] = name
+      return name
+    }
   }
 
   /** A generation's coordinates, for [sweep]'s live set. */

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStoreFileNameTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStoreFileNameTest.kt
@@ -53,6 +53,33 @@ class ThemeCacheStoreFileNameTest {
   }
 
   @Test
+  fun `a key that never lands on disk is not remembered`(@TempDir root: File) {
+    // The read path takes whatever key a request produces. `CatalogThemeCache.get` asks about
+    // ad-hoc
+    // override renders — widths, locales, knob values — that `CatalogThemeCache.put` deliberately
+    // refuses to persist because a visitor can mint them without limit. Memoizing those would move
+    // the unbounded growth the disk budget refuses into the heap instead, so the memo only keeps
+    // names this generation actually holds.
+    val generation = generation(root)
+    generation.put(CACHE_KEY, PNG)
+    // The one persisted key is remembered: that is the case #5322 is about.
+    generation.contains(CACHE_KEY)
+    assertEquals(1, memoSize(generation))
+
+    repeat(500) { i ->
+      generation.contains("$CACHE_KEY|width=$i")
+      generation.get("$CACHE_KEY|width=$i")
+      generation.wasAdopted("$CACHE_KEY|width=$i")
+    }
+
+    assertEquals(
+      1,
+      memoSize(generation),
+      "500 unpersistable keys must not be retained for the generation's lifetime",
+    )
+  }
+
+  @Test
   fun `a reopened generation finds what the previous one wrote`(@TempDir root: File) {
     // The memo is per generation, so the second one recomputes — and has to land on the same name,
     // which is the whole point of the digest being the contract.
@@ -79,6 +106,14 @@ class ThemeCacheStoreFileNameTest {
           ),
         )
     )
+
+  private fun memoSize(generation: ThemeCacheStore.Generation): Int =
+    (ThemeCacheStore.Generation::class
+        .java
+        .getDeclaredField("fileNames")
+        .apply { isAccessible = true }
+        .get(generation) as Map<*, *>)
+      .size
 
   private fun sha256Hex(value: String): String =
     MessageDigest.getInstance("SHA-256").digest(value.toByteArray()).joinToString("") {


### PR DESCRIPTION
Follow-up to #5324, which merged with a P1 from the Codex review unaddressed. The finding was right and my bounding claim in that PR was wrong.

## The problem

`#5324` memoised `Generation.fileName` into an unbounded `ConcurrentHashMap`, and its KDoc asserted "nothing reaches this with unbounded keys — every caller walks a catalog's own renders". That is not true of the read path.

`CatalogThemeCache.get` forwards **whatever key a request produces** to `Generation.wasAdopted` and `Generation.get` — ad-hoc override renders with arbitrary widths, locales, devices and knob values. `CatalogThemeCache.put` declines to persist exactly those keys, and says why in a comment right above the check:

> on a public box a visitor could mint distinct keys indefinitely, and since a live generation is never evicted to honour `--theme-cache-max-bytes`, that fills the volume

The memo took every one of those disk misses and retained it for the lifetime of the generation — outside the in-memory render LRU and outside the disk budget. That moves the unbounded growth the disk tier refuses into the heap, where nothing bounds it at all.

## The fix

Gate the **insert** on membership rather than memoising on the way in:

```kotlin
private fun fileName(cacheKey: String): String {
  fileNames[cacheKey]?.let { return it }
  val name = HEX.formatHex(MessageDigest.getInstance("SHA-256").digest(cacheKey.toByteArray()))
  if (name in present || name in adopted) fileNames[cacheKey] = name
  return name
}
```

An unpersistable key matches neither set, pays its digest, and is forgotten. What the map retains is a subset of the names on disk, so it is bounded by `--theme-cache-max-bytes` exactly as `present`, `dirtyNames` and `adopted` already are — and bounded by the same thing that bounds the tier it describes, rather than by a cap someone has to pick.

A bounded LRU was the other option. It was rejected because the cap would be a magic number, and because an adversary filling it first would evict the legitimate keys the memo exists for — the gate has no such failure mode.

## What this costs

A re-hash per lookup for a **configured target that is not yet on disk**. That set drains to nothing as the optimizer completes, and the steady state #5322 is about — a full generation walked once per `/status`, 48,400 names on `preview.coo.ee` — is entirely names in `present`, so the warm number in #5324's table is unchanged. The `HexFormat` half of that PR, which was the larger win (28.7×) and applies on every path, is untouched.

## Test plan

New `a key that never lands on disk is not remembered` in `ThemeCacheStoreFileNameTest`: persist one key, then hammer `contains` / `get` / `wasAdopted` with 500 distinct override keys and assert the memo still holds exactly one entry. Verified it fails without the gate (`expected:<1> but was:<501>`) and passes with it.

Plus `:render-host:test --tests '*ThemeCache*' --tests '*CatalogTheme*'` green, and `ktfmtCheckAll`.

Text-only evidence: nothing renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKaGa8Rtm7fRwkrwwiWJ3h

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKaGa8Rtm7fRwkrwwiWJ3h)_