### PR TITLE
fix: publish design reference match scores

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -4256,6 +4256,26 @@ jobs:
             echo "No design-map.json in this repo — no design references to publish."
             exit 0
           fi
+          # The scorer moved with the server repository (#4732). The export driver deliberately
+          # does not carry a copy, so materialise the asset from the server release this driver is
+          # pinned to before asking it to score. Using the version catalog's server pin keeps the
+          # baked number on the same scorer contract as the released server, while a failed fetch
+          # retains the reference lane's fail-soft behaviour (references still publish unscored).
+          server_version="$(sed -n 's/^composeai-preview-serve = "\(.*\)"$/\1/p' compose-ai-tools/gradle/libs.versions.toml)"
+          server_root="$RUNNER_TEMP/compose-preview-server"
+          server_asset="server/src/main/resources/ee/schimke/composeai/cli/serve/assets/format-compare.js"
+          if [ -n "$server_version" ]; then
+            mkdir -p "$server_root/$(dirname "$server_asset")"
+            if curl -fsSL --retry 3 \
+                -o "$server_root/$server_asset" \
+                "https://raw.githubusercontent.com/yschimke/compose-preview-server/v${server_version}/${server_asset}"; then
+              export COMPOSE_PREVIEW_SERVER_ROOT="$server_root"
+            else
+              echo "::warning title=Preview scorer fetch failed::Design references will publish without a match score."
+            fi
+          else
+            echo "::warning title=Preview scorer version missing::Could not read composeai-preview-serve from the pinned driver's version catalog; design references will publish without a match score."
+          fi
           # Chromium rasterises committed HTML mocks AND scores every published reference against
           # its sticker — the driver drives the viewer's own `format-compare.js` in a headless page
           # rather than reimplementing it, so the baked verdict on the design-spec chip and the


### PR DESCRIPTION
## Summary
- fetch the released preview server’s comparison asset before publishing design references
- pin the asset to the server version carried by the immutable export driver
- preserve fail-soft reference publication if the asset cannot be fetched

This restores `match.percent` in generated `references/index.json`, including the `remote-m3` catalog. The scorer itself already existed, but every external catalog run logged that `format-compare.js` was not where the driver expected after the server repository split.

## Test plan
- parsed `.github/workflows/design-artifacts-reusable.yml` with PyYAML
- ran `.github/ci/test_path_scope.py` (10 passed)
- fetched the v3.22.0 asset through the new pinned URL shape
- ran `node --test scripts/design-artifacts/design-reference-score.test.mjs` against that fetched asset (4 passed)