### PR TITLE
fix(bundle): forward the font and svg opt-outs to the Android child JVM

### DIFF
--- a/bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/AndroidBundleLaunch.kt
+++ b/bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/AndroidBundleLaunch.kt
@@ -98,6 +98,26 @@ public class AndroidBundleLaunch(
     System.getProperty("composeai.fonts.failOnFallback")?.let {
       put("composeai.fonts.failOnFallback", it)
     }
+    // Same forwarding, for the three the Android renderer and the figma-svg connector also read
+    // off system properties. A `-D` on this process does NOT reach a spawned JVM, so anything the
+    // child reads has to be named here or it silently takes its default:
+    //
+    //   composeai.fonts.offline   GoogleFontInterceptor, AndroidFigmaFontResolver
+    //   composeai.svg.embedFonts  AndroidFigmaFontResolver
+    //   composeai.svg.background  ComposeFigmaSvgDataProduct.PROP_BACKGROUND
+    //
+    // They were missing, so `-Dcomposeai.fonts.offline=true` reached the Gradle render task (which
+    // sets it in `AndroidPreviewClasspath`) and the desktop serve daemon (which forwards it in
+    // `ServeBundleDaemon.desktopFontSystemProperties`) but not ANY Android lane through here —
+    // `bundle render`, `bundle daemon`, or serve's Android backend. An air-gapped Android render
+    // still tried to fetch Google Fonts.
+    //
+    // The real fix is one launch plan owned by the daemon rather than three partial copies
+    // (compose-preview-daemon's docs/design/EMBEDDING.md); until tools adopts it, this closes the
+    // gap where every Android consumer already funnels through.
+    System.getProperty("composeai.fonts.offline")?.let { put("composeai.fonts.offline", it) }
+    System.getProperty("composeai.svg.embedFonts")?.let { put("composeai.svg.embedFonts", it) }
+    System.getProperty("composeai.svg.background")?.let { put("composeai.svg.background", it) }
   }
 
   /**

--- a/bundle/format/src/test/kotlin/ee/schimke/composeai/bundle/AndroidBundleLaunchTest.kt
+++ b/bundle/format/src/test/kotlin/ee/schimke/composeai/bundle/AndroidBundleLaunchTest.kt
@@ -84,6 +84,44 @@ class AndroidBundleLaunchTest {
     }
   }
 
+  /**
+   * The three the Android renderer and the figma-svg connector read off system properties.
+   *
+   * A `-D` on this process does not reach a spawned JVM, so anything the child reads has to be
+   * named in the map explicitly. These were not, so `-Dcomposeai.fonts.offline=true` took effect
+   * under the Gradle render task and on the desktop serve daemon but on no Android lane — an
+   * air-gapped Android render still tried to fetch Google Fonts.
+   *
+   * Table-driven because the failure is per-property and silent: a fourth one added to the child's
+   * read set and forgotten here looks exactly like this did.
+   */
+  @Test
+  fun `font and svg opt-outs are forwarded to the android child when set on this process`() {
+    for (prop in
+      listOf(
+        "composeai.fonts.offline",
+        "composeai.svg.embedFonts",
+        "composeai.svg.background",
+      )) {
+      val saved = System.getProperty(prop)
+      try {
+        System.clearProperty(prop)
+        assertTrue(
+          !AndroidBundleLaunch().robolectricSystemProperties().containsKey(prop),
+          "$prop must be absent when this process does not set it",
+        )
+        System.setProperty(prop, "true")
+        assertEquals(
+          "true",
+          AndroidBundleLaunch().robolectricSystemProperties()[prop],
+          "$prop must reach the child when set here",
+        )
+      } finally {
+        if (saved == null) System.clearProperty(prop) else System.setProperty(prop, saved)
+      }
+    }
+  }
+
   @Test
   fun `robolectric properties pin the sdk, graphics mode, stub application and font shadow`() {
     val body = AndroidBundleLaunch(sdkLevel = 34).robolectricPropertiesBody()


### PR DESCRIPTION
`-Dcomposeai.fonts.offline=true` took effect under the Gradle render task and on the desktop serve daemon, and **on no Android lane at all**. An air-gapped Android render still tried to fetch Google Fonts.

## The bug

A `-D` on this process does not reach a spawned JVM, so anything the child reads has to be named in the map explicitly. Three properties the Android renderer and the figma-svg connector read were not:

| property | read by |
| --- | --- |
| `composeai.fonts.offline` | `GoogleFontInterceptor`, `AndroidFigmaFontResolver` |
| `composeai.svg.embedFonts` | `AndroidFigmaFontResolver` |
| `composeai.svg.background` | `ComposeFigmaSvgDataProduct.PROP_BACKGROUND` |

`robolectricSystemProperties()` already forwarded `composeai.fonts.failOnFallback` exactly this way, so the pattern was there — these three were simply missed.

Every Android consumer funnels through that one method — `bundle render` (`BundleRenderer.spawnAndroidRenderer`), `bundle daemon`, and serve's Android backend (`ServeBundleDaemon:999`) — so fixing it there closes all three lanes at once. The desktop serve lane was never affected: `desktopFontSystemProperties()` forwards all three already, which is what made the asymmetry visible.

## How it was found, and why it recurs

I was auditing the Android launch inputs for the daemon-side launch plan and compared the two copies of that knowledge that exist **inside this repository**:

| | `AndroidPreviewClasspath` (gradle-plugin) | `AndroidBundleLaunch` (bundle/format) |
| --- | --- | --- |
| the five `--add-opens` | ✓ | ✓ |
| the four `robolectric.*` | ✓ | ✓ |
| `composeai.fonts.offline` | ✓ | **✗ — this bug** |
| `composeai.fonts.failOnFallback` | ✗ | ✓ |

`AndroidBundleLaunch`'s own KDoc describes the arrangement: *"The CLI links a different module graph, so we re-declare them here… **Keep them in sync if the plugin side changes.**"* Two copies held together by a comment, and neither lives in the repository that owns the fact — the daemon's Robolectric host. The divergence between them **is** this bug.

The real fix is one launch plan owned by the daemon ([compose-preview-daemon `docs/design/EMBEDDING.md`](https://github.com/yschimke/compose-preview-daemon/blob/main/docs/design/EMBEDDING.md), piece 1). This is the stopgap until tools adopts it, deliberately placed where every Android consumer already passes rather than patched at each call site — a third partial copy is what got us here.

## Test plan

The test is table-driven over the three properties rather than asserting one, because the failure is per-property and silent: a fourth property added to the child's read set and forgotten here would look exactly like this did.

| check | result |
| --- | --- |
| new `font and svg opt-outs are forwarded…` test | pass |
| same test against the **unfixed** method | fails, as intended — verified before landing |
| `:bundle-format:test` | pass |
| `ktfmtCheckAll` | pass |

Non-visual in the sense that no renderer logic changed — but note it *does* change rendered output in the case it fixes: an Android render with `-Dcomposeai.fonts.offline=true` now genuinely stays offline instead of fetching, and `-Dcomposeai.svg.embedFonts=false` now reaches the Android figma-svg export. That is the intended correction, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Py1S7WmQuhF6dFdrmGEqUY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Py1S7WmQuhF6dFdrmGEqUY)_