### PR TITLE
fix(deps): update compose-preview-daemon to v3.3.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -371,7 +371,7 @@ composeai-contracts = "2.16.0"
 # for the same reason as the contracts above. The Gradle plugin bakes this value in as
 # `PreviewDaemonVersion` and resolves `renderer-*` / `daemon-*` for external consumers at it, and
 # the CLI fetches that release's sidecar archives (`DaemonSidecarProvision`) at it.
-composeai-preview-daemon = "3.2.0"
+composeai-preview-daemon = "3.3.0"
 
 # The preview server, published from yschimke/compose-preview-server since its 2.0.0 — the
 # extraction #4732 planned. This repository no longer owns `cli/serve`: `compose-preview serve`,


### PR DESCRIPTION
## Why

Picks up the Kotlin Multiplatform `:data-preview-overrides-runtime` from [compose-preview-daemon#58](https://github.com/yschimke/compose-preview-daemon/pull/58), released as [v3.3.0](https://github.com/yschimke/compose-preview-daemon/releases/tag/v3.3.0).

The published module now carries a common variant alongside the JVM ones it already had:

```
metadataApiElements        common
metadataSourcesElements    common
jvmApiElements-published   jvm      <- unchanged
jvmRuntimeElements-published jvm    <- unchanged
wasmJsApiElements-published wasm
…
```

That is the last blocker to a single shared-source catalog: `previewOverride*` is now callable from a KMP consumer's `commonMain`, so one set of preview bodies can render on Android (Robolectric), CMP desktop and wasm. Measured on a 26-file port of the `wear-m3-catalog` components into `commonMain`, the `overrides` import and the four `previewOverride*` helpers accounted for all 27 remaining compile errors; against 3.3.0 that consumer compiles clean on both its `desktop` (jvm) and `android` targets.

No JVM consumer sees a changed type — `PreviewOverrideOption`'s JVM binding is an `actual typealias` to the existing `:data-preview-overrides-core` class, and the JVM variants keep their coordinates and their `api` edge.

Also rolls up 3.2.1 from the same line.

## Test plan

- `./gradlew build -x test` — zero compile errors, no unresolved dependencies; every `ee.schimke.composeai:*` coordinate resolves at 3.3.0.
- Pre-existing sandbox limitation, unrelated to this pin: `:kotlinWasmToolingSetup` cannot fetch the karma tarball from `codeload.github.com` here (the proxy answers 403), which in turn fails `:cli:serve-wasm:wasmJsBrowserTest`. With that task excluded the rest of `build -x test --continue` is green. CI has real network.

Dependency bump only — no render behaviour changes, so no visual evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkKpVkVtMQkHK78wJkh1Pe

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkKpVkVtMQkHK78wJkh1Pe)_