### PR TITLE
refactor(bundle): take the robolectric flags and font properties from the daemon

### DIFF
--- a/bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/AndroidBundleLaunch.kt
+++ b/bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/AndroidBundleLaunch.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.bundle
 
 import ee.schimke.composeai.daemon.client.AndroidSdk
 import ee.schimke.composeai.daemon.client.RobolectricConfig
+import ee.schimke.composeai.daemon.client.RobolectricLaunch
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.io.composeAiCacheDir
 import java.io.File
@@ -72,68 +73,34 @@ public class AndroidBundleLaunch(
   public val sdkLevel: Int = sdkLevel.coerceIn(MIN_SDK, MAX_SDK)
 
   /**
-   * JVM args the spawned Robolectric process needs on JDK 17+. Mirrors
-   * `AndroidPreviewClasspath.buildJvmArgs()` plus `--enable-native-access` (which the desktop spawn
-   * also passes). Without the `--add-opens` set Robolectric's reflective access into `java.base`
-   * internals fails with `IllegalAccessException` on SDK 36 sandboxes (issue #1328).
+   * JVM args the spawned Robolectric process needs on JDK 17+ — the daemon's, verbatim.
+   *
+   * Without the `--add-opens` set, Robolectric's reflective access into `java.base` internals fails
+   * with `IllegalAccessException` on SDK 36 sandboxes (#1328). Which opens are needed is a property
+   * of the renderer, not of this repository, so the list lives with the renderer.
    */
-  public fun jvmArgs(): List<String> =
-    listOf(
-      "--enable-native-access=ALL-UNNAMED",
-      "--add-opens=java.base/java.io=ALL-UNNAMED",
-      "--add-opens=java.base/java.lang=ALL-UNNAMED",
-      "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED",
-      "--add-opens=java.base/java.nio=ALL-UNNAMED",
-      "--add-opens=java.base/jdk.internal.access=ALL-UNNAMED",
-    )
+  public fun jvmArgs(): List<String> = RobolectricLaunch.jvmArgs()
 
   /**
    * Robolectric render flags — plus the shared GoogleFont download cache dir — shared by the
-   * one-shot renderer ([BundleRenderer]), the detached daemon ([BundleDaemonCommand]), and the
-   * serve host ([ee.schimke.composeai.cli.serve.ServeBundleDaemon], which forwards this map as its
-   * backend `extraSystemProperties`). Mirrors the `robolectric.*` flags and
-   * `composeai.fonts.cacheDir` from `AndroidPreviewClasspath.buildSystemProperties(...)`, so a
-   * downloadable `Font(GoogleFont(...))` resolves the same on a detached/serve render as it does
-   * under Gradle — without it the shadow's cache is disabled and such text silently falls back to
-   * the platform default. The daemon uses just these — it routes previews via
-   * `composeai.daemon.userClassDirs` / `previewsJsonPath`, not the render-batch props.
+   * one-shot renderer ([BundleRenderer]), the detached daemon ([BundleDaemonCommand]) and the serve
+   * host ([ee.schimke.composeai.cli.serve.ServeBundleDaemon], which forwards this map as its
+   * backend `extraSystemProperties`).
+   *
+   * The set is the daemon's. That includes the four properties a `-D` on *this* process cannot
+   * deliver to a spawned one and so have to be named explicitly — `composeai.fonts.failOnFallback`,
+   * `composeai.fonts.offline`, `composeai.svg.embedFonts`, `composeai.svg.background`. Three of
+   * them were missing from this copy, which is how `-Dcomposeai.fonts.offline=true` reached the
+   * Gradle render task and the desktop serve daemon but no Android lane at all, and an air-gapped
+   * Android render still tried to fetch Google Fonts (#5371). Taking the set from the renderer that
+   * reads it is what stops that recurring.
+   *
+   * The one thing added here is [fontsCacheDir], which wins over the daemon's own resolution: a
+   * caller that names a cache directory means it. Unset, the two compute the same path, so a
+   * `bundle`/serve render reuses the faces a pack-time render already downloaded.
    */
-  public fun robolectricSystemProperties(): Map<String, String> = buildMap {
-    put("robolectric.graphicsMode", "NATIVE")
-    put("robolectric.looperMode", "PAUSED")
-    put("robolectric.conscryptMode", "OFF")
-    put("robolectric.pixelCopyRenderMode", "hardware")
-    put("roborazzi.test.record", "true")
-    put("composeai.fonts.cacheDir", fontsCacheDir)
-    // An unresolved downloadable font fails its preview by default (`FontResolutionDiagnostics`).
-    // Forward the opt-out when this process carries it, so a detached/serve operator can set
-    // `-Dcomposeai.fonts.failOnFallback=false` on the CLI JVM and the child daemon honours it —
-    // else a cold-cache render on the live server fails previews with no downgrade path. Unset ⇒
-    // absent ⇒ the renderer's own default (fatal) applies.
-    System.getProperty("composeai.fonts.failOnFallback")?.let {
-      put("composeai.fonts.failOnFallback", it)
-    }
-    // Same forwarding, for the three the Android renderer and the figma-svg connector also read
-    // off system properties. A `-D` on this process does NOT reach a spawned JVM, so anything the
-    // child reads has to be named here or it silently takes its default:
-    //
-    //   composeai.fonts.offline   GoogleFontInterceptor, AndroidFigmaFontResolver
-    //   composeai.svg.embedFonts  AndroidFigmaFontResolver
-    //   composeai.svg.background  ComposeFigmaSvgDataProduct.PROP_BACKGROUND
-    //
-    // They were missing, so `-Dcomposeai.fonts.offline=true` reached the Gradle render task (which
-    // sets it in `AndroidPreviewClasspath`) and the desktop serve daemon (which forwards it in
-    // `ServeBundleDaemon.desktopFontSystemProperties`) but not ANY Android lane through here —
-    // `bundle render`, `bundle daemon`, or serve's Android backend. An air-gapped Android render
-    // still tried to fetch Google Fonts.
-    //
-    // The real fix is one launch plan owned by the daemon rather than three partial copies
-    // (compose-preview-daemon's docs/design/EMBEDDING.md); until tools adopts it, this closes the
-    // gap where every Android consumer already funnels through.
-    System.getProperty("composeai.fonts.offline")?.let { put("composeai.fonts.offline", it) }
-    System.getProperty("composeai.svg.embedFonts")?.let { put("composeai.svg.embedFonts", it) }
-    System.getProperty("composeai.svg.background")?.let { put("composeai.svg.background", it) }
-  }
+  public fun robolectricSystemProperties(): Map<String, String> =
+    RobolectricLaunch.systemProperties() + ("composeai.fonts.cacheDir" to fontsCacheDir)
 
   /**
    * [robolectricSystemProperties] plus the one-shot renderer's batch I/O props: the renderer reads

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -371,7 +371,7 @@ composeai-contracts = "2.14.0"
 # for the same reason as the contracts above. The Gradle plugin bakes this value in as
 # `PreviewDaemonVersion` and resolves `renderer-*` / `daemon-*` for external consumers at it, and
 # the CLI fetches that release's sidecar archives (`DaemonSidecarProvision`) at it.
-composeai-preview-daemon = "3.1.0"
+composeai-preview-daemon = "3.2.0"
 
 # The preview server, published from yschimke/compose-preview-server since its 2.0.0 — the
 # extraction #4732 planned. This repository no longer owns `cli/serve`: `compose-preview serve`,


### PR DESCRIPTION
Finishes what #5379 started, and closes the duplication that produced #5371. Pin bumped 3.1.0 → 3.2.0.

## Why this took two PRs

#5379 could only take the **jar-free** half of the Android launch facts — the `robolectric.properties` bodies, their packages, the SDK range. The rest was reachable only through `DaemonBackend.Android`, which requires an `android.jar` that `AndroidBundleLaunch` does not have and does not need. Threading one through to reach them changed a published constructor that compose-preview-server calls across a repository boundary, so that part was backed out.

compose-preview-daemon 3.2.0 publishes [`RobolectricLaunch`](https://github.com/yschimke/compose-preview-daemon/pull/47): the same facts with no backend and no jar, with `DaemonBackend.Android` delegating to it so a renderer launch and a daemon launch cannot configure Robolectric differently. So the remaining two methods become delegations, and the last of the duplicated knowledge leaves this class.

## What moves

| | |
| --- | --- |
| `jvmArgs()` | → `RobolectricLaunch.jvmArgs()` — which `--add-opens` Robolectric needs is a property of the renderer |
| `robolectricSystemProperties()` | → `RobolectricLaunch.systemProperties()`, plus `fontsCacheDir` |

That second one carries the four properties a `-D` on this process cannot deliver to a spawned one: `composeai.fonts.failOnFallback`, `composeai.fonts.offline`, `composeai.svg.embedFonts`, `composeai.svg.background`. Three were missing from this copy until #5371 — an air-gapped Android render still fetching Google Fonts — and they now come from the renderer that reads them instead of being re-listed here. That is the whole point of the seam: the list cannot go stale relative to its reader.

`fontsCacheDir` still wins over the daemon's own resolution, because a caller that names a cache directory means it. Left unset, the two compute the same path, so a `bundle`/serve render still reuses faces a pack-time render downloaded.

Net: 58 lines out, 25 in.

## No signature change this time

Same constructors, same companion signatures — `checkKotlinAbi` green against the committed dump, so compose-preview-server is unaffected. That was the constraint #5379 established the hard way.

## Test plan

- `:bundle-format:test` — 16/16 green, assertions unchanged. They now pin the daemon's values transitively, including the property-forwarding table from #5371 (set ⇒ forwarded, unset ⇒ absent rather than empty).
- `:bundle-format:checkKotlinAbi` green — published surface untouched.
- `:cli:compileKotlin`, `:render-host:compileKotlin` green.
- Resolved from Maven Central, not a local substitution: I held this push until 3.2.0 finished syncing, so the first CI run resolves the pin.
- `origin/main` merged in (99b81ce) and re-verified on the merged tree.

## What is still duplicated, deliberately

`resolveAndroidJar` keeps its own SDK discovery here. The daemon has `AndroidSdk.discover`, but this signature takes a `FileSystem` that its delegate does not, and dropping a parameter is the published-surface change this PR is specifically avoiding.

The Gradle plugin's `AndroidPreviewClasspath` also still holds a full copy. It is a separate composite build with no daemon dependency, and adopting there would put `daemon-client`, `daemon-core`, kotlinx-serialization and Okio on every consumer's buildscript classpath. Closing it properly needs these facts in an artifact light enough for that — a packaging decision, not a code one.

Text-only evidence: no renderer draws differently — the flags and properties are identical to what this code produced before, which is what the unchanged assertions verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Py1S7WmQuhF6dFdrmGEqUY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Py1S7WmQuhF6dFdrmGEqUY)_