### PR TITLE
feat: fold identical sibling runs into one repeat in generated screens

### DIFF
--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
@@ -1477,34 +1477,16 @@ class ScreenGeneratorTest {
   }
 
   /**
-   * A state named `kotlin` is refused, exactly as one named `androidx` is.
-   *
-   * The fold qualifies through that root, so it is one more thing a local may not shadow — and the
-   * check that already protects every other written-out root protects it.
-   */
-  @Test
-  fun `state named kotlin is refused, because a folded run qualifies through that root`() {
-    assertThat(
-        refusal(
-          cells(3).copy(state = listOf(ScreenState("kotlin", "app.Thing", ScreenValue.Text("x")))),
-          catalog(card, text),
-        )
-      )
-      .contains(
-        "state `kotlin` is the root of a package this screen writes in full, and would shadow it"
-      )
-  }
-
-  /**
-   * The qualifier a folded run writes is a name the file spends, so nothing else may claim it.
+   * The qualifier a folded run writes is a name the file spends, so nothing is imported under it.
    *
    * `kotlin.repeat(n)` is capture-proof against a local — that is why it is qualified — but an
    * import of a declaration whose simple name is `kotlin` would take the *qualifier* and leave
-   * `repeat` unresolved. A simple name enters this file three ways, and `kotlin` is refused at all
-   * of them: reserved for a component, and refused with a located reason for a value or a chain.
+   * `repeat` unresolved. A value naming one is written qualified instead, which is what this
+   * function replaced for every value and what a component in the same position already gets. It is
+   * not a refusal: the document is legal and generated before folding existed.
    */
   @Test
-  fun `a value importing the name kotlin is refused, because a folded run qualifies through it`() {
+  fun `a value named kotlin is written qualified rather than imported`() {
     val screen =
       column(
         ScreenNode(
@@ -1514,18 +1496,49 @@ class ScreenGeneratorTest {
         )
       )
 
-    val refusals =
+    val source =
       (ScreenGenerator.generate(
           screen,
           catalog(card, text),
           expressionPackages = setOf("app.theme"),
-        ) as ScreenGenerator.Result.Refused)
-        .reasons
+        ) as ScreenGenerator.Result.Emitted)
+        .source
 
-    assertThat(refusals)
-      .contains(
-        "`Text`.`text` imports `kotlin`, which the generated file spends on its own scaffolding"
-      )
+    assertThat(source).contains("Text(text = app.theme.kotlin)")
+    assertThat(source).doesNotContain("import app.theme.kotlin")
+  }
+
+  /**
+   * A state named `kotlin` turns the fold off rather than being refused.
+   *
+   * It is a local in the body, so it captures the qualifier — and unlike an import there is nowhere
+   * else to put it. State names are known before emission, so the fold is what gives way.
+   */
+  @Test
+  fun `state named kotlin turns the fold off rather than refusing the document`() {
+    // Typed outside the `kotlin` package on purpose: a declaration typed `kotlin.String` already
+    // puts that root in the shadowing set every state name is checked against, so the residual case
+    // this guard exists for is a document that names `kotlin` and never writes the package.
+    val source =
+      (ScreenGenerator.generate(
+          cells(6)
+            .copy(
+              state =
+                listOf(
+                  ScreenState(
+                    "kotlin",
+                    "app.theme.Thing",
+                    ScreenValue.Construct("app.theme.Thing", typeFqn = "app.theme.Thing"),
+                  )
+                )
+            ),
+          catalog(card, text),
+          expressionPackages = setOf("app.theme"),
+        ) as ScreenGenerator.Result.Emitted)
+        .source
+
+    assertThat(source).doesNotContain("kotlin.repeat(")
+    assertThat(occurrences(source, "Text(text = ")).isEqualTo(6)
   }
 
   /**

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
@@ -1401,4 +1401,65 @@ class ScreenGeneratorTest {
         "`LazyColumn`.`content` names `it.em`, which cannot be written as a Kotlin identifier"
       )
   }
+
+  /**
+   * A run of identical siblings is one `repeat`.
+   *
+   * A builder's document has no loop in it, so a twelve-cell contribution row arrives as twelve
+   * nodes and generated twelve identical `Text(…)` calls — faithful, and a screen nobody reads.
+   */
+  @Test
+  fun `identical siblings are generated as one repeat`() {
+    val source = emitted(cells(12), catalog(card, text)).source
+
+    assertThat(source).contains("repeat(12) {")
+    assertThat(occurrences(source, "Text(text = ")).isEqualTo(1)
+  }
+
+  @Test
+  fun `two identical siblings are still written out, because two calls read fine`() {
+    val source = emitted(cells(2), catalog(card, text)).source
+
+    assertThat(source).doesNotContain("repeat(")
+    assertThat(occurrences(source, "Text(text = ")).isEqualTo(2)
+  }
+
+  @Test
+  fun `a sibling that differs breaks the run at itself and neither side is lost`() {
+    val cells =
+      (0 until 8).map { index -> textNode(if (index == 3) "odd" else "cell") }.toTypedArray()
+    val source = emitted(column(*cells), catalog(card, text)).source
+
+    assertThat(source).contains("repeat(3) {")
+    assertThat(source).contains("repeat(4) {")
+    assertThat(source).contains("Text(text = \"odd\")")
+  }
+
+  @Test
+  fun `the folded body is the call it replaced, at one further indent`() {
+    val source = emitted(cells(4), catalog(card, text)).source
+
+    assertThat(source).contains("        repeat(4) {\n            Text(text = \"cell\")\n        }")
+  }
+
+  @Test
+  fun `a DSL slot is not folded, because item identity is not visible in the text`() {
+    val cells = (0 until 5).map { textNode("cell") }.toTypedArray()
+    val source = emitted(list(SlotItem("item", lazyListScope), *cells), catalog(lazyColumn, text))
+
+    assertThat(source.source).doesNotContain("repeat(")
+    assertThat(occurrences(source.source, "item {")).isEqualTo(5)
+  }
+
+  private fun occurrences(source: String, text: String) =
+    Regex(Regex.escape(text)).findAll(source).count()
+
+  private fun cells(count: Int) = column(*(0 until count).map { textNode("cell") }.toTypedArray())
+
+  private fun column(vararg children: ScreenNode) =
+    ScreenDocument(
+      name = "HomeScreen",
+      root =
+        ScreenNode(componentId = card.canonicalId, slots = mapOf("content" to children.toList())),
+    )
 }

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
@@ -1495,6 +1495,39 @@ class ScreenGeneratorTest {
       )
   }
 
+  /**
+   * The qualifier a folded run writes is a name the file spends, so nothing else may claim it.
+   *
+   * `kotlin.repeat(n)` is capture-proof against a local — that is why it is qualified — but an
+   * import of a declaration whose simple name is `kotlin` would take the *qualifier* and leave
+   * `repeat` unresolved. A simple name enters this file three ways, and `kotlin` is refused at all
+   * of them: reserved for a component, and refused with a located reason for a value or a chain.
+   */
+  @Test
+  fun `a value importing the name kotlin is refused, because a folded run qualifies through it`() {
+    val screen =
+      column(
+        ScreenNode(
+          text.canonicalId,
+          arguments =
+            mapOf("text" to ScreenValue.Reference("app.theme.kotlin", typeFqn = "kotlin.String")),
+        )
+      )
+
+    val refusals =
+      (ScreenGenerator.generate(
+          screen,
+          catalog(card, text),
+          expressionPackages = setOf("app.theme"),
+        ) as ScreenGenerator.Result.Refused)
+        .reasons
+
+    assertThat(refusals)
+      .contains(
+        "`Text`.`text` imports `kotlin`, which the generated file spends on its own scaffolding"
+      )
+  }
+
   private fun occurrences(source: String, text: String) =
     Regex(Regex.escape(text)).findAll(source).count()
 

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
@@ -1412,7 +1412,7 @@ class ScreenGeneratorTest {
   fun `identical siblings are generated as one repeat`() {
     val source = emitted(cells(12), catalog(card, text)).source
 
-    assertThat(source).contains("repeat(12) {")
+    assertThat(source).contains("kotlin.repeat(12) { _ ->")
     assertThat(occurrences(source, "Text(text = ")).isEqualTo(1)
   }
 
@@ -1430,8 +1430,8 @@ class ScreenGeneratorTest {
       (0 until 8).map { index -> textNode(if (index == 3) "odd" else "cell") }.toTypedArray()
     val source = emitted(column(*cells), catalog(card, text)).source
 
-    assertThat(source).contains("repeat(3) {")
-    assertThat(source).contains("repeat(4) {")
+    assertThat(source).contains("kotlin.repeat(3) { _ ->")
+    assertThat(source).contains("kotlin.repeat(4) { _ ->")
     assertThat(source).contains("Text(text = \"odd\")")
   }
 
@@ -1439,7 +1439,8 @@ class ScreenGeneratorTest {
   fun `the folded body is the call it replaced, at one further indent`() {
     val source = emitted(cells(4), catalog(card, text)).source
 
-    assertThat(source).contains("        repeat(4) {\n            Text(text = \"cell\")\n        }")
+    assertThat(source)
+      .contains("        kotlin.repeat(4) { _ ->\n            Text(text = \"cell\")\n        }")
   }
 
   @Test
@@ -1452,15 +1453,15 @@ class ScreenGeneratorTest {
   }
 
   /**
-   * `repeat` and the `it` it binds are names like any other.
+   * `repeat` and the `it` it binds are names like any other, and the emitted form owns that.
    *
-   * A document may legally declare state called either — `isUsableIdentifier` admits both — and
-   * inside a folded run a state named `it` is shadowed by the lambda's implicit `Int` while a local
-   * `val repeat` captures the call itself. Neither is a refusal: the siblings are written out one
-   * by one, which is what the generator did before the fold existed.
+   * A document may legally declare state called either — `isUsableIdentifier` admits both — so an
+   * unqualified `repeat(n) { … }` would resolve to a local `val repeat`, and its implicit `Int`
+   * would shadow a state named `it`. `kotlin.repeat(n) { _ -> … }` can be captured by neither, so
+   * the fold still happens and the child still reads what it read.
    */
   @Test
-  fun `state named it or repeat turns the fold off rather than changing what a child reads`() {
+  fun `state named it or repeat does not capture the folded call or its parameter`() {
     listOf("it", "repeat").forEach { name ->
       val source =
         emitted(
@@ -1470,9 +1471,28 @@ class ScreenGeneratorTest {
           )
           .source
 
-      assertThat(source).doesNotContain("repeat(6)")
-      assertThat(occurrences(source, "Text(text = ")).isEqualTo(6)
+      assertThat(source).contains("kotlin.repeat(6) { _ ->")
+      assertThat(occurrences(source, "Text(text = ")).isEqualTo(1)
     }
+  }
+
+  /**
+   * A state named `kotlin` is refused, exactly as one named `androidx` is.
+   *
+   * The fold qualifies through that root, so it is one more thing a local may not shadow — and the
+   * check that already protects every other written-out root protects it.
+   */
+  @Test
+  fun `state named kotlin is refused, because a folded run qualifies through that root`() {
+    assertThat(
+        refusal(
+          cells(3).copy(state = listOf(ScreenState("kotlin", "app.Thing", ScreenValue.Text("x")))),
+          catalog(card, text),
+        )
+      )
+      .contains(
+        "state `kotlin` is the root of a package this screen writes in full, and would shadow it"
+      )
   }
 
   private fun occurrences(source: String, text: String) =

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
@@ -1528,6 +1528,41 @@ class ScreenGeneratorTest {
       )
   }
 
+  /**
+   * The one import the document does not choose is reserved on the same terms.
+   *
+   * A constructed placeholder imports the *record's* parameter type, so a catalog whose parameter
+   * is typed `app.kotlin` would put that import in the file without any document asking for it —
+   * and it would capture the qualifier a folded run writes.
+   */
+  @Test
+  fun `a constructed placeholder typed kotlin is refused, like every other import of that name`() {
+    val holder =
+      component(
+        "Holder",
+        "androidx.compose.material3.Holder",
+        listOf(
+          TargetParameter(
+            "state",
+            "kotlin",
+            typeFqn = "app.kotlin",
+            noArgConstructible = true,
+            hasDefault = false,
+          )
+        ),
+      )
+
+    assertThat(
+        refusal(
+          ScreenDocument(name = "HomeScreen", root = ScreenNode(holder.canonicalId)),
+          catalog(holder),
+        )
+      )
+      .contains(
+        "`Holder`.`state` imports `kotlin`, which the generated file spends on its own scaffolding"
+      )
+  }
+
   private fun occurrences(source: String, text: String) =
     Regex(Regex.escape(text)).findAll(source).count()
 

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
@@ -1451,6 +1451,30 @@ class ScreenGeneratorTest {
     assertThat(occurrences(source.source, "item {")).isEqualTo(5)
   }
 
+  /**
+   * `repeat` and the `it` it binds are names like any other.
+   *
+   * A document may legally declare state called either — `isUsableIdentifier` admits both — and
+   * inside a folded run a state named `it` is shadowed by the lambda's implicit `Int` while a local
+   * `val repeat` captures the call itself. Neither is a refusal: the siblings are written out one
+   * by one, which is what the generator did before the fold existed.
+   */
+  @Test
+  fun `state named it or repeat turns the fold off rather than changing what a child reads`() {
+    listOf("it", "repeat").forEach { name ->
+      val source =
+        emitted(
+            cells(6)
+              .copy(state = listOf(ScreenState(name, "kotlin.String", ScreenValue.Text("x")))),
+            catalog(card, text),
+          )
+          .source
+
+      assertThat(source).doesNotContain("repeat(6)")
+      assertThat(occurrences(source, "Text(text = ")).isEqualTo(6)
+    }
+  }
+
   private fun occurrences(source: String, text: String) =
     Regex(Regex.escape(text)).findAll(source).count()
 

--- a/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -315,9 +315,6 @@ object ScreenGenerator {
     // next one, which is the worst place for this to surface.
     val qualifiedRoots = buildSet {
       add("androidx")
-      // `kotlin`, because a folded run of identical siblings is written `kotlin.repeat(n)` — see
-      // [foldRepeats] for why it is qualified there rather than trusted to resolve.
-      add("kotlin")
       // Every component, not only the ones that cannot claim a simple name: which of the two a
       // node gets is decided per record, and a state name may not shadow the root of either.
       components.components.mapTo(this) { it.symbol.callable.substringBefore('.') }
@@ -340,6 +337,12 @@ object ScreenGenerator {
         document.name,
         expressionPackages,
         document.state.associateBy(ScreenState::name),
+        // A state declaration is a local in the body, and a local named `kotlin` captures the
+        // qualifier a folded run writes. State names are the one shadowing surface known before
+        // emission, and they are spent on the fold rather than on a refusal: such a document is
+        // generated with its siblings written out, exactly as before folding existed. Every other
+        // way the name could enter the file is closed by never importing it — see [importedName].
+        foldsRepeatedSiblings = document.state.none { it.name == "kotlin" },
       )
     // Everything a hoisted binding must not shadow: the declarations, the components this file
     // calls by simple name, and the screen's own function. A `val FooInitial` sitting above a
@@ -574,6 +577,8 @@ object ScreenGenerator {
     val expressionPackages: Set<String>,
     /** Declared state by name, so a read can be checked against something rather than trusted. */
     val state: Map<String, ScreenState> = emptyMap(),
+    /** Whether [foldRepeats] may fold here — see the call that computes it. */
+    val foldsRepeatedSiblings: Boolean = true,
   ) {
     val imports = mutableSetOf<String>()
     /**
@@ -746,8 +751,11 @@ object ScreenGenerator {
             val inner = INDENT.repeat(depth + 1)
             val nested =
               try {
-                if (wrapper == null) foldRepeats(children.map { node(it, depth + 1) }, inner)
-                else
+                if (wrapper == null) {
+                  val rendered = children.map { node(it, depth + 1) }
+                  if (foldsRepeatedSiblings) foldRepeats(rendered, inner)
+                  else rendered.joinToString("\n")
+                } else
                   children.joinToString("\n") { child ->
                     "$inner$wrapper {\n${node(child, depth + 2)}\n$inner}"
                   }
@@ -1342,13 +1350,12 @@ object ScreenGenerator {
       val imported = if (memberOfClassifier) owner else fqn
       val simple = imported.substringAfterLast('.')
       if (simple in RESERVED_BY_THE_WRAPPER) {
-        // Not written qualified and carried on, the way a component in this position is: a value's
-        // qualified form is what `importedName` was introduced to stop writing, and a `kotlin` here
-        // is a name nobody has. Refusing says which import and why, which is the generator's
-        // promise — source that compiles, or a located reason.
-        reasons +=
-          "$where imports `$simple`, which the generated file spends on its own scaffolding"
-        return null
+        // Written qualified instead, which is the answer a component in this position already gets
+        // and the one this function replaced for every value. Not a refusal: a document that names
+        // `kotlin` is legal and generated fine before folding existed, and refusing it here would
+        // turn a spelling choice inside one `repeat` into a document the generator will not write.
+        // Nothing is imported, so the qualifier a folded run writes still means the package.
+        return qualifiedName(fqn, where)
       }
       if (simple == screenName) {
         // The generated function shadows an import of its own name, so the expression would name
@@ -1618,11 +1625,13 @@ object ScreenGenerator {
    *
    * `kotlin` is spent by [foldRepeats], which writes `kotlin.repeat(n)` precisely so that no
    * declaration in the body can capture the call. A declaration imported under that simple name
-   * would capture the *qualifier* instead and leave `repeat` unresolved, so it is reserved here for
-   * a component and refused for a value's reference or construct, for a chain link, and for the
-   * type a constructed placeholder imports — the four ways a simple name enters this file. The
-   * matching state name is refused by the root-shadowing check, which already carries `androidx`
-   * for the same reason.
+   * would capture the *qualifier* instead and leave `repeat` unresolved, so nothing is imported
+   * under it: a component and a value's reference or construct are written qualified instead, while
+   * a chain link and a constructed placeholder — neither of which can be called without its import
+   * — are refused by name. Those are the four ways a simple name enters this file. A state
+   * declaration is the fifth shadowing surface and is not an import, so it turns the fold off
+   * rather than being answered here. The matching state name is refused by the root-shadowing
+   * check, which already carries `androidx` for the same reason.
    */
   private val RESERVED_BY_THE_WRAPPER = setOf("Composable", "kotlin")
 

--- a/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -337,6 +337,18 @@ object ScreenGenerator {
         document.name,
         expressionPackages,
         document.state.associateBy(ScreenState::name),
+        // Whether a `repeat` written into the body would still mean `kotlin.repeat`, and whether
+        // its implicit `it` would shadow anything a folded child reads. Both are decided here,
+        // once, from the two things that can capture a name in the generated function: a state
+        // declaration, which is a local in the body, and a component imported by simple name. A
+        // document declaring `it` or `repeat` is rare and perfectly legal — `isUsableIdentifier`
+        // admits both — so it gets its siblings written out one by one rather than a refusal or a
+        // fold that changes what its reads resolve to.
+        foldsRepeatedSiblings =
+          document.state.none { it.name == "it" || it.name == "repeat" } &&
+            components.components.none {
+              it.canonicalId in simplyImportable && it.symbol.name == "repeat"
+            },
       )
     // Everything a hoisted binding must not shadow: the declarations, the components this file
     // calls by simple name, and the screen's own function. A `val FooInitial` sitting above a
@@ -571,6 +583,8 @@ object ScreenGenerator {
     val expressionPackages: Set<String>,
     /** Declared state by name, so a read can be checked against something rather than trusted. */
     val state: Map<String, ScreenState> = emptyMap(),
+    /** Whether [foldRepeats] may fold at all here — see the call that computes it. */
+    val foldsRepeatedSiblings: Boolean = true,
   ) {
     val imports = mutableSetOf<String>()
     /**
@@ -743,8 +757,11 @@ object ScreenGenerator {
             val inner = INDENT.repeat(depth + 1)
             val nested =
               try {
-                if (wrapper == null) foldRepeats(children.map { node(it, depth + 1) }, inner)
-                else
+                if (wrapper == null) {
+                  val rendered = children.map { node(it, depth + 1) }
+                  if (foldsRepeatedSiblings) foldRepeats(rendered, inner)
+                  else rendered.joinToString("\n")
+                } else
                   children.joinToString("\n") { child ->
                     "$inner$wrapper {\n${node(child, depth + 2)}\n$inner}"
                   }
@@ -1409,6 +1426,12 @@ object ScreenGenerator {
    *
    * Not applied to a slot filled through a [SlotItem]. `item { … }` is where child identity has
    * consequences a reader cannot see from the text, and the trade there is not obviously worth it.
+   *
+   * `repeat` is a name like any other, and so is the `it` it binds: a document may legally declare
+   * state called either, and then the fold would change what a child's reads resolve to — the
+   * lambda's implicit `Int` shadowing a state named `it`, a local `val repeat` capturing the call.
+   * Whether that can happen is decided once per document, before any of this runs, and a document
+   * where it can gets no folds at all.
    *
    * [MINIMUM_FOLDED_RUN] is where the pattern starts being the point: two of anything is a pair a
    * reader takes in at a glance, and folding it costs two lines to save one.

--- a/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -770,8 +770,19 @@ object ScreenGenerator {
               // writes that does not resolve on its own, so its import travels with it — through
               // the same conflict check every other import here goes through, which is what keeps
               // two same-named types from silently producing a file Kotlin refuses.
+              // The fourth door a simple name comes in by, and the only one the document does not
+              // choose: this import is the *record's* parameter type. It is reserved on the same
+              // terms as the other three — a type whose simple name is `kotlin` would capture the
+              // qualifier a folded run writes.
               ComponentSnippets.constructedTypeOf(parameter)?.let {
-                imports += ComponentSnippets.escapeCallableIfKeyword(it)
+                val simple = it.substringAfterLast('.')
+                if (simple in RESERVED_BY_THE_WRAPPER) {
+                  reasons +=
+                    "`${record.symbol.name}`.`${parameter.name}` imports `$simple`, which the " +
+                      "generated file spends on its own scaffolding"
+                } else {
+                  imports += ComponentSnippets.escapeCallableIfKeyword(it)
+                }
               }
               arguments += "${ComponentSnippets.escapeIfKeyword(parameter.name)} = $placeholder"
             }
@@ -1608,9 +1619,10 @@ object ScreenGenerator {
    * `kotlin` is spent by [foldRepeats], which writes `kotlin.repeat(n)` precisely so that no
    * declaration in the body can capture the call. A declaration imported under that simple name
    * would capture the *qualifier* instead and leave `repeat` unresolved, so it is reserved here for
-   * a component and refused in [Emission.importedName] for a value — the two ways a simple name
-   * enters this file. The matching state name is refused by the root-shadowing check, which already
-   * carries `androidx` for the same reason.
+   * a component and refused for a value's reference or construct, for a chain link, and for the
+   * type a constructed placeholder imports — the four ways a simple name enters this file. The
+   * matching state name is refused by the root-shadowing check, which already carries `androidx`
+   * for the same reason.
    */
   private val RESERVED_BY_THE_WRAPPER = setOf("Composable", "kotlin")
 

--- a/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -315,6 +315,9 @@ object ScreenGenerator {
     // next one, which is the worst place for this to surface.
     val qualifiedRoots = buildSet {
       add("androidx")
+      // `kotlin`, because a folded run of identical siblings is written `kotlin.repeat(n)` — see
+      // [foldRepeats] for why it is qualified there rather than trusted to resolve.
+      add("kotlin")
       // Every component, not only the ones that cannot claim a simple name: which of the two a
       // node gets is decided per record, and a state name may not shadow the root of either.
       components.components.mapTo(this) { it.symbol.callable.substringBefore('.') }
@@ -337,18 +340,6 @@ object ScreenGenerator {
         document.name,
         expressionPackages,
         document.state.associateBy(ScreenState::name),
-        // Whether a `repeat` written into the body would still mean `kotlin.repeat`, and whether
-        // its implicit `it` would shadow anything a folded child reads. Both are decided here,
-        // once, from the two things that can capture a name in the generated function: a state
-        // declaration, which is a local in the body, and a component imported by simple name. A
-        // document declaring `it` or `repeat` is rare and perfectly legal — `isUsableIdentifier`
-        // admits both — so it gets its siblings written out one by one rather than a refusal or a
-        // fold that changes what its reads resolve to.
-        foldsRepeatedSiblings =
-          document.state.none { it.name == "it" || it.name == "repeat" } &&
-            components.components.none {
-              it.canonicalId in simplyImportable && it.symbol.name == "repeat"
-            },
       )
     // Everything a hoisted binding must not shadow: the declarations, the components this file
     // calls by simple name, and the screen's own function. A `val FooInitial` sitting above a
@@ -583,8 +574,6 @@ object ScreenGenerator {
     val expressionPackages: Set<String>,
     /** Declared state by name, so a read can be checked against something rather than trusted. */
     val state: Map<String, ScreenState> = emptyMap(),
-    /** Whether [foldRepeats] may fold at all here — see the call that computes it. */
-    val foldsRepeatedSiblings: Boolean = true,
   ) {
     val imports = mutableSetOf<String>()
     /**
@@ -757,11 +746,8 @@ object ScreenGenerator {
             val inner = INDENT.repeat(depth + 1)
             val nested =
               try {
-                if (wrapper == null) {
-                  val rendered = children.map { node(it, depth + 1) }
-                  if (foldsRepeatedSiblings) foldRepeats(rendered, inner)
-                  else rendered.joinToString("\n")
-                } else
+                if (wrapper == null) foldRepeats(children.map { node(it, depth + 1) }, inner)
+                else
                   children.joinToString("\n") { child ->
                     "$inner$wrapper {\n${node(child, depth + 2)}\n$inner}"
                   }
@@ -1427,11 +1413,17 @@ object ScreenGenerator {
    * Not applied to a slot filled through a [SlotItem]. `item { … }` is where child identity has
    * consequences a reader cannot see from the text, and the trade there is not obviously worth it.
    *
-   * `repeat` is a name like any other, and so is the `it` it binds: a document may legally declare
-   * state called either, and then the fold would change what a child's reads resolve to — the
-   * lambda's implicit `Int` shadowing a state named `it`, a local `val repeat` capturing the call.
-   * Whether that can happen is decided once per document, before any of this runs, and a document
-   * where it can gets no folds at all.
+   * Written `kotlin.repeat(n) { _ -> … }`, and both halves of that are the point: `repeat` is a
+   * name like any other and so is the `it` it would bind. A document may legally declare state
+   * called either, a catalog may export a component simply imported under either name, and a
+   * value's `Reference`, `Construct` or `Chain` may import one while this very slot is being
+   * rendered. Any of those would silently change what a folded child's calls and reads resolve to —
+   * a local `val repeat` capturing the call, the lambda's implicit `Int` shadowing an `it`.
+   *
+   * A precomputed guard cannot see the last of those, because imports accumulate as nodes are
+   * emitted. So the fold does not ask what is in scope: it writes a form nothing in the body can
+   * capture. The one name left to protect is the `kotlin` root, which joins `androidx` in the
+   * shadowing check every state declaration already passes.
    *
    * [MINIMUM_FOLDED_RUN] is where the pattern starts being the point: two of anything is a pair a
    * reader takes in at a glance, and folding it costs two lines to save one.
@@ -1449,9 +1441,9 @@ object ScreenGenerator {
       } else {
         out
           .append(indent)
-          .append("repeat(")
+          .append("kotlin.repeat(")
           .append(run)
-          .append(") {\n")
+          .append(") { _ ->\n")
           .append(children[index].prependIndent(INDENT))
           .append("\n")
           .append(indent)

--- a/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -1213,6 +1213,13 @@ object ScreenGenerator {
                     "cannot be imported"
                 return null
               }
+              if (simple in RESERVED_BY_THE_WRAPPER) {
+                // The third door a simple name comes in by, refused for the reason the other two
+                // are: a `kotlin` here captures the qualifier `foldRepeats` writes.
+                reasons +=
+                  "$where imports `$simple`, which the generated file spends on its own scaffolding"
+                return null
+              }
               if (!link.property && simple == screenName) {
                 // An extension imported under the screen's own name is shadowed by the function
                 // being generated, so the chain would call the screen — or fail to resolve.
@@ -1323,6 +1330,15 @@ object ScreenGenerator {
       val memberOfClassifier = owner.substringAfterLast('.').firstOrNull()?.isUpperCase() == true
       val imported = if (memberOfClassifier) owner else fqn
       val simple = imported.substringAfterLast('.')
+      if (simple in RESERVED_BY_THE_WRAPPER) {
+        // Not written qualified and carried on, the way a component in this position is: a value's
+        // qualified form is what `importedName` was introduced to stop writing, and a `kotlin` here
+        // is a name nobody has. Refusing says which import and why, which is the generator's
+        // promise — source that compiles, or a located reason.
+        reasons +=
+          "$where imports `$simple`, which the generated file spends on its own scaffolding"
+        return null
+      }
       if (simple == screenName) {
         // The generated function shadows an import of its own name, so the expression would name
         // the screen rather than the declaration. The chain-link path refuses this already.
@@ -1588,8 +1604,15 @@ object ScreenGenerator {
    * happens to be called `Composable` would be imported alongside it and `Composable()` would be
    * ambiguous between the two. Such a component is called fully qualified instead — the same answer
    * the screen's own name and a two-package collision already get.
+   *
+   * `kotlin` is spent by [foldRepeats], which writes `kotlin.repeat(n)` precisely so that no
+   * declaration in the body can capture the call. A declaration imported under that simple name
+   * would capture the *qualifier* instead and leave `repeat` unresolved, so it is reserved here for
+   * a component and refused in [Emission.importedName] for a value — the two ways a simple name
+   * enters this file. The matching state name is refused by the root-shadowing check, which already
+   * carries `androidx` for the same reason.
    */
-  private val RESERVED_BY_THE_WRAPPER = setOf("Composable")
+  private val RESERVED_BY_THE_WRAPPER = setOf("Composable", "kotlin")
 
   /** The tooling annotation a [Preview] emits, imported only when one is asked for. */
   private const val PREVIEW_ANNOTATION = "androidx.compose.ui.tooling.preview.Preview"

--- a/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -175,6 +175,9 @@ object ScreenGenerator {
 
   private const val INDENT = "    "
 
+  /** How many identical siblings it takes before a `repeat` reads better than the calls. */
+  private const val MINIMUM_FOLDED_RUN = 3
+
   fun generate(
     document: ScreenDocument,
     components: ComponentRecordFile,
@@ -740,7 +743,7 @@ object ScreenGenerator {
             val inner = INDENT.repeat(depth + 1)
             val nested =
               try {
-                if (wrapper == null) children.joinToString("\n") { node(it, depth + 1) }
+                if (wrapper == null) foldRepeats(children.map { node(it, depth + 1) }, inner)
                 else
                   children.joinToString("\n") { child ->
                     "$inner$wrapper {\n${node(child, depth + 2)}\n$inner}"
@@ -1386,6 +1389,54 @@ object ScreenGenerator {
       }
       return quote(value)
     }
+  }
+
+  /**
+   * A slot's already-generated children, with runs of identical siblings written as one `repeat`.
+   *
+   * A builder's document has no loop in it, so a twelve-cell contribution row is twelve nodes —
+   * that is the only thing such a document can say, and the canvas draws exactly what is there.
+   * Emitting it back as twelve identical `Surface(…)` calls is faithful and unreadable, and a
+   * screen nobody can read is a poor answer for a generator whose output is meant to be handed to a
+   * person and kept.
+   *
+   * The fold is how the same composition is *spelled*, never what it is. It joins children that
+   * generated **byte-identical text**, so the run emits the calls it replaced, in the same order,
+   * in the same scope, with the same arguments; `repeat` is `inline`, so the body is composed in
+   * the caller's scope exactly as the separate calls were. Comparing the generated text rather than
+   * the [ScreenNode]s is what makes that true regardless of anything [node] does on the way —
+   * whatever two children print the same is interchangeable by construction.
+   *
+   * Not applied to a slot filled through a [SlotItem]. `item { … }` is where child identity has
+   * consequences a reader cannot see from the text, and the trade there is not obviously worth it.
+   *
+   * [MINIMUM_FOLDED_RUN] is where the pattern starts being the point: two of anything is a pair a
+   * reader takes in at a glance, and folding it costs two lines to save one.
+   */
+  private fun foldRepeats(children: List<String>, indent: String): String {
+    val out = StringBuilder()
+    var index = 0
+    while (index < children.size) {
+      var end = index + 1
+      while (end < children.size && children[end] == children[index]) end++
+      if (out.isNotEmpty()) out.append("\n")
+      val run = end - index
+      if (run < MINIMUM_FOLDED_RUN) {
+        out.append(children.subList(index, end).joinToString("\n"))
+      } else {
+        out
+          .append(indent)
+          .append("repeat(")
+          .append(run)
+          .append(") {\n")
+          .append(children[index].prependIndent(INDENT))
+          .append("\n")
+          .append(indent)
+          .append("}")
+      }
+      index = end
+    }
+    return out.toString()
   }
 
   /**


### PR DESCRIPTION
A builder's document has no loop in it, so a twelve-cell contribution row arrives as twelve nodes — the only thing such a document can say, and what the canvas draws. `ScreenGenerator` emitted it back as twelve identical calls:

```kotlin
Row(horizontalArrangement = Arrangement.spacedBy(3.dp), verticalAlignment = Alignment.CenterVertically, content = {
    Surface(modifier = Modifier.size(width = 11.dp, height = 11.dp), shape = RoundedCornerShape(3.dp), color = Color(4293124572L), content = { })
    Surface(modifier = Modifier.size(width = 11.dp, height = 11.dp), shape = RoundedCornerShape(3.dp), color = Color(4293124572L), content = { })
    // … ten more, character for character
```

Faithful, and a screen nobody can read — which for a generator whose output is meant to be handed to a person and kept is a real defect rather than a cosmetic one. Now:

```kotlin
Row(horizontalArrangement = Arrangement.spacedBy(3.dp), verticalAlignment = Alignment.CenterVertically, content = {
    kotlin.repeat(12) { _ ->
        Surface(modifier = Modifier.size(width = 11.dp, height = 11.dp), shape = RoundedCornerShape(3.dp), color = Color(4293124572L), content = { })
    }
})
```

## What is folded, and why it is safe

A run of three or more consecutive children whose **generated text is byte-identical**. The run emits the calls it replaced, in the same order, in the same scope, with the same arguments, and `repeat` is `inline`, so the body composes exactly where the separate calls did. Comparing the generated text rather than the `ScreenNode`s is what makes that hold regardless of anything `node()` does on the way: whatever two children print the same is interchangeable by construction.

- **Not** a slot filled through a `SlotItem` — `item { … }` is where child identity has consequences a reader cannot see in the text, so the readability trade is not obviously worth it there.
- Three is the shortest run folded: two of anything is a pair a reader takes in at a glance, and folding it costs two lines to save one.

## Why it is spelled `kotlin.repeat(n) { _ -> … }`

`repeat` is a name like any other, and so is the `it` it would bind. A document may legally declare state called either, a catalog may export a component simply imported under either name, and a value's `Reference`, `Construct` or `Chain` may import one *while the slot is being rendered* — so a check made before emission cannot see the last of those at all. Rather than ask what is in scope, the fold writes a form nothing in the body can capture.

That spends one name, `kotlin`, and nothing is imported under it: a component and a value's reference or construct are written **qualified** instead, while a chain link and a constructed placeholder — neither of which can be called without its import — are refused by name. Nothing is refused merely for naming `kotlin`: a document that does generated fine before folding existed, and still does. A state declaration is the one shadowing surface that is not an import, and it is known before emission, so it turns the fold off rather than failing.

The `ScreenDocument` vocabulary is unchanged; this is spelling, not semantics. Real loops over data are a separate, larger question (the document would need list-valued state and value bindings) and are not this change.

## Test plan

`./gradlew :gradle-plugin:preview-discovery:test` — 69 cases green, nine of them new:

- twelve identical siblings become one `kotlin.repeat(12) { _ -> … }` with one emitted body;
- a run of two is still written out;
- a sibling that differs breaks the run at itself (`repeat(3)`, the odd call, `repeat(4)`) and neither side is lost;
- the folded body is the call it replaced, at one further indent;
- a DSL slot's five `item { … }` children are not folded;
- state named `it` or `repeat` neither captures the call nor shadows a read;
- a value named `kotlin` is written qualified rather than imported, and not refused;
- a state named `kotlin` turns the fold off rather than refusing the document;
- a constructed placeholder typed `kotlin` is refused, like every other import of that name.

Also `./gradlew :screen-model:jvmTest`. (`:screen-model:allTests` cannot run in this sandbox — the Wasm karma toolchain download is blocked by the proxy, unrelated to the diff.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dZ7SNn7muC8ahNUuXJ5tz