### PR TITLE
fix(discovery): follow the project's own composables to the component a preview renders

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
@@ -61,6 +61,16 @@ object PreviewTargetInference {
   // Deliberately NOT the whole of `WRAPPER_FQN_PREFIXES`: `foundation.layout.Column`,
   // `runtime.remember` and `ui.Modifier` stay scaffolding under either question, and admitting them
   // would bury the one call a reader cares about under the frame that positions it.
+  /**
+   * How far a component may sit behind the project's own composables and still be the preview's.
+   *
+   * Three covers the shapes that motivated it — `Sticker { Frame { Component() } }` is two — with
+   * one to spare for a catalog that wraps its frame. Deeper than that and "the preview renders it"
+   * stops being a claim worth publishing: a screen four levels of project code above a `Text` is
+   * not a `Text` sticker.
+   */
+  private const val PROJECT_COMPOSABLE_MAX_DEPTH = 3
+
   private val COMPONENT_LIBRARY_FQN_PREFIXES =
     listOf(
       "androidx.compose.material3.",
@@ -204,8 +214,11 @@ object PreviewTargetInference {
       } catch (_: Throwable) {
         return emptyList()
       }
+    val lambdaCalls = extractComposeSingletonLambdaCalls(directCalls, scanResult, projectClassFqns)
     val calls =
-      directCalls + extractComposeSingletonLambdaCalls(directCalls, scanResult, projectClassFqns)
+      directCalls +
+        lambdaCalls +
+        extractProjectComposableCalls(directCalls + lambdaCalls, scanResult, projectClassFqns)
     val candidates =
       calls
         .asSequence()
@@ -518,6 +531,74 @@ object PreviewTargetInference {
    *   the body's own nested `$lambda$n$…` methods — the callbacks it declares — since a call made
    *   from one of those is still a call the lambda makes.
    */
+  /**
+   * The library components a preview reaches THROUGH its own composables.
+   *
+   * The walk above sees the preview's body plus one hop through Compose singleton lambdas, then
+   * keeps only calls whose owner is a component library. A sticker that factors its frame drops out
+   * of that entirely: `Sticker { TimePickerDialogFrame(…) }` lands on a project composable, which
+   * is neither a library call nor followed, so the `TimePicker` two hops further in is invisible.
+   * The cost is not one missing entry — m3-catalog's record carries `DateRangePicker` and neither
+   * picker, and wear-m3-catalog's `:remote-catalog` collapses 49 catalog entries into the two
+   * sticker composables that wrap them, because every component it publishes is behind a frame.
+   *
+   * So a call into the PROJECT's own code is followed, and the library calls inside it are the
+   * preview's too. Bounded by [PROJECT_COMPOSABLE_MAX_DEPTH] and a visited set: a frame that calls
+   * a frame is ordinary, a cycle is possible, and an unbounded walk over a large project's call
+   * graph would make discovery's cost a function of how deeply the project factors its UI.
+   *
+   * Deliberately NOT tagged `viaLambda`. That flag exists so `infer`'s project-local answer can
+   * discount lambda contents; this list feeds `inferComponents` only, where a component reached
+   * through a frame is exactly as much the sticker's subject as one called directly.
+   */
+  /**
+   * Compose's generated lambda holder, which [extractComposeSingletonLambdaCalls] already owns.
+   *
+   * Following one here would walk the `getLambda$N` getter rather than the lambda body, finding
+   * nothing, and then re-enter through the singleton path anyway.
+   */
+  private fun Invocation.isComposeSingleton(): Boolean = ".ComposableSingletons$" in ownerFqn
+
+  private fun extractProjectComposableCalls(
+    seed: List<Invocation>,
+    scanResult: ScanResult,
+    projectClassFqns: Set<String>,
+  ): List<Invocation> {
+    val found = mutableListOf<Invocation>()
+    val visited = mutableSetOf<Triple<String, String, String>>()
+    var frontier = seed.filter { it.ownerFqn in projectClassFqns && !it.isComposeSingleton() }
+    repeat(PROJECT_COMPOSABLE_MAX_DEPTH) {
+      val next = mutableListOf<Invocation>()
+      for (call in frontier) {
+        if (!visited.add(Triple(call.ownerFqn, call.methodName, call.descriptor))) continue
+        val resource = scanResult.getClassInfo(call.ownerFqn)?.resource ?: continue
+        val inner =
+          try {
+            extractCalls(
+              resource = resource,
+              ownerFqn = call.ownerFqn,
+              isRoot = { key -> key.name == call.methodName && key.descriptor == call.descriptor },
+              // The nested-method walk inside one class is already how a captured lambda's body is
+              // reached; keeping it means a frame whose content lambda captures still resolves.
+              shouldFollow = { key -> key.name.contains('$') },
+            )
+          } catch (_: Throwable) {
+            continue
+          }
+        found += inner
+        next += inner.filter { it.ownerFqn in projectClassFqns && !it.isComposeSingleton() }
+        // A project composable can hand its content to a singleton lambda too, so the same hop the
+        // preview body gets applies at every level rather than only the first.
+        val throughLambdas = extractComposeSingletonLambdaCalls(inner, scanResult, projectClassFqns)
+        found += throughLambdas
+        next += throughLambdas.filter { it.ownerFqn in projectClassFqns }
+      }
+      frontier = next
+      if (frontier.isEmpty()) return found
+    }
+    return found
+  }
+
   private fun extractComposeSingletonLambdaCalls(
     directCalls: List<Invocation>,
     scanResult: ScanResult,

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/FramedComponentDiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/FramedComponentDiscoveryFunctionalTest.kt
@@ -1,0 +1,183 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.discovery.ComponentRecordFile
+import java.io.File
+import kotlinx.serialization.json.Json
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * A component the preview reaches through the project's own composables is still the preview's.
+ *
+ * `PreviewTargetInference.inferComponents` read the preview body plus one hop through Compose
+ * singleton lambdas and kept only calls into a component library. Anything behind a project
+ * composable was invisible, and catalogs factor their stickers: m3-catalog's record carried
+ * `DateRangePicker` and neither `TimePicker` nor `DatePicker`, and wear-m3-catalog's
+ * `:remote-catalog` collapsed 49 catalog entries into the two sticker composables wrapping them.
+ *
+ * This builds a real project in each of the shapes that matters and reads the written
+ * `components.json`, because the claim is about bytecode: an in-process assertion about the walker
+ * would not have caught that the one-hop rule was the whole story.
+ *
+ * **The bound is asserted too.** A walk with no depth limit would pass every positive case here
+ * while making discovery's cost a function of how deeply a project factors its UI, so the test
+ * names a component too deep to claim and insists it is absent. Without that this test would pass
+ * just as well against an unbounded walk, which is not the change that was made.
+ */
+class FramedComponentDiscoveryFunctionalTest {
+
+  @get:Rule val tempDir = TemporaryFolder()
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  private fun createTestProject(): File {
+    val projectDir = tempDir.root
+    File(projectDir, "settings.gradle.kts")
+      .writeText(
+        """
+        pluginManagement {
+            repositories {
+                gradlePluginPortal()
+                google()
+                mavenCentral()
+            }
+        }
+        dependencyResolutionManagement {
+            repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+            repositories {
+                google()
+                mavenCentral()
+            }
+        }
+        rootProject.name = "test-framed-components"
+        """
+          .trimIndent()
+      )
+    File(projectDir, "build.gradle.kts")
+      .writeText(
+        """
+        @file:Suppress("DEPRECATION")
+        plugins {
+            kotlin("jvm") version "2.2.21"
+            kotlin("plugin.compose") version "2.2.21"
+            id("org.jetbrains.compose") version "1.10.3"
+            id("ee.schimke.composeai.preview")
+        }
+        dependencies {
+            implementation(compose.desktop.currentOs)
+            implementation(compose.material3)
+            implementation(compose.uiTooling)
+            implementation(compose.components.uiToolingPreview)
+        }
+        java {
+            toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
+        }
+        """
+          .trimIndent()
+      )
+    File(projectDir, "gradle.properties").writeText("org.gradle.configuration-cache=true\n")
+
+    val srcDir = File(projectDir, "src/main/kotlin/test")
+    srcDir.mkdirs()
+    // Four shapes, written the way a catalog writes them rather than for this test:
+    //   Direct    — the component in the preview body, which always worked.
+    //   OneFrame  — `Sticker { Frame { Component() } }`, the m3-catalog picker shape.
+    //   TwoFrames — a frame wrapping a frame, which a catalog with a themed frame reaches.
+    //   TooDeep   — one level past the bound, which must NOT be claimed.
+    File(srcDir, "Framed.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.material3.Button
+        import androidx.compose.material3.Card
+        import androidx.compose.material3.Checkbox
+        import androidx.compose.material3.Slider
+        import androidx.compose.material3.Text
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.tooling.preview.Preview
+
+        @Composable
+        fun Sticker(content: @Composable () -> Unit) { content() }
+
+        @Composable
+        fun ButtonFrame() { Button(onClick = {}) { Text("ok") } }
+
+        @Composable
+        fun CardFrame() { Card { Text("card") } }
+
+        @Composable
+        fun OuterFrame() { CheckboxFrame() }
+
+        @Composable
+        fun CheckboxFrame() { Checkbox(checked = true, onCheckedChange = null) }
+
+        @Composable
+        fun DeepA() { DeepB() }
+
+        @Composable
+        fun DeepB() { DeepC() }
+
+        @Composable
+        fun DeepC() { DeepD() }
+
+        @Composable
+        fun DeepD() { Slider(value = 0.5f, onValueChange = {}) }
+
+        @Preview
+        @Composable
+        fun DirectPreview() { Text("direct") }
+
+        @Preview
+        @Composable
+        fun OneFramePreview() { Sticker { ButtonFrame() } }
+
+        @Preview
+        @Composable
+        fun TwoFramesPreview() { Sticker { OuterFrame() } }
+
+        @Preview
+        @Composable
+        fun TooDeepPreview() { Sticker { DeepA() } }
+        """
+          .trimIndent()
+      )
+    return projectDir
+  }
+
+  private fun runGradle(projectDir: File, vararg arguments: String) =
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments(*arguments)
+      .withPluginClasspath()
+      .build()
+
+  @Test
+  fun `a component behind the project's own composables is discovered, up to the bound`() {
+    val projectDir = createTestProject()
+    val discover = runGradle(projectDir, "composePreviewDiscover")
+    assertThat(discover.task(":composePreviewDiscover")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val componentsFile = File(projectDir, "build/compose-previews/components.json")
+    assertThat(componentsFile.exists()).isTrue()
+    val record = json.decodeFromString(ComponentRecordFile.serializer(), componentsFile.readText())
+    val symbols = record.components.map { it.symbol.name }.toSet()
+
+    // The vacuity guard: a walker that found nothing would satisfy every "is absent" claim below.
+    assertThat(symbols).contains("Text")
+
+    // One frame — the shape m3-catalog's pickers are in, and every component wear-m3-catalog's
+    // `:remote-catalog` publishes.
+    assertThat(symbols).contains("Button")
+    // Two frames — a frame wrapping a frame.
+    assertThat(symbols).contains("Checkbox")
+
+    // And the bound. `Slider` sits four project composables deep; claiming it would make this a
+    // walk over the project's whole call graph rather than a rule about stickers.
+    assertThat(symbols).doesNotContain("Slider")
+  }
+}


### PR DESCRIPTION
Unblocks two things that looked unrelated and are the same bug. Refs [yschimke/m3-catalog#317](https://github.com/yschimke/m3-catalog/issues/317), [yschimke/compose-preview-server#660](https://github.com/yschimke/compose-preview-server/issues/660).

## The rule, and what it costs

`inferComponents` reads the preview's body plus one hop through Compose singleton lambdas, then keeps only calls whose owner is a component library. A sticker that factors its frame falls out of that entirely — `Sticker { Frame { Component() } }` lands on a project composable, which is neither a library call nor followed, so the component two hops in is invisible.

That is not a corner case. It is how catalogs are written:

| catalog | what the record says | why |
| --- | --- | --- |
| **m3-catalog** | `DateRangePicker` present; `TimePicker`, `DatePicker`, `SnackbarHost` absent | all three sit behind `TimePickerDialogFrame` and friends |
| **wear-m3-catalog `:remote-catalog`** | 49 catalog entries collapse into **2** records | every component it publishes is behind a frame, so only the two sticker composables are seen |

Three of the 25 components m3-catalog's published catalog offers therefore have no record to join to, and remote-m3 has essentially nothing to join to at all — which is what blocks the published-catalog cutover in compose-preview-server.

## What this does

A call into the project's own code is followed, and the library calls inside it are the preview's too.

- **Bounded at three levels.** `Sticker { Frame { Component() } }` is two, with one spare for a catalog that wraps its frame. Deeper than that and "the preview renders it" stops being a claim worth publishing — a screen four levels of project code above a `Text` is not a `Text` sticker. Unbounded would also make discovery's cost a function of how deeply a project factors its UI.
- **Cycle-safe**, via a visited set on `(owner, method, descriptor)`.
- **The singleton-lambda hop applies at every level**, not just the first, so a frame that hands its content to a lambda still resolves.
- **Not tagged `viaLambda`.** That flag exists so `infer`'s project-local answer can discount lambda contents; this feeds `inferComponents` only, where a component reached through a frame is exactly as much the sticker's subject as one called directly.

## Test plan

Proved against real bytecode rather than in-process, because the claim is about what the walker sees — an in-process assertion would not have caught that the one-hop rule was the whole story. `FramedComponentDiscoveryFunctionalTest` builds a real project with four shapes, runs `composePreviewDiscover`, and reads the written `components.json`:

| shape | component | expected |
| --- | --- | --- |
| `Text("direct")` | `Text` | present — the vacuity guard |
| `Sticker { ButtonFrame() }` | `Button` | present |
| `Sticker { OuterFrame() }` → `CheckboxFrame()` | `Checkbox` | present |
| four project composables deep | `Slider` | **absent** |

Reverting the recursion, that record contains **`[Text]` alone**:

```
FramedComponentDiscoveryFunctionalTest > a component behind the project's own composables … FAILED
    expected to contain: Button
    but was            : [Text]
```

The out-of-bounds assertion means the test cannot pass against an unbounded walk either, which is the other way this could have been wrong.

- `:gradle-plugin:preview-discovery:test` and `:gradle-plugin:functionalTest` — green, including the existing component-record tests, so no catalog's record changed shape unexpectedly.
- ktfmt on the touched files.

## Blast radius, stated plainly

Every catalog's `components.json` grows — that is the point, and it is why this is its own PR rather than part of a cutover. A consumer that assumed one record per sticker will see more records; none in this repository does, and the two that read the file (`ComponentSnippets`, the UI-builder catalog generator) key off `canonicalId`. Worth a look from anyone who knows a downstream reader I don't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01297vAqLHxgAc6XQuaQYCSe

---
_Generated by [Claude Code](https://claude.ai/code/session_01297vAqLHxgAc6XQuaQYCSe)_