### PR TITLE
test(plugin): fail the build when the gradle lane's robolectric inputs drift

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -62,6 +62,11 @@ dependencies {
   implementation(libs.okhttp)
   compileOnly("com.android.tools.build:gradle:${libs.versions.agp.get()}")
 
+  // Test-only, deliberately: `AndroidPreviewLaunchParityTest` compares this plugin's Robolectric
+  // launch inputs against the renderer's own `RobolectricLaunch`. A `testImplementation` keeps the
+  // daemon client, its core and their transitives off every consumer's buildscript classpath, which
+  // is the reason this module still holds its own copy of those values at all.
+  testImplementation(libs.composeai.daemon.client)
   testImplementation(libs.junit)
   testImplementation(libs.truth)
   testImplementation(gradleTestKit())

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/AndroidPreviewLaunchParityTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/AndroidPreviewLaunchParityTest.kt
@@ -1,0 +1,98 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.daemon.client.RobolectricLaunch
+import org.junit.Test
+
+/**
+ * The Gradle lane's Robolectric launch inputs, checked against the renderer's own.
+ *
+ * ### Why this test exists instead of a shared dependency
+ *
+ * These values are facts about the renderer, and compose-preview-daemon publishes them as
+ * `RobolectricLaunch` precisely so that nobody keeps a second copy. `bundle/format` now takes them
+ * from there (#5382). This module cannot: the Gradle plugin is a separate composite build with no
+ * daemon dependency, and adding one would put `daemon-client`, `daemon-core`, kotlinx-serialization
+ * and Okio on **every consumer's buildscript classpath** — a real cost paid by every project
+ * applying the plugin, to save a few dozen lines here.
+ *
+ * So the copy stays and the *drift* is what gets removed. The dependency is test-only, and these
+ * assertions fail the build when the two sets stop agreeing.
+ *
+ * That drift is not hypothetical: three properties the Android renderer reads
+ * (`composeai.fonts.offline`, `composeai.svg.embedFonts`, `composeai.svg.background`) were
+ * forwarded on this lane and missing from the CLI's copy, so an air-gapped Android render still
+ * fetched Google Fonts (#5371). The two copies were kept in sync by a KDoc comment asking the
+ * reader to keep them in sync.
+ */
+class AndroidPreviewLaunchParityTest {
+
+  /** All four forwarded properties set, so the renderer's map is at its full width. */
+  private fun rendererProperties(): Map<String, String> {
+    val forwarded =
+      listOf(
+        "composeai.fonts.offline",
+        "composeai.svg.embedFonts",
+        "composeai.svg.background",
+        "composeai.fonts.failOnFallback",
+      )
+    val saved = forwarded.associateWith { System.getProperty(it) }
+    return try {
+      forwarded.forEach { System.setProperty(it, "set-for-parity") }
+      RobolectricLaunch.systemProperties()
+    } finally {
+      saved.forEach { (name, value) ->
+        if (value == null) System.clearProperty(name) else System.setProperty(name, value)
+      }
+    }
+  }
+
+  private fun pluginProperties(): Map<String, String> =
+    AndroidPreviewClasspath.buildSystemProperties(
+      manifestPath = "/build/previews.json",
+      rendersDir = "/build/renders",
+      fontsCacheDir = "/cache/fonts",
+      fontsOffline = "false",
+    )
+
+  @Test
+  fun `the add-opens set is the renderer's`() {
+    val rendererOpens = RobolectricLaunch.jvmArgs().filter { it.startsWith("--add-opens") }
+
+    assertThat(AndroidPreviewClasspath.buildJvmArgs())
+      .containsExactlyElementsIn(rendererOpens)
+      .inOrder()
+  }
+
+  /**
+   * The one deliberate difference, asserted so it stays deliberate: a Gradle render runs in a
+   * `Test` task's forked JVM, whose launcher this plugin does not own, while the CLI and daemon
+   * lanes build their own command line and pass `--enable-native-access` on it.
+   */
+  @Test
+  fun `the renderer's jvm args differ only by enable-native-access`() {
+    assertThat(RobolectricLaunch.jvmArgs() - AndroidPreviewClasspath.buildJvmArgs().toSet())
+      .containsExactly("--enable-native-access=ALL-UNNAMED")
+  }
+
+  @Test
+  fun `the robolectric flags are the renderer's, value for value`() {
+    val renderer = rendererProperties()
+    val plugin = pluginProperties()
+
+    for (key in
+      renderer.keys.filter { it.startsWith("robolectric.") || it.startsWith("roborazzi.") }) {
+      assertThat(plugin).containsEntry(key, renderer.getValue(key))
+    }
+  }
+
+  /**
+   * The #5371 guard. A property the renderer reads but a lane never sets is silent: the child JVM
+   * takes its default and the render is subtly wrong rather than failing. Adding one to the
+   * renderer's set without adding it here fails this test.
+   */
+  @Test
+  fun `every property the renderer reads is set on this lane too`() {
+    assertThat(pluginProperties().keys).containsAtLeastElementsIn(rendererProperties().keys)
+  }
+}


### PR DESCRIPTION
Closes the last copy of the Android launch facts — the one #5379 and #5382 both deliberately left alone.

## The call, and why

The Gradle plugin keeps its own `--add-opens` set, `robolectric.*` flags, and the list of properties the render JVM reads off system properties. compose-preview-daemon publishes those as `RobolectricLaunch` and `bundle/format` now takes them from there (#5382), but **this module should not**: it is a separate composite build with no daemon dependency, and adding one would put `daemon-client`, `daemon-core`, kotlinx-serialization and Okio on **every consumer's buildscript classpath**. Every project applying the plugin would pay that, to save a few dozen lines here. I considered publishing a light facts-only artifact instead and rejected it too: the types would have to move packages (two artifacts sharing one package is the split-package problem `daemon-client`'s own build file warns about), which breaks an API released hours ago and buys a deprecation cycle for a problem that isn't the dependency.

The problem was never that two copies exist. It is that they drift **silently**. So the copy stays and the drift goes.

## How

`testImplementation(libs.composeai.daemon.client)` — test-only, reaching no consumer — and four assertions:

| assertion | catches |
| --- | --- |
| the `--add-opens` set is the renderer's, in order | an open added for a new Robolectric/JDK combination on one lane only |
| the two differ by exactly `--enable-native-access` | that known difference becoming accidental |
| every `robolectric.*` / `roborazzi.*` value matches | a flag changing meaning on one side |
| every property the renderer reads is set here too | **#5371** |

That last one is the real guard. A property the renderer reads but a lane never sets is *silent*: the child JVM takes its default and the render is subtly wrong rather than failing. That is exactly how `composeai.fonts.offline`, `composeai.svg.embedFonts` and `composeai.svg.background` ended up forwarded on this lane and on no Android lane at all, with an air-gapped render still fetching Google Fonts. Until now the two copies were kept in sync by a KDoc comment asking the reader to keep them in sync.

The `--enable-native-access` difference is deliberate and now asserted rather than assumed: a Gradle render runs inside a `Test` task's forked JVM whose launcher this plugin does not own, while the CLI and daemon lanes build their own command line.

## Test plan

- `:gradle-plugin:test --tests '*AndroidPreviewLaunchParityTest*'` — 4/4 green.
- **Verified by breaking it first.** Dropping one `--add-opens` and one forwarded property from `AndroidPreviewClasspath` fails three of the four assertions; both restored, all green again. A parity test that cannot fail is worse than none.
- `ktfmtCheckAll` green.

One note for whoever runs this locally: `-p gradle-plugin :test` hits a pre-existing configuration-cache problem in `:daemon-launch-builder:generateDaemonLaunchSchemaMetadata` ("cannot serialize Gradle script object references"), unrelated to this change and present on `main`. `--no-configuration-cache` works around it. Worth a separate look.

Text-only evidence: a test-only change; no renderer draws differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Py1S7WmQuhF6dFdrmGEqUY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Py1S7WmQuhF6dFdrmGEqUY)_