### PR TITLE
fix(ui-builder): keep an excluded component off the shelf

### DIFF
--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogsTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogsTest.kt
@@ -385,6 +385,44 @@ class UiBuilderCatalogsTest {
    * forbade both — so every builtin a schema-valid catalog could publish arrived on the shelf
    * claiming no traits, which the slot-acceptance rules read as "accepted nowhere".
    */
+  /**
+   * An excluded component gets no shelf entry.
+   *
+   * `excluded` means the consumer refuses to serve it — `PublishedUiBuilderCatalog` skips it and
+   * reports the reason — so a menu entry naming it offers a shelf item that disappears between the
+   * palette and the design. m3-catalog excluding its own `Sticker` and `MaterialExpressiveTheme`
+   * published both under "Badges" anyway, which is how this was found.
+   *
+   * The reason still ships in `statusSemantics.components`, so a component missing from the shelf
+   * can say why rather than looking lost. Only the menu drops it.
+   */
+  @Test
+  fun `an excluded component is not on the menu`() {
+    val generated =
+      UiBuilderCatalogs.generate(
+        record(
+          component("Card", catalogId = "Containment/Card", group = "Containment"),
+          component("Sticker", catalogId = "Containment/Sticker", group = "Containment"),
+        ),
+        cover,
+        policy(
+          componentIdPrefix = "wear-m3/",
+          components =
+            mapOf(
+              "wear-m3/sticker" to
+                UiBuilderAuthoredComponent(excluded = "the catalog's own preview frame")
+            ),
+        ),
+      )!!
+
+    val menu = generated.statusSemantics.componentMenu.components
+    assertThat(menu.keys).contains("wear-m3/card")
+    assertThat(menu.keys).doesNotContain("wear-m3/sticker")
+    // The reason is still published, so the shelf's absence is explained rather than silent.
+    assertThat(generated.statusSemantics.components.getValue("wear-m3/sticker").excluded)
+      .isEqualTo("the catalog's own preview frame")
+  }
+
   @Test
   fun `a builtin publishes the traits and modifiers a catalog states`() {
     val generated =

--- a/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogs.kt
+++ b/screen/generator/src/commonMain/kotlin/ee/schimke/composeai/discovery/UiBuilderCatalogs.kt
@@ -455,6 +455,17 @@ object UiBuilderCatalogs {
     for (component in record.components) {
       val builderId = builderIdFor(idPrefix, component, component.builder ?: BuilderPolicy())
       if (idOwners[builderId] != component.canonicalId) continue
+      // An excluded component gets no shelf entry. The consumer refuses to serve it — that is
+      // what `excluded` means — so a menu naming it offers something no catalog will hand over:
+      // a shelf item that disappears between the palette and the design. m3-catalog excluding
+      // its own `Sticker` and `MaterialExpressiveTheme` published both under "Badges" anyway.
+      //
+      // The reason still ships, in `statusSemantics.components`, so a component missing from the
+      // shelf can say why rather than looking lost. Only the menu drops it.
+      val excluded =
+        policy.components[builderId]?.excluded?.takeIf { it.isNotBlank() }
+          ?: component.builder?.exclude?.takeIf { it.isNotBlank() }
+      if (excluded != null) continue
       // The DECLARING sticker's group, matching the id and `catalogId` derived from the same
       // sticker. One callable is routinely published under several — `Button/Filled` and
       // `Button/Tonal` — and taking the first binding's group shelved a component whose id says


### PR DESCRIPTION
`excluded` means the consumer refuses to serve the component — `PublishedUiBuilderCatalog` skips it and reports the reason — but this generator wrote a **menu entry** for it anyway. A shelf item that disappears between the palette and the design.

## How it was found

Not by reading the code. [m3-catalog#327](https://github.com/yschimke/m3-catalog/pull/327) excludes the catalog's own `Sticker` and `MaterialExpressiveTheme` — neither is a Material component; one is the frame every preview is drawn inside, the other the theme scope wrapping them. I regenerated that catalog's published pair from the branch rather than assuming the change worked, and ran the server's equivalence gates against it:

- the served shelf went from 110 components to **108** — the two exclusions took effect;
- and both were still on the menu, under `Badges`.

```
m3/sticker                   | in componentMenu: True -> {'group': 'Badges'} | excluded declared: True
m3/material-expressive-theme | in componentMenu: True -> {'group': 'Badges'} | excluded declared: True
```

## The fix

The menu loop skips a component with an exclusion reason, from either source — the policy file's `excluded` or the annotation's `exclude`.

The reason still ships in `statusSemantics.components`, which is the point of publishing it: a component missing from the shelf says why rather than looking lost. Only the menu drops it.

## Test plan

`an excluded component is not on the menu` — a two-component record with one excluded, asserting the menu keeps the other, drops the excluded one, and still publishes its reason.

**Falsified before trusting it**: with the skip neutered (`&& false`) the test fails; restored, it passes.

`:gradle-plugin:preview-discovery:test`, `:screen-model:compileKotlinWasmJs` (these sources are shared with the Wasm target, which is how a JVM-only API has bitten this file before), `ktfmtCheckAll` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01297vAqLHxgAc6XQuaQYCSe

---
_Generated by [Claude Code](https://claude.ai/code/session_01297vAqLHxgAc6XQuaQYCSe)_