### PR TITLE
fix(usage-source-psi): register an extensions storage before parsing

### DIFF
--- a/usage-source-psi/src/main/kotlin/ee/schimke/composeai/usagepsi/UsageSourceAnalyzer.kt
+++ b/usage-source-psi/src/main/kotlin/ee/schimke/composeai/usagepsi/UsageSourceAnalyzer.kt
@@ -2,12 +2,15 @@ package ee.schimke.composeai.usagepsi
 
 import org.jetbrains.kotlin.CoreEnvironmentDeprecation
 import org.jetbrains.kotlin.K1Deprecation
+import org.jetbrains.kotlin.cli.extensionsStorage
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.com.intellij.openapi.Disposable
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
 import org.jetbrains.kotlin.com.intellij.psi.PsiFileFactory
 import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.idea.KotlinFileType
 import org.jetbrains.kotlin.psi.KtCallExpression
@@ -52,6 +55,7 @@ import org.jetbrains.kotlin.psi.KtValueArgument
   CompilerConfiguration.Internals::class,
   K1Deprecation::class,
   CoreEnvironmentDeprecation::class,
+  ExperimentalCompilerApi::class,
 )
 class UsageSourceAnalyzer : AutoCloseable {
 
@@ -61,7 +65,14 @@ class UsageSourceAnalyzer : AutoCloseable {
     val env =
       KotlinCoreEnvironment.createForProduction(
         disposable,
-        CompilerConfiguration(),
+        // Kotlin 2.4.20 reads `configuration.extensionsStorage` while wiring compiler-plugin
+        // extension points, and a bare `CompilerConfiguration()` carries none — every parse dies
+        // on `IllegalStateException: Extensions storage is not registered`. Parsing needs no
+        // plugins, so an empty storage is the whole fix. The property exists in 2.4.10 too, so
+        // this is not a version-gated branch.
+        CompilerConfiguration().apply {
+          extensionsStorage = CompilerPluginRegistrar.ExtensionStorage()
+        },
         EnvironmentConfigFiles.JVM_CONFIG_FILES,
       )
     PsiFileFactory.getInstance(env.project)


### PR DESCRIPTION
`KotlinCoreEnvironment.createForProduction` reads `configuration.extensionsStorage` while wiring compiler-plugin extension points. A bare `CompilerConfiguration()` carries none, and on Kotlin 2.4.20 that is fatal:

```
java.lang.IllegalStateException: Extensions storage is not registered
  at ExtensionPointUtilsKt.getCompilerExtensions(ExtensionPointUtils.kt:14)
  at KotlinCoreEnvironment$Companion.configureProjectEnvironment(KotlinCoreEnvironment.kt:654)
  at KotlinCoreEnvironment$Companion.createForProduction(KotlinCoreEnvironment.kt:435)
```

Every `UsageSourceAnalyzer` parse dies in the constructor, so the analyzer yields nothing and each consumer's assertions fail.

**Why this repository is green and still has the bug.** Not the Kotlin version — `main` is already on 2.4.20 (#5385). It is coverage: `usage-source-psi` has `src/main` and nothing else, no test source set, and no other module here references `UsageSourceAnalyzer`. The class is built and published from here and exercised nowhere in this repository.

Where it *is* exercised is compose-preview-server, which vendors this file under a hash pin (`usage-source-psi/upstream.json`) and has **21 tests** failing on it: `UsageSourceParserTest`, `PreviewUsageIndexTest`, `PlaygroundSourceCleanerTest`, and the PSI spike. The pin is why the fix belongs here — the consumer cannot edit the file without failing its vendor gate.

Parsing needs no compiler plugins, so an empty `ExtensionStorage` is the entire fix. `extensionsStorage` is present in 2.4.10 as well as 2.4.20, so this is not a version-gated branch.

## Test plan

- `./gradlew :usage-source-psi:build` — BUILD SUCCESSFUL. Worth being honest about what that does and does not prove: with no test source set it establishes compilation, not behaviour.
- `./gradlew :usage-source-psi:ktfmtFormatMain` clean.
- The behavioural evidence is downstream: applying this exact change to the vendored copy in a compose-preview-server checkout takes `:server:test` from 21 failures to none across all four affected test classes.

That asymmetry — a module whose only coverage lives in the repository that vendors it — is worth a follow-up on its own, and is how a fatal bug in it shipped green. Out of scope here.

Non-visual change, so no render evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dZ7SNn7muC8ahNUuXJ5tz