### PR TITLE
fix(deps): take compose-preview-daemon 3.0.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -365,7 +365,7 @@ composeai-contracts = "2.13.0"
 # for the same reason as the contracts above. The Gradle plugin bakes this value in as
 # `PreviewDaemonVersion` and resolves `renderer-*` / `daemon-*` for external consumers at it, and
 # the CLI fetches that release's sidecar archives (`DaemonSidecarProvision`) at it.
-composeai-preview-daemon = "3.0.0"
+composeai-preview-daemon = "3.0.1"
 
 # The preview server, published from yschimke/compose-preview-server since its 2.0.0 — the
 # extraction #4732 planned. This repository no longer owns `cli/serve`: `compose-preview serve`,


### PR DESCRIPTION
Bumps the single `composeai-preview-daemon` pin, 3.0.0 → 3.0.1.

## Why

[compose-preview-daemon v3.0.1](https://github.com/yschimke/compose-preview-daemon/releases/tag/v3.0.1) carries the figma-svg exporter fix, [yschimke/compose-preview-daemon#11](https://github.com/yschimke/compose-preview-daemon/pull/11) (`0104e4f`): an export that draws **no text** no longer degrades to the `ComposeAI Missing Font` tofu fallback. The tofu font is now built from the code points the model actually emits, instead of an empty scan being read as "nothing named, so degrade".

## Why the pin is the whole hop

`composeai-preview-daemon` is what `generatePluginVersionResource` bakes into the plugin jar as `PreviewDaemonVersion`. That value — not `PluginVersion` — is what resolves `data-layoutinspector-connector` (`AndroidPreviewSupport.kt:2019`), `renderer-*` and `daemon-*` for consumers who apply the plugin from Maven, and what the CLI's `DaemonSidecarProvision` fetches sidecar archives at. There is no property or extension override for it, so a downstream repo cannot take the fix by moving a pin of its own.

Concretely: wear-m3-catalog's design-artifacts / design-parity lane runs the CLI at `cli-version: catalog` / `catalog-key: composePreviewPlugin` (2.4.1) with `defer-figma-svg: true`, so the exporter it runs is whatever `PreviewDaemonVersion` that CLI release baked in. Its own `composePreviewDaemon` pin only covers the three artifacts it declares directly. The fix reaches it once a release carries this value.

Renovate would land the same bump on its own, but under `schedule: before 9am on Monday` + `minimumReleaseAge: 7 days` — a week out, with the false-positive degradations continuing in every parity run until then.

## Test plan

- `composeai-preview-daemon` is the single source of truth for the version (`release.yml`, `integration.yml`, `scripts/run-daemon.sh` and `docs/design/REPOSITORY_LAYERS.md` all reference the catalog key, not a literal), so no second value moves with it.
- 3.0.1 is a patch over 3.0.0 with no API change — the release is one bug fix plus daemon sandbox performance work and two internal refactors.
- CI resolves and builds against 3.0.1 across the Gradle jobs; the daemon's Maven Central publish went green at 06:29:53Z and the artifacts sync shortly after, so a resolution failure on the first run is sync lag, not the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkKpVkVtMQkHK78wJkh1Pe

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkKpVkVtMQkHK78wJkh1Pe)_