### PR TITLE
fix(build): stop the schema-metadata task capturing the build script

### DIFF
--- a/gradle-plugin/daemon-launch-builder/build.gradle.kts
+++ b/gradle-plugin/daemon-launch-builder/build.gradle.kts
@@ -77,16 +77,24 @@ val daemonLaunchSchemaMetadata = daemonLaunchSchemaResourcesDir.map {
 }
 val generateDaemonLaunchSchemaMetadata =
   tasks.register("generateDaemonLaunchSchemaMetadata") {
-    inputs.property("schemaVersion", daemonDescriptorSchemaVersion)
+    // Both values are read into locals of this configuration block *before* `doLast` closes over
+    // them. A top-level `val` in a Kotlin build script compiles to a property of the script object,
+    // so referring to one directly from an execution-time action captures the script itself — which
+    // the configuration cache cannot serialize ("cannot serialize Gradle script object
+    // references"), failing the build for every task in this composite. Locals are captured by
+    // value, and a `Provider` is a type the cache knows how to store.
+    val schemaVersion = daemonDescriptorSchemaVersion
+    val outputFile = daemonLaunchSchemaMetadata
+    inputs.property("schemaVersion", schemaVersion)
     outputs.dir(daemonLaunchSchemaResourcesDir)
     doLast {
-      val output = daemonLaunchSchemaMetadata.get().asFile
+      val output = outputFile.get().asFile
       output.parentFile.mkdirs()
       output.writeText(
         """
         {
           "schema": "compose-preview-daemon-launch",
-          "schemaVersion": $daemonDescriptorSchemaVersion
+          "schemaVersion": $schemaVersion
         }
         """
           .trimIndent() + "\n"

--- a/usage-source-psi/src/main/kotlin/ee/schimke/composeai/usagepsi/UsageSourceAnalyzer.kt
+++ b/usage-source-psi/src/main/kotlin/ee/schimke/composeai/usagepsi/UsageSourceAnalyzer.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.usagepsi
 
+import org.jetbrains.kotlin.CoreEnvironmentDeprecation
 import org.jetbrains.kotlin.K1Deprecation
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
@@ -42,7 +43,16 @@ import org.jetbrains.kotlin.psi.KtValueArgument
  * This hands over the receiver as an exact string so the caller can look it up, which is precisely
  * what the regex it replaces could not do.
  */
-@OptIn(CompilerConfiguration.Internals::class, K1Deprecation::class)
+// `CoreEnvironmentDeprecation` arrived with Kotlin 2.4.20:
+// `KotlinCoreEnvironment.createForProduction`
+// now carries an opt-in marker ("planned to be reworked"), which is a hard compile error without
+// this. The call is still the supported way to stand up a parse-only frontend — see
+// `docs/design/PSI_PARSE_SPIKE.md` — so this opts in rather than changing how the parser is built.
+@OptIn(
+  CompilerConfiguration.Internals::class,
+  K1Deprecation::class,
+  CoreEnvironmentDeprecation::class,
+)
 class UsageSourceAnalyzer : AutoCloseable {
 
   private val disposable: Disposable = Disposer.newDisposable("usage-source-psi")


### PR DESCRIPTION
The configuration-cache failure flagged in #5390.

## What was broken

`:daemon-launch-builder:generateDaemonLaunchSchemaMetadata` failed with `cannot serialize Gradle script object references`. Because that happens while *storing* the cache, it failed the whole composite build — `-p gradle-plugin :test` could not run at all without `--no-configuration-cache`, which is how the parity test in #5390 had to be run locally.

## Why

A Kotlin DSL detail, not anything about this task. A top-level `val` in a build script compiles to a **property of the script object**, so reading one from an execution-time action closes over the script itself — and the script is not something the configuration cache can serialize. `doLast` referenced `daemonLaunchSchemaMetadata` and `daemonDescriptorSchemaVersion` directly, so the task dragged the script into the cache entry.

## The fix

Read both into locals of the configuration block before `doLast` closes over them. Locals are captured by value, and a `Provider` is a type the cache knows how to store. Three lines, with a comment recording why they exist so nobody inlines them back.

## Test plan

- **Reproduced first**: `-p gradle-plugin :daemon-launch-builder:generateDaemonLaunchSchemaMetadata` → `1 problem was found storing the configuration cache`, `BUILD FAILED`.
- Same command after the change → `BUILD SUCCESSFUL`.
- The real proof is reuse, not just storage: `-p gradle-plugin :test --tests '*AndroidPreviewLaunchParityTest*'` stores the entry on the first run and reports **`Configuration cache entry reused`** on the second, with the cache enabled and no `--no-configuration-cache`.
- `:daemon-launch-builder:build` green; the generated `daemon-launch-schema.json` is byte-identical (`{"schema": "compose-preview-daemon-launch", "schemaVersion": 2}`).
- `ktfmtCheckAll` green.

## Separate, pre-existing, not fixed here

`-p gradle-plugin :validatePlugins` fails on `main` as well — I confirmed it with this change reverted:

```
Type 'ee.schimke.composeai.plugin.RobolectricRenderTask' must be annotated either
with @CacheableTask or with @DisableCachingByDefault
```

It is a one-annotation fix, but which annotation is a real decision about whether that task's output should be build-cached, so it belongs in its own change rather than folded into this one.

Text-only evidence: a build-script change; no renderer draws differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Py1S7WmQuhF6dFdrmGEqUY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Py1S7WmQuhF6dFdrmGEqUY)_