### PR TITLE
fix(ui-builder): let the policy schema describe the block catalogs use

### DIFF
--- a/gradle-plugin/preview-discovery/build.gradle.kts
+++ b/gradle-plugin/preview-discovery/build.gradle.kts
@@ -98,3 +98,24 @@ composeAiMavenPublishing {
 tasks.named<Jar>("jar").configure {
   manifest { attributes("Main-Class" to "ee.schimke.composeai.discovery.PreviewDiscoveryCli") }
 }
+
+// The published policy schema is a test INPUT, and Gradle cannot know that.
+//
+// `UiBuilderPolicySchemaTest` reads `scripts/design-artifacts/ui-builder.policy.schema.json` and
+// holds it to the serial names of `UiBuilderAuthoredComponent` and `UiBuilderBuiltin`. Without
+// this the test task is up to date after a schema edit — so the one change the test exists to
+// catch is the one change that would not re-run it, which is how a check stops checking.
+tasks.named<Test>("test").configure {
+  inputs
+    .file(
+      // `..` because `gradle-plugin` is an INCLUDED build: its `rootProject` is that directory,
+      // not the repository, and the schema lives beside the other design-artifact scripts at the
+      // top. Resolved wrongly this fails loudly at configuration time rather than silently
+      // skipping the input, which is the failure mode worth having.
+      rootProject.layout.projectDirectory.file(
+        "../scripts/design-artifacts/ui-builder.policy.schema.json"
+      )
+    )
+    .withPropertyName("uiBuilderPolicySchema")
+    .withPathSensitivity(PathSensitivity.RELATIVE)
+}

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/UiBuilderPolicySchemaTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/UiBuilderPolicySchemaTest.kt
@@ -1,0 +1,75 @@
+package ee.schimke.composeai.discovery
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.descriptors.elementNames
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import org.junit.Test
+
+/**
+ * The published policy schema and the type a catalog author writes against must agree.
+ *
+ * They did not, and the way they came apart is the argument for this test.
+ * `UiBuilderPolicy.components` — the block the whole "a catalog describes itself" contract runs on,
+ * and the one m3-catalog uses for all 26 of its entries — was never added to
+ * `scripts/design-artifacts/ui-builder.policy.schema.json`. The schema declares
+ * `additionalProperties: false`, so it did not merely fail to describe the block: it **forbade**
+ * it. Every catalog using the feature was schema-invalid, and nothing said so, because the
+ * JavaScript pre-flight validates by hand and never looks at `components` either.
+ *
+ * The same drift had already happened once, one level down: a builtin's `traits` and
+ * `modifierCapabilities` were read by the consumer, absent from this type, and forbidden by the
+ * schema — see `a builtin publishes the traits and modifiers a catalog states`. Fixing an instance
+ * twice is what a test is for.
+ *
+ * Checked in both directions and against the SERIAL names, which are what a JSON file actually
+ * carries: a field the schema forbids is a catalog that cannot validate, and a schema key no field
+ * reads is a catalog author writing something nothing consumes.
+ */
+class UiBuilderPolicySchemaTest {
+
+  private val schema: JsonObject by lazy {
+    Json.parseToJsonElement(schemaFile().readText()).jsonObject
+  }
+
+  @OptIn(ExperimentalSerializationApi::class)
+  @Test
+  fun `the schema declares every field a component policy serialises`() {
+    assertThat(schemaKeys("components"))
+      .containsExactlyElementsIn(UiBuilderAuthoredComponent.serializer().descriptor.elementNames)
+  }
+
+  @OptIn(ExperimentalSerializationApi::class)
+  @Test
+  fun `the schema declares every field a builtin serialises`() {
+    assertThat(schemaKeys("builtins"))
+      .containsExactlyElementsIn(UiBuilderBuiltin.serializer().descriptor.elementNames)
+  }
+
+  /** The property names the schema allows under one map-valued top-level block. */
+  private fun schemaKeys(block: String): Set<String> =
+    schema["properties"]!!
+      .jsonObject[block]!!
+      .jsonObject["additionalProperties"]!!
+      .jsonObject["properties"]!!
+      .jsonObject
+      .keys
+
+  /**
+   * Walked up from the working directory rather than resolved from a property, so the file is found
+   * whether the test runs from the module directory or the root.
+   */
+  private fun schemaFile(): File {
+    val relative = "scripts/design-artifacts/ui-builder.policy.schema.json"
+    var directory: File? = File(".").absoluteFile
+    while (directory != null) {
+      val candidate = File(directory, relative)
+      if (candidate.isFile) return candidate
+      directory = directory.parentFile
+    }
+    error("could not find $relative from ${File(".").absolutePath}")
+  }
+}

--- a/scripts/design-artifacts/ui-builder.policy.schema.json
+++ b/scripts/design-artifacts/ui-builder.policy.schema.json
@@ -136,9 +136,60 @@
         }
       }
     },
+    "components": {
+      "type": "object",
+      "description": "One entry per component the record already carries, joined to it by `record` and keyed by the builder component id the file publishes. This is where a catalog states the shelf decisions a signature cannot: which group the component sits on, what a design may set on it, what its slots accept, and what draws it on the canvas. It is NOT a second inventory \u2014 an entry naming no record component is reported rather than dropped \u2014 and it is not where a component with no call site goes, which is `builtins`.",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "record": {
+            "type": "string",
+            "description": "The record component's `canonicalId`. The join between policy and inventory, and the only field here that has to agree with another file: without it the consumer derives an id from the symbol, which is right for an unannotated component and wrong for a renamed one."
+          },
+          "group": {
+            "type": "string",
+            "description": "The shelf this component appears on, as `@BuilderComponent(group = \u2026)` would say it. A group no `menu.groupOrder` entry names is appended after the ordered ones and alphabetised."
+          },
+          "displayName": { "type": "string" },
+          "canvas": {
+            "type": "string",
+            "description": "Canvas adapter id, or `placeholder`. Same negotiation as `frame.adapter`: unknown to this build means placeholder plus a log line, never a refused catalog. Stating NOTHING is not neutral \u2014 the component composes to `platformSupported: false` and draws a named placeholder, which is how a whole shelf goes blank with every other field still correct."
+          },
+          "nativeOnly": {
+            "type": "boolean",
+            "description": "Drawn by the native lane and a placeholder on the canvas, deliberately. The honest way to say a component has no browser adapter, as against omitting `canvas` and leaving it ambiguous."
+          },
+          "traits": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "What this component IS, for the slot-acceptance rules \u2014 the same vocabulary a builtin's `traits` uses."
+          },
+          "excluded": {
+            "type": "string",
+            "description": "Kept off the shelf, with the stated reason. The reason is published, so a component missing from a catalog says why rather than looking lost."
+          },
+          "propertyCapabilities": {
+            "type": "array",
+            "items": { "type": "object" },
+            "description": "`PropertyCapabilityV1` entries, carried as raw JSON: the shape belongs to the UI builder, and re-declaring it here would be the second definition of a contract this repository does not own. The preview server validates them when it composes the shelf and refuses a catalog whose declarations it cannot serve."
+          },
+          "slotCapabilities": {
+            "type": "array",
+            "items": { "type": "object" },
+            "description": "`SlotCapabilityV1` entries, carried as raw JSON for the reason `propertyCapabilities` is."
+          },
+          "modifierCapabilities": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Stated as empty means the component accepts no modifier; omitted means the consumer falls back to what the component's structure implies. Two different answers, which is why the field is nullable rather than defaulted."
+          }
+        }
+      }
+    },
     "builtins": {
       "type": "object",
-      "description": "The ONLY components this file may declare, and the reason the restriction exists: a builtin has no call site and therefore cannot be in the record — a screen scaffold the catalog structures around, a shape or an image asset that is not a composable at all. A component that HAS a call site belongs in the record, with `@BuilderComponent` on its sticker for anything the signature cannot say. A builtin must name a structural role, so the template engine knows which template writes it.",
+      "description": "The components this file may declare that are NOT in the record, and the reason the restriction exists: a builtin has no call site and therefore cannot be in the record — a screen scaffold the catalog structures around, a shape or an image asset that is not a composable at all. A component that HAS a call site belongs in the record, with `@BuilderComponent` on its sticker or an entry under `components` for anything the signature cannot say. A builtin must name a structural role, so the template engine knows which template writes it.",
       "additionalProperties": {
         "type": "object",
         "additionalProperties": false,


### PR DESCRIPTION
## What was wrong

`UiBuilderPolicy.components` — the block the whole "a catalog describes itself" contract runs on, and the one m3-catalog uses for all 26 of its entries — was never added to `scripts/design-artifacts/ui-builder.policy.schema.json`.

The schema declares `additionalProperties: false`. So it did not merely fail to describe the block; it **forbade** it. Every catalog using the feature was schema-invalid against the file its own `$schema` points at, and nothing said so, because the JavaScript pre-flight (`validate-ui-builder-policy.mjs`) validates by hand and never looks at `components` either:

```
$ node scripts/design-artifacts/validate-ui-builder-policy.mjs \
    --policy ../m3-catalog/ui-builder.policy.json --strict
../m3-catalog/ui-builder.policy.json: ok (platform mobile).
```

## How it was found

Measuring what a published m3 catalog draws on the browser canvas. The answer is **nothing**: `PublishedUiBuilderCatalog.wasm()` computes `drawn` from the policy's `canvas`, and m3-catalog's policy contains zero occurrences of the field, so all twenty-five drawn components compose to `platformSupported: false` and a named placeholder. That half is [m3-catalog#324](https://github.com/yschimke/m3-catalog/issues/324) — but the reason nobody had typed a `canvas` is here: the schema an author writes against does not admit the block the field lives in.

## The fix, and the test that keeps it fixed

The schema gains `components`, mirroring `UiBuilderAuthoredComponent` field for field, with each description saying what the field decides rather than restating its type. `canvas` in particular says the thing that bit m3-catalog: *stating nothing is not neutral — the component draws a named placeholder, which is how a whole shelf goes blank with every other field still correct.*

The same drift had already happened one level down, in [#5354](https://github.com/yschimke/compose-ai-tools/pull/5354): a builtin's `traits` and `modifierCapabilities` were read by the consumer, absent from the type, and forbidden by the schema. Fixing an instance twice is what a test is for.

`UiBuilderPolicySchemaTest` holds the schema's declared keys to the **serial names** of `UiBuilderAuthoredComponent` and `UiBuilderBuiltin`, in both directions:

- a field the schema forbids is a catalog that cannot validate;
- a schema key no field reads is a catalog author writing something nothing consumes.

Serial names rather than property names, because they are what a JSON file actually carries.

## The input declaration is part of the fix

The schema file is declared as an input of the `test` task. Without it the task is up to date after a schema edit — so the one change the test exists to catch is the one change that would not re-run it. Verified by editing a key and watching the test fail *without* `--rerun-tasks`; before the declaration it passed.

`..` in that path because `gradle-plugin` is an included build: its `rootProject` is that directory, not the repository.

## What this deliberately does not do

Teach the JavaScript pre-flight about `components`. The JSON Schema now covers the block and the drift test guards it against the model; duplicating the field list a third time in `ui-builder-policy.mjs` would be a third thing to keep in step. The pre-flight's own value is the checks a schema cannot express (a trailing slash, a role that selects a template), and none of those apply here yet.

## Test plan

`:gradle-plugin:preview-discovery:test`, `ktfmtCheckAll` — green. The pre-flight re-run over both real catalogs (m3-catalog, wear-m3-catalog's `remote-catalog`) still reports ok, and the schema now parses with `components` declared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01297vAqLHxgAc6XQuaQYCSe

---
_Generated by [Claude Code](https://claude.ai/code/session_01297vAqLHxgAc6XQuaQYCSe)_