### PR TITLE
fix(figma-svg): don't degrade an export that draws no text

### DIFF
--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeFigmaSvgDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeFigmaSvgDataProduct.kt
@@ -182,7 +182,22 @@ object ComposeFigmaSvgDataProducer {
       fonts?.familyOverrides?.values?.forEach { add(it) }
       addAll(capturedFamilies(model.root))
     }
-    val unnamed = FigmaSvgRenderedFonts.unnamedIn(named)
+    // An export that draws NO TEXT cannot misattribute a face, so it never degrades.
+    //
+    // The branch below exists to stop a wrong face reaching *visible text*. When the SVG carries no
+    // glyphs there is no visible text to get wrong, and degrading anyway produces a tofu face built
+    // from an empty code-point set, a warning sidecar about a face nothing rendered, and a
+    // `bundle pack` that fails over a picture containing no text at all.
+    //
+    // `ScreenEdgeButton` is the case that found this: its layered SVG carries zero `<text>` nodes,
+    // so the render's recorded family had nothing to attach to, `named` came back empty, and every
+    // one of its ~70 variants failed the pack the moment the catalog started drawing a face the
+    // recorder tracks — a vendored variable Roboto Flex (yschimke/wear-m3-catalog#401). Before
+    // that the same export declared a harmless `sans-serif` and passed, so the check was firing on
+    // the font's presence rather than on anything being lost.
+    val emittedCodePoints = codePoints(model.root)
+    val unnamed =
+      if (emittedCodePoints.isEmpty()) emptyList() else FigmaSvgRenderedFonts.unnamedIn(named)
     val svg =
       when {
         // The render drew with a face this export can't name. Emitting the default here is what
@@ -194,8 +209,7 @@ object ComposeFigmaSvgDataProducer {
               family = TofuFont.FAMILY,
               weight = 400,
               italic = false,
-              dataBase64 =
-                Base64.getEncoder().encodeToString(TofuFont.build(codePoints(model.root))),
+              dataBase64 = Base64.getEncoder().encodeToString(TofuFont.build(emittedCodePoints)),
               format = "truetype",
             )
           System.err.println(

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/FigmaSvgTofuFallbackTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/FigmaSvgTofuFallbackTest.kt
@@ -123,6 +123,29 @@ class FigmaSvgTofuFallbackTest {
   }
 
   @Test
+  fun `an export that draws no text does not degrade`() {
+    // The render drew a face the recorder tracks, but this preview emits no glyphs at all — the
+    // shape `ScreenEdgeButton` exports (yschimke/wear-m3-catalog#401). There is no visible text to
+    // put in the wrong typeface, so there is nothing to warn about and nothing to box: degrading
+    // here fails `bundle pack` over a picture that contains no text.
+    FigmaSvgRenderedFonts.record("Roboto Flex")
+
+    ComposeFigmaSvgDataProducer.writeSvg(
+      rootDir = dir,
+      previewId = "textless",
+      layout = layout(),
+      semantics =
+        ComposeSemanticsPayload(
+          ComposeSemanticsNode(nodeId = "root", boundsInRoot = "0,0,200,100")
+        ),
+    )
+
+    val svg = dir.resolve("textless").resolve(ComposeFigmaSvgDataProducer.FILE_SVG).readText()
+    assertFalse("a textless export has nothing to box", svg.contains(TofuFont.FAMILY))
+    assertFalse("and nothing to warn about", warnings("textless").exists())
+  }
+
+  @Test
   fun `a preview that legitimately uses the platform default stays quiet`() {
     // Nothing branded was drawn, so an absent captured family is the truth, not a defect.
     val svg = writeSvg("stock-material")


### PR DESCRIPTION
The lost-font-family check fires on the **render's** recorded face and asks whether the export can name it. An SVG carrying no `<text>` nodes can name nothing — there is no node to carry a family — so the check read "no glyphs emitted" as "the branded face was lost": it boxed a picture containing no text, wrote a warning sidecar naming a face nothing had drawn, and failed `bundle pack`.

The branch exists to stop a wrong face reaching **visible text** — silently substituting the Material default is how a sticker sheet shipped in the wrong typeface. That reasoning needs text to apply to. With no glyphs emitted the tofu face is built from an empty code-point set, and the whole degradation describes nothing.

## How it surfaced

[yschimke/wear-m3-catalog#401](https://github.com/yschimke/wear-m3-catalog/pull/401) vendored a variable Roboto Flex so the Wear type scale's `wght` / `wdth` axes could apply. `ScreenEdgeButton` exports **zero** `<text>` nodes; before that change the same export declared a harmless `sans-serif` and passed. Once the catalog drew a face the recorder tracks, all ~70 of its variants failed the pack — along with `ImageBackgroundButton`, `SingleColumnPicker`, `RadioRow` and `SwitchRow`. **86 previews, not one of which draws any text.** The check was firing on the font's *presence*, not on anything being lost.

Reproduced with the released CLI (`compose-preview 2.4.1`) against that catalog, one preview, before and after the font change:

| `ScreenEdgeButton` figma-svg | before | after |
|---|---|---|
| exit | 0 | **1** |
| SVG | 336 bytes | 1,482 bytes |
| `<text>` nodes | **0** | **0** |
| declared `font-family` | `sans-serif` | `ComposeAI Missing Font` |

```json
{"unnamedRenderedFamilies":["Roboto Flex"],"namedFamilies":[],"tofuFamily":"ComposeAI Missing Font"}
```

`FilledButton` is the control: it has text, and both before and after the export names `Roboto Flex` and embeds the face in a 430 KB SVG with a real `@font-face`. So naming a vendored `res/font` family was never the problem — the exporter handles it correctly whenever there is text to name.

## The change

`unnamed` is computed only when the export actually emits code points, and the tofu face reuses that same set rather than recomputing it.

## Test plan

- New case in `FigmaSvgTofuFallbackTest`: *an export that draws no text does not degrade* — records a tracked family, exports a text-free tree, asserts no tofu family and no warning sidecar.
- Verified the test guards the fix: reverting the one-line guard makes it fail, restoring it makes it pass.
- `./gradlew :data-layoutinspector-connector:test :data-layoutinspector-connector:ktfmtCheckMain :data-layoutinspector-connector:ktfmtCheckTest` — green, all 8 cases in the class including the existing degradation coverage.

Unblocks wear-m3-catalog's hourly design-parity run, which fails at bundle-pack on every execution today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkKpVkVtMQkHK78wJkh1Pe

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkKpVkVtMQkHK78wJkh1Pe)_