### PR TITLE
perf(daemon): overlap sandbox worker boots and archive catalog daemon classes

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -49,6 +49,8 @@ import ee.schimke.composeai.data.theme.ThemePayload
 import ee.schimke.composeai.io.composeAiCacheDir
 import java.io.File
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.FutureTask
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
@@ -533,10 +535,11 @@ open class RobolectricHost(
 
     // SANDBOX-POOL.md — slot 0 is the in-process sandbox and always boots eagerly: [start]'s
     // contract is that the host can serve a render when it returns. Slots 1..N-1 are worker JVMs,
-    // booted sequentially (either here or on the background thread below). Sequential because the
-    // cost is CPU- and memory-bound — N concurrent Robolectric bootstraps thrash a build machine
-    // far worse than they save wall-clock — and because a serial boot keeps failure diagnosis to
-    // one worker's stderr at a time.
+    // booted one at a time (either here or on the background thread below), each boot overlapping
+    // only the previous slot's warm render — see [bootRemainingSlots]. One boot at a time because
+    // the cost is CPU- and memory-bound — N concurrent Robolectric bootstraps thrash a build
+    // machine far worse than they save wall-clock — and because a serial boot keeps failure
+    // diagnosis to one worker's stderr at a time.
     try {
       bootSlotWithRetries(0, timeoutMs)
       readySlotCount.set(1)
@@ -591,14 +594,43 @@ open class RobolectricHost(
    * so its first affinity-routed real render doesn't pay the per-sandbox first-render init (Compose
    * runtime, HardwareRenderer native pipeline, font + text stack, PNG encode). Publishing first
    * would let a live render hash onto the just-advertised slot and queue behind the cold warm-up.
+   *
+   * **The warm render overlaps the next worker's boot.** Measured on the deployed preview server's
+   * shape (`sandboxCount=3`, warm `android-all` cache, idle 4-core box; STARTUP.md § "Where the
+   * time goes"), a worker's sandbox boot is ~6 s and its warm render another ~6-8 s — the warm
+   * render is the sandbox's cold first render (Compose runtime, `HardwareRenderer`, the font stack,
+   * ~12,000 classes) and costs as much as the boot it follows. Running them strictly in series
+   * charged the pool `N × (boot + warm)`; booting worker `i+1` while worker `i` warm-renders
+   * charges `N × boot + warm` instead, which took the 3-sandbox pool from ~32 s to ~25 s on that
+   * box. Still one *boot* at a time: two concurrent Robolectric bootstraps thrash a build machine
+   * and would interleave two workers' stderr, whereas a warm render is one JVM rendering one frame.
+   * A slot is published into [readySlotCount] only after its own warm render, exactly as before, so
+   * the overlap never lets a live render land on a cold slot.
+   *
+   * The helper thread that boots the next worker is a daemon thread and is never joined on an early
+   * return (shutdown mid-pool-boot): joining could block for the whole boot budget on a worker that
+   * has connected but is still bootstrapping. A worker that finishes booting after the pool was
+   * shut down is registered into a closed pool and simply exits with this JVM — it watches the
+   * parent process (see `SandboxWorkerMain`), so nothing leaks past the daemon's own lifetime.
    */
   private fun bootRemainingSlots(timeoutMs: Long, background: Boolean) {
     val pool = processPool ?: return
+    fun bootAsync(slot: Int): FutureTask<Unit> =
+      FutureTask<Unit> { pool.bootWorker(slot - 1) }
+        .also { task ->
+          Thread(task, "compose-ai-daemon-worker-boot-$slot").apply {
+            isDaemon = true
+            start()
+          }
+        }
+    if (DaemonHostBridge.shutdown.get()) return
+    var booting: FutureTask<Unit>? = bootAsync(1)
     for (i in 1 until sandboxCount) {
-      if (DaemonHostBridge.shutdown.get()) return
+      val boot = booting ?: return
       try {
-        pool.bootWorker(i - 1)
-      } catch (t: Throwable) {
+        boot.get()
+      } catch (e: ExecutionException) {
+        val t = e.cause ?: e
         if (!background) throw t
         System.err.println(
           "RobolectricHost: background boot of sandbox worker $i failed permanently " +
@@ -608,6 +640,9 @@ open class RobolectricHost(
         return
       }
       if (DaemonHostBridge.shutdown.get()) return
+      // Launch the next worker now, so its JVM start + Robolectric bootstrap runs underneath this
+      // slot's warm render instead of after it.
+      booting = if (i + 1 < sandboxCount) bootAsync(i + 1) else null
       warmSlotRender(i)
       readySlotCount.set(i + 1)
       StartupTimings.mark(

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/pool/SandboxProcessPool.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/pool/SandboxProcessPool.kt
@@ -252,7 +252,7 @@ class SandboxProcessPool(
     val java = File(File(System.getProperty("java.home"), "bin"), "java").absolutePath
     val command = buildList {
       add(java)
-      addAll(inheritedJvmArgs())
+      addAll(workerJvmArgs(inheritedJvmArgs(), index))
       addAll(workerSysprops(index, port).map { (k, v) -> "-D$k=$v" })
       add("-cp")
       add(System.getProperty("java.class.path") ?: "")
@@ -333,6 +333,33 @@ class SandboxProcessPool(
 
   companion object {
     const val WORKER_PORT_PROP: String = DaemonProperties.Names.SANDBOX_WORKER_PORT
+
+    /**
+     * The inherited JVM args, with the class-data-sharing archive re-pointed at a **per-slot**
+     * file: `-XX:SharedArchiveFile=<name>.jsa` becomes `<name>-worker<index>.jsa`.
+     *
+     * Serve hands a catalog daemon `-XX:+AutoCreateSharedArchive -XX:SharedArchiveFile=…` so the
+     * JVM writes an archive of its loaded classes when it exits and maps it on the next launch of
+     * the same classpath. Both halves of that reach the workers through the inherited `-XX` flags,
+     * and both are wanted: the worker's archive is the one that carries the warm render's classes
+     * (Compose, the font stack, the PNG encoder), which the daemon JVM's slot 0 never loads. What
+     * must not be shared is the *file*. The dump runs from `before_exit`, so a worker that halts
+     * because its parent died dumps at the same moment the parent does, and two JVMs writing one
+     * archive path is a torn file. One file per JVM removes the race: a slot has at most one live
+     * worker, and a replacement is spawned only after the failed one is gone.
+     *
+     * Pure; `index` is the pool slot. Args without a `SharedArchiveFile` pass through unchanged.
+     */
+    internal fun workerJvmArgs(inherited: List<String>, index: Int): List<String> =
+      inherited.map { arg ->
+        if (!arg.startsWith(SHARED_ARCHIVE_FLAG)) return@map arg
+        val path = arg.removePrefix(SHARED_ARCHIVE_FLAG)
+        val stem = path.removeSuffix(".jsa")
+        val ext = if (path.endsWith(".jsa")) ".jsa" else ""
+        "$SHARED_ARCHIVE_FLAG$stem-worker$index$ext"
+      }
+
+    private const val SHARED_ARCHIVE_FLAG = "-XX:SharedArchiveFile="
     const val WORKER_SLOT_PROP: String = DaemonProperties.Names.SANDBOX_WORKER_SLOT
 
     private const val SANDBOX_COUNT_PROP = DaemonProperties.Names.SANDBOX_COUNT

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/pool/SandboxProcessPoolWorkerJvmArgsTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/pool/SandboxProcessPoolWorkerJvmArgsTest.kt
@@ -1,0 +1,49 @@
+package ee.schimke.composeai.daemon.pool
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * [SandboxProcessPool.workerJvmArgs] gives each worker slot its own class-data-sharing archive, so
+ * a worker halting alongside its parent never dumps into the parent's file.
+ */
+class SandboxProcessPoolWorkerJvmArgsTest {
+
+  @Test
+  fun `the shared archive is re-pointed at a per-slot file`() {
+    val inherited =
+      listOf(
+        "-XX:MaxRAMPercentage=70",
+        "-XX:+AutoCreateSharedArchive",
+        "-XX:SharedArchiveFile=/cache/cds/android-daemon-abc.jsa",
+        "--add-opens=java.base/java.lang=ALL-UNNAMED",
+      )
+    assertEquals(
+      listOf(
+        "-XX:MaxRAMPercentage=70",
+        "-XX:+AutoCreateSharedArchive",
+        "-XX:SharedArchiveFile=/cache/cds/android-daemon-abc-worker0.jsa",
+        "--add-opens=java.base/java.lang=ALL-UNNAMED",
+      ),
+      SandboxProcessPool.workerJvmArgs(inherited, 0),
+    )
+    assertEquals(
+      "-XX:SharedArchiveFile=/cache/cds/android-daemon-abc-worker3.jsa",
+      SandboxProcessPool.workerJvmArgs(inherited, 3)[2],
+    )
+  }
+
+  @Test
+  fun `an archive path without the jsa suffix still gets the slot suffix`() {
+    assertEquals(
+      listOf("-XX:SharedArchiveFile=/tmp/archive-worker1"),
+      SandboxProcessPool.workerJvmArgs(listOf("-XX:SharedArchiveFile=/tmp/archive"), 1),
+    )
+  }
+
+  @Test
+  fun `args without an archive pass through untouched`() {
+    val args = listOf("-Xmx1g", "-XX:+UseG1GC", "--enable-native-access=ALL-UNNAMED")
+    assertEquals(args, SandboxProcessPool.workerJvmArgs(args, 2))
+  }
+}

--- a/docs/daemon/BOOT-ROADMAP.md
+++ b/docs/daemon/BOOT-ROADMAP.md
@@ -1,0 +1,215 @@
+# Sandbox boot: the road to 2-3 seconds
+
+[STARTUP.md](STARTUP.md) has the profile: on an idle box a Robolectric sandbox
+boots in ~4 s, its warm render costs another ~6-8 s, and neither number is
+CPU queueing — it is the JVM defining ~6,000 classes and spinning ~6,500
+`java.lang.invoke` hidden classes for Robolectric's invokedynamic dispatch,
+per JVM, per boot. This page is the menu of what could change that, ranked by
+what each item returns against a **2-3 s** target for "a catalog that was not
+resident can render", with the short-term items that already shipped at the
+bottom. Costs quoted are the idle-4-core figures; the deployed box runs 2-3×
+slower per boot under memory pressure.
+
+The one-line conclusion: **no JVM flag or Robolectric tuning gets a cold boot
+plus warm render under ~8 s. The target is reached by not booting — a warmed
+sandbox is adopted, restored, or pre-linked — and a Robolectric fork that
+binds shadows statically is what makes the cold path itself cheap enough to
+stop mattering.**
+
+## Tier A — don't boot: adopt a warmed sandbox
+
+### A1. Pre-booted generic workers, keyed by overlay signature
+
+A sandbox does not depend on the catalog. The catalog's classes ride the
+disposable child loader (`UserClassLoaderHolder`), and the boot-time warm
+render touches none of them. So a worker booted and warm-rendered against
+*no* catalog can be handed to whichever daemon needs a slot next, and pays
+only that catalog's first real render (1-2 s, since Compose, the font stack
+and the PNG encoder are already hot). A warmed idle worker is ~570 MB RSS.
+
+The catch is the parent classpath. `ServeBundleDaemon.bundleDaemonClasspaths`
+puts each catalog's own Compose/AndroidX/coroutines overlay jars *ahead* of
+the sidecar on the daemon `-cp`, so a catalog compiled against a newer
+Material or Lifecycle resolves its own versions. A generic worker is
+therefore generic only within one **overlay signature** (the ordered set of
+overlay jars). The spare pool is keyed by that signature; the common
+signature on a box (all the design-artifacts catalogs on one Compose BOM) is
+pre-booted, a new signature pays a cold boot once — "first can be slower".
+
+What has to change:
+
+- **The worker protocol gains `configure`** (`SandboxWorkerProtocol`): user
+  class dirs, user packages, previews manifest. Today those are sysprops read
+  once at `SandboxWorkerMain` start; the holder's URL list is fixed at
+  construction. `swap()` already rebuilds the child loader, so a
+  `configure` that replaces the URL list and swaps is a small change.
+- **Slot 0 stops being special.** The daemon JVM hosts a sandbox too, and it
+  is the one that cannot be adopted. Either the daemon becomes a thin router
+  whose every slot is a worker (the interactive slot pinned to one of them),
+  or the daemon itself is the pre-booted unit: serve launches N generic
+  daemons per signature ahead of demand and `initialize` carries the catalog
+  (user class dirs, previews manifest) instead of the launch descriptor. The
+  second is less code and keeps the protocol shape; it needs a new
+  `initialize` parameter in `compose-preview-contracts`.
+- **Serve owns the spares.** `ServeSharedDaemonPool` / `ServePerPreviewDaemonPool`
+  currently open a daemon per catalog on demand and reap replicas after 60 s
+  idle — the churn that produced 60 boots in 8 h on the deployed box. With
+  spares, reaping a replica returns it to the spare pool (after a classloader
+  swap that drops the catalog's classes) instead of killing three JVMs.
+
+Cost to build: protocol + serve pool work, a week-ish. Return: a resident
+signature's "boot" becomes adopt (ms) + first render, i.e. the target, on
+the JDK and Robolectric we have.
+
+### A2. CRaC checkpoint of a warmed worker
+
+Coordinated Restore at Checkpoint: boot, warm-render, checkpoint the worker
+JVM to disk; every later worker `restore`s in well under a second and dials
+the parent. Same overlay-signature keying as A1, same "first is slow". It
+needs a CRaC-enabled JDK (Azul Zulu CRaC or the OpenJDK CRaC builds —
+Temurin does not ship it) and CRIU privileges in the container
+(`CAP_CHECKPOINT_RESTORE`, or `--privileged`), and the Robolectric native
+runtime (`libandroid_runtime`, software GL) has to survive checkpoint, which
+mostly means no open sockets or GPU handles at checkpoint time — the
+worker's parent socket would have to be opened after restore. Higher
+operational risk than A1 for a similar payoff; worth a spike once A1 exists,
+because it also covers the *first* worker of a signature after a deploy.
+
+## Tier B — make a cold boot itself cheap (a Robolectric fork)
+
+Robolectric is where the cold cost lives, and every item here is a change
+to it. The daemon already runs an unusual Robolectric — one sandbox held
+open for the JVM's life, no per-test reconfiguration — and several of
+Robolectric's costs exist to support exactly the flexibility the daemon
+never uses. That is the argument for a fork with upstreamable opt-ins.
+
+### B1. Closed-world shadow binding (the big one)
+
+Every method call in instrumented code is an `invokedynamic` whose bootstrap
+asks `ShadowWrangler` whether a shadow applies, then links a `MethodHandle`
+chain. That indirection exists so a *later test* can install different
+shadows. The daemon's shadow set is fixed at boot, so every one of those
+6,500 hidden classes per JVM is paid for a flexibility that is never used.
+
+A fork would add an instrumentation mode that, given the shadow map at
+instrumentation time, emits **direct calls**: `invokevirtual` to the real
+method where no shadow applies, `invokestatic` to the shadow method where one
+does. `android-all-instrumented` would be re-instrumented once per
+(Robolectric version, shadow set) — a build-time job, published as our own
+`android-all` coordinate (see B3). Effect: the `java.lang.invoke` cost
+disappears from both the boot (~3 s of 4) and the warm render (roughly half
+of it), and — because nothing is defined at runtime any more — every class
+becomes archivable (B5). This is the change that makes the cold path itself
+approach the target. Upstream shape: `-Drobolectric.instrumentation=static`
+with the shadow set frozen after the first sandbox.
+
+### B2. Boot without JUnit, on the sandbox / simulator API
+
+The daemon boots through `JUnitCore.runClasses(SandboxRunner)` with a dummy
+`@Test` that holds the sandbox open (DESIGN.md § 9). The JUnit layer itself
+is cheap (~130 classes, config resolution), but it dictates the lifecycle:
+`AndroidTestEnvironment.setUpApplicationState` runs in full — manifest
+parsing, `ActivityThread`, every `SystemServiceRegistry` initializer (97
+`*FrameworkInitializer` classes loaded at boot for telephony, wifi, NFC,
+health, UWB, virtualization…), a `FakeMediaProvider`, Espresso hooks. Since
+4.15 Robolectric ships **`robolectric-simulator`**, a supported non-JUnit
+entry point that builds an `AndroidSandbox` and drives an app from plain
+`main`; its `pluginapi` package is already on the sandbox's do-not-acquire
+list in 4.17. Booting on that API (or directly on `SandboxManager` /
+`AndroidSandbox`) lets the daemon own the lifecycle, skip the test-only
+setup, and never load a test class into the sandbox. Return: modest on its
+own (a few hundred ms and ~700 classes), large as the foundation for B1/B4.
+
+### B3. Our own SDK artifact
+
+Robolectric's `MavenArtifactFetcher` downloads `android-all-instrumented`
+(200 MB, the whole framework) into `~/.m2`. The deploy image bakes it, so the
+download is not the problem; the *contents* are. A published
+`compose-preview-android-all` would be: pre-instrumented **statically** (B1),
+trimmed of the framework services a preview never reaches, with a lazy
+`SystemServiceRegistry` (register on first `getSystemService`, not in
+`<clinit>`), and shipped alongside a pre-built class archive (B5) and the
+pre-extracted native runtime. SDK management stays Robolectric's — one
+coordinate per SDK level — it just points at our artifact.
+
+### B4. A capture path without an Activity
+
+The warm render (and every catalog's cold first render) loads
+`ActivityScenario`, Espresso and the `Activity`/`Window`/`ActionBar` stack
+because Roborazzi's `captureRoboImage` goes through them. Compose needs a
+`View` tree with lifecycle/saved-state owners and a `HardwareRenderer` to
+draw a `RenderNode`; none of that needs an Activity. A daemon-owned capture —
+`ComposeView` under a `FrameLayout` attached through `WindowManager`, tree
+owners set by hand, drawn with `HardwareRenderer` — drops ~700 classes and
+their call-site linking from the first render, and removes the ActionBar
+workaround Roborazzi logs five times per render.
+
+### B5. Make the sandbox archivable
+
+CDS/AppCDS can archive classes from custom loaders, but only ones the JVM
+saw come from a jar (`source:` in the classlist). `SandboxClassLoader`
+reads bytes and calls `defineClass` for *everything* it acquires, so the JVM
+records no source and nothing is archived — the shipped archive covers the
+~3,500 builtin-loader classes only. Two fork changes: delegate
+un-instrumented classes to `URLClassLoader.findClass` so they become
+archivable, and — with B1 — stop needing a custom loader at all, at which
+point Project Leyden's AOT cache (JDK 24+, `-XX:AOTCache`, loaded *and
+linked* classes with training-run profiles) covers the whole sandbox and a
+cold boot is sub-second before the warm render.
+
+### B6. Parallel class definition
+
+`SandboxClassLoader` is not registered parallel-capable, so every
+`loadClass` on it serializes on the loader. With the boot class list known
+(it is deterministic per classpath), a fork could pre-define the list from
+N threads while the main bootstrap proceeds. Useful only until B5 removes
+the definition cost; skip if B1/B5 land first.
+
+### B7. Smaller items
+
+- `libandroid_runtime.so` and the font set are extracted from the
+  nativeruntime jar into a temp directory on every JVM start; pointing
+  `robolectric.nativeruntime.fontdir` (and a matching library-dir override,
+  which 4.17 lacks) at a pre-extracted image path saves the I/O on a box
+  whose page cache is under pressure.
+- BouncyCastle: `AndroidTestEnvironment` constructs and installs the
+  provider unconditionally (~0.75 s, 709 classes from a signed jar). A fork
+  makes it lazy; nothing outside a fork can.
+- Pure-JVM libraries (`kotlinx.serialization`, guava, okio) are acquired by
+  the sandbox by default and re-defined per JVM; `doNotAcquirePackage` moves
+  them to the parent (and into the archive). Coroutines is the trap:
+  `Dispatchers.Main` is discovered by `ServiceLoader` from core, and the
+  `kotlinx.coroutines.android` factory is invisible from the parent.
+
+## Tier C — the other runtimes
+
+- **GraalVM native-image** is the very long-term version of B1+B5: a closed
+  world where class loading, verification and call-site linking are done at
+  build time and the process starts in ~100 ms. It is incompatible with
+  Robolectric as it stands — runtime bytecode instrumentation and custom
+  loaders do not exist under native-image — but a statically bound
+  Robolectric (B1) plus a fixed sidecar is a closed world, and the JNI
+  native runtime is configurable. The catalog's classes would have to be in
+  the image too, so it becomes "build a native image per overlay signature
+  on first sight, minutes, then start every daemon from it in a fraction of
+  a second". Leyden gets most of that without leaving HotSpot.
+- **Layoutlib** (what Android Studio previews render with) is a rewrite of
+  the renderer, not a boot optimisation; it removes Robolectric's costs by
+  removing Robolectric, at the price of every shadow-based data product.
+
+## Shipped short-term (this profile's PR)
+
+- Worker `i+1` boots underneath worker `i`'s warm render
+  ([SANDBOX-POOL.md](SANDBOX-POOL.md)).
+- Serve-spawned catalog daemons get a per-classpath auto-created CDS archive
+  and skip remote bytecode verification, with JVM logging routed off the
+  JSON-RPC stdout (`ServeBundleDaemon.androidDaemonStartupJvmArgs`).
+
+## Suggested order
+
+1. A1 (adoptable warmed workers keyed by overlay signature) — reaches the
+   target on today's Robolectric; the serve-side churn fix falls out of it.
+2. B2 then B1 in a fork, published as B3 — makes the first boot of a
+   signature and every capacity burst cheap, and unlocks B5.
+3. B4 alongside, since it also speeds every catalog's cold first render.
+4. A2 / Leyden as spikes once 1-2 exist.

--- a/docs/daemon/README.md
+++ b/docs/daemon/README.md
@@ -54,6 +54,8 @@ the CI-canonical render path.
   bytecode instrumentation, shadows).
 - **[SANDBOX-POOL.md](SANDBOX-POOL.md)** — in-JVM sandbox pool.
 - **[STARTUP.md](STARTUP.md)** — daemon startup latency analysis.
+- **[BOOT-ROADMAP.md](BOOT-ROADMAP.md)** — the ranked plan for a 2-3 s sandbox boot: adoptable
+  warmed workers, and what a Robolectric fork would change.
 - **[HISTORY.md](HISTORY.md)** — preview history archive: on-disk
   schema, JSON-RPC API, MCP mappings, `HistorySource` backends.
 - **[INTERACTIVE.md](INTERACTIVE.md)** — focus-mode live stream and

--- a/docs/daemon/SANDBOX-POOL.md
+++ b/docs/daemon/SANDBOX-POOL.md
@@ -128,7 +128,7 @@ pre-pool path.
 
 `composeai.daemon.backgroundSandboxBoot` (launch descriptors default it **on**,
 the raw sysprop defaults **off** — see [CONFIG.md](CONFIG.md)) makes `start()`
-block only until slot 0 is up; the workers boot sequentially on a background
+block only until slot 0 is up; the workers boot one at a time on a background
 daemon thread. Dispatch routes across the ready prefix meanwhile, so a render
 never queues on a still-booting worker.
 
@@ -139,6 +139,12 @@ never queues on a still-booting worker.
   `DaemonWarmupPreview` once before it is published for dispatch (disable with
   `-Dcomposeai.daemon.warmRenderOnBoot=false`), so a live render never queues
   behind a cold warm-up. Slot 0 is left to serve's own `prewarm()`.
+- **The warm render overlaps the next worker's boot.** A worker's sandbox boot
+  and its warm render cost about the same (~6 s and ~6-8 s on an idle 4-core
+  box — [STARTUP.md](STARTUP.md) has the profile), so worker `i+1` is launched
+  the moment worker `i` has booted and boots underneath `i`'s warm render. The
+  pool still boots one worker at a time; only the warm render is overlapped,
+  and a slot is still published only after its own warm render.
 - **A worker that dies mid-request is dropped from the pool**, logged with its
   pid; the remaining slots keep serving.
 

--- a/docs/daemon/STARTUP.md
+++ b/docs/daemon/STARTUP.md
@@ -112,6 +112,32 @@ plus `-XX:-BytecodeVerificationRemote`
 per classpath: serve puts a catalog's own Compose/AndroidX overlay jars
 *ahead* of the sidecar, so one image-wide archive would never validate.
 
+### The pool, before and after
+
+Same box, `sandboxCount=3`, time from the daemon JVM's start to the last
+slot published (`sandbox 2 ready`), and the resident memory of the daemon
+plus its two workers once the pool is up (`Rss` from `smaps_rollup`):
+
+| daemon | pool complete | daemon + worker + worker RSS |
+|---|---|---|
+| released 2.4.0 | 21.7-23.4 s | 375 + 582 + 592 MB |
+| + warm render overlapped with the next boot | 19.9 s | same |
+| + archive, first boot of this classpath (records + writes it) | 27.4 s | +0-100 MB |
+| + archive, every later boot | 14.5-15.2 s | metaspace 52→13 / 98→24 MB, RSS about the same |
+| + serial collector, archive present | 14.9-15.2 s | 307 + 459 + 451 MB |
+
+The archive moves ~40 MB (daemon) and ~75 MB (worker) of metaspace into a
+mapped file; RSS does not fall by that much because the mapping is
+relocated on load and its touched pages are private.
+`-XX:ArchiveRelocationMode=0` would keep them shared, but on JDK 21 it
+silently disabled the archive here (mapping at the requested address
+failed), so it is not used. The serial collector is where the memory goes:
+~20-25 % per JVM, no boot cost, and on a box running dozens of three-JVM
+daemons that is the difference between sitting at its limit and not. Every
+JVM in the container otherwise inherits `-XX:MaxRAMPercentage=70` of the
+*container*, i.e. a 28 GB heap ceiling each on a 40 GB box, which is the
+first thing to look at for the memory climb the same issue reports.
+
 ### What it means for the target
 
 A single-sandbox boot floors at ~3 s on an idle box with every JVM lever

--- a/docs/daemon/STARTUP.md
+++ b/docs/daemon/STARTUP.md
@@ -215,6 +215,9 @@ Two changes shipped:
 
 ## Future options
 
+The ranked medium-term plan, including what a Robolectric fork would change,
+is [BOOT-ROADMAP.md](BOOT-ROADMAP.md). The list below predates it.
+
 Menu of follow-ups, by leverage:
 
 - ~~**Reconsider the eager warm-spare pool on the launch-descriptor

--- a/docs/daemon/STARTUP.md
+++ b/docs/daemon/STARTUP.md
@@ -27,25 +27,105 @@ both for this reason.
 
 ## Where the time goes
 
-Rough breakdown on cold first run:
+Measured, not estimated (compose-preview-server#626). The deployed preview
+server's shape — the released 2.4.0 `lib-daemon-android` sidecar, Temurin 21,
+`sandboxCount=3`, `backgroundSandboxBoot=true`, a warm `android-all` cache —
+on an idle 4-core / 16 GB box, with `StartupTimings` marks, `-Xlog:class+load`
+and a JFR recording across one boot:
 
-1. **Robolectric `InstrumentingClassLoader` instrumenting every class on
-   the classpath at load time.** ~5–10 s for a 344-class daemon. Happens
-   *every* boot, hot or cold. Bytecode rewriting via ASM.
-2. **First-time Maven download of `android-all-instrumented-{ver}-{sdk}.jar`
-   (~150 MB).** 0–60 s+ depending on network. Cached after first run.
-3. **JVM startup + classpath resolve + first render.** ~1–2 s + ~50–500 ms.
+```
+[+   407ms] worker 0 launched (Robolectric init begins)      daemon JVM
+[+  5515ms] sandbox-ready latch fired (slot 0)               → slot 0 boot   5.1 s
+[+  6610ms] sandbox-ready latch fired                        worker 1 JVM, from ITS start
+[+ 19912ms] sandbox 1 warm render done (7425ms)              → slot 1: 6.6 s boot + 7.4 s warm
+[+ 32190ms] sandbox 2 warm render done (6003ms)              → slot 2: 6.3 s boot + 6.0 s warm
+```
 
-(1) is the persistent cost. (2) piles on for cold-cache first runs.
+So a **sandbox "boot" as the pool reports it is two equal halves**: ~6 s of
+Robolectric bootstrap and ~6-8 s of boot-time warm render, in series, and the
+3-sandbox pool completes ~32 s after the daemon JVM started. On the deployed
+box the same marks read 9-60 s (p50 22 s) with the CPU idle, so the box is
+2-3× slower per boot than this one — consistent with its 81 % memory and
+active swap paging the 450 MB of jars each boot re-reads, not with CPU
+queueing.
 
-**Multiply (1) by the pool.** `start()` boots the eager slots
-*sequentially*, and `warmSpare` (on by default on the Gradle-plugin
-launch path) means five of them. At ~11.6 s per sandbox on a warm
-`android-all` cache — the figure
-[SANDBOX-POOL.md](SANDBOX-POOL.md) measures — a warm-spare pool is
-~58 s of boot before `initialize` can answer, on top of (2). That is
-what makes the observed 141 s on a GitHub runner: a cold jar download
-plus five sequential sandbox boots.
+Inside one single-sandbox boot (4.3 s JVM start → ready, 3.9 s after
+`host.start()`), by the class-load timeline:
+
+| window | what loads | cost |
+|---|---|---|
+| 0.0-0.75 s | JVM + daemon classes, kotlin stdlib, guava, JUnit, Robolectric's injector | ~0.5 s |
+| 1.5-2.25 s | **BouncyCastle**: 709 classes from a *signed* jar (the JDK verifies the manifest on first load), then the JCE provider registers every algorithm. Robolectric installs it because `conscryptMode=OFF` | ~0.75 s |
+| 2.25-5.25 s | the sandbox: 2,154 classes defined by Robolectric's `SandboxClassLoader` (android-all, shadows, resources, `ActivityThread`), plus **2,392 `java.lang.invoke` hidden classes** — one `LambdaForm`/species class per distinct invokedynamic call-site shape the instrumented framework links | ~3 s |
+
+JFR's Java-level sampler caught only 52 samples in that window: the time is
+inside the VM, parsing, defining and verifying classes, not in Java code.
+GC pauses total ~0.1 s; file reads ~20 ms; there is no I/O wait on a warm
+page cache.
+
+The **warm render** is the same story, bigger. The worker JVM loads 5,600
+classes to boot its sandbox and **12,500 more** to render the 64×64
+`DaemonWarmupPreview`: `Activity`/`View`/Espresso setup, Compose runtime + UI
++ foundation, `sun.font` / `java2d` / `imageio` for the PNG, then the data
+products (`compose/figma-svg` alone is ~0.9 s). Of the worker's 18,184
+classes, **6,580 are `java.lang.invoke` hidden classes** and 6,261 are
+sandbox-defined — the cost of Robolectric's invokedynamic dispatch, paid per
+JVM, per call-site shape, and not cacheable by anything the JVM ships.
+
+The old description of this section — "the classloader instruments every
+class on the classpath, ~5-10 s" — no longer holds: `android-all-instrumented`
+is pre-instrumented, so no ASM rewriting happens at boot (2 of 52 samples).
+What is paid every boot is *defining* those classes, and linking their
+call sites.
+
+### What each JVM-level lever is worth
+
+Same box, single-sandbox boot, JVM start → `sandbox-ready latch fired`,
+best of 2-3 runs (run-to-run noise is ~±0.2 s):
+
+| variant | JVM → ready | after `host.start()` |
+|---|---|---|
+| baseline | 4.3 s | 3.9 s |
+| `-Xshare:off` (no CDS at all — sizes what the JDK's own archive buys) | 5.2 s | 4.7 s |
+| static AppCDS archive of the daemon classpath (3,081 shared classes) | 3.7 s | 3.5 s |
+| … + `-XX:-BytecodeVerificationRemote` | 3.4 s | 3.25 s |
+| … + bcprov repacked unsigned (so CDS can archive it) + `-XX:TieredStopAtLevel=1` | 3.0 s | 2.8 s |
+| `-XX:TieredStopAtLevel=1` alone, `-XX:+UseSerialGC`, `-Xmx1g`, `-Xmx512m` | noise | noise |
+| `-Djava.lang.invoke.MethodHandle.COMPILE_THRESHOLD=30` (keep LambdaForms interpreted) | noise | noise |
+| … `=1000` | 4.9 s | 4.5 s |
+
+Reading it: about a second of a four-second boot is class parsing and
+verification of the builtin-loader classes, which an archive and a
+verification opt-out remove. The other three seconds are the sandbox loader
+defining classes and the JVM spinning `java.lang.invoke` classes, which no
+JVM flag touches. The `COMPILE_THRESHOLD` result rules out "LambdaForms are
+compiled to bytecode too eagerly" — those hidden classes are species and
+invoker shapes, not compiled forms.
+
+An archive is worth the same ~0.5 s again on every worker, and more on a box
+whose page cache is under pressure, since a mapped archive replaces
+re-reading and re-parsing jars. `ServeBundleDaemon` therefore hands every
+catalog daemon `-XX:+AutoCreateSharedArchive` with a per-classpath archive
+under the shared `composeai` cache dir (`composeai.serve.androidDaemonCds`),
+plus `-XX:-BytecodeVerificationRemote`
+(`composeai.serve.androidDaemonBytecodeVerification`). The archive has to be
+per classpath: serve puts a catalog's own Compose/AndroidX overlay jars
+*ahead* of the sidecar, so one image-wide archive would never validate.
+
+### What it means for the target
+
+A single-sandbox boot floors at ~3 s on an idle box with every JVM lever
+pulled, and the warm render adds ~6 s that no flag reaches. **A 2-3 s
+"boot" is only reachable by not booting**: the sandbox does not depend on the
+catalog — the catalog's classes ride the disposable child loader, and the
+warm render touches none of them — so a worker booted and warmed against no
+catalog at all can be adopted by whichever daemon needs one next and pay only
+the catalog's first real render. A warmed idle worker is ~570 MB RSS (the
+daemon JVM ~380 MB), so a few spares fit on the deployed box. That is the
+"pre-booted spare workers" item under Future options; the changes shipped
+with this profile are the ones that were cheap: overlapping each worker's
+warm render with the next worker's boot (SANDBOX-POOL.md), and the two flags
+above.
 
 ## What caching can and can't reach
 
@@ -161,9 +241,19 @@ Menu of follow-ups, by leverage:
 - **Machine-resident daemon** (highest priority). Daemon survives editor
   restarts; cold start moves from "every editor open" to "every reboot."
   Lifecycle change only; needs a different anchor than parent-PID.
-- **AppCDS / Class Data Sharing.** Standard OpenJDK feature. May be
-  defeated by Robolectric's load-time bytecode rewriting; needs a
-  benchmark.
+- ~~**AppCDS / Class Data Sharing.**~~ **Measured** (§ "What each JVM-level
+  lever is worth"): ~0.5-0.6 s per JVM, because it can only hold the
+  builtin-loader classes — Robolectric's sandbox loader defines the rest
+  from streams and the JVM cannot archive those. Shipped for serve-spawned
+  catalog daemons as an auto-created per-classpath archive.
+- **Pre-booted spare workers.** The lever that actually reaches a 2-3 s
+  boot: a sandbox worker booted and warm-rendered against *no* catalog, held
+  idle, and handed to the next daemon that needs a slot with its child
+  loader pointed at that catalog's classes. Needs a `configure(userClassDirs)`
+  step on the worker protocol (the `UserClassLoaderHolder` URL list is fixed
+  at construction today) and a way for a worker to re-dial a different parent
+  daemon, or for the spare pool to live in the serve process and lend workers
+  to daemons. ~570 MB RSS per warmed spare.
 - **Cache instrumented bytecode on disk.** Robolectric's instrumentation
   is deterministic per (input class, Robolectric version, shadow set).
   Persist post-instrumentation bytes to a side cache. ~2 weeks of work;

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -1039,15 +1039,23 @@ public object ServeBundleDaemon {
    *   [bundleDaemonClasspaths] puts the bundle's own Compose/AndroidX overlay jars ahead of the
    *   sidecar — so one baked image-wide archive could never validate. It lives under the shared
    *   `composeai` cache dir, which the deploy image keeps on a volume, so it survives a container
-   *   restart. The first boot of a catalog is unchanged (the archive is written at exit); the
-   *   second and later ones skip parsing and verifying the ~3,500 sidecar and JDK classes the
-   *   sandbox boot touches. Robolectric's own sandbox classes are defined by a custom loader and
-   *   stay out of any archive — that is the part only a pre-booted sandbox can remove.
+   *   restart. The first boot of a classpath is *slower* — recording dump info and writing the
+   *   archive at exit cost it 40-75 % in the profile — and every later one is ~35 % faster to a
+   *   full pool: it skips parsing and verifying the ~3,500 sidecar and JDK classes the sandbox boot
+   *   touches, and the workers' archives carry the warm render's classes too. Robolectric's own
+   *   sandbox classes are defined by a custom loader and stay out of any archive — that is the part
+   *   only a pre-booted sandbox can remove.
    * - **No remote bytecode verification** (`composeai.serve.androidDaemonBytecodeVerification`,
    *   default off). Verification is a linear pass over every class the sandbox defines, worth ~0.25
    *   s per JVM on an idle box, and a catalog daemon already runs the catalog's producers' code
    *   with no further trust boundary. The playground lane, which compiles a stranger's Kotlin, does
    *   not get this flag — see the descriptor site.
+   *
+   * - **The serial collector** (`composeai.serve.androidDaemonSerialGc`, default on). A sandbox
+   *   renders one frame at a time on a ~100 MB live heap; G1's regions, remembered sets and its
+   *   eight parallel GC threads per JVM buy it nothing, and cost it ~20-25 % of resident memory —
+   *   measured 375/582/592 MB → 313/461/475 MB for a daemon and its two workers, with the same boot
+   *   time. On a box running dozens of three-JVM daemons that is gigabytes.
    *
    * Two things the archive flag drags in, both load-bearing:
    *
@@ -1062,9 +1070,16 @@ public object ServeBundleDaemon {
    *   carry the dynamic-archive magic, and the JVM refuses to auto-create over a file it cannot
    *   read as an archive, which would leave that catalog without CDS until someone deleted the file
    *   by hand. [validateArchive] checks the four magic bytes and unlinks anything else.
+   * - **The directory is bounded.** Each sandbox worker gets its own archive beside the daemon's
+   *   (`SandboxProcessPool.workerJvmArgs` — one writer per file), so a classpath costs about 50 MB
+   *   for the daemon plus ~100 MB per worker, and the deployed box serves dozens of catalogs whose
+   *   overlay jars are content-addressed, so catalogs on one Compose BOM share a classpath and an
+   *   archive. [pruneArchives] evicts the least recently written archives past
+   *   `composeai.serve.androidDaemonCdsMaxBytes` (default 2 GiB), never the ones this launch is
+   *   about to use.
    *
-   * Pure apart from the directory and that unlink; [javaFeatureVersion] and [cdsDir] are seams for
-   * the unit test.
+   * Pure apart from the directory, that unlink and that eviction; [javaFeatureVersion] and [cdsDir]
+   * are seams for the unit test.
    */
   internal fun androidDaemonStartupJvmArgs(
     daemonClasspath: List<String>,
@@ -1072,12 +1087,18 @@ public object ServeBundleDaemon {
     cdsDir: File = composeAiCacheDir("cds"),
     cdsEnabled: Boolean = System.getProperty(ANDROID_DAEMON_CDS_PROP)?.toBoolean() ?: true,
     verifyBytecode: Boolean = System.getProperty(ANDROID_DAEMON_VERIFY_PROP)?.toBoolean() ?: false,
+    cdsMaxBytes: Long =
+      System.getProperty(ANDROID_DAEMON_CDS_MAX_BYTES_PROP)?.toLongOrNull()
+        ?: DEFAULT_ANDROID_DAEMON_CDS_MAX_BYTES,
+    serialGc: Boolean = System.getProperty(ANDROID_DAEMON_SERIAL_GC_PROP)?.toBoolean() ?: true,
   ): List<String> = buildList {
+    if (serialGc) add("-XX:+UseSerialGC")
     if (cdsEnabled && javaFeatureVersion >= 19) {
       val key = classpathArchiveKey(daemonClasspath)
       val archive = File(cdsDir, "android-daemon-$key.jsa")
       runCatching { cdsDir.mkdirs() }
       validateArchive(archive)
+      pruneArchives(cdsDir, keepStem = "android-daemon-$key", maxBytes = cdsMaxBytes)
       add("-XX:+AutoCreateSharedArchive")
       add("-XX:SharedArchiveFile=${archive.absolutePath}")
       add("-Xlog:disable")
@@ -1112,6 +1133,38 @@ public object ServeBundleDaemon {
 
   /** HotSpot `CDS_DYNAMIC_ARCHIVE_MAGIC` (src/hotspot/share/cds/filemap.hpp). */
   private const val CDS_DYNAMIC_ARCHIVE_MAGIC: Int = 0xf00baba8.toInt()
+
+  /**
+   * Keeps the `.jsa` files under [cdsDir] within [maxBytes] by deleting the least recently modified
+   * ones first. Files whose name starts with [keepStem] — the archive this launch will use and its
+   * per-worker siblings — are never candidates. Returns the deleted files, for the test.
+   * Best-effort: an unreadable directory prunes nothing.
+   */
+  internal fun pruneArchives(cdsDir: File, keepStem: String, maxBytes: Long): List<File> {
+    val archives =
+      cdsDir.listFiles { f -> f.isFile && f.name.endsWith(".jsa") } ?: return emptyList()
+    var total = archives.sumOf { it.length() }
+    if (total <= maxBytes) return emptyList()
+    val deleted = mutableListOf<File>()
+    for (candidate in
+      archives.filterNot { it.name.startsWith(keepStem) }.sortedBy { it.lastModified() }) {
+      if (total <= maxBytes) break
+      val size = candidate.length()
+      if (candidate.delete()) {
+        total -= size
+        deleted += candidate
+      }
+    }
+    return deleted
+  }
+
+  /** `-Dcomposeai.serve.androidDaemonSerialGc=false` keeps the JVM's default collector. */
+  internal const val ANDROID_DAEMON_SERIAL_GC_PROP = "composeai.serve.androidDaemonSerialGc"
+
+  /** `-Dcomposeai.serve.androidDaemonCdsMaxBytes=<bytes>` bounds the archive directory. */
+  internal const val ANDROID_DAEMON_CDS_MAX_BYTES_PROP = "composeai.serve.androidDaemonCdsMaxBytes"
+
+  private const val DEFAULT_ANDROID_DAEMON_CDS_MAX_BYTES: Long = 2L * 1024 * 1024 * 1024
 
   /**
    * Stable name for the archive of one daemon classpath: the SHA-256 of the entries in order. The

--- a/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/render-host/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -357,7 +357,13 @@ public object ServeBundleDaemon {
         mainClass = DAEMON_MAIN_CLASS,
         javaLauncher = null,
         classpath = classpaths.daemonClasspath,
-        jvmArgs = backendLaunch.jvmArgs,
+        // Catalog daemons only: the playground descriptor below runs a stranger's snippet and
+        // keeps bytecode verification, and its per-session classpath would never hit an archive.
+        jvmArgs =
+          backendLaunch.jvmArgs +
+            (if (backendLaunch.variant == "android")
+              androidDaemonStartupJvmArgs(classpaths.daemonClasspath)
+            else emptyList()),
         systemProperties =
           buildMap {
             put("composeai.daemon.userClassDirs", classpaths.userClassPath)
@@ -1015,6 +1021,121 @@ public object ServeBundleDaemon {
       put("composeai.daemon.warmRenderOnBoot", it)
     }
   }
+
+  /**
+   * JVM flags that make a serve-spawned Android daemon — and every sandbox worker it spawns, since
+   * `SandboxProcessPool` hands its `-XX` flags on — boot faster. Profiled on the deployed preview
+   * server's shape (compose-preview-server#626; STARTUP.md § "Where the time goes"): a Robolectric
+   * sandbox boot is ~4 s of mostly class definition and verification, and every catalog daemon on
+   * the box pays it three times over (slot 0 plus two workers), on every launch.
+   *
+   * Two flags, each with its own opt-out so an operator can bisect a regression on the box:
+   *
+   * - **A per-classpath class-data-sharing archive** (`composeai.serve.androidDaemonCds`, default
+   *   on, JDK 19+). `-XX:+AutoCreateSharedArchive` makes the JVM write a dynamic archive of every
+   *   builtin-loader class it loaded when it exits, and map it on the next launch of the same
+   *   classpath; a missing, stale or corrupt archive is regenerated, never fatal. The archive is
+   *   keyed by the daemon classpath because that classpath is *per catalog* —
+   *   [bundleDaemonClasspaths] puts the bundle's own Compose/AndroidX overlay jars ahead of the
+   *   sidecar — so one baked image-wide archive could never validate. It lives under the shared
+   *   `composeai` cache dir, which the deploy image keeps on a volume, so it survives a container
+   *   restart. The first boot of a catalog is unchanged (the archive is written at exit); the
+   *   second and later ones skip parsing and verifying the ~3,500 sidecar and JDK classes the
+   *   sandbox boot touches. Robolectric's own sandbox classes are defined by a custom loader and
+   *   stay out of any archive — that is the part only a pre-booted sandbox can remove.
+   * - **No remote bytecode verification** (`composeai.serve.androidDaemonBytecodeVerification`,
+   *   default off). Verification is a linear pass over every class the sandbox defines, worth ~0.25
+   *   s per JVM on an idle box, and a catalog daemon already runs the catalog's producers' code
+   *   with no further trust boundary. The playground lane, which compiles a stranger's Kotlin, does
+   *   not get this flag — see the descriptor site.
+   *
+   * Two things the archive flag drags in, both load-bearing:
+   *
+   * - **The JVM's own log must not land on stdout.** Unified logging defaults to
+   *   `all=warning:stdout`, and the daemon's stdout *is* the JSON-RPC channel. A CDS mismatch
+   *   warning at startup, or the several hundred `Skipping …: Signed JAR` lines the dump writes at
+   *   exit, would be fed to the client as protocol bytes. So the JVM log is re-pointed at stderr,
+   *   where the daemon's free-form log already goes, and the `cds` tags are silenced outright — an
+   *   archive that fails to load is regenerated, which is the only diagnosis that matters.
+   * - **A torn archive is deleted before launch.** The archive is written when the daemon exits,
+   *   and serve force-kills a daemon that ignores `shutdown` — a file cut off mid-write does not
+   *   carry the dynamic-archive magic, and the JVM refuses to auto-create over a file it cannot
+   *   read as an archive, which would leave that catalog without CDS until someone deleted the file
+   *   by hand. [validateArchive] checks the four magic bytes and unlinks anything else.
+   *
+   * Pure apart from the directory and that unlink; [javaFeatureVersion] and [cdsDir] are seams for
+   * the unit test.
+   */
+  internal fun androidDaemonStartupJvmArgs(
+    daemonClasspath: List<String>,
+    javaFeatureVersion: Int = Runtime.version().feature(),
+    cdsDir: File = composeAiCacheDir("cds"),
+    cdsEnabled: Boolean = System.getProperty(ANDROID_DAEMON_CDS_PROP)?.toBoolean() ?: true,
+    verifyBytecode: Boolean = System.getProperty(ANDROID_DAEMON_VERIFY_PROP)?.toBoolean() ?: false,
+  ): List<String> = buildList {
+    if (cdsEnabled && javaFeatureVersion >= 19) {
+      val key = classpathArchiveKey(daemonClasspath)
+      val archive = File(cdsDir, "android-daemon-$key.jsa")
+      runCatching { cdsDir.mkdirs() }
+      validateArchive(archive)
+      add("-XX:+AutoCreateSharedArchive")
+      add("-XX:SharedArchiveFile=${archive.absolutePath}")
+      add("-Xlog:disable")
+      add("-Xlog:all=warning:stderr")
+      add("-Xlog:cds*=off:stderr")
+      add("-XX:+DisplayVMOutputToStderr")
+    }
+    if (!verifyBytecode) {
+      add("-XX:+UnlockDiagnosticVMOptions")
+      add("-XX:-BytecodeVerificationRemote")
+    }
+  }
+
+  /**
+   * Unlinks [archive] unless it starts with HotSpot's dynamic-archive magic
+   * (`CDS_DYNAMIC_ARCHIVE_MAGIC`, written in host byte order). Missing is fine — the JVM creates it
+   * at exit. Returns whether a file was removed, for the test.
+   */
+  internal fun validateArchive(archive: File): Boolean {
+    if (!archive.isFile) return false
+    val magic = runCatching {
+      archive.inputStream().use { stream ->
+        val header = stream.readNBytes(4)
+        if (header.size < 4) null
+        else java.nio.ByteBuffer.wrap(header).order(java.nio.ByteOrder.nativeOrder()).int
+      }
+    }
+      .getOrNull()
+    if (magic == CDS_DYNAMIC_ARCHIVE_MAGIC) return false
+    return archive.delete()
+  }
+
+  /** HotSpot `CDS_DYNAMIC_ARCHIVE_MAGIC` (src/hotspot/share/cds/filemap.hpp). */
+  private const val CDS_DYNAMIC_ARCHIVE_MAGIC: Int = 0xf00baba8.toInt()
+
+  /**
+   * Stable name for the archive of one daemon classpath: the SHA-256 of the entries in order. The
+   * JVM validates the archive against the classpath (and its own build) anyway; the key only keeps
+   * catalogs from thrashing one file.
+   */
+  private fun classpathArchiveKey(daemonClasspath: List<String>): String {
+    val digest = java.security.MessageDigest.getInstance("SHA-256")
+    for (entry in daemonClasspath) {
+      digest.update(entry.toByteArray(Charsets.UTF_8))
+      digest.update(0)
+    }
+    return digest.digest().joinToString("") { "%02x".format(it) }.take(16)
+  }
+
+  /** `-Dcomposeai.serve.androidDaemonCds=false` turns the per-classpath CDS archive off. */
+  internal const val ANDROID_DAEMON_CDS_PROP = "composeai.serve.androidDaemonCds"
+
+  /**
+   * `-Dcomposeai.serve.androidDaemonBytecodeVerification=true` restores bytecode verification in
+   * catalog daemons.
+   */
+  internal const val ANDROID_DAEMON_VERIFY_PROP =
+    "composeai.serve.androidDaemonBytecodeVerification"
 
   /**
    * `ee.schimke.composeai.daemon.DaemonMain` — the daemon entrypoint a bundle spawns (both

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonStartupJvmArgsTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonStartupJvmArgsTest.kt
@@ -1,0 +1,138 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pins the flag set [ServeBundleDaemon.androidDaemonStartupJvmArgs] hands a catalog's Android
+ * daemon: an auto-created, per-classpath CDS archive on a JDK that has the feature, and remote
+ * bytecode verification off, each behind its own opt-out.
+ */
+class ServeBundleDaemonStartupJvmArgsTest {
+
+  private fun cdsDir(): File = Files.createTempDirectory("serve-daemon-cds").toFile()
+
+  @Test
+  fun `jdk 19 and later get an auto-created archive keyed by the classpath`() {
+    val dir = cdsDir()
+    val args =
+      ServeBundleDaemon.androidDaemonStartupJvmArgs(
+        daemonClasspath = listOf("/opt/catalog/material3.jar", "/opt/lib-daemon-android/a.jar"),
+        javaFeatureVersion = 21,
+        cdsDir = dir,
+        cdsEnabled = true,
+        verifyBytecode = false,
+      )
+    assertTrue("-XX:+AutoCreateSharedArchive" in args, args.toString())
+    val archive = args.single { it.startsWith("-XX:SharedArchiveFile=") }
+    assertTrue(
+      archive.startsWith(
+        "-XX:SharedArchiveFile=${dir.absolutePath}${File.separator}android-daemon-"
+      ),
+      archive,
+    )
+    assertTrue(archive.endsWith(".jsa"), archive)
+    assertTrue(dir.isDirectory, "the archive directory is created so the JVM can write into it")
+    // The daemon's stdout is the JSON-RPC channel: JVM warnings must go to stderr, and the dump's
+    // own chatter (hundreds of "Skipping …" lines at exit) must not go anywhere.
+    assertEquals(
+      listOf("-Xlog:disable", "-Xlog:all=warning:stderr", "-Xlog:cds*=off:stderr"),
+      args.filter { it.startsWith("-Xlog:") },
+    )
+    assertTrue("-XX:+DisplayVMOutputToStderr" in args, args.toString())
+    assertTrue("-XX:+UnlockDiagnosticVMOptions" in args, args.toString())
+    assertTrue("-XX:-BytecodeVerificationRemote" in args, args.toString())
+  }
+
+  @Test
+  fun `a torn archive is unlinked before launch, an intact one is kept`() {
+    val dir = cdsDir()
+    val cp = listOf("/x/one.jar")
+    val archivePath =
+      ServeBundleDaemon.androidDaemonStartupJvmArgs(cp, 21, dir, cdsEnabled = true)
+        .single { it.startsWith("-XX:SharedArchiveFile=") }
+        .removePrefix("-XX:SharedArchiveFile=")
+    val archive = File(archivePath)
+
+    // Cut off mid-write: a few bytes of anything but the magic.
+    archive.writeBytes(byteArrayOf(1, 2, 3, 4, 5, 6))
+    ServeBundleDaemon.androidDaemonStartupJvmArgs(cp, 21, dir, cdsEnabled = true)
+    assertFalse(archive.exists(), "a file without the dynamic-archive magic is removed")
+
+    // Shorter than the magic itself.
+    archive.writeBytes(byteArrayOf(1))
+    ServeBundleDaemon.androidDaemonStartupJvmArgs(cp, 21, dir, cdsEnabled = true)
+    assertFalse(archive.exists(), "a truncated header is removed")
+
+    // A real dynamic archive starts with CDS_DYNAMIC_ARCHIVE_MAGIC in host byte order.
+    val magic =
+      java.nio.ByteBuffer.allocate(4)
+        .order(java.nio.ByteOrder.nativeOrder())
+        .putInt(0xf00baba8.toInt())
+        .array()
+    archive.writeBytes(magic + ByteArray(64))
+    ServeBundleDaemon.androidDaemonStartupJvmArgs(cp, 21, dir, cdsEnabled = true)
+    assertTrue(archive.exists(), "an archive with the right magic is left for the JVM")
+    assertFalse(ServeBundleDaemon.validateArchive(archive))
+  }
+
+  @Test
+  fun `the archive name follows the classpath, in order`() {
+    val dir = cdsDir()
+    fun archiveFor(cp: List<String>) =
+      ServeBundleDaemon.androidDaemonStartupJvmArgs(cp, 21, dir, cdsEnabled = true).single {
+        it.startsWith("-XX:SharedArchiveFile=")
+      }
+    val a = archiveFor(listOf("/x/one.jar", "/x/two.jar"))
+    assertEquals(a, archiveFor(listOf("/x/one.jar", "/x/two.jar")), "same classpath, same archive")
+    assertNotEquals(a, archiveFor(listOf("/x/two.jar", "/x/one.jar")), "order is part of the key")
+    assertNotEquals(a, archiveFor(listOf("/x/one.jar")), "a different catalog gets its own file")
+  }
+
+  @Test
+  fun `no archive flags below jdk 19 or when the archive is opted out`() {
+    val dir = cdsDir()
+    val cp = listOf("/x/one.jar")
+    for (args in
+      listOf(
+        ServeBundleDaemon.androidDaemonStartupJvmArgs(cp, 17, dir, cdsEnabled = true),
+        ServeBundleDaemon.androidDaemonStartupJvmArgs(cp, 21, dir, cdsEnabled = false),
+      )) {
+      assertFalse(args.any { it.contains("SharedArchive") }, args.toString())
+      assertTrue("-XX:-BytecodeVerificationRemote" in args, args.toString())
+    }
+  }
+
+  @Test
+  fun `restoring verification leaves nothing but the archive flags`() {
+    val args =
+      ServeBundleDaemon.androidDaemonStartupJvmArgs(
+        listOf("/x/one.jar"),
+        21,
+        cdsDir(),
+        cdsEnabled = true,
+        verifyBytecode = true,
+      )
+    assertFalse(args.any { it.contains("BytecodeVerification") }, args.toString())
+    assertFalse("-XX:+UnlockDiagnosticVMOptions" in args, args.toString())
+    assertEquals(6, args.size, args.toString())
+  }
+
+  @Test
+  fun `everything off yields no flags at all`() {
+    val args =
+      ServeBundleDaemon.androidDaemonStartupJvmArgs(
+        listOf("/x/one.jar"),
+        21,
+        cdsDir(),
+        cdsEnabled = false,
+        verifyBytecode = true,
+      )
+    assertEquals(emptyList(), args)
+  }
+}

--- a/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonStartupJvmArgsTest.kt
+++ b/render-host/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonStartupJvmArgsTest.kt
@@ -47,6 +47,7 @@ class ServeBundleDaemonStartupJvmArgsTest {
     assertTrue("-XX:+DisplayVMOutputToStderr" in args, args.toString())
     assertTrue("-XX:+UnlockDiagnosticVMOptions" in args, args.toString())
     assertTrue("-XX:-BytecodeVerificationRemote" in args, args.toString())
+    assertEquals("-XX:+UseSerialGC", args.first(), "the collector flag leads, so a later -XX wins")
   }
 
   @Test
@@ -120,7 +121,65 @@ class ServeBundleDaemonStartupJvmArgsTest {
       )
     assertFalse(args.any { it.contains("BytecodeVerification") }, args.toString())
     assertFalse("-XX:+UnlockDiagnosticVMOptions" in args, args.toString())
-    assertEquals(6, args.size, args.toString())
+    assertEquals(7, args.size, args.toString())
+  }
+
+  @Test
+  fun `the archive directory is pruned oldest-first, sparing this launch's archives`() {
+    val dir = cdsDir()
+    fun put(name: String, bytes: Int, ageMinutes: Long): File =
+      File(dir, name).apply {
+        writeBytes(ByteArray(bytes))
+        setLastModified(System.currentTimeMillis() - ageMinutes * 60_000)
+      }
+    val oldest = put("android-daemon-aaaa.jsa", 100, 30)
+    val oldestWorker = put("android-daemon-aaaa-worker0.jsa", 100, 29)
+    val middle = put("android-daemon-bbbb.jsa", 100, 20)
+    val current = put("android-daemon-cccc.jsa", 100, 40)
+    val currentWorker = put("android-daemon-cccc-worker1.jsa", 100, 39)
+    val notAnArchive = put("notes.txt", 100, 60)
+
+    val deleted =
+      ServeBundleDaemon.pruneArchives(dir, keepStem = "android-daemon-cccc", maxBytes = 350)
+
+    assertEquals(listOf(oldest, oldestWorker), deleted)
+    assertTrue(middle.exists(), "under budget once the two oldest are gone")
+    assertTrue(current.exists() && currentWorker.exists(), "this launch's archives are spared")
+    assertTrue(notAnArchive.exists(), "only .jsa files are ever candidates")
+    assertEquals(emptyList(), ServeBundleDaemon.pruneArchives(dir, "android-daemon-cccc", 350))
+  }
+
+  @Test
+  fun `pruning cannot evict below the budget when only this launch's archives remain`() {
+    val dir = cdsDir()
+    File(dir, "android-daemon-cccc.jsa").writeBytes(ByteArray(500))
+    File(dir, "android-daemon-cccc-worker0.jsa").writeBytes(ByteArray(500))
+    assertEquals(emptyList(), ServeBundleDaemon.pruneArchives(dir, "android-daemon-cccc", 100))
+    assertEquals(2, dir.listFiles()!!.size)
+  }
+
+  @Test
+  fun `the serial collector has its own opt-out`() {
+    val off =
+      ServeBundleDaemon.androidDaemonStartupJvmArgs(
+        listOf("/x/one.jar"),
+        21,
+        cdsDir(),
+        cdsEnabled = false,
+        verifyBytecode = true,
+        serialGc = false,
+      )
+    assertEquals(emptyList(), off)
+    val on =
+      ServeBundleDaemon.androidDaemonStartupJvmArgs(
+        listOf("/x/one.jar"),
+        21,
+        cdsDir(),
+        cdsEnabled = false,
+        verifyBytecode = true,
+        serialGc = true,
+      )
+    assertEquals(listOf("-XX:+UseSerialGC"), on)
   }
 
   @Test
@@ -132,6 +191,7 @@ class ServeBundleDaemonStartupJvmArgsTest {
         cdsDir(),
         cdsEnabled = false,
         verifyBytecode = true,
+        serialGc = false,
       )
     assertEquals(emptyList(), args)
   }


### PR DESCRIPTION
## Summary

Profiles the Robolectric sandbox boot that compose-preview-server#626 asked about, and ships the levers that measured well. Non-visual change; text-only evidence.

**What a boot is.** On an idle 4-core box, in the deployed shape (released 2.4.0 `lib-daemon-android`, Temurin 21, `sandboxCount=3`, background boot): a sandbox boots in ~4 s and its warm render costs another ~5-8 s, serialized, so the pool completes ~22 s after the daemon JVM starts. JFR caught 52 Java samples across a whole boot — the time is the VM defining ~6,000 classes and spinning ~6,500 `java.lang.invoke` hidden classes for Robolectric's invokedynamic dispatch, per JVM. The worker loads 18,184 classes: 5,600 to boot, 12,500 more for the warm render. `docs/daemon/STARTUP.md` now carries the measured timeline, the class-load breakdown, and what each JVM flag is worth (`-Xshare:off`, static AppCDS, verification off, C1-only, SerialGC, `-Xmx`, LambdaForm compile threshold, unsigned bcprov).

**Changes**

- `RobolectricHost.bootRemainingSlots`: worker `i+1` is launched as soon as worker `i` has booted, so its JVM start and bootstrap run under slot `i`'s warm render. Still one boot at a time; a slot is still published only after its own warm render.
- `ServeBundleDaemon.androidDaemonStartupJvmArgs` (catalog daemons only, not the playground): `-XX:+AutoCreateSharedArchive` with a per-classpath archive under the `composeai` cache dir (JDK 19+; per classpath because each catalog's overlay jars precede the sidecar), `-XX:-BytecodeVerificationRemote`, `-XX:+UseSerialGC`. The JVM's unified log is routed to stderr and `cds` tags silenced — by default JVM warnings go to **stdout**, which is the daemon's JSON-RPC channel. A torn archive (wrong magic) is unlinked before launch; the archive dir is pruned oldest-first past 2 GiB, never touching the launch's own archives. Each flag has an opt-out sysprop (`composeai.serve.androidDaemonCds`, `…BytecodeVerification`, `…SerialGc`, `…CdsMaxBytes`).
- `SandboxProcessPool.workerJvmArgs`: each worker slot gets its own archive file. `Runtime.halt` still runs the exit-time dump, so a worker halting with its parent otherwise wrote the parent's file at the same moment (observed). The worker archives also carry the warm render's classes.
- `docs/daemon/BOOT-ROADMAP.md`: the ranked medium-term plan for a 2-3 s boot — adoptable warmed workers keyed by overlay signature (#5334), CRaC, and what a Robolectric fork would change (static shadow binding, non-JUnit boot on the simulator API, our own SDK artifact, an Activity-free capture, archivable sandbox classes, Leyden/GraalVM).

**Measured, same box, `sandboxCount=3`, daemon JVM start → last slot published, and RSS of daemon + two workers**

| daemon | pool complete | RSS |
|---|---|---|
| released 2.4.0 | 21.7-23.4 s | 375 + 582 + 592 MB |
| + overlapped boots | 19.9 s | same |
| + archive, first boot of a classpath (records and writes it) | 27.4 s | +0-100 MB |
| + archive, later boots | 14.5-15.2 s | metaspace 52→13 / 98→24 MB |
| + serial collector, archive present | 14.9-15.2 s | 307 + 459 + 451 MB |

The first boot of a classpath is slower; every later one is ~35 % faster to a full pool and ~25 % lighter. Verified on the real daemon over three consecutive runs: stdout stayed at 0 bytes, the workers inherited every flag, a worker archive truncated by a kill mid-dump was regenerated on the next boot.

## Test plan

- [x] `:render-host:test --tests '*ServeBundleDaemonStartupJvmArgsTest*'` (9 tests: flag set, per-classpath archive key, JDK < 19 and opt-outs, torn-archive unlink, oldest-first pruning sparing the launch's archives, serial-collector opt-out)
- [x] `:daemon:android:testDebugUnitTest --tests '*SandboxProcessPoolWorkerJvmArgsTest*'` (3 tests)
- [x] `ktfmtFormat` on both modules; `:daemon:android:assembleRelease`
- [x] Real-daemon runs with the patched `classes.jar` swapped into the released sidecar (numbers above); `RobolectricHostPoolTest` exercises the changed loop in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbUBZwnYVBNQmasoWiSqaX

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbUBZwnYVBNQmasoWiSqaX)_