### PR TITLE
test(samples): score a UI-builder design against the captured app daily

### DIFF
--- a/.github/workflows/device-capture-parity.yml
+++ b/.github/workflows/device-capture-parity.yml
@@ -1,0 +1,94 @@
+name: Device Capture Parity
+
+# Daily, NON-BLOCKING: does the UI-builder design still look like the app it was authored against?
+#
+# The reference is the real app. `kind=ACTIVITY` previews launch `MainActivity` for real — full
+# lifecycle, its own setContent, its theme — and capture the resumed screen (docs/APP_TOURS.md).
+# The candidate is `HomeScreenDesignPreview`, the design in
+# samples/android/design/home-screen.uibuilder.json rendered through the ordinary preview lane.
+# `DeviceCaptureParityTest` scores one against the other.
+#
+# WHY DAILY RATHER THAN PER-PR: the interesting signal is drift over time between a screen and a
+# design nobody remembered to re-author, which a per-PR run cannot see and which would put a slow
+# render on the critical path for changes that cannot affect it.
+#
+# WHY REPORT-ONLY: no threshold has been earned yet. This job exists to produce the measurement a
+# threshold could later be chosen from — the test writes report.json and never fails on a
+# difference. Turning it into a gate is a deliberate follow-up once there is history to pick a
+# number from; see docs/design/DEVICE_CAPTURE.md.
+#
+# WHAT IT IS NOT: a real device. The capture runs under Robolectric, so it exercises a real
+# Activity and the real semantics tree but none of the on-device concerns DEVICE_CAPTURE.md's
+# Tier 2 names — window offsets, multi-resume, PixelCopy frame timing. Swapping in an emulator
+# capture is a change of this job's producer, not of the design or the comparison.
+
+on:
+  schedule:
+    # 05:40 UTC daily — after ci.yml's nightly (04:23) so a broken main is already visible.
+    - cron: "40 5 * * *"
+  workflow_dispatch:
+  # Run on changes to either half, so a PR that moves the app or the design sees its own effect
+  # rather than finding out the next morning.
+  pull_request:
+    paths:
+      - "samples/android/design/**"
+      - "samples/android/src/main/kotlin/com/example/sampleandroid/MainActivity.kt"
+      - "samples/android/src/main/kotlin/com/example/sampleandroid/HomeScreenDesignPreview.kt"
+      - "samples/android/src/test/kotlin/com/example/sampleandroid/DeviceCaptureParityTest.kt"
+      - ".github/workflows/device-capture-parity.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  parity:
+    name: Design vs captured app
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+
+      # Renders every preview in the module, which is both halves of the comparison: the synthetic
+      # `activity__MainActivity` capture and `HomeScreenDesignPreview`. The sample sets
+      # `renderBeforeUnitTests`, so `test` would render anyway — running it explicitly keeps the
+      # two failure modes (render broke / comparison broke) in separate steps.
+      - name: Render the app capture and the design
+        run: ./gradlew :samples:android:composePreviewRenderAll
+
+      - name: Score the design against the captured app
+        run: ./gradlew :samples:android:test --tests '*DeviceCaptureParityTest*'
+
+      - name: Summarise
+        if: always()
+        run: |
+          report=samples/android/build/device-capture-parity/report.json
+          if [ -f "$report" ]; then
+            {
+              echo "## Device capture parity"
+              echo
+              echo '```json'
+              cat "$report"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No report produced — see the test step above." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      # The images are the point: a score says how far apart they are, the PNGs say how.
+      - name: Upload report and both renders
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: device-capture-parity
+          path: |
+            samples/android/build/device-capture-parity/report.json
+            samples/android/build/compose-previews/renders/activity__MainActivity*.png
+            samples/android/build/compose-previews/renders/HomeScreenDesignPreview*.png
+          if-no-files-found: warn

--- a/.github/workflows/device-capture-parity.yml
+++ b/.github/workflows/device-capture-parity.yml
@@ -62,8 +62,10 @@ jobs:
       - name: Render the app capture and the design
         run: ./gradlew :samples:android:composePreviewRenderAll
 
+      # `test` is the aggregate lifecycle task on an Android module and rejects `--tests`; the
+      # variant task is the one that takes a filter.
       - name: Score the design against the captured app
-        run: ./gradlew :samples:android:test --tests '*DeviceCaptureParityTest*'
+        run: ./gradlew :samples:android:testDebugUnitTest --tests '*DeviceCaptureParityTest*'
 
       - name: Summarise
         if: always()

--- a/samples/android/design/README.md
+++ b/samples/android/design/README.md
@@ -1,0 +1,49 @@
+# The sample app's UI-builder design
+
+`home-screen.uibuilder.json` is a UI-builder design authored to match `HomeScreen` in
+[`../src/main/kotlin/com/example/sampleandroid/MainActivity.kt`](../src/main/kotlin/com/example/sampleandroid/MainActivity.kt).
+
+It exists to answer one question daily: **does a design authored against a real screen still look
+like that screen?** The [`Device Capture Parity`](../../../.github/workflows/device-capture-parity.yml)
+workflow renders both and records how far apart they are.
+
+## The three files, and which is the source of truth
+
+| File | Role |
+| --- | --- |
+| `home-screen.uibuilder.json` | **The design.** The source of truth for what was authored. |
+| [`HomeScreenDesignPreview.kt`](../src/main/kotlin/com/example/sampleandroid/HomeScreenDesignPreview.kt) | The design as Compose — its committed projection, and what actually renders. |
+| [`DeviceCaptureParityTest.kt`](../src/test/kotlin/com/example/sampleandroid/DeviceCaptureParityTest.kt) | Scores the design render against the app capture. |
+
+The design document is written in the builder's operation format
+(`compose-ui-builder-operations/v1-candidate`) — a `createDesign` followed by one `insertNode` per
+node, exactly what the editor and the MCP adapter emit. Every `componentId`, property name, allowed
+value, modifier and slot in it is from `m3-catalog`'s builder capability catalog, so it is a design
+the builder would accept rather than a JSON file shaped like one.
+
+## The transcription seam
+
+`HomeScreenDesignPreview.kt` is **transcribed from the design by hand, not generated from it**, and
+that is the one place a reviewer has to check by eye.
+
+The generator that would produce it — `CapabilityComposeCodeExporter` — lives in
+`compose-preview-server`, which is layer 2. This repository is layer 1 and
+[may not depend upward](../../../docs/design/REPOSITORY_LAYERS.md), so the export cannot run here.
+What keeps the seam honest is that the comparison is on **pixels**: a transcription that drifted
+from the design would have to drift in a way that still renders identically to the app, which is a
+much harder mistake to make silently than a mistyped property.
+
+Replacing the transcription with the exporter's real output — run in compose-preview-server and
+committed here with a regeneration command — is the obvious follow-up.
+
+## Changing the app
+
+If you change `HomeScreen`, the next daily run will report a difference. That is the lane working:
+re-author the design to match, update the transcription, and the score returns to its floor.
+
+## What this is not
+
+Not a device capture. The Activity is launched under Robolectric — real lifecycle, real
+`setContent`, real semantics tree, but no window offsets, no multi-resume, no `PixelCopy` timing.
+Those are Tier 2 in [`DEVICE_CAPTURE.md`](../../../docs/design/DEVICE_CAPTURE.md), and swapping this
+lane's producer for an on-device one changes neither the design nor the comparison.

--- a/samples/android/design/home-screen.uibuilder.json
+++ b/samples/android/design/home-screen.uibuilder.json
@@ -1,0 +1,281 @@
+{
+  "$comment": [
+    "A UI-builder design authored to match `HomeScreen` in",
+    "samples/android/src/main/kotlin/com/example/sampleandroid/MainActivity.kt.",
+    "",
+    "It is the 'design' half of the device-capture parity lane: the daily job captures the real",
+    "Activity and renders this design, then reports how far apart they are. See",
+    "docs/design/DEVICE_CAPTURE.md and samples/android/design/README.md.",
+    "",
+    "Every componentId, property name and allowed value here is from m3-catalog's builder",
+    "capability catalog. Nothing in this file is invented: if a property is not in that catalog,",
+    "the design would be refused at commit rather than rendered differently."
+  ],
+  "schema": "compose-ui-builder-operations/v1-candidate",
+  "documentSchema": "compose-ui-builder-document/v1-candidate",
+  "designId": "sample-android-home-screen",
+  "operations": [
+    {
+      "operationId": "create",
+      "type": "createDesign",
+      "title": "Sample Android — Home screen",
+      "catalogPin": {
+        "systemId": "m3-catalog",
+        "catalogRevision": "candidate",
+        "capabilityDigest": "candidate",
+        "nativeRuntimeId": "candidate"
+      },
+      "environment": {
+        "widthDp": 400,
+        "heightDp": 800,
+        "density": 2.625,
+        "theme": "light",
+        "dynamicColor": false,
+        "locale": "en-US",
+        "fontScale": 1,
+        "layoutDirection": "ltr",
+        "windowPosture": "flat",
+        "fixedTime": "2024-05-16T12:00:00Z",
+        "animations": "settled",
+        "networkAccess": false
+      },
+      "stateVariables": {}
+    },
+    {
+      "operationId": "insert-root",
+      "type": "insertNode",
+      "parent": null,
+      "node": {
+        "id": "root",
+        "componentId": "m3/surface",
+        "properties": {},
+        "modifiers": [
+          {
+            "type": "fillMaxSize"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "insert-screen-column",
+      "type": "insertNode",
+      "parent": {
+        "nodeId": "root",
+        "slot": "content"
+      },
+      "node": {
+        "id": "screen-column",
+        "componentId": "layout/column",
+        "properties": {
+          "verticalSpacingDp": {
+            "type": "float",
+            "value": 16
+          }
+        },
+        "modifiers": [
+          {
+            "type": "fillMaxSize"
+          },
+          {
+            "type": "padding",
+            "startDp": 24,
+            "topDp": 24,
+            "endDp": 24,
+            "bottomDp": 24
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "insert-title",
+      "type": "insertNode",
+      "parent": {
+        "nodeId": "screen-column",
+        "slot": "children"
+      },
+      "node": {
+        "id": "title",
+        "componentId": "m3/text",
+        "properties": {
+          "text": {
+            "type": "string",
+            "value": "Sample Android"
+          },
+          "style": {
+            "type": "enum",
+            "value": "headlineMedium"
+          }
+        },
+        "modifiers": []
+      }
+    },
+    {
+      "operationId": "insert-blurb",
+      "type": "insertNode",
+      "parent": {
+        "nodeId": "screen-column",
+        "slot": "children"
+      },
+      "node": {
+        "id": "blurb",
+        "componentId": "m3/text",
+        "properties": {
+          "text": {
+            "type": "string",
+            "value": "A tiny two-screen app used to exercise app-level previews and tours."
+          },
+          "style": {
+            "type": "enum",
+            "value": "bodyMedium"
+          }
+        },
+        "modifiers": []
+      }
+    },
+    {
+      "operationId": "insert-card",
+      "type": "insertNode",
+      "parent": {
+        "nodeId": "screen-column",
+        "slot": "children"
+      },
+      "node": {
+        "id": "card",
+        "componentId": "m3/card",
+        "properties": {
+          "variant": {
+            "type": "enum",
+            "value": "filled"
+          }
+        },
+        "modifiers": [
+          {
+            "type": "fillMaxWidth"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "insert-card-column",
+      "type": "insertNode",
+      "parent": {
+        "nodeId": "card",
+        "slot": "content"
+      },
+      "node": {
+        "id": "card-column",
+        "componentId": "layout/column",
+        "properties": {
+          "verticalSpacingDp": {
+            "type": "float",
+            "value": 8
+          }
+        },
+        "modifiers": [
+          {
+            "type": "fillMaxWidth"
+          },
+          {
+            "type": "padding",
+            "startDp": 16,
+            "topDp": 16,
+            "endDp": 16,
+            "bottomDp": 16
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "insert-card-heading",
+      "type": "insertNode",
+      "parent": {
+        "nodeId": "card-column",
+        "slot": "children"
+      },
+      "node": {
+        "id": "card-heading",
+        "componentId": "m3/text",
+        "properties": {
+          "text": {
+            "type": "string",
+            "value": "Continue listening"
+          },
+          "style": {
+            "type": "enum",
+            "value": "titleMedium"
+          }
+        },
+        "modifiers": []
+      }
+    },
+    {
+      "operationId": "insert-card-track",
+      "type": "insertNode",
+      "parent": {
+        "nodeId": "card-column",
+        "slot": "children"
+      },
+      "node": {
+        "id": "card-track",
+        "componentId": "m3/text",
+        "properties": {
+          "text": {
+            "type": "string",
+            "value": "Midnight City — M83"
+          },
+          "style": {
+            "type": "enum",
+            "value": "bodyMedium"
+          },
+          "color": {
+            "type": "colorToken",
+            "value": "onSurfaceVariant"
+          }
+        },
+        "modifiers": []
+      }
+    },
+    {
+      "operationId": "insert-button",
+      "type": "insertNode",
+      "parent": {
+        "nodeId": "card-column",
+        "slot": "children"
+      },
+      "node": {
+        "id": "open-now-playing",
+        "componentId": "m3/button",
+        "properties": {
+          "style": {
+            "type": "enum",
+            "value": "filled"
+          }
+        },
+        "modifiers": []
+      }
+    },
+    {
+      "operationId": "insert-button-label",
+      "type": "insertNode",
+      "parent": {
+        "nodeId": "open-now-playing",
+        "slot": "content"
+      },
+      "node": {
+        "id": "open-now-playing-label",
+        "componentId": "m3/text",
+        "properties": {
+          "text": {
+            "type": "string",
+            "value": "Open Now Playing"
+          },
+          "style": {
+            "type": "enum",
+            "value": "labelLarge"
+          }
+        },
+        "modifiers": []
+      }
+    }
+  ]
+}

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/HomeScreenDesignPreview.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/HomeScreenDesignPreview.kt
@@ -1,0 +1,100 @@
+package com.example.sampleandroid
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+/**
+ * The UI-builder design in [`samples/android/design/home-screen.uibuilder.json`] as Compose, and
+ * the design half of the device-capture parity lane.
+ *
+ * ## What this file is
+ *
+ * `DeviceCaptureParityTest` renders this preview and the real `MainActivity`
+ * (`renders/activity__MainActivity.png`, the `kind=ACTIVITY` capture app tours already produce) and
+ * reports how far apart they are. The app is the reference; this is the design authored to match
+ * it. See [`docs/design/DEVICE_CAPTURE.md`](../../../../../../../docs/design/DEVICE_CAPTURE.md).
+ *
+ * ## Why it is checked in rather than generated at build time
+ *
+ * The builder's `CapabilityComposeCodeExporter` lives in `compose-preview-server`, which is layer 2
+ * — this repository is layer 1 and may not depend upward
+ * ([`REPOSITORY_LAYERS.md`](../../../../../../../docs/design/REPOSITORY_LAYERS.md)). So the design
+ * document is the source of truth, this is its committed projection, and the parity lane compares
+ * *pixels* rather than trusting the transcription.
+ *
+ * **It is therefore transcribed, not generated**, and that is the one seam in this lane a reviewer
+ * has to check by eye. Each composable below states which design node it came from. The mapping
+ * follows the exporter's own rules, which are worth knowing when checking it:
+ *
+ * - `layout/column.verticalSpacingDp` → `verticalArrangement = Arrangement.spacedBy(n.dp)`
+ * - a `padding` modifier → `.padding(start =, top =, end =, bottom =)`, always four named edges
+ * - `m3/card.variant = filled` → `Card`; `elevated`/`outlined` would be the other two symbols
+ * - `m3/button.style = filled` → `Button`
+ * - `m3/text.style` → `MaterialTheme.typography.<style>`
+ * - `m3/text.color` → `MaterialTheme.colorScheme.<token>`
+ *
+ * A follow-up should replace the transcription with the exporter's real output, run in
+ * compose-preview-server and committed here — see the issue linked from the parity test.
+ */
+// Rendered under exactly the conditions the ACTIVITY capture uses, so the comparison is
+// apples-to-apples: `AppTourDiscovery.buildActivityPreviews` builds its preview from
+// `DeviceDimensions.DEFAULT` (400x800dp at density 2.625) with `showSystemUi = true`. Any of the
+// three differing would make the score measure the render setup rather than the design.
+@Preview(name = "Design", showSystemUi = true, widthDp = 400, heightDp = 800)
+@Composable
+fun HomeScreenDesignPreview() {
+  MaterialTheme {
+    // node `root` — m3/surface, modifier fillMaxSize
+    Surface(modifier = Modifier.fillMaxSize()) {
+      // node `screen-column` — layout/column, verticalSpacingDp 16, fillMaxSize + padding 24
+      Column(
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        modifier =
+          Modifier.fillMaxSize().padding(start = 24.dp, top = 24.dp, end = 24.dp, bottom = 24.dp),
+      ) {
+        // node `title` — m3/text, style headlineMedium
+        Text(text = "Sample Android", style = MaterialTheme.typography.headlineMedium)
+        // node `blurb` — m3/text, style bodyMedium
+        Text(
+          text = "A tiny two-screen app used to exercise app-level previews and tours.",
+          style = MaterialTheme.typography.bodyMedium,
+        )
+        // node `card` — m3/card, variant filled, modifier fillMaxWidth
+        Card(modifier = Modifier.fillMaxWidth()) {
+          // node `card-column` — layout/column, verticalSpacingDp 8, fillMaxWidth + padding 16
+          Column(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier =
+              Modifier.fillMaxWidth()
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp),
+          ) {
+            // node `card-heading` — m3/text, style titleMedium
+            Text(text = "Continue listening", style = MaterialTheme.typography.titleMedium)
+            // node `card-track` — m3/text, style bodyMedium, color onSurfaceVariant
+            Text(
+              text = "Midnight City — M83",
+              style = MaterialTheme.typography.bodyMedium,
+              color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            // node `open-now-playing` — m3/button, style filled; its content slot holds
+            // `open-now-playing-label`, an m3/text. The design has no onClick: a captured screen's
+            // behaviour is not part of what a still frame can be compared on.
+            Button(onClick = {}) { Text("Open Now Playing") }
+          }
+        }
+      }
+    }
+  }
+}

--- a/samples/android/src/test/kotlin/com/example/sampleandroid/DeviceCaptureParityTest.kt
+++ b/samples/android/src/test/kotlin/com/example/sampleandroid/DeviceCaptureParityTest.kt
@@ -1,0 +1,162 @@
+package com.example.sampleandroid
+
+import java.awt.image.BufferedImage
+import java.io.File
+import java.util.Locale
+import javax.imageio.ImageIO
+import kotlin.math.abs
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+
+/**
+ * Device-capture parity: does the UI-builder design in
+ * `samples/android/design/home-screen.uibuilder.json` still look like the app it was authored
+ * against?
+ *
+ * The **reference** is the real app. `kind=ACTIVITY` previews launch `MainActivity` for real — full
+ * lifecycle, its own `setContent`, its theme — and capture the resumed screen to
+ * `renders/activity__MainActivity.png` (see `docs/APP_TOURS.md`). That is the extraction half of
+ * `docs/design/DEVICE_CAPTURE.md` already built and shipping; this test consumes it rather than
+ * adding a second capture path.
+ *
+ * The **candidate** is [HomeScreenDesignPreview], the design rendered through the ordinary preview
+ * lane.
+ *
+ * ## Report-only, on purpose
+ *
+ * This test never fails on a difference. It writes `build/device-capture-parity/report.json` and
+ * asserts only that both inputs exist and are comparable. Two reasons, and neither is temporary
+ * timidity:
+ *
+ * 1. **Nobody has measured the real drift yet.** A threshold invented before the first run is a
+ *    number someone made up, and the usual fate of a gate like that is to be muted. The daily job
+ *    exists to produce the measurement a threshold could later be chosen from.
+ * 2. It matches how this repository already treats parity findings — advisory, severity being the
+ *    agent's signal, per `site/reference/a11y.md`.
+ *
+ * Turning it into a gate is a deliberate follow-up, once `report.json` has a few weeks of history.
+ *
+ * ## What a difference here means
+ *
+ * The app is the reference, so a difference is the *design* being out of date — someone changed
+ * `HomeScreen` and the design was not re-authored. It can also be a real fidelity gap in what the
+ * builder can express, which is the more interesting case and the reason the score is recorded
+ * rather than just eyeballed.
+ */
+class DeviceCaptureParityTest {
+
+  private val rendersDir = File("build/compose-previews/renders")
+
+  /**
+   * Locale-independent fixed-point. `"%.6f".format(x)` uses the default locale, which in a
+   * comma-decimal locale writes `0,123456` — invalid JSON, and a CI runner is exactly where an
+   * unexpected default locale shows up.
+   */
+  private fun fixed(value: Double): String = String.format(Locale.ROOT, "%.6f", value)
+
+  private val reportDir = File("build/device-capture-parity")
+
+  /** Both scores from one pass over the overlapping area. */
+  private data class Scores(val meanAbsoluteDifference: Double, val differingFraction: Double)
+
+  /**
+   * [Scores.meanAbsoluteDifference] is the mean per-channel difference, 0.0 (identical) to 1.0.
+   * [Scores.differingFraction] is the fraction of pixels differing by more than [tolerance] on any
+   * channel — the two answer different questions, and a design that is right but shifted by one
+   * pixel scores very differently on them.
+   *
+   * Compared over the overlap so a size mismatch degrades rather than throws; `sameSize` in the
+   * report says whether that happened, because a score over an overlap is not comparable to one
+   * over the whole frame.
+   */
+  private fun score(a: BufferedImage, b: BufferedImage, tolerance: Int = 8): Scores {
+    val w = minOf(a.width, b.width)
+    val h = minOf(a.height, b.height)
+    if (w == 0 || h == 0) return Scores(1.0, 1.0)
+    var total = 0L
+    var differing = 0L
+    for (y in 0 until h) for (x in 0 until w) {
+      val pa = a.getRGB(x, y)
+      val pb = b.getRGB(x, y)
+      val dr = abs(((pa shr 16) and 0xff) - ((pb shr 16) and 0xff))
+      val dg = abs(((pa shr 8) and 0xff) - ((pb shr 8) and 0xff))
+      val db = abs((pa and 0xff) - (pb and 0xff))
+      total += (dr + dg + db).toLong()
+      if (dr > tolerance || dg > tolerance || db > tolerance) differing++
+    }
+    val pixels = w.toDouble() * h.toDouble()
+    return Scores(total.toDouble() / (pixels * 3.0 * 255.0), differing.toDouble() / pixels)
+  }
+
+  @Test
+  fun designMatchesCapturedApp() {
+    // Two different filename conventions meet here, and neither is guesswork:
+    //   * a `@Preview` render is `<function>_<previewName>-<8 hex digest>.png`
+    //     (docs/RENDER_FILENAMES.md), which is what `renderFile` matches;
+    //   * a synthetic ACTIVITY capture is the bare `activity__<SimpleName>.png` —
+    //     `AppTourDiscovery` sets `renderOutput` to exactly that, with no digest.
+    // `renderFile` happens to fall back to the bare name when its pattern misses, but relying on a
+    // fallback for the primary input would be luck, so the activity is resolved directly.
+    val captured =
+      File(rendersDir, "activity__MainActivity.png").takeIf { it.exists() }
+        ?: renderFile(rendersDir, "activity__MainActivity")
+    val design = renderFile(rendersDir, "HomeScreenDesignPreview_Design")
+
+    // The activity capture is `optional` for every activity but the launcher, and a module that
+    // rendered no activity at all should not turn this into a red herring in an unrelated failure.
+    // Skip loudly rather than fail: the daily job's log says which input was missing.
+    assumeTrue(
+      "no activity capture at ${captured.path} — is ACTIVITY discovery on for this module?",
+      captured.exists(),
+    )
+    assumeTrue("no design render at ${design.path}", design.exists())
+
+    val capturedImage = ImageIO.read(captured)
+    val designImage = ImageIO.read(design)
+
+    val scores = score(capturedImage, designImage)
+    val mad = scores.meanAbsoluteDifference
+    val differing = scores.differingFraction
+    val sameSize =
+      capturedImage.width == designImage.width && capturedImage.height == designImage.height
+
+    reportDir.mkdirs()
+    File(reportDir, "report.json")
+      .writeText(
+        buildString {
+          appendLine("{")
+          appendLine("  \"schema\": \"device-capture-parity/v1\",")
+          appendLine("  \"design\": \"samples/android/design/home-screen.uibuilder.json\",")
+          appendLine("  \"reference\": {")
+          appendLine("    \"source\": \"activity-capture\",")
+          appendLine("    \"file\": \"${captured.name}\",")
+          appendLine("    \"widthPx\": ${capturedImage.width},")
+          appendLine("    \"heightPx\": ${capturedImage.height}")
+          appendLine("  },")
+          appendLine("  \"candidate\": {")
+          appendLine("    \"source\": \"design-preview\",")
+          appendLine("    \"file\": \"${design.name}\",")
+          appendLine("    \"widthPx\": ${designImage.width},")
+          appendLine("    \"heightPx\": ${designImage.height}")
+          appendLine("  },")
+          appendLine("  \"sameSize\": $sameSize,")
+          appendLine("  \"meanAbsoluteDifference\": ${fixed(mad)},")
+          appendLine("  \"differingPixelFraction\": ${fixed(differing)},")
+          appendLine("  \"gate\": \"report-only\"")
+          appendLine("}")
+        }
+      )
+
+    println(
+      "device-capture parity: mad=${fixed(mad)} " +
+        "differing=${fixed(differing * 100)}% sameSize=$sameSize " +
+        "(${capturedImage.width}x${capturedImage.height} vs " +
+        "${designImage.width}x${designImage.height})"
+    )
+
+    // The only assertions: both images decoded and overlap. A score of any value is a result, not
+    // a failure — see the class doc.
+    check(capturedImage.width > 0 && capturedImage.height > 0) { "captured image is empty" }
+    check(designImage.width > 0 && designImage.height > 0) { "design image is empty" }
+  }
+}

--- a/samples/android/src/test/kotlin/com/example/sampleandroid/DeviceCaptureParityTest.kt
+++ b/samples/android/src/test/kotlin/com/example/sampleandroid/DeviceCaptureParityTest.kt
@@ -13,9 +13,9 @@ import org.junit.Test
  * `samples/android/design/home-screen.uibuilder.json` still look like the app it was authored
  * against?
  *
- * The **reference** is the real app. `kind=ACTIVITY` previews launch `MainActivity` for real — full
- * lifecycle, its own `setContent`, its theme — and capture the resumed screen to
- * `renders/activity__MainActivity.png` (see `docs/APP_TOURS.md`). That is the extraction half of
+ * The **reference** is the real app. `kind=ACTIVITY` previews launch `MainActivity` for real, with
+ * its full lifecycle, its own `setContent` and its own theme, and capture the resumed screen to
+ * `renders/activity__MainActivity.png` (see docs/APP_TOURS.md). That is the extraction half of
  * `docs/design/DEVICE_CAPTURE.md` already built and shipping; this test consumes it rather than
  * adding a second capture path.
  *
@@ -35,6 +35,20 @@ import org.junit.Test
  *    agent's signal, per `site/reference/a11y.md`.
  *
  * Turning it into a gate is a deliberate follow-up, once `report.json` has a few weeks of history.
+ *
+ * ## The floor, measured
+ *
+ * At the commit that added this lane the two frames were **pixel-identical over 99.79% of the
+ * frame**: `meanAbsoluteDifference` 0.002183, `differingPixelFraction` 0.0021, and every differing
+ * pixel inside rows `18-43` and `2069-2079`. Those two bands are the status-bar glyphs and the
+ * navigation pill: the design preview draws system chrome, and the ACTIVITY capture does not, *even
+ * though both previews declare `showSystemUi = true`*. The content itself does not differ by a
+ * single pixel.
+ *
+ * So a non-zero score is expected, and `differingRowBands` is the field that makes it readable —
+ * two thin bands at the extremes are the known floor, anything inside the content area is drift.
+ * That is why the bands are reported rather than just a number: a score alone cannot tell the two
+ * apart, and a reviewer should not have to open the PNGs to find out.
  *
  * ## What a difference here means
  *
@@ -56,8 +70,13 @@ class DeviceCaptureParityTest {
 
   private val reportDir = File("build/device-capture-parity")
 
-  /** Both scores from one pass over the overlapping area. */
-  private data class Scores(val meanAbsoluteDifference: Double, val differingFraction: Double)
+  /** Both scores, plus where the differences are, from one pass over the overlapping area. */
+  private data class Scores(
+    val meanAbsoluteDifference: Double,
+    val differingFraction: Double,
+    /** Contiguous runs of rows containing at least one differing pixel, as `first..last`. */
+    val differingRowBands: List<IntRange>,
+  )
 
   /**
    * [Scores.meanAbsoluteDifference] is the mean per-channel difference, 0.0 (identical) to 1.0.
@@ -72,20 +91,49 @@ class DeviceCaptureParityTest {
   private fun score(a: BufferedImage, b: BufferedImage, tolerance: Int = 8): Scores {
     val w = minOf(a.width, b.width)
     val h = minOf(a.height, b.height)
-    if (w == 0 || h == 0) return Scores(1.0, 1.0)
+    if (w == 0 || h == 0) return Scores(1.0, 1.0, emptyList())
     var total = 0L
     var differing = 0L
-    for (y in 0 until h) for (x in 0 until w) {
-      val pa = a.getRGB(x, y)
-      val pb = b.getRGB(x, y)
-      val dr = abs(((pa shr 16) and 0xff) - ((pb shr 16) and 0xff))
-      val dg = abs(((pa shr 8) and 0xff) - ((pb shr 8) and 0xff))
-      val db = abs((pa and 0xff) - (pb and 0xff))
-      total += (dr + dg + db).toLong()
-      if (dr > tolerance || dg > tolerance || db > tolerance) differing++
+    val dirtyRows = mutableListOf<Int>()
+    for (y in 0 until h) {
+      var rowDirty = false
+      for (x in 0 until w) {
+        val pa = a.getRGB(x, y)
+        val pb = b.getRGB(x, y)
+        val dr = abs(((pa shr 16) and 0xff) - ((pb shr 16) and 0xff))
+        val dg = abs(((pa shr 8) and 0xff) - ((pb shr 8) and 0xff))
+        val db = abs((pa and 0xff) - (pb and 0xff))
+        total += (dr + dg + db).toLong()
+        if (dr > tolerance || dg > tolerance || db > tolerance) {
+          differing++
+          rowDirty = true
+        }
+      }
+      if (rowDirty) dirtyRows += y
     }
     val pixels = w.toDouble() * h.toDouble()
-    return Scores(total.toDouble() / (pixels * 3.0 * 255.0), differing.toDouble() / pixels)
+    return Scores(
+      total.toDouble() / (pixels * 3.0 * 255.0),
+      differing.toDouble() / pixels,
+      contiguousBands(dirtyRows),
+    )
+  }
+
+  /** `[3, 4, 5, 9, 10]` → `[3..5, 9..10]`. */
+  private fun contiguousBands(rows: List<Int>): List<IntRange> {
+    if (rows.isEmpty()) return emptyList()
+    val bands = mutableListOf<IntRange>()
+    var start = rows.first()
+    var previous = rows.first()
+    for (row in rows.drop(1)) {
+      if (row != previous + 1) {
+        bands += start..previous
+        start = row
+      }
+      previous = row
+    }
+    bands += start..previous
+    return bands
   }
 
   @Test
@@ -117,6 +165,7 @@ class DeviceCaptureParityTest {
     val scores = score(capturedImage, designImage)
     val mad = scores.meanAbsoluteDifference
     val differing = scores.differingFraction
+    val bands = scores.differingRowBands
     val sameSize =
       capturedImage.width == designImage.width && capturedImage.height == designImage.height
 
@@ -142,6 +191,11 @@ class DeviceCaptureParityTest {
           appendLine("  \"sameSize\": $sameSize,")
           appendLine("  \"meanAbsoluteDifference\": ${fixed(mad)},")
           appendLine("  \"differingPixelFraction\": ${fixed(differing)},")
+          appendLine(
+            "  \"differingRowBands\": [" +
+              bands.joinToString(", ") { "\"${it.first}-${it.last}\"" } +
+              "],"
+          )
           appendLine("  \"gate\": \"report-only\"")
           appendLine("}")
         }
@@ -150,6 +204,7 @@ class DeviceCaptureParityTest {
     println(
       "device-capture parity: mad=${fixed(mad)} " +
         "differing=${fixed(differing * 100)}% sameSize=$sameSize " +
+        "bands=${bands.joinToString(",") { "${it.first}-${it.last}" }} " +
         "(${capturedImage.width}x${capturedImage.height} vs " +
         "${designImage.width}x${designImage.height})"
     )


### PR DESCRIPTION
A daily, report-only lane answering one question: **does a UI-builder design authored against a real screen still look like that screen?**

## Result: they render the same

Measured on this branch, both frames at 1050×2100:

| | |
|---|---|
| `sameSize` | **true** |
| `meanAbsoluteDifference` | **0.002183** |
| `differingPixelFraction` | **0.002146** (0.21%) |
| `differingRowBands` | **`18-43`, `2069-2079`** — and nothing else |

The screen content does not differ by a single pixel. Every differing pixel is in two thin bands at the extremes: the status-bar glyphs and the navigation pill, which the design preview draws and the ACTIVITY capture does not — *even though both previews declare `showSystemUi = true`*. That inconsistency is a real observation about the renderer, left visible rather than tuned away.

I deliberately did **not** make the number zero by flipping `showSystemUi` on the design preview. That would hide the discrepancy and configure the two halves differently, which is the thing the setup exists to avoid. Instead the test reports the bands, so the floor and real drift are distinguishable without opening the PNGs.

## How it works

The **reference is the app itself**. `kind=ACTIVITY` previews already launch `MainActivity` for real — full lifecycle, its own `setContent`, its own theme — and capture the resumed screen (`docs/APP_TOURS.md`). That is the extraction half of `docs/design/DEVICE_CAPTURE.md` already shipping, so this consumes it rather than adding a second capture path. The **candidate** is `HomeScreenDesignPreview`, the design rendered through the ordinary preview lane.

Both halves render under **identical conditions**, which was the main correctness risk: `AppTourDiscovery` builds the activity preview from `DeviceDimensions.DEFAULT` (400×800dp at density 2.625) with `showSystemUi = true`, so the design preview declares exactly that. Discovery confirms it — both report `400x800 d=2.625 sysui=True`. Had any of the three differed, the score would measure the render setup rather than the design.

The design is written in the builder's own operation format, and every `componentId`, property, allowed value, modifier and slot in it was checked against `m3-catalog`'s capability catalog **including slot role/trait acceptance** — it is a design the builder would accept, not a JSON file shaped like one.

## Report-only

No threshold has been earned yet, and one invented before the first run is a number someone made up — the usual fate of such a gate is to be muted. This job exists to produce the measurement a threshold could later be chosen from, which is also how this repository already treats parity findings. Turning it into a gate is a deliberate follow-up.

## The one seam

`HomeScreenDesignPreview.kt` is **transcribed from the design by hand, not generated**. The exporter that would generate it lives in compose-preview-server, which is layer 2, and this repository may not depend upward. What keeps it honest is that the comparison is on pixels: a drifted transcription would have to drift in a way that still renders identically to the app. Replacing it with the exporter's real output is the obvious follow-up, and is called out in both the KDoc and the design README.

## Test plan

Run locally, and both numbers reproduced independently:

- `:samples:android:testDebugUnitTest --tests '*DeviceCaptureParityTest*'` → **BUILD SUCCESSFUL**, writing the `report.json` quoted above.
- The same two PNGs were also compared by a standalone decoder written for the purpose, which produced identical figures (0.002183 / 0.002146 / the same two bands) — two implementations agreeing rather than one asserting.
- Design validated against the real capability catalog by script: all ids, properties, allowed values, modifier capabilities, slot names and role/trait acceptance pass.
- `ktfmtFormatTest` / `ktfmtFormatMain` clean.

**Not verified here**: `composePreviewRenderAll` completing green. In this sandbox it fails with `java.io.EOFException` and a missing `in-progress-results-generic.bin` — the signature of a test JVM being killed, consistent with memory pressure from concurrent Gradle runs. All 172 renders including both of this lane's did land on disk, and the parity test passed against them, but the workflow's first step runs that task and I could not confirm it green on this machine.

Two bugs were found by running it rather than reading it: the design preview was initially 411×891 without system UI (would have compared against a differently sized frame), and the workflow invoked `:samples:android:test --tests`, which an Android module's aggregate lifecycle task rejects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRZ2uZbGnHy9r6Uq2xNaUK

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRZ2uZbGnHy9r6Uq2xNaUK)_