### PR TITLE
feat(ui-builder): let a catalog state a component's vocabulary in its policy file

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
@@ -61,6 +61,16 @@ object PreviewTargetInference {
   // Deliberately NOT the whole of `WRAPPER_FQN_PREFIXES`: `foundation.layout.Column`,
   // `runtime.remember` and `ui.Modifier` stay scaffolding under either question, and admitting them
   // would bury the one call a reader cares about under the frame that positions it.
+  /**
+   * How far a component may sit behind the project's own composables and still be the preview's.
+   *
+   * Three covers the shapes that motivated it — `Sticker { Frame { Component() } }` is two — with
+   * one to spare for a catalog that wraps its frame. Deeper than that and "the preview renders it"
+   * stops being a claim worth publishing: a screen four levels of project code above a `Text` is
+   * not a `Text` sticker.
+   */
+  private const val PROJECT_COMPOSABLE_MAX_DEPTH = 3
+
   private val COMPONENT_LIBRARY_FQN_PREFIXES =
     listOf(
       "androidx.compose.material3.",
@@ -204,8 +214,11 @@ object PreviewTargetInference {
       } catch (_: Throwable) {
         return emptyList()
       }
+    val lambdaCalls = extractComposeSingletonLambdaCalls(directCalls, scanResult, projectClassFqns)
     val calls =
-      directCalls + extractComposeSingletonLambdaCalls(directCalls, scanResult, projectClassFqns)
+      directCalls +
+        lambdaCalls +
+        extractProjectComposableCalls(directCalls + lambdaCalls, scanResult, projectClassFqns)
     val candidates =
       calls
         .asSequence()
@@ -518,6 +531,74 @@ object PreviewTargetInference {
    *   the body's own nested `$lambda$n$…` methods — the callbacks it declares — since a call made
    *   from one of those is still a call the lambda makes.
    */
+  /**
+   * The library components a preview reaches THROUGH its own composables.
+   *
+   * The walk above sees the preview's body plus one hop through Compose singleton lambdas, then
+   * keeps only calls whose owner is a component library. A sticker that factors its frame drops out
+   * of that entirely: `Sticker { TimePickerDialogFrame(…) }` lands on a project composable, which
+   * is neither a library call nor followed, so the `TimePicker` two hops further in is invisible.
+   * The cost is not one missing entry — m3-catalog's record carries `DateRangePicker` and neither
+   * picker, and wear-m3-catalog's `:remote-catalog` collapses 49 catalog entries into the two
+   * sticker composables that wrap them, because every component it publishes is behind a frame.
+   *
+   * So a call into the PROJECT's own code is followed, and the library calls inside it are the
+   * preview's too. Bounded by [PROJECT_COMPOSABLE_MAX_DEPTH] and a visited set: a frame that calls
+   * a frame is ordinary, a cycle is possible, and an unbounded walk over a large project's call
+   * graph would make discovery's cost a function of how deeply the project factors its UI.
+   *
+   * Deliberately NOT tagged `viaLambda`. That flag exists so `infer`'s project-local answer can
+   * discount lambda contents; this list feeds `inferComponents` only, where a component reached
+   * through a frame is exactly as much the sticker's subject as one called directly.
+   */
+  /**
+   * Compose's generated lambda holder, which [extractComposeSingletonLambdaCalls] already owns.
+   *
+   * Following one here would walk the `getLambda$N` getter rather than the lambda body, finding
+   * nothing, and then re-enter through the singleton path anyway.
+   */
+  private fun Invocation.isComposeSingleton(): Boolean = ".ComposableSingletons$" in ownerFqn
+
+  private fun extractProjectComposableCalls(
+    seed: List<Invocation>,
+    scanResult: ScanResult,
+    projectClassFqns: Set<String>,
+  ): List<Invocation> {
+    val found = mutableListOf<Invocation>()
+    val visited = mutableSetOf<Triple<String, String, String>>()
+    var frontier = seed.filter { it.ownerFqn in projectClassFqns && !it.isComposeSingleton() }
+    repeat(PROJECT_COMPOSABLE_MAX_DEPTH) {
+      val next = mutableListOf<Invocation>()
+      for (call in frontier) {
+        if (!visited.add(Triple(call.ownerFqn, call.methodName, call.descriptor))) continue
+        val resource = scanResult.getClassInfo(call.ownerFqn)?.resource ?: continue
+        val inner =
+          try {
+            extractCalls(
+              resource = resource,
+              ownerFqn = call.ownerFqn,
+              isRoot = { key -> key.name == call.methodName && key.descriptor == call.descriptor },
+              // The nested-method walk inside one class is already how a captured lambda's body is
+              // reached; keeping it means a frame whose content lambda captures still resolves.
+              shouldFollow = { key -> key.name.contains('$') },
+            )
+          } catch (_: Throwable) {
+            continue
+          }
+        found += inner
+        next += inner.filter { it.ownerFqn in projectClassFqns && !it.isComposeSingleton() }
+        // A project composable can hand its content to a singleton lambda too, so the same hop the
+        // preview body gets applies at every level rather than only the first.
+        val throughLambdas = extractComposeSingletonLambdaCalls(inner, scanResult, projectClassFqns)
+        found += throughLambdas
+        next += throughLambdas.filter { it.ownerFqn in projectClassFqns }
+      }
+      frontier = next
+      if (frontier.isEmpty()) return found
+    }
+    return found
+  }
+
   private fun extractComposeSingletonLambdaCalls(
     directCalls: List<Invocation>,
     scanResult: ScanResult,

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogsTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogsTest.kt
@@ -22,6 +22,7 @@ class UiBuilderCatalogsTest {
     builtins: Map<String, UiBuilderBuiltin> = emptyMap(),
     code: UiBuilderCode? = null,
     componentIdPrefix: String? = null,
+    components: Map<String, UiBuilderAuthoredComponent> = emptyMap(),
   ) =
     UiBuilderPolicyFile(
       schema = UI_BUILDER_POLICY_SCHEMA,
@@ -30,6 +31,7 @@ class UiBuilderCatalogsTest {
       builtins = builtins,
       code = code,
       componentIdPrefix = componentIdPrefix,
+      components = components,
     )
 
   private fun record(vararg components: ComponentRecord) =
@@ -71,6 +73,111 @@ class UiBuilderCatalogsTest {
             ComponentBinding(previewId = "${name}Preview", componentId = catalogId, group = group)
           ),
     )
+
+  /**
+   * A catalog states a component's vocabulary in the policy file, without annotating anything.
+   *
+   * This is m3-catalog's shape exactly: 104 record components, zero `@BuilderComponent`
+   * annotations, and a shelf whose properties, slots and modifiers are editorial decisions that
+   * belong in one reviewable file rather than sprayed across stickers.
+   */
+  @Test
+  fun `an authored component publishes its vocabulary, with no annotation`() {
+    val file =
+      UiBuilderCatalogs.generate(
+        record(component("Button", catalogId = "Controls/Button", group = "Actions")),
+        cover,
+        policy(
+          componentIdPrefix = "wear-m3/",
+          components =
+            mapOf(
+              "wear-m3/button" to
+                UiBuilderAuthoredComponent(
+                  displayName = "Button",
+                  traits = listOf("Action"),
+                  modifierCapabilities = listOf("padding", "size"),
+                  propertyCapabilities =
+                    listOf(Json.parseToJsonElement("""{"name":"style","jsonType":"string"}""")),
+                  slotCapabilities =
+                    listOf(Json.parseToJsonElement("""{"name":"label","ordered":false}""")),
+                )
+            ),
+        ),
+      )
+    val policy = file!!.statusSemantics.components.getValue("wear-m3/button")
+    assertThat(policy.record).isEqualTo(":catalog/androidx.wear.compose.material3.ButtonKt.Button")
+    assertThat(policy.displayName).isEqualTo("Button")
+    assertThat(policy.traits).containsExactly("Action")
+    assertThat(policy.modifierCapabilities).containsExactly("padding", "size").inOrder()
+    assertThat(policy.propertyCapabilities).hasSize(1)
+    assertThat(policy.slotCapabilities).hasSize(1)
+  }
+
+  /**
+   * "Not stated" and "stated as empty" are different questions.
+   *
+   * A catalog declaring `modifierCapabilities: []` means the component accepts none; one omitting
+   * it means the consumer should fall back to whatever it does when a catalog says nothing.
+   * Collapsing the two would make the contract unable to express a component that takes no
+   * modifiers.
+   */
+  @Test
+  fun `an omitted capability block stays absent rather than becoming empty`() {
+    val file =
+      UiBuilderCatalogs.generate(
+        record(component("Button", catalogId = "Controls/Button", group = "Actions")),
+        cover,
+        policy(
+          componentIdPrefix = "wear-m3/",
+          components =
+            mapOf("wear-m3/button" to UiBuilderAuthoredComponent(displayName = "Button")),
+        ),
+      )
+    val policy = file!!.statusSemantics.components.getValue("wear-m3/button")
+    assertThat(policy.modifierCapabilities).isNull()
+    assertThat(policy.propertyCapabilities).isNull()
+    assertThat(policy.slotCapabilities).isNull()
+  }
+
+  /** The policy file places a component the sticker never annotated. */
+  @Test
+  fun `an authored group shelves a component`() {
+    val file =
+      UiBuilderCatalogs.generate(
+        record(component("Button", catalogId = "Controls/Button", group = "Actions")),
+        cover,
+        policy(
+          componentIdPrefix = "wear-m3/",
+          components = mapOf("wear-m3/button" to UiBuilderAuthoredComponent(group = "Controls")),
+        ),
+      )
+    assertThat(file!!.statusSemantics.componentMenu.components.getValue("wear-m3/button").group)
+      .isEqualTo("Controls")
+  }
+
+  /**
+   * A policy naming a component that is not there is a rename that got away.
+   *
+   * Reported rather than dropped, for the same reason an orphaned `@BuilderComponent` is: silently
+   * ignoring it leaves the component with a default nobody meant it to have and no symptom at all.
+   * A hand-authored vocabulary is exactly where a mistyped id is likely.
+   */
+  @Test
+  fun `an authored policy naming no component is reported`() {
+    val file =
+      UiBuilderCatalogs.generate(
+        record(component("Button", catalogId = "Controls/Button", group = "Actions")),
+        cover,
+        policy(
+          componentIdPrefix = "wear-m3/",
+          components = mapOf("wear-m3/buton" to UiBuilderAuthoredComponent(displayName = "Typo")),
+        ),
+      )
+    val orphan =
+      file!!.diagnostics.single { it.code == UiBuilderCatalogs.Diagnostics.POLICY_ORPHANED }
+    assertThat(orphan.subject).isEqualTo("wear-m3/buton")
+    assertThat(orphan.message).contains("no component in this record derives")
+  }
 
   @Test
   fun `a catalog that authors no policy publishes no builder file`() {

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/FramedComponentDiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/FramedComponentDiscoveryFunctionalTest.kt
@@ -1,0 +1,183 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.discovery.ComponentRecordFile
+import java.io.File
+import kotlinx.serialization.json.Json
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * A component the preview reaches through the project's own composables is still the preview's.
+ *
+ * `PreviewTargetInference.inferComponents` read the preview body plus one hop through Compose
+ * singleton lambdas and kept only calls into a component library. Anything behind a project
+ * composable was invisible, and catalogs factor their stickers: m3-catalog's record carried
+ * `DateRangePicker` and neither `TimePicker` nor `DatePicker`, and wear-m3-catalog's
+ * `:remote-catalog` collapsed 49 catalog entries into the two sticker composables wrapping them.
+ *
+ * This builds a real project in each of the shapes that matters and reads the written
+ * `components.json`, because the claim is about bytecode: an in-process assertion about the walker
+ * would not have caught that the one-hop rule was the whole story.
+ *
+ * **The bound is asserted too.** A walk with no depth limit would pass every positive case here
+ * while making discovery's cost a function of how deeply a project factors its UI, so the test
+ * names a component too deep to claim and insists it is absent. Without that this test would pass
+ * just as well against an unbounded walk, which is not the change that was made.
+ */
+class FramedComponentDiscoveryFunctionalTest {
+
+  @get:Rule val tempDir = TemporaryFolder()
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  private fun createTestProject(): File {
+    val projectDir = tempDir.root
+    File(projectDir, "settings.gradle.kts")
+      .writeText(
+        """
+        pluginManagement {
+            repositories {
+                gradlePluginPortal()
+                google()
+                mavenCentral()
+            }
+        }
+        dependencyResolutionManagement {
+            repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+            repositories {
+                google()
+                mavenCentral()
+            }
+        }
+        rootProject.name = "test-framed-components"
+        """
+          .trimIndent()
+      )
+    File(projectDir, "build.gradle.kts")
+      .writeText(
+        """
+        @file:Suppress("DEPRECATION")
+        plugins {
+            kotlin("jvm") version "2.2.21"
+            kotlin("plugin.compose") version "2.2.21"
+            id("org.jetbrains.compose") version "1.10.3"
+            id("ee.schimke.composeai.preview")
+        }
+        dependencies {
+            implementation(compose.desktop.currentOs)
+            implementation(compose.material3)
+            implementation(compose.uiTooling)
+            implementation(compose.components.uiToolingPreview)
+        }
+        java {
+            toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
+        }
+        """
+          .trimIndent()
+      )
+    File(projectDir, "gradle.properties").writeText("org.gradle.configuration-cache=true\n")
+
+    val srcDir = File(projectDir, "src/main/kotlin/test")
+    srcDir.mkdirs()
+    // Four shapes, written the way a catalog writes them rather than for this test:
+    //   Direct    — the component in the preview body, which always worked.
+    //   OneFrame  — `Sticker { Frame { Component() } }`, the m3-catalog picker shape.
+    //   TwoFrames — a frame wrapping a frame, which a catalog with a themed frame reaches.
+    //   TooDeep   — one level past the bound, which must NOT be claimed.
+    File(srcDir, "Framed.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.material3.Button
+        import androidx.compose.material3.Card
+        import androidx.compose.material3.Checkbox
+        import androidx.compose.material3.Slider
+        import androidx.compose.material3.Text
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.tooling.preview.Preview
+
+        @Composable
+        fun Sticker(content: @Composable () -> Unit) { content() }
+
+        @Composable
+        fun ButtonFrame() { Button(onClick = {}) { Text("ok") } }
+
+        @Composable
+        fun CardFrame() { Card { Text("card") } }
+
+        @Composable
+        fun OuterFrame() { CheckboxFrame() }
+
+        @Composable
+        fun CheckboxFrame() { Checkbox(checked = true, onCheckedChange = null) }
+
+        @Composable
+        fun DeepA() { DeepB() }
+
+        @Composable
+        fun DeepB() { DeepC() }
+
+        @Composable
+        fun DeepC() { DeepD() }
+
+        @Composable
+        fun DeepD() { Slider(value = 0.5f, onValueChange = {}) }
+
+        @Preview
+        @Composable
+        fun DirectPreview() { Text("direct") }
+
+        @Preview
+        @Composable
+        fun OneFramePreview() { Sticker { ButtonFrame() } }
+
+        @Preview
+        @Composable
+        fun TwoFramesPreview() { Sticker { OuterFrame() } }
+
+        @Preview
+        @Composable
+        fun TooDeepPreview() { Sticker { DeepA() } }
+        """
+          .trimIndent()
+      )
+    return projectDir
+  }
+
+  private fun runGradle(projectDir: File, vararg arguments: String) =
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments(*arguments)
+      .withPluginClasspath()
+      .build()
+
+  @Test
+  fun `a component behind the project's own composables is discovered, up to the bound`() {
+    val projectDir = createTestProject()
+    val discover = runGradle(projectDir, "composePreviewDiscover")
+    assertThat(discover.task(":composePreviewDiscover")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val componentsFile = File(projectDir, "build/compose-previews/components.json")
+    assertThat(componentsFile.exists()).isTrue()
+    val record = json.decodeFromString(ComponentRecordFile.serializer(), componentsFile.readText())
+    val symbols = record.components.map { it.symbol.name }.toSet()
+
+    // The vacuity guard: a walker that found nothing would satisfy every "is absent" claim below.
+    assertThat(symbols).contains("Text")
+
+    // One frame — the shape m3-catalog's pickers are in, and every component wear-m3-catalog's
+    // `:remote-catalog` publishes.
+    assertThat(symbols).contains("Button")
+    // Two frames — a frame wrapping a frame.
+    assertThat(symbols).contains("Checkbox")
+
+    // And the bound. `Slider` sits four project composables deep; claiming it would make this a
+    // walk over the project's whole call graph rather than a rule about stickers.
+    assertThat(symbols).doesNotContain("Slider")
+  }
+}

--- a/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogs.kt
+++ b/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogs.kt
@@ -153,7 +153,42 @@ data class UiBuilderComponentPolicy(
   val variants: Map<String, String> = emptyMap(),
   /** Present only when the component is kept off the shelf; the value is the stated reason. */
   val excluded: String? = null,
+  /**
+   * The vocabulary the catalog states for this component — see `UiBuilderAuthoredComponent`.
+   *
+   * Raw JSON, carried rather than modelled: the shape is the UI builder's and the preview server
+   * validates it. Absent when the catalog states nothing, which is not the same as an empty list.
+   */
+  val propertyCapabilities: List<JsonElement>? = null,
+  val slotCapabilities: List<JsonElement>? = null,
+  val modifierCapabilities: List<String>? = null,
 )
+
+/**
+ * The annotation's policy with the authored one laid over it.
+ *
+ * Field by field rather than wholesale, so the two sources can each say what they are good at: a
+ * sticker states its group and variant property, the policy file states the component's vocabulary,
+ * and neither has to restate the other. A field the policy file leaves null is the annotation's
+ * answer — which is why every field of `UiBuilderAuthoredComponent` is nullable, and why an
+ * authored `modifierCapabilities: []` means "accepts none" rather than "not stated".
+ */
+internal fun UiBuilderComponentPolicy.mergedWith(
+  authored: UiBuilderAuthoredComponent?
+): UiBuilderComponentPolicy {
+  if (authored == null) return this
+  return copy(
+    record = authored.record ?: record,
+    displayName = authored.displayName ?: displayName,
+    canvas = authored.canvas ?: canvas,
+    nativeOnly = authored.nativeOnly ?: nativeOnly,
+    traits = authored.traits ?: traits,
+    excluded = authored.excluded ?: excluded,
+    propertyCapabilities = authored.propertyCapabilities ?: propertyCapabilities,
+    slotCapabilities = authored.slotCapabilities ?: slotCapabilities,
+    modifierCapabilities = authored.modifierCapabilities ?: modifierCapabilities,
+  )
+}
 
 /**
  * Something the generator noticed, addressed to a person reading the published file.
@@ -340,7 +375,34 @@ object UiBuilderCatalogs {
       // catalog, which never reached this loop. The one diagnostic written for that case was the
       // one case it could not fire in.
       diagnose(component, builder, builderId, diagnostics)
-      if (component.builder != null) components[builderId] = policyFor(component, builder)
+      val authored = policy.components[builderId]
+      if (component.builder != null || authored != null) {
+        val fromAnnotation =
+          if (component.builder != null) policyFor(component, builder)
+          else UiBuilderComponentPolicy(record = component.canonicalId)
+        components[builderId] = fromAnnotation.mergedWith(authored)
+      }
+    }
+
+    // An authored entry naming an id no component derives.
+    //
+    // Reported rather than dropped, for the same reason `POLICY_ORPHANED` reports an annotation
+    // that bound to nothing: a policy naming a component that is not there is a rename that got
+    // away, and dropping it leaves the component with a default nobody meant it to have and no
+    // symptom at all. This is the shape a catalog authoring its vocabulary by hand will hit — a
+    // typo in a builder id looks exactly like a component that is deliberately not stated.
+    for ((builderId, _) in policy.components) {
+      if (builderId in idOwners) continue
+      diagnostics +=
+        UiBuilderDiagnostic(
+          code = Diagnostics.POLICY_ORPHANED,
+          subject = builderId,
+          message =
+            "ui-builder.policy.json states a policy for \"$builderId\", which no component in this " +
+              "record derives, so every field in it does nothing. The ids this catalog publishes " +
+              "are derived from componentIdPrefix \"$idPrefix\"; check the spelling against " +
+              "components.json.",
+        )
     }
 
     // The shelf covers EVERY admitted component, so the menu has to as well.
@@ -370,7 +432,11 @@ object UiBuilderCatalogs {
       // under Tonal's group. Same defect as the one above, in the branch I did not change.
       val idAlias = component.builder?.declaredForCatalogId ?: component.componentIds.firstOrNull()
       val group =
-        component.builder?.group?.takeIf { it.isNotBlank() }
+        // The policy file first, then the annotation, then the catalog's own grouping. A catalog
+        // stating its shelf in one reviewable file should not have to annotate a sticker to place
+        // a component — that is the whole reason the authored block exists.
+        policy.components[builderId]?.group?.takeIf { it.isNotBlank() }
+          ?: component.builder?.group?.takeIf { it.isNotBlank() }
           ?: component.bindings
             .firstOrNull { it.componentId == idAlias && !it.group.isNullOrBlank() }
             ?.group

--- a/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/UiBuilderPolicy.kt
+++ b/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/UiBuilderPolicy.kt
@@ -145,6 +145,53 @@ data class UiBuilderPolicyFile(
   val templates: List<String> = emptyList(),
   val colorTokens: JsonElement? = null,
   val assetRegistry: JsonElement? = null,
+  /**
+   * Per-component policy the catalog states here rather than on a sticker, keyed by builder id.
+   *
+   * `@BuilderComponent` is the right place for what belongs to one sticker — its group, its variant
+   * property, whether to exclude it. It is the wrong place for a component's **vocabulary**: the
+   * properties a design may set, the slots it may fill and the modifiers it accepts are editorial
+   * decisions about the catalog's shelf, they run to dozens of entries per component, and a catalog
+   * can hold them without annotating anything. m3-catalog has 104 record components and **zero**
+   * `@BuilderComponent` annotations, and the vocabulary it needs to publish is the one its frozen
+   * capability document already states.
+   *
+   * Merged onto the annotation-derived entry for the same id, so the two can be used together and
+   * neither has to carry the other's concerns. An entry naming an id no component derives is
+   * reported rather than dropped — see `Diagnostics.POLICY_ORPHANED`'s sibling for the annotation
+   * case, and the same argument: a policy naming nothing is a rename that got away.
+   */
+  val components: Map<String, UiBuilderAuthoredComponent> = emptyMap(),
+)
+
+/**
+ * One component's authored policy.
+ *
+ * The three capability blocks are carried as raw JSON on purpose. Their shape is the UI builder's —
+ * `PropertyCapabilityV1`, `SlotCapabilityV1` — and re-declaring it here would be a second
+ * definition of a contract this repository does not own, which is exactly the drift the published
+ * `ui-builder.json` exists to avoid. The preview server validates them when it composes the shelf
+ * and refuses a catalog whose declarations it cannot serve; this carries them faithfully.
+ *
+ * Every field is nullable so that "not stated" and "stated as empty" stay different questions: a
+ * catalog declaring `modifierCapabilities: []` means the component accepts none, and one omitting
+ * it means the consumer should fall back.
+ */
+@Serializable
+data class UiBuilderAuthoredComponent(
+  /** The record's `canonicalId`, joining this policy to the inventory. */
+  val record: String? = null,
+  /** The shelf this component appears on, as `@BuilderComponent(group = …)` would say it. */
+  val group: String? = null,
+  val displayName: String? = null,
+  val canvas: String? = null,
+  val nativeOnly: Boolean? = null,
+  val traits: List<String>? = null,
+  /** Kept off the shelf, with the stated reason. */
+  val excluded: String? = null,
+  val propertyCapabilities: List<JsonElement>? = null,
+  val slotCapabilities: List<JsonElement>? = null,
+  val modifierCapabilities: List<String>? = null,
 )
 
 /**


### PR DESCRIPTION
Closes the **writer** half of the published-catalog contract. Fixes #5348; refs [yschimke/compose-preview-server#660](https://github.com/yschimke/compose-preview-server/issues/660).

Deliberately separate from #5350. That one changes what every catalog's record contains; this one is additive and changes nothing for a catalog that does not use it. They are the two things compose-ai-tools must ship for the cutover, and they are worth merging on their own schedules.

## The gap

compose-preview-server reads `propertyCapabilities`, `slotCapabilities` and `modifierCapabilities` off `statusSemantics.components`, and **no catalog could put them there**:

- `UiBuilderPolicyFile` had no `components` field at all.
- `@BuilderComponent` → `BuilderPolicy` carries a group, a variant property, an exclusion — not a vocabulary.
- `catalog-ui-builder.mjs` only validates and packs what this generator already wrote, so there was no pass-through either.

## Why the policy file rather than the annotation

`@BuilderComponent` is the right place for what belongs to **one sticker**. It is the wrong place for a component's vocabulary: which properties a design may set, which slots it may fill and which modifiers it accepts are editorial decisions about the shelf, they run to dozens of entries per component, and a catalog can hold them without annotating anything.

m3-catalog is the case in front of us — **104 record components and zero `@BuilderComponent` annotations**, and the vocabulary it needs to publish is the one its frozen capability document already states.

So the policy file gains `components`, keyed by builder id, merged onto the annotation-derived entry **field by field**. The two can be used together and neither has to carry the other's concerns.

## Two decisions worth flagging

**Every field is nullable.** A field the policy file leaves null is the annotation's answer. That keeps "not stated" and "stated as empty" as different questions: `modifierCapabilities: []` means the component accepts none, omitting it means fall back. Collapsing them would leave the contract unable to express a component that takes no modifiers.

**The capability blocks are raw JSON.** Their shape is the UI builder's — `PropertyCapabilityV1`, `SlotCapabilityV1` — and re-declaring it here would be a second definition of a contract this repository does not own, which is exactly the drift the published file exists to avoid. The preview server validates them when it composes the shelf and refuses a catalog whose declarations it cannot serve; this carries them faithfully.

## Test plan

Four tests, each mutation-tested by reverting its fix to confirm the test fails without it:

| test | reverting… | fails |
| --- | --- | --- |
| the vocabulary reaches the published file with no annotation present | the merge at its call site | ✓ |
| an omitted block stays absent rather than becoming empty | (covered by the same merge) | ✓ |
| an authored group shelves a component the sticker never annotated | the group override | ✓ |
| a typo'd builder id is reported | the orphan diagnostic | ✓ |

That last one matters more than it looks: an authored entry naming an id no component derives is **reported, not dropped**, for the reason `POLICY_ORPHANED` already gives for an annotation that bound to nothing — a policy naming a component that is not there is a rename that got away, and dropping it leaves the component with a default nobody meant it to have and no symptom at all. A hand-authored vocabulary is exactly where a mistyped id is likely.

`:gradle-plugin:preview-discovery:test` — 563 tests green. ktfmt on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01297vAqLHxgAc6XQuaQYCSe

---
_Generated by [Claude Code](https://claude.ai/code/session_01297vAqLHxgAc6XQuaQYCSe)_