### PR TITLE
fix(plugin): stop the KMP-Android lane leaking into modules that didn't ask

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -867,7 +867,14 @@ internal object AndroidPreviewSupport {
           // them: `ViewTreeLifecycleOwner.get` reads `androidx.lifecycle.runtime.R.id`, so the
           // first `setContent` dies with `NoClassDefFoundError: androidx/lifecycle/runtime/R$id`.
           // Unlike `withHostTest { }` this is a plain property AGP is happy to see set here.
-          if (extension.enabled.get()) {
+          //
+          // Gated on the OPT-IN, not on `enabled`. `finalizeDsl` runs on every KMP-Android module
+          // the plugin is applied to, including the ones that keep the Desktop lane — and turning
+          // resource processing on there would be a real behaviour change (an existing
+          // `src/androidMain/res` tree starts being processed and packaged) for a module that
+          // never asked for the lane that needs it. The promise is that upgrading the plugin
+          // changes nothing for them.
+          if (extension.enabled.get() && extension.kmpAndroidRobolectric.get()) {
             android.androidResources.enable = true
           }
           // NOT the `isIncludeAndroidResources` flip the classic branch does. `withHostTest { }`
@@ -1329,12 +1336,20 @@ internal object AndroidPreviewSupport {
         ),
       )
     if (isKmp) {
-      // `androidTarget()` + `com.android.library` (issue #1492): target `android`, variant `debug`.
-      sourceClassDirs.from(project.layout.buildDirectory.dir("classes/kotlin/android/$variantName"))
-      // `com.android.kotlin.multiplatform.library` (issue #248): one compilation called `main`
-      // under the same target, whatever the variant is named. Listing both is safe —
-      // [DiscoverPreviewsTask] skips directories that don't exist.
-      sourceClassDirs.from(project.layout.buildDirectory.dir("classes/kotlin/android/main"))
+      // Both KMP shapes, both named after the TARGET rather than hardcoded to `android`: a
+      // consumer who renamed it (`androidTarget("mobile")`, or the KMP-Android plugin under a
+      // renamed target) compiles into `classes/kotlin/mobile/…`, and the render classpath has to
+      // carry it or `composePreviewRender` cannot load a class discovery already found. Listing
+      // both is safe — [DiscoverPreviewsTask] skips directories that don't exist.
+      naming.extraClassDirs.forEach { sourceClassDirs.from(project.layout.buildDirectory.dir(it)) }
+      // The `androidTarget()` + `com.android.library` shape (issue #1492) keeps `android` as its
+      // default target name and the variant as its compilation, which `classic` naming does not
+      // carry — add it here so that path is unchanged.
+      if (naming.extraClassDirs.isEmpty()) {
+        sourceClassDirs.from(
+          project.layout.buildDirectory.dir("classes/kotlin/android/$variantName")
+        )
+      }
     }
     if (screenshotTestEnabled) {
       sourceClassDirs.from(
@@ -3507,7 +3522,7 @@ internal object AndroidPreviewSupport {
           project.files(
             unitTestConfigDir,
             project.layout.buildDirectory.dir(
-              "intermediates/apk_for_local_test/${variantName}UnitTest"
+              naming.apkForLocalTest ?: "intermediates/apk_for_local_test/${variantName}UnitTest"
             ),
             variant.artifacts.get(SingleArtifact.MERGED_MANIFEST),
           ),

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidVariantNaming.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidVariantNaming.kt
@@ -66,10 +66,49 @@ internal data class AndroidVariantNaming(
    * Null when there is no host-test component.
    */
   val unitTestTask: String?,
+  /**
+   * AGP's merged unit-test resource APK directory (`apk_for_local_test`), relative to the build
+   * directory. `BundlePreviewTask` reads the real APK during its action, so this has to be declared
+   * as an input or a resource-only change leaves a cache hit carrying stale resources.
+   */
+  val apkForLocalTest: String?,
+  /**
+   * Extra compiled-class directories beyond the classic AGP ones, relative to the build directory.
+   * On KMP the target's own output lives under `classes/kotlin/<target>/…`, and the target is NOT
+   * always `android` — a consumer who renames it gets `classes/kotlin/mobile/main`, which the
+   * render classpath has to carry or `composePreviewRender` cannot load a class discovery already
+   * found.
+   */
+  val extraClassDirs: List<String>,
 ) {
   val capVariant: String = variantName.replaceFirstChar { it.uppercase() }
 
   companion object {
+    /**
+     * The naming for [variantName] on [project], picking the KMP-Android mapping when that plugin
+     * is applied. The host-test compilation is derived (`<target>HostTest`) and verified against
+     * the configuration it names rather than assumed, because this entry point has no `Variant` to
+     * read `unitTest` off — it exists for callers outside `onVariants`, the Tooling API model
+     * builder above all, which resolves the same configurations for `compose-preview doctor`.
+     */
+    fun forProject(project: org.gradle.api.Project, variantName: String): AndroidVariantNaming {
+      if (!project.pluginManager.hasPlugin("com.android.kotlin.multiplatform.library")) {
+        return classic(variantName)
+      }
+      val target = variantName.removeSuffix("Main").ifEmpty { "android" }
+      val targetName =
+        if (project.configurations.findByName("${target}RuntimeClasspath") != null) target
+        else "android"
+      val hostTest = "${targetName}HostTest"
+      return kmpAndroid(
+        variantName = variantName,
+        targetName = targetName,
+        unitTestName =
+          if (project.configurations.findByName("${hostTest}RuntimeClasspath") != null) hostTest
+          else null,
+      )
+    }
+
     fun classic(variantName: String): AndroidVariantNaming {
       val cap = variantName.replaceFirstChar { it.uppercase() }
       return AndroidVariantNaming(
@@ -82,6 +121,9 @@ internal data class AndroidVariantNaming(
         unitTestConfigDir =
           "intermediates/unit_test_config_directory/${variantName}UnitTest/generate${cap}UnitTestConfig/out",
         unitTestTask = "test${cap}UnitTest",
+        apkForLocalTest = "intermediates/apk_for_local_test/${variantName}UnitTest",
+        // Classic AGP's own class outputs are listed at the call site; KMP adds the target dir.
+        extraClassDirs = emptyList(),
       )
     }
 
@@ -107,6 +149,15 @@ internal data class AndroidVariantNaming(
           if (unitTestName == null || cap == null) null
           else "intermediates/unit_test_config_directory/$unitTestName/generate${cap}Config/out",
         unitTestTask = cap?.let { "test$it" },
+        apkForLocalTest = unitTestName?.let { "intermediates/apk_for_local_test/$it" },
+        extraClassDirs =
+          listOf(
+            // `androidTarget()` + `com.android.library` (issue #1492): compilation named after
+            // the variant.
+            "classes/kotlin/$targetName/$variantName",
+            // `com.android.kotlin.multiplatform.library` (issue #248): one compilation, `main`.
+            "classes/kotlin/$targetName/main",
+          ),
       )
     }
   }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewPlugin.kt
@@ -125,7 +125,15 @@ constructor(
     // vice-versa. Both withPlugin hooks fire when their plugin lands, and
     // the idempotent handlers only run once — whichever fires second is a no-op.
     project.pluginManager.withPlugin("com.android.kotlin.multiplatform.library") {
-      if (!androidConfigured && !kmpAndroidRouting) {
+      // `desktopRegistered` is the third condition and it is load-bearing. Plugin apply order is
+      // the consumer's, and a convention plugin can apply `org.jetbrains.compose` BEFORE
+      // `com.android.kotlin.multiplatform.library` — in which case the compose hook has already
+      // committed to the Desktop lane and registered `composePreviewDiscover` /
+      // `composePreviewRender`
+      // by the time this one fires. Taking the Robolectric lane on top of that would try to
+      // register those same names a second time and fail configuration outright. The module keeps
+      // Desktop instead, which is the pre-existing behaviour for every apply order.
+      if (!androidConfigured && !kmpAndroidRouting && !desktopRegistered) {
         kmpAndroidRouting = true
         // `registerDesktop`, not `desktopHandler`: this IS the fallback, and it has to get past
         // the `kmpAndroidRouting` guard it just set.

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewPlugin.kt
@@ -138,6 +138,25 @@ constructor(
         // `registerDesktop`, not `desktopHandler`: this IS the fallback, and it has to get past
         // the `kmpAndroidRouting` guard it just set.
         AndroidPreviewSupport.configure(project, extension, kmpAndroidFallback = registerDesktop)
+      } else if (desktopRegistered) {
+        // Losing the race is silent otherwise, and silence is the worst outcome here: the
+        // consumer's `kmpAndroidRobolectric = true` is simply ignored and their Android-only
+        // previews fail to render with nothing pointing at why. The flag cannot be read at THIS
+        // moment — `withPlugin` callbacks run while the `plugins { }` block is still applying, so
+        // the `composePreview { }` block has not been evaluated yet — hence the deferred check.
+        // Warning only; it wires no tasks.
+        project.afterEvaluate {
+          if (extension.kmpAndroidRobolectric.getOrElse(false)) {
+            logger.warn(
+              "compose-preview: `composePreview { kmpAndroidRobolectric = true }` is set on " +
+                "'$path', but `org.jetbrains.compose` was applied before " +
+                "`com.android.kotlin.multiplatform.library`, so the Desktop renderer was already " +
+                "wired up by the time the Robolectric lane could claim it. The module is " +
+                "rendering on Desktop. Apply `com.android.kotlin.multiplatform.library` first, or " +
+                "apply `ee.schimke.composeai.preview` after both, to get the Robolectric lane."
+            )
+          }
+        }
       }
     }
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModelBuilder.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModelBuilder.kt
@@ -36,11 +36,11 @@ internal class ComposePreviewModelBuilder : ToolingModelBuilder {
     }
     val variant = resolveVariant(project)
     // NOT `"${'$'}{variant}RuntimeClasspath"`: on a `com.android.kotlin.multiplatform.library`
-    // module the variant is `androidMain` while the configurations are `androidRuntimeClasspath`
-    // and `androidHostTestRuntimeClasspath`, so deriving from the variant resolves nothing and
-    // `compose-preview doctor` reports empty dependency maps — silently, since an empty map is
-    // also what a genuine non-Android module returns. See [AndroidVariantNaming].
-    val naming = AndroidVariantNaming.forProject(project, variant)
+    // module that took the Robolectric lane the variant is `androidMain` while the configurations
+    // are `androidRuntimeClasspath` and `androidHostTestRuntimeClasspath`, so deriving from the
+    // variant resolves nothing and `compose-preview doctor` reports empty dependency maps —
+    // silently, since an empty map is also what a genuine non-Android module returns.
+    val naming = resolveNaming(project, variant)
     val main = resolveConfiguration(project, naming.runtimeClasspath)
     val test =
       naming.unitTestRuntimeClasspath?.let { resolveConfiguration(project, it) } ?: emptyMap()
@@ -161,6 +161,27 @@ internal class ComposePreviewModelBuilder : ToolingModelBuilder {
    * Keeps the doctor's `${variant}RuntimeClasspath` / `${variant}UnitTestRuntimeClasspath` lookups
    * pointing at real configs when the model builder runs before / outside `onVariants`.
    */
+  /**
+   * The AGP name mapping for this project, keyed on the lane it actually renders through.
+   *
+   * The KMP-Android mapping is taken ONLY when the module opted into the Robolectric lane. A
+   * KMP-Android module on the default Desktop lane is not an Android module as far as this model is
+   * concerned — its renderer resolves `jvmRuntimeClasspath` / `desktopRuntimeClasspath`, and
+   * pointing the doctor at `androidRuntimeClasspath` would both snapshot the wrong backend's
+   * dependencies and switch on the Android-only compatibility checks in
+   * [androidPreviewToolingSignals], producing findings about a classpath the renders never touch.
+   * Plugin presence alone is the wrong question; the lane is the right one.
+   */
+  private fun resolveNaming(project: Project, variant: String): AndroidVariantNaming {
+    val robolectric =
+      project.extensions
+        .findByType(PreviewExtension::class.java)
+        ?.kmpAndroidRobolectric
+        ?.getOrElse(false) == true
+    return if (robolectric) AndroidVariantNaming.forProject(project, variant)
+    else AndroidVariantNaming.classic(variant)
+  }
+
   private fun resolveVariant(project: Project): String {
     val ext = project.extensions.findByType(PreviewExtension::class.java) ?: return "debug"
     val target = ext.variant.getOrElse("debug")
@@ -186,9 +207,7 @@ internal class ComposePreviewModelBuilder : ToolingModelBuilder {
     variant: String,
   ): Pair<Boolean?, Boolean?> {
     val isAndroid =
-      project.configurations.findByName(
-        AndroidVariantNaming.forProject(project, variant).runtimeClasspath
-      ) != null
+      project.configurations.findByName(resolveNaming(project, variant).runtimeClasspath) != null
     if (!isAndroid) return null to null
     val ext = project.extensions.findByType(PreviewExtension::class.java) ?: return null to null
     val declared =

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModelBuilder.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModelBuilder.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.plugin.tooling
 
 import ee.schimke.composeai.plugin.AndroidPreviewSupport
+import ee.schimke.composeai.plugin.AndroidVariantNaming
 import ee.schimke.composeai.plugin.PluginVersion
 import ee.schimke.composeai.plugin.PreviewExtension
 import java.io.Serializable
@@ -34,8 +35,15 @@ internal class ComposePreviewModelBuilder : ToolingModelBuilder {
       return ComposePreviewModelData(PluginVersion.value, emptyMap())
     }
     val variant = resolveVariant(project)
-    val main = resolveConfiguration(project, "${variant}RuntimeClasspath")
-    val test = resolveConfiguration(project, "${variant}UnitTestRuntimeClasspath")
+    // NOT `"${'$'}{variant}RuntimeClasspath"`: on a `com.android.kotlin.multiplatform.library`
+    // module the variant is `androidMain` while the configurations are `androidRuntimeClasspath`
+    // and `androidHostTestRuntimeClasspath`, so deriving from the variant resolves nothing and
+    // `compose-preview doctor` reports empty dependency maps — silently, since an empty map is
+    // also what a genuine non-Android module returns. See [AndroidVariantNaming].
+    val naming = AndroidVariantNaming.forProject(project, variant)
+    val main = resolveConfiguration(project, naming.runtimeClasspath)
+    val test =
+      naming.unitTestRuntimeClasspath?.let { resolveConfiguration(project, it) } ?: emptyMap()
     val gradleVersion = org.gradle.util.GradleVersion.current().version
     val (toolingDeclared, enforceTooling) = androidPreviewToolingSignals(project, variant)
     val findings: List<ModuleFinding> =
@@ -46,7 +54,9 @@ internal class ComposePreviewModelBuilder : ToolingModelBuilder {
         previewToolingDeclared = toolingDeclared,
         enforcePreviewToolingDependency = enforceTooling,
         moduleMinSdk = resolveModuleMinSdk(project),
-        libraryMinSdks = resolveLibraryMinSdks(project, "${variant}UnitTestRuntimeClasspath"),
+        libraryMinSdks =
+          naming.unitTestRuntimeClasspath?.let { resolveLibraryMinSdks(project, it) }
+            ?: emptyList(),
       )
     val info: ModuleInfo =
       ModuleInfoData(
@@ -175,7 +185,10 @@ internal class ComposePreviewModelBuilder : ToolingModelBuilder {
     project: Project,
     variant: String,
   ): Pair<Boolean?, Boolean?> {
-    val isAndroid = project.configurations.findByName("${variant}RuntimeClasspath") != null
+    val isAndroid =
+      project.configurations.findByName(
+        AndroidVariantNaming.forProject(project, variant).runtimeClasspath
+      ) != null
     if (!isAndroid) return null to null
     val ext = project.extensions.findByType(PreviewExtension::class.java) ?: return null to null
     val declared =

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/AndroidVariantNamingTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/AndroidVariantNamingTest.kt
@@ -171,4 +171,44 @@ class AndroidVariantNamingTest {
 
     assertThat(extension.kmpAndroidRobolectric.get()).isFalse()
   }
+
+  @Test
+  fun `KMP class dirs and the resource APK follow the target, not the literal android`() {
+    // A renamed target compiles into `classes/kotlin/<target>/…` and packages into
+    // `apk_for_local_test/<hostTest>`. Hardcoding `android` / `${variant}UnitTest` leaves the
+    // render classpath unable to load a class discovery already found, and leaves
+    // `BundlePreviewTask` reading an APK it never declared as an input — a cache hit then keeps
+    // stale resources.
+    val naming =
+      AndroidVariantNaming.kmpAndroid(
+        variantName = "mobileMain",
+        targetName = "mobile",
+        unitTestName = "mobileHostTest",
+      )
+
+    assertThat(naming.extraClassDirs)
+      .containsExactly("classes/kotlin/mobile/mobileMain", "classes/kotlin/mobile/main")
+    assertThat(naming.apkForLocalTest).isEqualTo("intermediates/apk_for_local_test/mobileHostTest")
+  }
+
+  @Test
+  fun `classic AGP contributes no KMP class dirs and keeps its own APK path`() {
+    val naming = AndroidVariantNaming.classic("debug")
+
+    assertThat(naming.extraClassDirs).isEmpty()
+    assertThat(naming.apkForLocalTest).isEqualTo("intermediates/apk_for_local_test/debugUnitTest")
+  }
+
+  @Test
+  fun `forProject falls back to classic naming off a KMP-Android module`() {
+    // The Tooling API model builder has no `Variant` to read `unitTest` off, so it resolves the
+    // mapping from the project. On anything that is not KMP-Android that must be the classic
+    // derivation, unchanged.
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+
+    val naming = AndroidVariantNaming.forProject(project, "debug")
+
+    assertThat(naming.runtimeClasspath).isEqualTo("debugRuntimeClasspath")
+    assertThat(naming.unitTestRuntimeClasspath).isEqualTo("debugUnitTestRuntimeClasspath")
+  }
 }


### PR DESCRIPTION
Follow-up to #5375, which auto-merged while Codex's second review pass was still running. Five findings on its head commit, all verified — one of them is a promise #5375 made and broke.

## The one that matters

**`androidResources.enable` was being forced on before the lane was known.** `finalizeDsl` runs on *every* KMP-Android module the plugin is applied to, including every one that keeps the Desktop lane, and #5375 set the flag from `extension.enabled` alone. So merely upgrading the plugin would start processing and packaging an existing `src/androidMain/res` tree on a module that never asked for the lane that needs it — the exact opposite of what #5375 said, which was that a module that does not ask keeps the Desktop lane it has always had. Now gated on `kmpAndroidRobolectric`.

**The Robolectric lane could also be taken on top of an already-registered Desktop one.** Apply order is the consumer's: a convention plugin can apply `org.jetbrains.compose` before `com.android.kotlin.multiplatform.library`, and then the compose hook has already registered `composePreviewDiscover` / `composePreviewRender` by the time the KMP hook fires. Taking the other lane re-registers those names and fails configuration outright. `desktopRegistered` is now the third condition on that hook, so such a module keeps Desktop — what every apply order gave it before #5375.

## Three places the mapping stopped at the module boundary

- **`ComposePreviewModelBuilder` still derived `${variant}RuntimeClasspath`.** With the variant snapped to `androidMain` it resolved `androidMainRuntimeClasspath` and `androidMainUnitTestRuntimeClasspath`, neither of which exists, so `compose-preview doctor` got empty dependency maps and suppressed every Android compatibility finding on the new lane — silently, since an empty map is also what a genuine non-Android module returns. `AndroidVariantNaming.forProject` is the entry point for callers with no `Variant` to read `unitTest` off; it derives the host-test name and verifies it against the configuration before trusting it.
- **The class-output directory hardcoded `classes/kotlin/android/main`.** A renamed target compiles into `classes/kotlin/<target>/…`, so discovery could find a preview the render classpath could not load.
- **`apk_for_local_test/${variantName}UnitTest` was not the host test's.** `BundlePreviewTask` reads the real APK in its action, so the wrong path leaves a resource-only change out of its declared inputs and a cache hit keeps stale resources in the bundle.

## Test plan

- `:samples:cmp-android-robolectric:composePreviewRenderAll` — still green, one PNG.
- The default lane is unchanged now that resources are no longer forced on: `:samples:cmp-shared` 4 previews, `:samples:cmp-android-only` 0 (the #1852/#1855 fail-soft fixture), `:samples:cmp` 76.
- `AndroidVariantNamingTest` gains the renamed-target class dirs, the host-test APK path, and `forProject`'s classic fallback.
- `:gradle-plugin:test`, `:gradle-plugin:gradle-plugin-config:test`, `ktfmtCheckAll`, `:gradle-plugin:functionalTest --tests '*KmpAndroid*'` green.

Text-only: no rendered surface changes, and the sample's PNG is byte-identical to the one embedded in #5375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkKpVkVtMQkHK78wJkh1Pe

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkKpVkVtMQkHK78wJkh1Pe)_