### PR TITLE
docs: correct the gate's scope and the launcher split's state

### DIFF
--- a/docs/design/DAEMON_LAUNCH_SCHEMA.md
+++ b/docs/design/DAEMON_LAUNCH_SCHEMA.md
@@ -1,9 +1,16 @@
 # The daemon-launch descriptor schema gate
 
 `<module>/build/compose-previews/daemon-launch.json` is written by the Gradle plugin and read by the
-daemon JVM, `compose-preview doctor`, and the VS Code extension — four representations of one file,
-in two languages, across three separate Gradle builds, with nothing in the build knowing they
-describe the same thing. `./gradlew :cli:checkDaemonLaunchSchema` is what knows.
+daemon JVM, `compose-preview doctor`, and the VS Code extension — several representations of one
+file, spread across separate Gradle builds, with nothing in the build knowing they describe the same
+thing. `./gradlew :cli:checkDaemonLaunchSchema` is what knows.
+
+**Its scope is Kotlin.** The task's inputs are `**/*.kt` and `walk_sources()` reads nothing else, so
+what it covers is this repository's Kotlin representations plus the ones in a
+`compose-preview-contracts` checkout when `COMPOSE_PREVIEW_CONTRACTS_ROOT` resolves one. The VS Code
+extension's reader lives in [`yschimke/compose-preview-vscode`](https://github.com/yschimke/compose-preview-vscode)
+and is **not** covered — it owns its own check. Treat a green run here as saying the Kotlin copies
+agree, never that the extension does.
 
 The schema version is the sharp edge. It was declared four times, as a literal `2` each time, and
 two of those copies carried a comment asking a human to remember:
@@ -35,9 +42,10 @@ links against, so that is not a same-commit mistake but cross-repo version skew 
   `…DESCRIPTOR_SCHEMA_VERSION`, and stamps real descriptors with it, so a fifth mirror sat outside
   a check whose entire claim was that every mirror is registered;
 - **structural agreement** — every field a reader requires is one the writer emits, shared fields
-  carry corresponding types across Kotlin and TypeScript, and a reader-only field is optional;
-- **`BtaCompileConfig` field-for-field** across the two languages, which its KDoc claimed and
-  nothing enforced;
+  carry corresponding types across the registered Kotlin copies, and a reader-only field is
+  optional;
+- **`BtaCompileConfig` field-for-field** across the copies that declare it, which its KDoc claimed
+  and nothing enforced;
 - **unknown-key tolerance** — the JVM reader keeps `ignoreUnknownKeys = true`, the single line that
   makes the writer's `btaCompile` (which that reader does not declare) safe rather than fatal;
 - **mirrored constants** — sysprop keys the descriptor carries that other modules re-declare
@@ -86,19 +94,17 @@ Every rule was falsified — each made to fail on purpose, then restored — and
 unit-tested by `scripts/test_check_daemon_launch_schema.py`.
 
 Two reachability notes, both of which made earlier versions of this weaker than they looked. The
-Gradle task declares **every** Kotlin/TypeScript source as its input, not just the representations:
+Gradle task declares **every** Kotlin source as its input, not just the representations:
 the repo-wide rule reads files nobody listed, so a narrower input set let Gradle call the task
 up-to-date on precisely the change that added a new mirror. And because CI runs `test` tasks rather
 than `check`, the enforcement that actually runs on a PR is `test_check_daemon_launch_schema.py` in
 the `Actions Script Tests` job — which is why `ci-paths.json` scopes that job to `**/*.kt`. A
 repo-wide claim is only worth as much as the trigger that runs it.
 
-The TypeScript side is scoped to [`src/daemon/**`](https://github.com/yschimke/compose-preview-vscode/blob/main/src/daemon/**) rather than `**/*.ts`, and that
-is a deliberate limitation rather than an oversight: `test_path_scope.py` pins the rule that a
-VS Code-only change skips every Gradle CI group, and a blanket `**/*.ts` broke it. A new mirror in
-some other TypeScript file would therefore be caught on `main` rather than on the PR. Widening the
-trigger means relaxing that rule, which is a CI-cost decision worth making on its own terms rather
-than smuggling in here.
+The extension's TypeScript reader is outside all of this, and that is a boundary rather than a gap:
+it ships from its own repository on its own cadence, so a mirror added there is its check to catch.
+The cost is real and worth stating — `daemonProcess.ts` is the only reader that verifies the schema
+version, and nothing in this repository can tell you when it stops agreeing.
 
 The representations agreed when the gate landed. That is the point: it was written while the
 answer was still "no drift", so the first time it fails will be the first real drift.

--- a/docs/design/PREVIEW_SERVER_SPLIT.md
+++ b/docs/design/PREVIEW_SERVER_SPLIT.md
@@ -10,31 +10,32 @@
 ## What is left in this repository
 
 Nothing that this document described as preparation. `cli/serve` and `cli/serve-web` are gone and
-`:cli` consumes the published `compose-preview-serve` artifact, so the three instruments built to
+`:cli` launches the published server rather than linking it, so the three instruments built to
 measure the seam went with them: the symbol ratchet (`scripts/check-serve-seam.py`), the artifact
 probe (`preview-server/`, `scripts/check-preview-server-contracts.sh`) and the coupling gate
 (`scripts/measure-serve-coupling.py`). A Maven coordinate is a stronger boundary than a source
 scanner, so the ratchet had nothing left to measure.
 
 One check from that work survives because it was never about the split:
-[`checkDaemonLaunchSchema`](DAEMON_LAUNCH_SCHEMA.md), which polices a cross-language contract that
-has no module at all.
+[`checkDaemonLaunchSchema`](DAEMON_LAUNCH_SCHEMA.md), which polices a contract that has no module at
+all.
 
-## Two corrections the finished job earned
+## What the finished job settled
 
-**The seam measured a package boundary, not a process boundary.** The symbols it counted are not all
-server types: most contain no Ktor, being the render-host and history plumbing that `bundle render`,
-`render matrix` and `history manifest` use offline. compose-preview-server 2.2.0 split those into
-`ee.schimke.composeai:compose-preview-render-host`, which `:cli` depends on directly. Four symbols
-still cross into the server proper, all from `ServeCommand.kt`, so the Ktor floor remains until the
-`serve` command surface itself is decided —
-[#4832](https://github.com/yschimke/compose-ai-tools/issues/4832) and
-[compose-preview-server#9](https://github.com/yschimke/compose-preview-server/issues/9).
+**The seam measured a package boundary, not a process boundary.** The symbols it counted were not
+all server types: most contained no Ktor, being the render-host and history plumbing that
+`bundle render`, `render matrix` and `history manifest` use offline. Those are now
+[`:render-host`](../../render-host) in this repository — `:cli` takes `api(project(":render-host"))`
+— after compose-preview-server#180 moved the module to the repository everything it serves already
+lived in.
 
-**`browse` still delegates to serve.** `BrowseCommand` runs
-`ServeCommand(serveArgs(args), browseProject = true)` outright. What is narrowly true is that
-`browse` names no `ee.schimke.composeai.cli.serve` type *directly* — it reaches all of them through
-`ServeCommand` — so it is still a command the server's command surface has to account for.
+**The Ktor floor is gone, and `serve` is a launcher.** `ServeCommand` execs the published
+`compose-preview-server` binary rather than linking `ServeRunner`, and names no
+`ee.schimke.composeai.cli.serve` type; `compose-preview-serve` remains only as a test dependency, so
+the server is absent from the production classpath entirely. That removes the forward edge of the
+dependency cycle compose-preview-server#180 described. `browse`, `design` and `ui` reach it the same
+way — `BrowseCommand` runs `ServeCommand(args, browseProject = true)` — so they are launcher
+callers, not server consumers.
 
 ## The one durable lesson
 


### PR DESCRIPTION
Follow-up to #5329, which merged before I could act on its review. Two Codex findings, **both real** — and both are the exact failure that PR existed to fix: I moved text verbatim into a document I was presenting as normative without re-checking that it still described the code.

## 1. `DAEMON_LAUNCH_SCHEMA.md` overstated the gate's scope (P2)

It claimed the gate spans "two languages" and that the Gradle task "declares every Kotlin/TypeScript source as its input". Verified against the code — it does not:

- `cli/build.gradle.kts` sets `representations.from(rootProject.fileTree(repoRoot) { include("**/*.kt") … })` — Kotlin only.
- `walk_sources()` in `scripts/check-daemon-launch-schema.py` skips anything not ending `.kt`.
- The script contains **zero** references to `.ts`, `typescript` or `daemonProcess`.
- There is no in-repo `src/daemon/**`; the extension is external now.

So the scope is this repository's Kotlin copies plus a `compose-preview-contracts` checkout when `COMPOSE_PREVIEW_CONTRACTS_ROOT` resolves one. The doc now says that, and names the cost rather than hiding it: `daemonProcess.ts` is the only reader that verifies the schema version, and nothing in this repository can tell you when it stops agreeing.

Promoting that stale paragraph to a normative doc was worse than leaving it where it was, because it reads as an assurance. Good catch.

## 2. `PREVIEW_SERVER_SPLIT.md` presented an intermediate architecture as current (P2)

It said four symbols still cross into the server proper from `ServeCommand.kt` and the Ktor floor remains open. The launcher split finished:

- `:cli` takes `api(project(":render-host"))` — the module moved into this repository (compose-preview-server#180).
- `ServeCommand.kt` execs the published `compose-preview-server` binary via `ProcessBuilder(command).inheritIO()` and names no `ee.schimke.composeai.cli.serve` type.
- `compose-preview-serve` is a **test** dependency only, so the server is off the production classpath.
- `BrowseCommand` still calls `ServeCommand(args, browseProject = true)`, but that is now a launcher call, not a server consumer — as are `design` and `ui`.

## The third finding, which I did not act on

Codex also filed a **P1** asking to recreate the commit under a human identity, reporting `Codex <codex@openai.com>` as author and committer of `a9331ad`. `AGENTS.md` asks reviewers to run the detector before filing exactly this, so I did:

```
$ git cat-file -t a9331ad
fatal: Not a valid object name a9331ad

$ git log --format='%h %an <%ae> | %cn <%ce>' origin/main..HEAD
171d1dc Yuri Schimke <yuri@schimke.ee> | Yuri Schimke <yuri@schimke.ee>

$ .github/scripts/agent-attribution-scan.sh --range 'origin/main..HEAD'
No agent co-author trailers or agent commit identities found.        # exit 0
```

`a9331ad` is not an object in this repository, and the scanner exits 0 on the real range. This is the false positive `AGENTS.md` documents as "the most-reported and least-real finding on this repo".

## Test plan

Docs only. Every claim above was checked against the working tree (`cli/build.gradle.kts`, `scripts/check-daemon-launch-schema.py`, `ServeCommand.kt`, `BrowseCommand.kt`) rather than inferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMUJqsX7ATEVkYxiQEQNY2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMUJqsX7ATEVkYxiQEQNY2)_