### PR TITLE
fix(ui-builder): name a component by what it is, in the record, in the id, and in the file

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -62,6 +62,24 @@ object PreviewDiscovery {
      * by the scanner.
      */
     val dependencyJars: List<File>,
+    /**
+     * Maven coordinate of each [dependencyJars] entry, keyed by absolute path — `group:module` or
+     * anything containing them, as produced by Gradle's `ComponentIdentifier.displayName`.
+     *
+     * Supplied because **a jar's path does not carry its group**. A JVM dependency sits under
+     * `<cache>/modules-2/files-2.1/<group>/<module>/…`, so matching the path was the same as
+     * matching the coordinate; an AAR does not, because AGP's transform extracts it to
+     * `<cache>/transforms/<hash>/transformed/<module>/jars/classes.jar`, keeping only the module
+     * name. `androidx.compose.material3:material3` and
+     * `androidx.wear.compose.remote:remote-material3` are the shapes that exposed it: both are
+     * Compose component libraries, neither module name says so, and both were silently dropped from
+     * the scan classpath on every Android consumer — so every component call into them failed to
+     * resolve and the catalog collapsed onto its own wrapper composable.
+     *
+     * Optional: an entry with no coordinate here falls back to matching on its path, which is still
+     * right for a file dependency or a jar the caller could not attribute.
+     */
+    val dependencyJarCoordinates: Map<String, String> = emptyMap(),
     /** Source files used to attach module-relative `sourceFile` paths to each [PreviewInfo]. */
     val sourceFiles: List<File>,
     /**
@@ -476,6 +494,20 @@ object PreviewDiscovery {
     runCatching { add(file.canonicalPath) }
   }
 
+  /**
+   * Tokens that mark a dependency as one whose classes a preview scan needs to see: the Compose
+   * libraries, the tooling/preview annotations, and the annotation artifacts that carry
+   * multi-preview definitions. Everything else stays off the ClassGraph classpath, which is what
+   * keeps the scan proportional to the previews rather than to the app.
+   */
+  private val PREVIEW_RELEVANT_TOKENS = listOf("preview", "tooling", "compose", "annotation")
+
+  /** Whether [subject] — a coordinate, or a path standing in for one — names such a dependency. */
+  private fun isPreviewRelevant(subject: String): Boolean {
+    val lowered = subject.lowercase()
+    return PREVIEW_RELEVANT_TOKENS.any { it in lowered }
+  }
+
   fun discover(input: Input): Outcome {
     val warnings = mutableListOf<String>()
     val infoMessages = mutableListOf<String>()
@@ -491,7 +523,11 @@ object PreviewDiscovery {
       input.projectClassJars.filter {
         it.exists() && it.isFile && it.name.lowercase().endsWith(".jar")
       }
-    // Match on the absolute path, not just the file name: AGP 9.x +
+    // Prefer the Maven coordinate; fall back to the absolute path when the caller could not
+    // attribute the jar. The path is a poor stand-in for the coordinate on Android and a fine one
+    // on the JVM — see [Input.dependencyJarCoordinates] for why, and for what it cost.
+    //
+    // The path fallback still matches on the whole path rather than the file name: AGP 9.x +
     // KGP 2.3 resolve AAR dependencies to `<cache>/transforms/<hash>/
     // transformed/<library>/jars/classes.jar` where the library name
     // lives in the parent directory, not the filename. Filtering on
@@ -500,13 +536,7 @@ object PreviewDiscovery {
       input.dependencyJars.filter { file ->
         file.exists() &&
           file.name.lowercase().endsWith(".jar") &&
-          run {
-            val path = file.absolutePath.lowercase()
-            path.contains("preview") ||
-              path.contains("tooling") ||
-              path.contains("compose") ||
-              path.contains("annotation")
-          }
+          isPreviewRelevant(input.dependencyJarCoordinates[file.absolutePath] ?: file.absolutePath)
       }
     // Project jars BEFORE dependency jars so a class present in both (the
     // module's own output shadowing a stale dependency copy) is attributed by

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
@@ -493,6 +493,38 @@ object PreviewTargetInference {
                     .filter { it.owner == ownerInternal }
                     .forEach { nestedMethods += MethodKey(it.name, it.desc) }
                 }
+
+                /**
+                 * A singleton lambda reached by READING its field rather than calling its getter.
+                 *
+                 * The getter is what a preview body compiles to, and it was the only edge the walk
+                 * knew. One singleton lambda passing another as content does not go through it:
+                 * `lambda_521476302$lambda$0` reaches `lambda$1915723479` with a GETSTATIC on the
+                 * private field, and the accessor is never called. So the walk stopped at the first
+                 * nested `{ … }` — `DatePickerModalSticker` reaches `DatePicker` through four of
+                 * them and m3-catalog's record carried `DateRangePicker` and neither picker
+                 * (yschimke/m3-catalog#317).
+                 *
+                 * Spelled as the getter call it stands for, so the one place that resolves a lambda
+                 * key keeps being the only one.
+                 */
+                override fun visitFieldInsn(
+                  opcode: Int,
+                  owner: String,
+                  name: String,
+                  descriptor: String,
+                ) {
+                  if (opcode != Opcodes.GETSTATIC) return
+                  if (!name.startsWith("lambda$")) return
+                  val ownerFqnRead = owner.replace('/', '.')
+                  if (".ComposableSingletons$" !in ownerFqnRead) return
+                  calls +=
+                    Invocation(
+                      ownerFqnRead,
+                      "getLambda$" + name.removePrefix("lambda$") + "\$fieldRead",
+                      descriptor,
+                    )
+                }
               }
             }
           },
@@ -605,70 +637,106 @@ object PreviewTargetInference {
     return found
   }
 
-  private fun extractComposeSingletonLambdaCalls(
-    directCalls: List<Invocation>,
-    scanResult: ScanResult,
+  /**
+   * How many singleton lambdas deep the walk goes.
+   *
+   * One hop was the whole of it, and one hop is not what a sticker with a frame does: `Sticker {
+   * KeyboardNavigable { InlineDialogHost { DatePickerDialog { DatePicker() } } } }` lifts each `{ …
+   * }` into its own singleton entry, and each reaches the next. Bounded for the same reason
+   * [PROJECT_COMPOSABLE_MAX_DEPTH] is — a lambda that hands content to a lambda is ordinary, and an
+   * unbounded walk makes discovery cost a function of how deeply a sticker nests.
+   */
+  private const val SINGLETON_LAMBDA_MAX_DEPTH = 4
+
+  /** The singleton lambda a call names, as `owner to key`. */
+  private fun singletonLambdaTargets(
+    calls: List<Invocation>,
     projectClassFqns: Set<String>,
-  ): List<Invocation> =
-    directCalls
-      .asSequence()
+  ): List<Pair<String, String>> =
+    calls
       .filter {
         it.ownerFqn in projectClassFqns &&
           ".ComposableSingletons$" in it.ownerFqn &&
           it.methodName.startsWith("getLambda$")
       }
-      .flatMap { getter ->
-        val lambdaKey = getter.methodName.removePrefix("getLambda$").substringBefore('$')
-        if (lambdaKey.isEmpty()) return@flatMap emptySequence()
-        val lambdaClassPrefix = getter.ownerFqn + "\$lambda\$$lambdaKey\$"
-        val ownerResource = scanResult.getClassInfo(getter.ownerFqn)?.resource
-        if (ownerResource == null) return@flatMap emptySequence()
-        val lambdaClasses =
-          referencedClasses(ownerResource, lambdaClassPrefix)
+      .mapNotNull { getter ->
+        val key = getter.methodName.removePrefix("getLambda$").substringBefore('$')
+        if (key.isEmpty()) null else getter.ownerFqn to key
+      }
+
+  private fun extractComposeSingletonLambdaCalls(
+    directCalls: List<Invocation>,
+    scanResult: ScanResult,
+    projectClassFqns: Set<String>,
+  ): List<Invocation> {
+    val found = mutableListOf<Invocation>()
+    val visited = mutableSetOf<Pair<String, String>>()
+    var frontier = singletonLambdaTargets(directCalls, projectClassFqns)
+    repeat(SINGLETON_LAMBDA_MAX_DEPTH) {
+      val next = mutableListOf<Pair<String, String>>()
+      for (target in frontier) {
+        if (!visited.add(target)) continue
+        val calls = callsInSingletonLambda(target.first, target.second, scanResult)
+        found += calls
+        next += singletonLambdaTargets(calls, projectClassFqns)
+      }
+      frontier = next
+      if (frontier.isEmpty()) return found.distinct()
+    }
+    return found.distinct()
+  }
+
+  /** Every call the singleton lambda [lambdaKey] of [singletonsFqn] makes, from either shape. */
+  private fun callsInSingletonLambda(
+    singletonsFqn: String,
+    lambdaKey: String,
+    scanResult: ScanResult,
+  ): List<Invocation> {
+    val ownerResource = scanResult.getClassInfo(singletonsFqn)?.resource ?: return emptyList()
+    val lambdaClassPrefix = singletonsFqn + "\$lambda\$$lambdaKey\$"
+    val lambdaClasses =
+      referencedClasses(ownerResource, lambdaClassPrefix)
+        .asSequence()
+        .flatMap { lambdaClassFqn ->
+          scanResult
+            .getResourcesWithPathIgnoringAccept(lambdaClassFqn.replace('.', '/') + ".class")
             .asSequence()
-            .flatMap { lambdaClassFqn ->
-              scanResult
-                .getResourcesWithPathIgnoringAccept(lambdaClassFqn.replace('.', '/') + ".class")
-                .asSequence()
-                .map { lambdaClassFqn to it }
-            }
-            .filter { it.second.classpathElementURI == ownerResource.classpathElementURI }
-            .flatMap { (lambdaClassFqn, resource) ->
-              try {
-                extractCalls(
-                    resource = resource,
-                    ownerFqn = lambdaClassFqn,
-                    isRoot = { key ->
-                      key.name == "invoke" &&
-                        "Landroidx/compose/runtime/Composer;" in key.descriptor
-                    },
-                    shouldFollow = { false },
-                  )
-                  .asSequence()
-              } catch (_: Throwable) {
-                emptySequence()
-              }
-            }
-        val lambdaMethods =
+            .map { lambdaClassFqn to it }
+        }
+        .filter { it.second.classpathElementURI == ownerResource.classpathElementURI }
+        .flatMap { (lambdaClassFqn, resource) ->
           try {
-            val bodyPrefix = "_" + normaliseLambdaName(lambdaKey) + "_lambda_"
             extractCalls(
-                resource = ownerResource,
-                ownerFqn = getter.ownerFqn,
+                resource = resource,
+                ownerFqn = lambdaClassFqn,
                 isRoot = { key ->
-                  isSingletonLambdaMethod(key.name, bodyPrefix) &&
-                    "Landroidx/compose/runtime/Composer;" in key.descriptor
+                  key.name == "invoke" && "Landroidx/compose/runtime/Composer;" in key.descriptor
                 },
-                shouldFollow = { key -> isSingletonLambdaMethod(key.name, bodyPrefix) },
+                shouldFollow = { false },
               )
               .asSequence()
           } catch (_: Throwable) {
             emptySequence()
           }
-        lambdaClasses + lambdaMethods
+        }
+    val lambdaMethods =
+      try {
+        val bodyPrefix = "_" + normaliseLambdaName(lambdaKey) + "_lambda_"
+        extractCalls(
+            resource = ownerResource,
+            ownerFqn = singletonsFqn,
+            isRoot = { key ->
+              isSingletonLambdaMethod(key.name, bodyPrefix) &&
+                "Landroidx/compose/runtime/Composer;" in key.descriptor
+            },
+            shouldFollow = { key -> isSingletonLambdaMethod(key.name, bodyPrefix) },
+          )
+          .asSequence()
+      } catch (_: Throwable) {
+        emptySequence()
       }
-      .distinct()
-      .toList()
+    return (lambdaClasses + lambdaMethods).distinct().toList()
+  }
 
   /**
    * Whether [methodName] is the static body of the singleton lambda whose normalised key gives

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
@@ -41,6 +41,7 @@ object PreviewTargetInference {
       "androidx.compose.ui.",
       "androidx.compose.animation.",
       "androidx.wear.compose.material.",
+      "androidx.wear.compose.remote.material3.",
       "androidx.wear.compose.material3.",
       "androidx.wear.compose.foundation.",
       "org.jetbrains.compose.",
@@ -77,6 +78,7 @@ object PreviewTargetInference {
       "androidx.compose.material.",
       "androidx.wear.compose.material3.",
       "androidx.wear.compose.material.",
+      "androidx.wear.compose.remote.material3.",
     )
 
   // Theme entry points inside the component libraries. They pass every other test here — real
@@ -97,6 +99,10 @@ object PreviewTargetInference {
       "androidx.compose.material.MaterialThemeKt.MaterialTheme",
       "androidx.wear.compose.material3.MaterialThemeKt.MaterialTheme",
       "androidx.wear.compose.material.MaterialThemeKt.MaterialTheme",
+      // Remote Compose's own theme entry point. Same role, different spelling — and it earns its
+      // line the same way the four above did: 60 of remote-catalog's previews reported
+      // `RemoteMaterialTheme` as their component before it was listed.
+      "androidx.wear.compose.remote.material3.RemoteMaterialThemeKt.RemoteMaterialTheme",
     )
 
   // Stdlib / JVM / Kotlin-runtime owners. Filtered explicitly so we never attempt to look

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryDependencyCoordinateTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryDependencyCoordinateTest.kt
@@ -1,0 +1,174 @@
+package ee.schimke.composeai.discovery
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Opcodes
+
+/**
+ * The scan-classpath filter must ask what a dependency **is**, not where its cache entry landed.
+ *
+ * A JVM dependency resolves under `<cache>/modules-2/files-2.1/<group>/<module>/…`, so matching the
+ * path was the same as matching the coordinate and the filter looked correct for years. An AAR does
+ * not: AGP extracts it to `<cache>/transforms/<hash>/transformed/<module>/jars/ classes.jar`, which
+ * keeps the module name and **drops the group**. Every Compose component library whose module name
+ * does not itself say "compose" was therefore dropped from the scan classpath on every Android
+ * consumer — `androidx.compose.material3:material3` and
+ * `androidx.wear.compose.remote:remote-material3` among them.
+ *
+ * Measured on `wear-m3-catalog:remote-catalog`, whose 725 previews draw 26 distinct Remote Compose
+ * components: every one of them failed to resolve, so all 49 catalog ids collapsed onto the
+ * project's own `RemoteSticker` wrapper — two component records for the whole module. With the
+ * coordinate supplied, the same run yields 28.
+ *
+ * The observable here is the cheapest one that isolates the filter: put the `@Preview` annotation
+ * class itself in an AAR-shaped jar. On the classpath, discovery resolves it; dropped, discovery
+ * says so in as many words.
+ */
+class PreviewDiscoveryDependencyCoordinateTest {
+
+  @get:Rule val tempDir = TemporaryFolder()
+
+  /** The path AGP's transform produces: the module name, and nothing about its group. */
+  private fun aarShapedJar(module: String): File {
+    val dir = File(tempDir.root, "transforms/8c3a2aab/transformed/$module/jars")
+    dir.mkdirs()
+    return File(dir, "classes.jar")
+  }
+
+  private var runCount = 0
+
+  private fun discoverWith(jar: File, coordinates: Map<String, String>): List<String> {
+    val classDir = tempDir.newFolder("classes-${runCount++}")
+    writeEmptyClass(classDir, "test/Empty")
+    val outcome =
+      PreviewDiscovery.discover(
+        PreviewDiscovery.Input(
+          classDirs = listOf(classDir),
+          dependencyJars = listOf(jar),
+          dependencyJarCoordinates = coordinates,
+          sourceFiles = emptyList(),
+          moduleName = ":remote-catalog",
+          variantName = "debug",
+          projectDirectory = classDir,
+          failOnEmpty = false,
+        )
+      )
+    assertThat(outcome).isInstanceOf(PreviewDiscovery.Outcome.Success::class.java)
+    return (outcome as PreviewDiscovery.Outcome.Success).warnings
+  }
+
+  private val droppedMessage = "@Preview annotation class is not on the ClassGraph classpath"
+
+  @Test
+  fun `an AAR whose module name carries no token is dropped without its coordinate`() {
+    // The control, and the bug as shipped: nothing in
+    // `…/transformed/remote-material3-1.0.0/jars/classes.jar` says "compose", so the path-only
+    // filter drops it and every class it carries goes unseen.
+    val jar = aarShapedJar("remote-material3-1.0.0")
+    writeAnnotationJar(jar)
+
+    assertThat(discoverWith(jar, emptyMap()).joinToString("\n")).contains(droppedMessage)
+  }
+
+  @Test
+  fun `the same AAR is kept once its coordinate names the group`() {
+    val jar = aarShapedJar("remote-material3-1.0.0")
+    writeAnnotationJar(jar)
+
+    val warnings =
+      discoverWith(
+        jar,
+        mapOf(jar.absolutePath to "androidx.wear.compose.remote:remote-material3:1.0.0"),
+      )
+
+    assertThat(warnings.joinToString("\n")).doesNotContain(droppedMessage)
+  }
+
+  @Test
+  fun `androidx compose material3 is the same shape, and was dropped the same way`() {
+    // Not a hypothetical sibling: `androidx.compose.material3:material3` extracts to
+    // `…/transformed/material3/jars/classes.jar`. Every Android consumer of the plugin has been
+    // scanning without Material 3 on the classpath.
+    val jar = aarShapedJar("material3")
+    writeAnnotationJar(jar)
+
+    assertThat(discoverWith(jar, emptyMap()).joinToString("\n")).contains(droppedMessage)
+    assertThat(
+        discoverWith(jar, mapOf(jar.absolutePath to "androidx.compose.material3:material3:1.4.0"))
+          .joinToString("\n")
+      )
+      .doesNotContain(droppedMessage)
+  }
+
+  @Test
+  fun `a jar with no coordinate still falls back to its path`() {
+    // Callers that cannot attribute a jar — a file dependency, a test harness — keep the old
+    // behaviour rather than losing the classpath entirely.
+    val jar = File(tempDir.root, "compose-tooling-preview.jar")
+    writeAnnotationJar(jar)
+
+    assertThat(discoverWith(jar, emptyMap()).joinToString("\n")).doesNotContain(droppedMessage)
+  }
+
+  @Test
+  fun `a coordinate that names nothing preview-related is still dropped`() {
+    // The filter has to keep filtering: an app's own unrelated dependencies stay off the scan
+    // classpath, which is what keeps the scan proportional to the previews.
+    val jar = aarShapedJar("okhttp-5.0.0")
+    writeAnnotationJar(jar)
+
+    assertThat(discoverWith(jar, mapOf(jar.absolutePath to "com.squareup.okhttp3:okhttp:5.0.0")))
+      .isNotEmpty()
+    assertThat(
+        discoverWith(jar, mapOf(jar.absolutePath to "com.squareup.okhttp3:okhttp:5.0.0"))
+          .joinToString("\n")
+      )
+      .contains(droppedMessage)
+  }
+
+  private fun writeAnnotationJar(jar: File) {
+    jar.parentFile.mkdirs()
+    val internalName = "androidx/compose/ui/tooling/preview/Preview"
+    JarOutputStream(jar.outputStream()).use { out ->
+      out.putNextEntry(JarEntry("$internalName.class"))
+      out.write(annotationClassBytes(internalName))
+      out.closeEntry()
+    }
+  }
+
+  private fun annotationClassBytes(internalName: String): ByteArray {
+    val cw = ClassWriter(0)
+    cw.visit(
+      Opcodes.V17,
+      Opcodes.ACC_PUBLIC or Opcodes.ACC_INTERFACE or Opcodes.ACC_ABSTRACT or Opcodes.ACC_ANNOTATION,
+      internalName,
+      null,
+      "java/lang/Object",
+      arrayOf("java/lang/annotation/Annotation"),
+    )
+    cw.visitEnd()
+    return cw.toByteArray()
+  }
+
+  private fun writeEmptyClass(outDir: File, internalName: String) {
+    val cw = ClassWriter(0)
+    cw.visit(
+      Opcodes.V17,
+      Opcodes.ACC_PUBLIC or Opcodes.ACC_FINAL or Opcodes.ACC_SUPER,
+      internalName,
+      null,
+      "java/lang/Object",
+      null,
+    )
+    cw.visitEnd()
+    val classFile = File(outDir, "$internalName.class")
+    classFile.parentFile.mkdirs()
+    classFile.writeBytes(cw.toByteArray())
+  }
+}

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogsTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogsTest.kt
@@ -899,6 +899,64 @@ class UiBuilderCatalogsTest {
     assertThat(menu["wear-m3/button"]?.group).isEqualTo("Overridden")
   }
 
+  /**
+   * A callable the sticker draws but does not declare is still on the sticker's shelf.
+   *
+   * A binding carries a group only for the component it DECLARES. `TopAppBar/Small` draws
+   * `CenterAlignedTopAppBar` and `LargeTopAppBar` on the way past, and both arrived with a null
+   * group — so the chain fell through to `continue` and neither got a menu entry at all. In
+   * m3-catalog that was twenty-eight of a hundred and eight components, filed by the editor under a
+   * generic role heading, while the comment over the loop said the menu covered every admitted
+   * component.
+   */
+  @Test
+  fun `a component the sticker did not declare is shelved by its catalog id`() {
+    val generated =
+      UiBuilderCatalogs.generate(
+        record(
+          component("TopAppBar", catalogId = "TopAppBar/Small", group = "Top app bar"),
+          component("LargeTopAppBar", catalogId = "TopAppBar/Small", group = null),
+        ),
+        cover,
+        policy(),
+      )!!
+
+    val menu = generated.statusSemantics.componentMenu.components
+    assertThat(menu["wear-m3/top-app-bar"]?.group).isEqualTo("Top app bar")
+    assertThat(menu["wear-m3/large-top-app-bar"]?.group).isEqualTo("Top app bar")
+    // The invariant the loop's own comment states, asserted rather than described.
+    assertThat(menu.keys).containsExactlyElementsIn(generated.statusSemantics.components.keys)
+  }
+
+  /**
+   * What the catalog id cannot place, only the policy file can.
+   *
+   * A component no sticker declares has no catalog id and therefore no shelf to inherit —
+   * m3-catalog's `AnimatedPane`, `NavigationSuiteScaffold` and four more. Asserted as absent so the
+   * gap is a stated fact rather than a silently generic heading, and asserted as placeable so the
+   * way out is checked too.
+   */
+  @Test
+  fun `a component no sticker declares is left for the policy file to place`() {
+    val unclaimed = record(component("AnimatedPane", catalogId = null, group = null))
+
+    val bare = UiBuilderCatalogs.generate(unclaimed, cover, policy())!!
+    assertThat(bare.statusSemantics.components.keys).contains("wear-m3/animated-pane")
+    assertThat(bare.statusSemantics.componentMenu.components["wear-m3/animated-pane"]).isNull()
+
+    val placed =
+      UiBuilderCatalogs.generate(
+        unclaimed,
+        cover,
+        policy(
+          components =
+            mapOf("wear-m3/animated-pane" to UiBuilderAuthoredComponent(group = "Layout"))
+        ),
+      )!!
+    assertThat(placed.statusSemantics.componentMenu.components["wear-m3/animated-pane"]?.group)
+      .isEqualTo("Layout")
+  }
+
   @Test
   fun `a starter naming something that is not a parameter is reported`() {
     // A starter value is printed as a NAMED ARGUMENT, so a `lable=` typo is either dropped by a

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogsTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogsTest.kt
@@ -237,7 +237,7 @@ class UiBuilderCatalogsTest {
       )!!
 
     assertThat(generated.catalog.id).isEqualTo("m3-catalog")
-    assertThat(generated.statusSemantics.components.keys).containsExactly("m3/filled")
+    assertThat(generated.statusSemantics.components.keys).containsExactly("m3/button")
   }
 
   @Test
@@ -593,12 +593,26 @@ class UiBuilderCatalogsTest {
     // The consumer shelves an unannotated component by deriving its id from `componentIdPrefix`,
     // exactly as this does — so a collision between two of them is two records claiming one
     // saved-design identity. Excluding them from the check made it blind to most of the shelf.
+    //
+    // Two callables of the same simple name in different packages is what a collision looks like
+    // now that the id is the symbol's rather than a catalog id's last segment. It is the realistic
+    // shape — a `Card` in `material3` and a `Card` in `foundation` — and it is rare, which is the
+    // point: the previous rule collided six unrelated components on `…/filled` because it named
+    // the variant.
+    val foundationCard =
+      component("Card", catalogId = "Layout/Card").let {
+        it.copy(
+          canonicalId = ":catalog/androidx.wear.compose.foundation.CardKt.Card",
+          symbol =
+            it.symbol.copy(
+              jvmOwner = "androidx.wear.compose.foundation.CardKt",
+              callable = "androidx.wear.compose.foundation.Card",
+            ),
+        )
+      }
     val generated =
       UiBuilderCatalogs.generate(
-        record(
-          component("Card", catalogId = "Containment/Card"),
-          component("Card2", catalogId = "Layout/Card"),
-        ),
+        record(component("Card", catalogId = "Containment/Card"), foundationCard),
         cover,
         policy(),
       )!!
@@ -928,8 +942,9 @@ class UiBuilderCatalogsTest {
 
   @Test
   fun `a published entry names the catalog alias of the sticker that declared it`() {
-    // The entry must not contradict its own builder id: keyed `…/tonal` while linking a consumer to
-    // `Buttons/Filled` would land them on a different sticker than the one whose author wrote this.
+    // The entry links a consumer to the sticker whose author wrote this policy, which is still the
+    // declaring one — `Buttons/Tonal`, not the sorted-first `Buttons/Filled`. The id beside it is
+    // the component's, so the two answer different questions and both have to be right.
     val generated =
       UiBuilderCatalogs.generate(
         record(
@@ -945,7 +960,7 @@ class UiBuilderCatalogsTest {
 
     val entry = generated.statusSemantics.components.values.single()
     assertThat(entry.catalogId).isEqualTo("Buttons/Tonal")
-    assertThat(generated.statusSemantics.components.keys.single()).endsWith("/tonal")
+    assertThat(generated.statusSemantics.components.keys.single()).isEqualTo("wear-m3/button")
   }
 
   @Test
@@ -979,9 +994,10 @@ class UiBuilderCatalogsTest {
   @Test
   fun `a derived id comes from the sticker that declared the policy`() {
     // One callable is routinely published under several catalog ids — `Button/Filled` and
-    // `Button/Tonal` over one `Button` — and `componentIds` is the sorted union across previews.
-    // Taking its first would give a policy declared on Tonal the identity `…/filled`, which is the
-    // string every saved design then stores.
+    // `Button/Tonal` over one `Button`. Which of them the id came from used to matter, and picking
+    // wrong renamed the component in every saved design. It no longer arises: the id is the
+    // COMPONENT's symbol, so all three stickers of one `Button` publish `wear-m3/button` and there
+    // is no variant to pick between.
     val generated =
       UiBuilderCatalogs.generate(
         record(
@@ -993,7 +1009,7 @@ class UiBuilderCatalogsTest {
         policy(),
       )!!
 
-    assertThat(generated.statusSemantics.components.keys).containsExactly("wear-m3/tonal")
+    assertThat(generated.statusSemantics.components.keys).containsExactly("wear-m3/button")
   }
 
   @Test
@@ -1237,7 +1253,7 @@ class UiBuilderCatalogsTest {
         policy(),
       )!!
 
-    assertThat(generated.statusSemantics.componentMenu.components["wear-m3/tonal"]?.group)
+    assertThat(generated.statusSemantics.componentMenu.components["wear-m3/button"]?.group)
       .isEqualTo("Selection")
   }
 
@@ -1490,8 +1506,10 @@ class UiBuilderCatalogsTest {
         policy(),
       )!!
 
-    // The id comes from `Buttons/Filled`, so the shelf has to be Filled's.
-    assertThat(generated.statusSemantics.componentMenu.components["wear-m3/filled"]?.group)
+    // The id is the component's now, so it names no alias — but the shelf still has to come from
+    // the alias the id was ATTRIBUTED to (the sorted-first `Buttons/Filled`) rather than from the
+    // first binding, which is preview-id order and would shelve this under Tonal's group.
+    assertThat(generated.statusSemantics.componentMenu.components["wear-m3/button"]?.group)
       .isEqualTo("Actions")
   }
 

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogsTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogsTest.kt
@@ -376,6 +376,39 @@ class UiBuilderCatalogsTest {
       )
   }
 
+  /**
+   * A builtin's traits and modifiers reach the published file.
+   *
+   * A builtin is the only way a catalog offers a component the record cannot carry, so what it
+   * declares is all there is. The consumer (`PublishedUiBuilderCatalog.builtinCapability`) reads
+   * `traits` and `modifierCapabilities`, and this type had neither field and the policy schema
+   * forbade both — so every builtin a schema-valid catalog could publish arrived on the shelf
+   * claiming no traits, which the slot-acceptance rules read as "accepted nowhere".
+   */
+  @Test
+  fun `a builtin publishes the traits and modifiers a catalog states`() {
+    val generated =
+      UiBuilderCatalogs.generate(
+        record(component("Card", catalogId = "Containment/Card", group = "Containment")),
+        cover,
+        policy(
+          builtins =
+            mapOf(
+              "wear-m3/widget-host" to
+                UiBuilderBuiltin(
+                  role = "screen-root",
+                  traits = listOf("WearWidgetHost", "ScreenContent"),
+                  modifierCapabilities = listOf("padding"),
+                )
+            )
+        ),
+      )!!
+
+    val builtin = generated.statusSemantics.builtins.getValue("wear-m3/widget-host")
+    assertThat(builtin.traits).containsExactly("WearWidgetHost", "ScreenContent").inOrder()
+    assertThat(builtin.modifierCapabilities).containsExactly("padding")
+  }
+
   @Test
   fun `a builtin slot names a structural role too`() {
     // The slot's role selects a template exactly as the builtin's own role does. It was checked in

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogsTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogsTest.kt
@@ -620,8 +620,11 @@ class UiBuilderCatalogsTest {
     val collision =
       generated.diagnostics.single { it.code == UiBuilderCatalogs.Diagnostics.ID_COLLISION }
     assertThat(collision.subject).isEqualTo("wear-m3/card")
-    // Neither is annotated, so neither has a policy entry — and the collision is still reported.
-    assertThat(generated.statusSemantics.components).isEmpty()
+    // Exactly one of them owns the id — the first — and the collision is still reported. Both
+    // being named is what makes "which one survives" answerable from the file rather than from
+    // record order.
+    assertThat(generated.statusSemantics.components.getValue("wear-m3/card").record)
+      .isEqualTo(":catalog/androidx.wear.compose.material3.CardKt.Card")
   }
 
   @Test
@@ -1191,8 +1194,11 @@ class UiBuilderCatalogsTest {
           .subject
       )
       .isEqualTo("wear-m3/button")
-    // The loser publishes nothing under the id it lost, and the winner keeps the shelf entry.
-    assertThat(generated.statusSemantics.components).doesNotContainKey("wear-m3/button")
+    // The shelf entry under the contested id belongs to the WINNER, and so does the menu entry.
+    // Stronger than the old "no entry at all": every component is named now, so an id pointing at
+    // the loser's record would be the file itself disagreeing with the diagnostic beside it.
+    assertThat(generated.statusSemantics.components.getValue("wear-m3/button").record)
+      .isEqualTo(":catalog/androidx.wear.compose.material3.ButtonKt.Button")
     assertThat(generated.statusSemantics.componentMenu.components["wear-m3/button"]?.group)
       .isEqualTo("Actions")
   }
@@ -1218,8 +1224,15 @@ class UiBuilderCatalogsTest {
           .map { it.subject }
       )
       .containsExactly("wear-m3/card", "wear-m3/chip")
-    // Still no policy entry: the diagnostics are about the component, the map is about the policy.
-    assertThat(generated.statusSemantics.components).isEmpty()
+    // Both are named, with no policy on either. The map is what says which record an id belongs
+    // to, so an unannotated catalog is exactly the case that must not be missing from it — a
+    // consumer with no entry has to re-derive the id, which is a second answer to one question.
+    assertThat(generated.statusSemantics.components.keys)
+      .containsExactly("wear-m3/card", "wear-m3/chip")
+    assertThat(generated.statusSemantics.components.getValue("wear-m3/card").record)
+      .isEqualTo(":catalog/androidx.wear.compose.material3.CardKt.Card")
+    assertThat(generated.statusSemantics.components.getValue("wear-m3/card").propertyCapabilities)
+      .isNull()
   }
 
   @Test

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -4248,6 +4248,86 @@ class DiscoveryFunctionalTest {
     assertThat(target.parameters.map { it.name }).containsExactly("title")
   }
 
+  /**
+   * Two non-capturing lambdas, one inside the other — a sticker that wraps a frame.
+   *
+   * Each `{ … }` is lifted into its own `ComposableSingletons$…` entry, and the outer one reaches
+   * the inner by reading its FIELD: `lambda_<a>$lambda$0` does a GETSTATIC on the private
+   * `lambda$<b>`, never calling the `getLambda$<b>$…` accessor. The walk only knew the accessor
+   * edge, so it stopped at the first lambda and the component two frames in was invisible.
+   *
+   * The reproduction is m3-catalog's `DatePickerModalSticker` — `Sticker { KeyboardNavigable {
+   * InlineDialogHost { DatePickerDialog { DatePicker() } } } }` — whose record carried
+   * `DateRangePicker` and neither picker (yschimke/m3-catalog#317). Two hops is the smallest shape
+   * that shows it.
+   */
+  @Test
+  fun `composePreviewDiscover looks through a lambda that another lambda holds`() {
+    val projectDir = createCmpTestProject(kotlinVersion = "2.4.10", composeVersion = "1.11.1")
+
+    val srcDir = File(projectDir, "src/main/kotlin/test")
+    File(srcDir, "Previews.kt").delete()
+
+    File(srcDir, "Components.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.material3.Text
+        import androidx.compose.runtime.Composable
+
+        @Composable
+        fun CalendarCard(month: String) {
+            Text(month)
+        }
+        """
+          .trimIndent()
+      )
+
+    File(srcDir, "Previews.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.tooling.preview.Preview
+
+        @Composable
+        fun Sticker(content: @Composable () -> Unit) {
+            content()
+        }
+
+        @Composable
+        fun DialogHost(content: @Composable () -> Unit) {
+            content()
+        }
+
+        @Preview
+        @Composable
+        fun CalendarCardModalPreview() {
+            Sticker { DialogHost { CalendarCard("March") } }
+        }
+        """
+          .trimIndent()
+      )
+
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("composePreviewDiscover", "--stacktrace")
+      .withPluginClasspath()
+      .build()
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+    val target =
+      manifest.previews.single { it.functionName == "CalendarCardModalPreview" }.targets.single()
+    assertThat(target.functionName).isEqualTo("CalendarCard")
+    assertThat(target.sourceFile).contains("Components.kt")
+    assertThat(target.parameters.map { it.name }).containsExactly("month")
+  }
+
   @Test
   fun `composePreviewDiscover emits no target when preview body is purely framework`() {
     // A preview that only calls AndroidX Compose primitives (no project-local composable) gets no

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1257,6 +1257,22 @@ internal object AndroidPreviewSupport {
                 .artifactView { attributes.attribute(artifactType, "android-classes") }
                 .files
             )
+            // Coordinates for the same two views, for the reason given where the main consumer
+            // classpath is wired in [ComposePreviewTasks]: on Android the jar's path names the
+            // module but not its group, so the scan-classpath filter needs the coordinate.
+            for (attributeValue in listOf("jar", "android-classes")) {
+              dependencyJarCoordinates.putAll(
+                stConfig.incoming
+                  .artifactView { attributes.attribute(artifactType, attributeValue) }
+                  .artifacts
+                  .resolvedArtifacts
+                  .map { artifacts ->
+                    artifacts.associate {
+                      it.file.absolutePath to it.id.componentIdentifier.displayName
+                    }
+                  }
+              )
+            }
           }
         }
       }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -1795,6 +1795,29 @@ internal object ComposePreviewTasks {
             }
             .files
         )
+        // The coordinate of every jar the two views above contribute, so the scan-classpath
+        // filter can match on what a dependency IS rather than on where its cache entry landed.
+        // Read from the SAME views, because an AAR's transformed `classes.jar` is the path the
+        // filter sees and the untransformed `.aar` is not — the mismatch
+        // [dependencyClasspathBinding] documents for the bundle's coordinate map. The transformed
+        // artifact keeps its original `componentIdentifier`, so the coordinate is still the Maven
+        // module's. Provider transformations throughout: config-cache-safe, resolved on demand.
+        for (attributeValue in listOf("jar", "android-classes")) {
+          dependencyJarCoordinates.putAll(
+            config.incoming
+              .artifactView {
+                if (useLenient) lenient(true)
+                attributes.attribute(artifactType, attributeValue)
+              }
+              .artifacts
+              .resolvedArtifacts
+              .map { artifacts ->
+                artifacts.associate {
+                  it.file.absolutePath to it.id.componentIdentifier.displayName
+                }
+              }
+          )
+        }
       }
       moduleName.set(project.name)
       variantName.set(extension.variant)

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -15,6 +15,7 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
@@ -84,6 +85,17 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
   @get:InputFiles
   @get:PathSensitive(PathSensitivity.NONE)
   abstract val dependencyJars: ConfigurableFileCollection
+
+  /**
+   * Maven coordinate of each [dependencyJars] entry, keyed by absolute path, so the scan-classpath
+   * filter can ask what a jar *is* instead of guessing from where the cache put it. See
+   * [PreviewDiscovery.Input.dependencyJarCoordinates].
+   *
+   * `@Internal`, deliberately: it is derived from [dependencyJars], which is already tracked as a
+   * `@Classpath`, and its keys are absolute paths — declaring it an input would pin this task's
+   * cache key to one machine's Gradle cache layout for no added coverage.
+   */
+  @get:Internal abstract val dependencyJarCoordinates: MapProperty<String, String>
 
   @get:InputFiles
   @get:PathSensitive(PathSensitivity.RELATIVE)
@@ -307,6 +319,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
       PreviewDiscovery.Input(
         classDirs = classDirs.files.toList() + scopedClassDirs,
         dependencyJars = dependencyJars.files.toList(),
+        dependencyJarCoordinates = dependencyJarCoordinates.getOrElse(emptyMap()),
         sourceFiles = sourceFiles.files.toList(),
         activeSourceFiles = activeSourceFiles.files.toList(),
         moduleName = moduleName.get(),

--- a/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogs.kt
+++ b/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogs.kt
@@ -375,13 +375,24 @@ object UiBuilderCatalogs {
       // catalog, which never reached this loop. The one diagnostic written for that case was the
       // one case it could not fire in.
       diagnose(component, builder, builderId, diagnostics)
+      // EVERY admitted component gets an entry, annotated or not — the same argument as the
+      // `diagnose` call above and the menu loop below, both of which already cover all of them.
+      // The shelf was the odd one out, and the omission was not cosmetic: an entry is where the
+      // file states which record an id belongs to, so a component with no entry is a component the
+      // published file does not NAME. A consumer then has to re-derive the id from the record, and
+      // a second implementation of a derivation is a second answer to it.
+      //
+      // That is not hypothetical. `PublishedUiBuilderCatalog` derives the ids it cannot read, by
+      // the rule this generator used before the id became the component's symbol — so a catalog
+      // that annotates and authors nothing handed the server 27 unnamed components and got 7 id
+      // collisions back on a file this generator had just reported zero for. m3-catalog, 108
+      // unnamed, got 49 and was refused outright. Naming them all is what makes the file
+      // self-describing, and it costs a `{record, displayName}` pair per component.
       val authored = policy.components[builderId]
-      if (component.builder != null || authored != null) {
-        val fromAnnotation =
-          if (component.builder != null) policyFor(component, builder)
-          else UiBuilderComponentPolicy(record = component.canonicalId)
-        components[builderId] = fromAnnotation.mergedWith(authored)
-      }
+      val fromAnnotation =
+        if (component.builder != null) policyFor(component, builder)
+        else UiBuilderComponentPolicy(record = component.canonicalId)
+      components[builderId] = fromAnnotation.mergedWith(authored)
     }
 
     // An authored entry naming an id no component derives.

--- a/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogs.kt
+++ b/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogs.kt
@@ -485,7 +485,7 @@ object UiBuilderCatalogs {
 
   /**
    * The builder id for a record component: the annotation's, else [prefix] plus a slug of the
-   * catalog identity's last segment, else of the symbol's own name.
+   * component symbol's own name, else of the catalog identity's last segment.
    *
    * Derived rather than required so the common case costs nothing, and overridable because a
    * published design stores this string: a component renamed in the catalog can keep the id designs
@@ -507,16 +507,31 @@ object UiBuilderCatalogs {
       ?.let {
         return it
       }
-    // The DECLARING sticker's catalog id, not the record's first alias. One callable is routinely
-    // published under several — `Button/Filled` and `Button/Tonal` over one `Button` — and
-    // `componentIds` is the sorted union across every preview, so the first of it can belong to a
-    // different sticker than the one that declared this policy. The id a saved design stores must
-    // come from the sticker whose author chose it.
-    val leaf =
+    // The COMPONENT's own symbol, not the sticker's catalog id.
+    //
+    // A record is one callable and a catalog publishes several stickers over it — `Button/Filled`,
+    // `Button/Tonal` and `Button/Text` are all `ButtonKt.Button`. Naming the id after a catalog
+    // id's last segment therefore names the VARIANT, so two components sharing a variant word
+    // claim one id: `Button/Filled`, `Card/Filled`, `TextField/Filled`, `IconButton/Filled`,
+    // `ToggleButton/Filled` and `SplitButton/Filled` all derived `m3/filled`. m3-catalog produced
+    // 66 id collisions over 108 records that way, remote-catalog 7 over 27 — and the ids that did
+    // not collide were still the wrong noun for what a design references.
+    //
+    // The symbol is 1:1 with the record by construction, so an id derived from it is unique for
+    // the same reason the record is. It is also the noun the frozen catalogs already use:
+    // `m3/button`, `m3/horizontal-divider`, `m3/list-item`. Nineteen of the twenty-two
+    // hand-authored ids in the frozen m3 capability document come back exactly; the other three
+    // are deliberate renames (`AlertDialog` to `m3/dialog`, `LinearProgressIndicator` to
+    // `m3/progress-indicator`, `SearchBarDefaults.InputField` to `m3/search-input-field`), which
+    // is what `@BuilderComponent(id = …)` above is for.
+    //
+    // The catalog id stays as the fallback for a record whose symbol name is unreadable, so a
+    // catalog that relied on it is not left with no id at all.
+    val fromCatalogId =
       (builder.declaredForCatalogId ?: component.componentIds.firstOrNull())
         ?.substringAfterLast('/')
-        ?.takeIf { it.isNotBlank() } ?: component.symbol.name
-    return "$prefix${slug(leaf)}"
+        ?.takeIf { it.isNotBlank() }
+    return "$prefix${slug(component.symbol.name.takeIf { it.isNotBlank() } ?: fromCatalogId.orEmpty())}"
   }
 
   /**

--- a/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogs.kt
+++ b/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogs.kt
@@ -416,6 +416,29 @@ object UiBuilderCatalogs {
         )
     }
 
+    // One catalog id is one shelf, whoever draws it.
+    //
+    // A binding carries a group only for the component the sticker DECLARES. Every other callable
+    // the preview reaches — `CenterAlignedTopAppBar` and `LargeTopAppBar` under `TopAppBar/Small`,
+    // four floating action buttons under `Fab/Standard`, twenty-two components in m3-catalog —
+    // gets a binding with a null group, so the chain below ran out and `continue` dropped the
+    // entry. The comment under it claimed the menu covered every admitted component; it covered
+    // eighty of a hundred and eight.
+    //
+    // The catalog id is the fact that survives: a component published under `TopAppBar/Small` is
+    // on whatever shelf that catalog id is on, and the sticker that declares it says which. First
+    // writer wins, because two groups for one catalog id is one shelf disagreeing with itself and
+    // taking the later one would make the answer depend on record order.
+    val groupByCatalogId = buildMap {
+      for (component in record.components) {
+        for (binding in component.bindings) {
+          val catalogId = binding.componentId ?: continue
+          val group = binding.group?.takeIf(String::isNotBlank) ?: continue
+          putIfAbsent(catalogId, group)
+        }
+      }
+    }
+
     // The shelf covers EVERY admitted component, so the menu has to as well.
     //
     // `builder.group` was the only source, which meant a menu entry existed solely for a component
@@ -452,6 +475,10 @@ object UiBuilderCatalogs {
             .firstOrNull { it.componentId == idAlias && !it.group.isNullOrBlank() }
             ?.group
           ?: component.bindings.firstNotNullOfOrNull { it.group?.takeIf(String::isNotBlank) }
+          // The shelf of the catalog id this component is published under, stated by whichever
+          // sticker declares it. What is left after this is a component with no catalog id at
+          // all — nothing declares it, so nothing but the policy file can place it.
+          ?: idAlias?.let { groupByCatalogId[it] }
           ?: continue
       menuEntries[builderId] = UiBuilderMenuEntry(group)
     }

--- a/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogs.kt
+++ b/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogs.kt
@@ -428,13 +428,15 @@ object UiBuilderCatalogs {
     // The catalog id is the fact that survives: a component published under `TopAppBar/Small` is
     // on whatever shelf that catalog id is on, and the sticker that declares it says which. First
     // writer wins, because two groups for one catalog id is one shelf disagreeing with itself and
-    // taking the later one would make the answer depend on record order.
+    // taking the later one would make the answer depend on record order. Spelled as a containment
+    // check rather than `putIfAbsent`, which is a JVM-only extension: this file is also compiled
+    // for `wasmJs`, by `:screen-model`.
     val groupByCatalogId = buildMap {
       for (component in record.components) {
         for (binding in component.bindings) {
           val catalogId = binding.componentId ?: continue
           val group = binding.group?.takeIf(String::isNotBlank) ?: continue
-          putIfAbsent(catalogId, group)
+          if (catalogId !in this) put(catalogId, group)
         }
       }
     }

--- a/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/UiBuilderPolicy.kt
+++ b/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/UiBuilderPolicy.kt
@@ -208,8 +208,19 @@ data class UiBuilderBuiltin(
   val displayName: String? = null,
   val group: String? = null,
   val canvas: String? = null,
+  /**
+   * What this builtin IS, for the slot-acceptance rules — a component whose slot accepts
+   * `AnyContent` cannot admit one that claims no traits at all.
+   *
+   * The consumer already reads it; without it here there was no way to write it, so every builtin a
+   * catalog could publish arrived on the shelf with an empty list. The same was true of
+   * [modifierCapabilities].
+   */
+  val traits: List<String> = emptyList(),
   val slots: Map<String, JsonElement> = emptyMap(),
   val properties: List<JsonElement> = emptyList(),
+  /** The modifiers this builtin accepts, or null for the consumer's structural default. */
+  val modifierCapabilities: List<String>? = null,
 )
 
 /**

--- a/scripts/design-artifacts/ui-builder.policy.schema.json
+++ b/scripts/design-artifacts/ui-builder.policy.schema.json
@@ -166,6 +166,7 @@
               "type": "object",
               "additionalProperties": false,
               "properties": {
+                "acceptedRoles": { "type": "array", "items": { "type": "string" } },
                 "acceptedTraits": { "type": "array", "items": { "type": "string" } },
                 "required": { "type": "boolean" },
                 "role": {

--- a/scripts/design-artifacts/ui-builder.policy.schema.json
+++ b/scripts/design-artifacts/ui-builder.policy.schema.json
@@ -154,6 +154,11 @@
             "type": "string",
             "description": "Canvas adapter id, or `placeholder`. Same negotiation as `frame.adapter`: unknown to this build means placeholder plus a log line, never a refused catalog."
           },
+          "traits": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "What this builtin IS, for the slot-acceptance rules: a slot accepting `AnyContent` cannot admit a component that claims no traits. The consumer already reads these and there was no way to write them, so every builtin a catalog could publish arrived on the shelf claiming nothing."
+          },
           "slots": {
             "type": "object",
             "description": "What each of the builtin's slots accepts.",
@@ -185,6 +190,11 @@
                 "notes": { "type": "string" }
               }
             }
+          },
+          "modifierCapabilities": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "The modifiers this builtin accepts. Omit for the consumer's structural default — the leaf or container set — and state `[]` to accept none. It cannot be inferred: whether `fillMaxWidth` means anything on a host frame is editorial rather than structural."
           }
         }
       }


### PR DESCRIPTION
Four defects, all one shape — "the record names the wrong thing" — found by taking `wear-m3-catalog:remote-catalog` and `m3-catalog` all the way from a component record to a composed builder catalog and measuring each step. One commit each.

---

## 1. The scan classpath was filtered by cache path, not by coordinate

An AAR does not carry its group in its path. AGP extracts it to `<cache>/transforms/<hash>/transformed/<module>/jars/classes.jar` — module name kept, **group dropped**. A JVM dependency sits under `<cache>/modules-2/files-2.1/<group>/<module>/…`, where the group is right there.

The filter matched `preview|tooling|compose|annotation` against the **path**, so on the JVM it read the coordinate and on Android it guessed from a module name:

| Coordinate | Path the filter saw | Verdict |
| --- | --- | --- |
| `androidx.wear.compose:compose-material3` | `…/compose-material3-1.7.0-beta02/…` | kept — the module name happens to say "compose" |
| `androidx.compose.material3:material3` | `…/material3/jars/classes.jar` | **dropped** |
| `androidx.wear.compose.remote:remote-material3` | `…/remote-material3-1.0.0-SNAPSHOT/…` | **dropped** |

A dropped jar is invisible to ClassGraph, so every component call into it fails to resolve and the preview falls back to the project's own wrapper. On `remote-catalog` — 725 previews over 49 catalog ids — that produced **2** records, both project composables, with all 49 ids piled onto `RemoteSticker`.

The walk was never the problem: instrumenting `inferComponents` showed 54–92 library calls reached per preview with `resolved=0` on every one.

The task now hands `PreviewDiscovery` each jar's coordinate, from the **same** artifact views that contribute the files — the mismatch `dependencyClasspathBinding` already documents for the bundle's coordinate map. The token list is unchanged; it was being asked about the wrong string.

## 2. A component's builder id named its variant

A record is one callable and a catalog publishes several stickers over it. The id was a slug of the catalog id's **last segment**:

```
Button/Filled, Card/Filled, TextField/Filled,
IconButton/Filled, ToggleButton/Filled, SplitButton/Filled   ->  m3/filled
```

**66 collisions over 108 records in m3-catalog; 7 over 27 in remote-catalog.** A collision decides which component a saved design resolves to.

Deriving from the component's own **symbol** makes the id 1:1 with the record by construction, and it is the noun the frozen capability documents already use. m3-catalog derives **18 of the 22** frozen ids by itself; the other four are deliberate renames stated with `@BuilderComponent(id = …)`, which already wins.

## 3. The published file named only its annotated components

An entry in `statusSemantics.components` is where the file states which record an id belongs to. A component with no entry is one the file does not **name**, so a consumer re-derives the id — and a second implementation of a derivation is a second answer to it.

`PublishedUiBuilderCatalog` does exactly that, by the pre-#2 rule. So a catalog that annotates and authors nothing handed the server a file this generator had just reported zero collisions for, and got back:

```
remote-catalog    27 components ->  7 collisions
m3-catalog       108 components -> 49 collisions, file refused outright
```

The shelf was the odd loop out: `diagnose` above it and the menu loop below it already cover every admitted component. Now the shelf does too — `{record, displayName}` for the plain case, merged with the annotation and authored block where those exist. ~10 KB on a 108-component catalog, and it makes the file self-describing.

## 4. …and the menu named 80 of them

Which the loop's own comment, written in commit 3, claimed it did not do: *"the shelf covers EVERY admitted component, so the menu has to as well."*

A binding carries a group only for the component its sticker **declares**. `TopAppBar/Small` also draws `CenterAlignedTopAppBar`, `LargeTopAppBar`, `MediumTopAppBar` and the search variant; `Fab/Standard` draws four more sizes. Each arrived with a null group, the resolution chain ran out, and `?: continue` dropped the entry — so the editor filed **28 of m3-catalog's 108** under a generic role heading instead of a shelf, which is where a person looks for a component and does not find it.

The catalog id is the fact that survives: a component published under `TopAppBar/Small` belongs on whatever shelf that catalog id is on, and the sticker that declares it says which. First writer wins, so the answer does not depend on record order. That places **22 of the 28**; the other six have no catalog id at all — nothing declares them — so only the policy file can, and both halves are now tests.

## Test plan

- New `PreviewDiscoveryDependencyCoordinateTest` — 5 cases over the real AAR path shape. **Mutation-checked**: reverting the coordinate lookup fails 2 of 5.
- Six `UiBuilderCatalogsTest` cases move to the new id rule. One asserted `m3/filled` under a comment explaining the id should be `m3/button` — that is now what it asserts. The collision fixture needed to still collide: two callables of the same simple name in different packages. **Mutation-checked**: restoring the old derivation fails 5.
- Three more asserted the shelf map was empty for an unannotated catalog; each now asserts something stronger, because there is something to assert. **Mutation-checked**: restoring the guard fails exactly those 3.
- Two new cases for the shelf fallback, one per half, the first also asserting the invariant the comment states — that the menu covers every admitted component. **Mutation-checked**: removing the fallback fails it.
- `:gradle-plugin:test`, `:gradle-plugin:preview-discovery:test`, `ktfmtCheckAll` — green.

### Measured end to end on three real catalogs, through a composite build

| Module | Lane | Records | Id collisions | Named in the file | Shelved in the menu | Composes? |
| --- | --- | --- | --- | --- | --- | --- |
| `wear-m3-catalog:remote-catalog` | Android (AAR) | 2 → **27** | 7 → **0** | 0 → **27** | — | refused → **yes** |
| `wear-m3-catalog:catalog` | Android (AAR) | 78 → **80** | — | — | — | — |
| `m3-catalog:catalog` | JVM / desktop | 108 → 108 | 66 → **0** | 0 → **108** | 80 → **102** | refused → **yes** |

No records lost anywhere. The JVM lane's id set is byte-identical after commit 1 — a no-op there by design, since its paths already carried the group. The six m3-catalog components still unshelved are the ones nothing declares, filed as [yschimke/m3-catalog#323](https://github.com/yschimke/m3-catalog/issues/323).

Downstream integration checks (nowinandroid, androidify, meshcore-mobile, homeassistant-remotecompose, cadence, wear-os-samples ×2, adaptive-apps-samples) all green — those are the Android consumers whose scan classpath grows.

Text-only: no rendered surface changes, only what the record names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01297vAqLHxgAc6XQuaQYCSe