### PR TITLE
fix(design-artifacts): report the CMP/Wasm first-frame budget, stop gating on it

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -235,7 +235,7 @@ on:
         type: boolean
         default: false
       rc-cmp-wasm-lane:
-        description: "Add the required CMP/Wasm player lane to rc-compare.html. When enabled, its distribution must build and every ir/*.rc must render unless named in rc-cmp-wasm-allowlist. Evidence is uploaded before a failed gate stops publication. No-op for a catalog that ships no ir/*.rc. Stays OFF by default — unlike the two embedded lanes, this one is a gate rather than enrichment: a document the Wasm player cannot draw, or one that misses the first-frame budgets, fails the step and the catalog does not publish. Opt in per catalog once you know what its documents do in that player."
+        description: "Add the required CMP/Wasm player lane to rc-compare.html. When enabled, its distribution must build and every ir/*.rc must render unless named in rc-cmp-wasm-allowlist. Evidence is uploaded before a failed gate stops publication. No-op for a catalog that ships no ir/*.rc. Stays OFF by default — unlike the two embedded lanes, this one is a gate rather than enrichment: a document the Wasm player cannot draw fails the step and the catalog does not publish. The first-frame budgets below are report-only. Opt in per catalog once you know what its documents do in that player."
         required: false
         type: boolean
         default: false
@@ -245,12 +245,12 @@ on:
         type: string
         default: ''
       rc-cmp-wasm-max-cold-first-frame-ms:
-        description: 'Maximum cold CMP/Wasm navigation-to-painted-ready time. The strict lane fails above it.'
+        description: 'Cold CMP/Wasm navigation-to-painted-ready time to report against. REPORT-ONLY: rows above it are named in the job summary and the lane still passes — the budget ran post-merge, so it could only strand a publish, never stop a slow player landing. A missing measurement is still a failure.'
         required: false
         type: number
         default: 10000
       rc-cmp-wasm-max-warm-first-frame-ms:
-        description: 'Maximum cached CMP/Wasm navigation-to-painted-ready time. The strict lane fails above it.'
+        description: 'Cached CMP/Wasm navigation-to-painted-ready time to report against. REPORT-ONLY, on the same terms as the cold budget above.'
         required: false
         type: number
         default: 5000

--- a/scripts/design-artifacts/rc-compare-gate.mjs
+++ b/scripts/design-artifacts/rc-compare-gate.mjs
@@ -60,8 +60,35 @@ export function evaluateCmpWasmGate(expectedIds, rows, allowlist = new Map()) {
   };
 }
 
-/** Add cold/warm first-frame budget failures to an existing strict-lane verdict. */
-export function applyCmpWasmPerformanceBudgets(gate, rows, coldBudgetMs, warmBudgetMs) {
+/**
+ * Measure cold/warm first frames against their budgets — **without gating on them.**
+ *
+ * This used to fail the lane on the slowest single sample, and it is deliberately no longer a
+ * pass/fail signal. The argument is the one [summarizeCmpWasmPixelParity] makes one function down,
+ * and it applies here with less room for doubt.
+ *
+ * The lane runs in the publish job, on `main`, after the change has landed. It could never stop a
+ * slow player arriving — only strand `design-artifacts/<system>` on the last render that happened
+ * to come in under the line, which is the worst of both: the regression ships and the published
+ * catalog stops being refreshed. (Which is what happened: wear-m3-catalog `main` went red on
+ * 10 Sep 2026 for one warm frame at 10,023 ms, on a commit whose entire diff was shelf names in a
+ * JSON policy file, and the catalog bundle was not published.)
+ *
+ * And this measurement is *noisier* than the pixel one it sits beside. A mismatch percentage is a
+ * property of the two images; a first frame is a wall clock on a shared runner, one sample per
+ * document, competing with whatever else that machine is doing. Gating a build on the maximum of
+ * several hundred such samples fails when the runner hiccups and says nothing about the player.
+ *
+ * What stays is everything that is not the verdict. Every row's `cmpWasmFirstFrameMs` is in
+ * `rc-compare-summary.json`, the max and the count are reported here, and rows over budget are
+ * named in the job summary rather than left to be found. **A missing measurement is still a
+ * failure**, and that one is not about speed: it means the lane stopped recording the number, and
+ * a report nobody can read is the one way this check could quietly become nothing.
+ *
+ * A guard that should stop a performance regression has to run on the pull request, against the
+ * change proposing it, and compare like with like — a budget applied post-merge is not that.
+ */
+export function summarizeCmpWasmFirstFrame(gate, rows, coldBudgetMs, warmBudgetMs) {
   gate.performance = {};
   const budgets = [
     ["cold", coldBudgetMs],
@@ -69,35 +96,31 @@ export function applyCmpWasmPerformanceBudgets(gate, rows, coldBudgetMs, warmBud
   ];
   for (const [kind, budget] of budgets) {
     if (budget == null) continue;
-    const measured = rows.filter(
-      (row) => row.cmpWasmRendered && row.cmpWasmStartup === kind,
-    );
+    const measured = rows.filter((row) => row.cmpWasmRendered && row.cmpWasmStartup === kind);
     const slowest = measured.reduce(
       (current, row) =>
         current == null || row.cmpWasmFirstFrameMs > current.cmpWasmFirstFrameMs ? row : current,
       null,
     );
-    gate.performance[kind] =
-      slowest == null
-        ? null
-        : {
-            count: measured.length,
-            maxMs: slowest.cmpWasmFirstFrameMs,
-            budgetMs: budget,
-          };
     if (slowest == null) {
+      gate.performance[kind] = null;
+      // Not a speed judgement: nothing was measured, so there is no report. See above.
       gate.failures.push({
         id: `performance-${kind}`,
         note: `no ${kind} first-frame measurement was recorded`,
       });
-    } else if (slowest.cmpWasmFirstFrameMs > budget) {
-      gate.failures.push({
-        id: `performance-${kind}`,
-        note:
-          `${kind} first frame ${slowest.cmpWasmFirstFrameMs.toFixed(0)} ms exceeds ` +
-          `${budget.toFixed(0)} ms budget (${slowest.id})`,
-      });
+      continue;
     }
+    const over = measured
+      .filter((row) => row.cmpWasmFirstFrameMs > budget)
+      .map((row) => ({ id: row.id, firstFrameMs: row.cmpWasmFirstFrameMs }))
+      .sort((a, b) => b.firstFrameMs - a.firstFrameMs);
+    gate.performance[kind] = {
+      count: measured.length,
+      maxMs: slowest.cmpWasmFirstFrameMs,
+      budgetMs: budget,
+      over,
+    };
   }
   gate.passed = gate.failures.length === 0;
   return gate;
@@ -144,13 +167,18 @@ export function formatCmpWasmGate(gate) {
   for (const entry of gate.allowed) {
     lines.push(`- ${entry.id}: allowed until ${entry.expires} — ${entry.reason} (${entry.note})`);
   }
+  // Report-only, on the same terms as pixel parity below and for the same reason: this lane runs
+  // after the merge, so a budget here can strand a publish and cannot stop a regression.
   for (const kind of ["cold", "warm"]) {
     const performance = gate.performance?.[kind];
-    if (performance) {
-      lines.push(
-        `- ${kind} first frame: ${performance.maxMs.toFixed(0)} ms max / ` +
-          `${performance.budgetMs.toFixed(0)} ms budget (${performance.count} measured)`,
-      );
+    if (!performance) continue;
+    lines.push(
+      `- ${kind} first frame (report-only): ${performance.maxMs.toFixed(0)} ms max / ` +
+        `${performance.budgetMs.toFixed(0)} ms budget (${performance.count} measured, ` +
+        `${performance.over.length} over)`,
+    );
+    for (const row of performance.over) {
+      lines.push(`  · ${row.id}: ${row.firstFrameMs.toFixed(0)} ms`);
     }
   }
   // Report-only, and said out loud rather than left to be found on the page: these rows are how a

--- a/scripts/design-artifacts/rc-compare-gate.test.mjs
+++ b/scripts/design-artifacts/rc-compare-gate.test.mjs
@@ -5,7 +5,7 @@ import path from "node:path";
 import test from "node:test";
 
 import {
-  applyCmpWasmPerformanceBudgets,
+  summarizeCmpWasmFirstFrame,
   evaluateCmpWasmGate,
   formatCmpWasmGate,
   readCmpWasmAllowlist,
@@ -39,30 +39,39 @@ test("pixel parity is reported, never gated", () => {
   assert.match(formatCmpWasmGate(gate), /pixel parity \(report-only\): 2 of 3 row\(s\) above 1%/);
 });
 
-test("cold and warm first-frame budgets fail on the slowest measured render", () => {
+test("a first frame over budget is reported, and does not fail the lane", () => {
   const rows = [
     { id: "cold", cmpWasmRendered: true, cmpWasmStartup: "cold", cmpWasmFirstFrameMs: 9001 },
     { id: "warm-a", cmpWasmRendered: true, cmpWasmStartup: "warm", cmpWasmFirstFrameMs: 1200 },
     { id: "warm-b", cmpWasmRendered: true, cmpWasmStartup: "warm", cmpWasmFirstFrameMs: 5200 },
+    { id: "warm-c", cmpWasmRendered: true, cmpWasmStartup: "warm", cmpWasmFirstFrameMs: 10_023 },
   ];
-  const gate = applyCmpWasmPerformanceBudgets(
+  const gate = summarizeCmpWasmFirstFrame(
     evaluateCmpWasmGate(rows.map((row) => row.id), rows),
     rows,
     10_000,
     5_000,
   );
 
-  assert.equal(gate.passed, false);
-  assert.deepEqual(gate.failures, [
-    {
-      id: "performance-warm",
-      note: "warm first frame 5200 ms exceeds 5000 ms budget (warm-b)",
-    },
-  ]);
+  assert.equal(gate.passed, true);
+  assert.deepEqual(gate.failures, []);
+  assert.equal(gate.performance.cold.maxMs, 9001);
+  assert.deepEqual(gate.performance.cold.over, []);
+  assert.equal(gate.performance.warm.count, 3);
+  assert.equal(gate.performance.warm.maxMs, 10_023);
+  // Every row over the line, slowest first — not just the maximum, which is what the verdict used
+  // to name and is the least useful half of the report.
+  assert.deepEqual(
+    gate.performance.warm.over.map((row) => row.id),
+    ["warm-c", "warm-b"],
+  );
+  const formatted = formatCmpWasmGate(gate);
+  assert.match(formatted, /warm first frame \(report-only\): 10023 ms max \/ 5000 ms budget \(3 measured, 2 over\)/);
+  assert.match(formatted, /· warm-c: 10023 ms/);
 });
 
-test("an enabled first-frame budget requires a measurement", () => {
-  const gate = applyCmpWasmPerformanceBudgets(
+test("an enabled first-frame budget still requires a measurement", () => {
+  const gate = summarizeCmpWasmFirstFrame(
     evaluateCmpWasmGate([], []),
     [],
     10_000,

--- a/scripts/design-artifacts/rc-compare.mjs
+++ b/scripts/design-artifacts/rc-compare.mjs
@@ -48,7 +48,7 @@ import { CHROMIUM_LAUNCH_ARGS } from "./rc-chromium.mjs";
 import { settledScreenshot } from "./rc-settle.mjs";
 import { PARITY_CLOCK_ISO, PARITY_CLOCK_TIMEZONE, pinWallClock } from "./rc-clock.mjs";
 import {
-  applyCmpWasmPerformanceBudgets,
+  summarizeCmpWasmFirstFrame,
   evaluateCmpWasmGate,
   formatCmpWasmGate,
   readCmpWasmAllowlist,
@@ -885,7 +885,7 @@ let cmpWasmGate = null;
 if (REQUIRE_CMP_WASM) {
   try {
     cmpWasmGate = evaluateCmpWasmGate(rcIds, rows, readCmpWasmAllowlist(CMP_WASM_ALLOWLIST));
-    applyCmpWasmPerformanceBudgets(
+    summarizeCmpWasmFirstFrame(
       cmpWasmGate,
       rows,
       CMP_WASM_MAX_COLD_FIRST_FRAME_MS,


### PR DESCRIPTION
`wear-m3-catalog` `main` is red, and the catalog bundle it should have published is not published. The failing step:

```
CMP/Wasm gate: 651/709 rendered, 58 allowlisted, 1 failing
Failing documents — each needs a player fix or an allowlist entry:
  performance-warm
      warm first frame 10023 ms exceeds 5000 ms budget
      (…SliderPreviewsKt.ValueSliderRemote_…VARIANT_continuous-disabled)
```

Every document rendered. Every pixel matched. The commit under test — [wear-m3-catalog#425](https://github.com/yschimke/wear-m3-catalog/pull/425) — changed shelf names in a JSON policy file and nothing else. It cannot make a slider's warm frame take ten seconds.

## The argument is already in the file

One function below the budget, `summarizeCmpWasmPixelParity` carries the reasoning for why the per-preview mismatch check stopped being a gate:

> The check ran in the publish job, on `main`, after the change that moved a number had already landed: it could never stop a regression arriving, only strand `design-artifacts/<system>` on the last render that happened to be under the line. That is the worst of both — the divergence lands anyway, and the published catalog silently rots.

The first-frame budget is the same check in the same job with the same two outcomes, and it has now produced exactly that failure: the (non-existent) regression landed, and the publish is stranded.

It is also **noisier than the check that was already report-only'd**. A mismatch percentage is a property of two images and is reproducible. A first frame is a wall clock on a shared runner — one sample per document, several hundred documents, and the verdict is the maximum of them. Gating on a max-of-N wall clocks fails when the machine hiccups.

## What changes

`applyCmpWasmPerformanceBudgets` → `summarizeCmpWasmFirstFrame`, on the same terms as its pixel sibling.

- **The verdict goes.** A first frame over budget no longer fails the lane or holds back the publish.
- **The measurement gets louder.** The job summary now names *every* row over the budget, slowest first, rather than only the maximum the failure used to quote. Every `cmpWasmFirstFrameMs` stays in `rc-compare-summary.json`.
- **A missing measurement is still a failure.** That one is not a speed judgement: it means the lane stopped recording the number, and a report nobody can read is the one way this check could quietly become nothing.

The two workflow inputs keep their names and defaults and say `REPORT-ONLY` in their descriptions, so a caller reads the truth at the call site.

A guard that should stop a performance regression has to run on the pull request, against the change proposing it, and compare like with like. That is worth building; a post-merge maximum is not it.

## Test plan

`node --test scripts/design-artifacts/rc-compare-gate.test.mjs` — 6 pass.

The budget test is rewritten to the new contract and given a fourth row at the exact 10,023 ms that caused this: the lane passes, `performance.warm.over` names `warm-c` and `warm-b` in that order, and the formatted summary carries both. The missing-measurement test is unchanged and still red-on-absence.

**Falsified before trusting it**: truncate the over-budget list to one entry and the new test fails; restored, it passes.

## Short term

The pin means this does not reach `wear-m3-catalog` until the next release moves `.github/design-artifacts-driver-pin.txt`. Its `main` was unblocked separately by re-running the failed job — the right move for a single noisy wall-clock sample on a JSON-only diff, and the thing this PR exists so nobody has to do again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01297vAqLHxgAc6XQuaQYCSe

---
_Generated by [Claude Code](https://claude.ai/code/session_01297vAqLHxgAc6XQuaQYCSe)_