### PR TITLE
feat(remote-json): compile named integer expressions with an explicit profile

### DIFF
--- a/remotecompose/json/README.md
+++ b/remotecompose/json/README.md
@@ -1,0 +1,60 @@
+# Remote Compose JSON compiler
+
+`RemoteComposeJson.compile(source)` assembles authoring JSON into standard `.rc` bytes on a plain
+JVM. Without `compilerProfile`, it uses AndroidX's unextended authoring parser. `dump(bytes)` is
+operation-level inspection JSON, not an editable source round trip.
+
+## Named integer expressions
+
+Use the explicit top-level profile `compose-preview-integer-expressions-v1` when an integer state
+value needs a computed expression, for example to select a StateLayout branch. This profile is an
+extension provided by this compiler; it is not accepted by AndroidX's unextended JSON parser.
+An unknown profile fails compilation. The profile name describes the source compiler, separately
+from the Remote Compose API level and binary `profiles` feature mask in the document header.
+
+```json
+{
+  "compilerProfile": "compose-preview-integer-expressions-v1",
+  "header": { "width": 100, "height": 100 },
+  "root": [
+    { "type": "resources", "integers": { "page": { "value": 10, "export": true } } },
+    {
+      "type": "box",
+      "modifiers": ["fillMaxSize"],
+      "children": [
+        { "type": "integerExpression", "name": "index", "value": "clamp(@page / 10 - 1, 0, 1)" },
+        {
+          "type": "stateLayout",
+          "indexId": "@index",
+          "children": [
+            { "type": "box", "modifiers": ["fillMaxSize", { "background": "#FFFF0000" }] },
+            { "type": "box", "modifiers": ["fillMaxSize", { "background": "#FF00FF00" }] }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+Each `integerExpression` declares a document-wide integer name with a `value` expression. Names
+use letters, digits and underscores, starting with a letter or underscore. References use `@name`
+and must refer to previously declared integers. Forward references, duplicate names and float
+references fail compilation. Expressions support signed 32-bit literals, parentheses, `+ - * / %`,
+unary minus, `abs`, `min`, `max` and `clamp`, using AndroidX's integer expression compiler and normal
+32-bit arithmetic. They are not promoted to floats. Division by zero and integer overflow retain
+the runtime's arithmetic behavior; the compiler does not promise arbitrary-precision arithmetic.
+
+A declaration must fit the wire operation's 32 operand/operator slots. Split larger expressions
+into ordered named declarations. Declarations only accept `type`, `name` and `value`; they do not
+draw a component or accept modifiers. Put expressions inside a layout-bearing Box before the
+StateLayout or other content that reads them, so the player's normal paint path evaluates updates.
+Inactive-branch evaluation and transitions follow the player's behavior.
+
+The adapter registers a parser extension and emits ordinary `IntegerExpression` operations. It
+does not replace AndroidX parser classes, convert integer state to floats, or patch binary bytes.
+Its internal package placement allows access to the expression compiler and symbol tables exposed
+with package visibility in AndroidX alpha18/19. Dependency upgrades must run the profile tests.
+Player support remains a separate requirement: compiling successfully is not a rendering claim.
+
+Run `./gradlew :remotecompose-json:test :remotecompose-json:checkKotlinAbi`.

--- a/remotecompose/json/api/remotecompose-json.api
+++ b/remotecompose/json/api/remotecompose-json.api
@@ -43,6 +43,7 @@ public final class ee/schimke/composeai/remotecompose/json/RemoteComposeDocument
 
 public final class ee/schimke/composeai/remotecompose/json/RemoteComposeJson {
 	public static final field INSTANCE Lee/schimke/composeai/remotecompose/json/RemoteComposeJson;
+	public static final field INTEGER_EXPRESSIONS_PROFILE Ljava/lang/String;
 	public final fun compile (Ljava/lang/String;)[B
 	public final fun dump ([BZ)Ljava/lang/String;
 	public static synthetic fun dump$default (Lee/schimke/composeai/remotecompose/json/RemoteComposeJson;[BZILjava/lang/Object;)Ljava/lang/String;

--- a/remotecompose/json/src/main/kotlin/androidx/compose/remote/creation/json/ComposePreviewIntegerExpressions.kt
+++ b/remotecompose/json/src/main/kotlin/androidx/compose/remote/creation/json/ComposePreviewIntegerExpressions.kt
@@ -1,0 +1,141 @@
+package androidx.compose.remote.creation.json
+
+import androidx.compose.remote.core.operations.Utils
+import androidx.compose.remote.core.operations.utilities.IntegerExpressionEvaluator
+import org.json.JSONException
+
+/**
+ * Adapter for AndroidX's component-parser registration seam. The package is necessary because the
+ * expression compiler and symbol tables exposed by that seam have Java package visibility. This
+ * does not replace parser classes or patch wire bytes. Keep it internal and verify against the
+ * pinned AndroidX parser whenever that dependency changes.
+ */
+internal object ComposePreviewIntegerExpressions {
+  private val identifier = Regex("[A-Za-z_][A-Za-z0-9_]*")
+  private val token = Regex("@[A-Za-z_][A-Za-z0-9_]*|[A-Za-z_][A-Za-z0-9_]*|[0-9]+|[-+*/%(),]")
+  private val functions = setOf("abs", "min", "max", "clamp")
+
+  fun install(parser: RemoteComposeJsonParser) {
+    parser.registerComponentParser("integerExpression") { component, _, writer, current ->
+      val name = component.getString("name")
+      try {
+        require(identifier.matches(name)) { "name must be an identifier" }
+        require(component.keySet().all { it in setOf("type", "name", "value") }) {
+          "only type, name and value are supported"
+        }
+        require(
+          name !in current.mIntegerVariables &&
+            name !in current.mVariables &&
+            name !in current.mDeferredVariables
+        ) {
+          "duplicate name '$name'"
+        }
+        val source = component.getString("value")
+        validateTokens(source, current)
+        val rpn = current.expressionParser.infixToIntegerRpn(source)
+        require(rpn.size in 1..32) {
+          "expression needs 1–32 operands/operators; split larger expressions into declarations"
+        }
+        // The integer wire operation carries a 32-bit operand mask. Do not let the upstream writer
+        // silently truncate it, or emit a stack program the player cannot evaluate.
+        val operands = rpn.map { (it as Number).toLong() }.toLongArray()
+        var depth = 0
+        for (operand in operands) {
+          val arity =
+            when (operand) {
+              encoded(IntegerExpressionEvaluator.I_NEG),
+              encoded(IntegerExpressionEvaluator.I_ABS) -> 1
+              encoded(IntegerExpressionEvaluator.I_ADD),
+              encoded(IntegerExpressionEvaluator.I_SUB),
+              encoded(IntegerExpressionEvaluator.I_MUL),
+              encoded(IntegerExpressionEvaluator.I_DIV),
+              encoded(IntegerExpressionEvaluator.I_MOD),
+              encoded(IntegerExpressionEvaluator.I_MIN),
+              encoded(IntegerExpressionEvaluator.I_MAX) -> 2
+              encoded(IntegerExpressionEvaluator.I_CLAMP) -> 3
+              else -> 0
+            }
+          require(depth >= arity) { "expression has too few arguments" }
+          depth += 1 - arity
+        }
+        require(depth == 1) { "expression must produce exactly one integer" }
+        val encoded = writer.integerExpression(*operands)
+        val id = encoded.toInt()
+        current.mIntegerVariables[name] = encoded
+        current.mVariables[name] = Utils.asNan(id)
+        current.recordVariable(name, id)
+      } catch (e: RuntimeException) {
+        throw JSONException(
+          "${current.contextPathString}: integerExpression '$name': ${e.message}",
+          e,
+        )
+      }
+    }
+  }
+
+  private fun encoded(operation: Int): Long = 0x100000000L + operation
+
+  private class Parentheses(val arity: Int?, var arguments: Int = 1)
+
+  private fun validateTokens(source: String, parser: RemoteComposeJsonParser) {
+    val tokens = token.findAll(source).map { it.value }.toList()
+    require(tokens.joinToString("") == source.filterNot { it.isWhitespace() }) {
+      "unsupported syntax; use integer literals, @integer references, + - * / %, abs, min, max or clamp"
+    }
+    val parentheses = mutableListOf<Parentheses>()
+    var expectOperand = true
+    for ((index, part) in tokens.withIndex()) {
+      when {
+        part == "(" -> {
+          require(expectOperand) { "expected an operator before (" }
+          val arity =
+            when (tokens.getOrNull(index - 1)) {
+              "abs" -> 1
+              "min",
+              "max" -> 2
+              "clamp" -> 3
+              else -> null
+            }
+          parentheses += Parentheses(arity)
+        }
+        part == ")" -> {
+          require(parentheses.isNotEmpty()) { "mismatched parentheses" }
+          require(!expectOperand) { "expected an operand before )" }
+          val group = parentheses.removeAt(parentheses.lastIndex)
+          require(group.arity == null || group.arity == group.arguments) {
+            "function requires ${group.arity} arguments, got ${group.arguments}"
+          }
+        }
+        part == "," -> {
+          require(!expectOperand && parentheses.lastOrNull()?.arity != null) { "unexpected comma" }
+          parentheses.last().arguments++
+          expectOperand = true
+        }
+        part in setOf("+", "-", "*", "/", "%") -> {
+          require(!expectOperand || part == "-") { "expected an operand before $part" }
+          expectOperand = true
+        }
+        part.startsWith("@") -> {
+          require(expectOperand) { "expected an operator before $part" }
+          require(part.drop(1) in parser.mIntegerVariables) {
+            "unknown integer reference '$part'; declare integers before using them"
+          }
+          expectOperand = false
+        }
+        identifier.matches(part) -> {
+          require(expectOperand) { "expected an operator before $part" }
+          require(part in functions) {
+            "unsupported function '$part'; integer references must start with @"
+          }
+          require(tokens.getOrNull(index + 1) == "(") { "function $part requires parentheses" }
+        }
+        else -> {
+          require(expectOperand) { "expected an operator before $part" }
+          expectOperand = false
+        }
+      }
+    }
+    require(parentheses.isEmpty()) { "mismatched parentheses" }
+    require(!expectOperand) { "expected an operand" }
+  }
+}

--- a/remotecompose/json/src/main/kotlin/ee/schimke/composeai/remotecompose/json/RemoteComposeJson.kt
+++ b/remotecompose/json/src/main/kotlin/ee/schimke/composeai/remotecompose/json/RemoteComposeJson.kt
@@ -3,12 +3,15 @@ package ee.schimke.composeai.remotecompose.json
 import androidx.compose.remote.core.CoreDocument
 import androidx.compose.remote.core.RemoteComposeBuffer
 import androidx.compose.remote.core.operations.Header
+import androidx.compose.remote.creation.RemoteComposeWriter
+import androidx.compose.remote.creation.json.ComposePreviewIntegerExpressions
 import androidx.compose.remote.creation.json.RemoteComposeJsonParser
 import java.io.ByteArrayInputStream
 import java.io.IOException
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.json.JSONException
@@ -82,6 +85,13 @@ import org.json.JSONException
 public object RemoteComposeJson {
 
   /**
+   * Opt-in authoring profile for named integer expressions. Put this value in the document's
+   * top-level `compilerProfile` field. The resulting bytes use standard Remote Compose operations;
+   * the source requires this compiler, rather than AndroidX's unextended JSON parser.
+   */
+  public const val INTEGER_EXPRESSIONS_PROFILE: String = "compose-preview-integer-expressions-v1"
+
+  /**
    * Compile an **authoring JSON** document to binary `.rc` bytes.
    *
    * @throws RemoteComposeJsonException if [json] is not valid JSON, or is valid JSON that the
@@ -90,8 +100,29 @@ public object RemoteComposeJson {
    *   path it gave up on, which is the only thing that makes a 200-line document debuggable.
    */
   public fun compile(json: String): ByteArray {
-    requireRoot(json)
+    val document = requireRoot(json)
+    val profile = document["compilerProfile"]
+    if (
+      profile != null &&
+        (profile !is JsonPrimitive ||
+          !profile.isString ||
+          profile.content != INTEGER_EXPRESSIONS_PROFILE)
+    ) {
+      throw RemoteComposeJsonException("Unsupported compilerProfile: $profile")
+    }
     return try {
+      if (profile != null) {
+        val writer =
+          RemoteComposeWriter(
+            RemoteComposeJsonParser.DEFAULT_PLATFORM,
+            RemoteComposeJsonParser.parseApiLevel(json),
+            *RemoteComposeJsonParser.parseHeaderOnly(json).sortedBy { it.tag }.toTypedArray(),
+          )
+        val parser = RemoteComposeJsonParser(writer)
+        ComposePreviewIntegerExpressions.install(parser)
+        parser.parse(json)
+        return writer.encodeToByteArray()
+      }
       val buffer = RemoteComposeJsonParser.parseToByteBuffer(json)
       ByteArray(buffer.remaining()).also { buffer.get(it) }
     } catch (e: JSONException) {
@@ -117,7 +148,7 @@ public object RemoteComposeJson {
    * gets its own sentence in the message because unwrapping is the fix and "missing root" alone
    * does not suggest it.
    */
-  private fun requireRoot(json: String) {
+  private fun requireRoot(json: String): JsonObject {
     val parsed =
       try {
         Json.parseToJsonElement(json)
@@ -130,7 +161,7 @@ public object RemoteComposeJson {
           "Not a RemoteCompose JSON document: the top level is ${parsed::class.simpleName}, " +
             "expected an object with a \"root\""
         )
-    if ("root" in obj) return
+    if ("root" in obj) return obj
     val wrapped =
       if ("json" in obj)
         " It looks like a generation-library entry — compile its \"json\" value, not the wrapper."

--- a/remotecompose/json/src/test/kotlin/ee/schimke/composeai/remotecompose/json/IntegerExpressionsProfileTest.kt
+++ b/remotecompose/json/src/test/kotlin/ee/schimke/composeai/remotecompose/json/IntegerExpressionsProfileTest.kt
@@ -1,0 +1,170 @@
+package ee.schimke.composeai.remotecompose.json
+
+import com.google.common.truth.Truth.assertThat
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class IntegerExpressionsProfileTest {
+  private fun expression(name: String, value: String): JSONObject =
+    JSONObject().put("type", "integerExpression").put("name", name).put("value", value)
+
+  private fun source(vararg expressions: JSONObject): JSONObject =
+    JSONObject()
+      .put("compilerProfile", RemoteComposeJson.INTEGER_EXPRESSIONS_PROFILE)
+      .put("header", JSONObject().put("width", 100).put("height", 100))
+      .put(
+        "root",
+        JSONArray()
+          .put(
+            JSONObject()
+              .put("type", "resources")
+              .put("integers", JSONObject().put("page", Int.MIN_VALUE))
+          )
+          .put(JSONObject().put("type", "box").put("children", JSONArray(expressions.toList()))),
+      )
+
+  @Test
+  fun `profile emits real integer expressions and a state layout`() {
+    val document =
+      source(expression("low", "@page % 65536"), expression("index", "min(1, abs(@low))"))
+    document
+      .getJSONArray("root")
+      .getJSONObject(1)
+      .getJSONArray("children")
+      .put(
+        JSONObject()
+          .put("type", "stateLayout")
+          .put("indexId", "@index")
+          .put("children", JSONArray().put(JSONObject().put("type", "box")))
+      )
+    val bytes = RemoteComposeJson.compile(document.toString())
+    val dump = RemoteComposeJson.dump(bytes)
+    assertThat(dump).contains("IntegerExpression")
+    assertThat(dump).contains("STATE_LAYOUT")
+    assertThat(RemoteComposeJson.header(bytes).width).isEqualTo(100)
+    assertThat(RemoteComposeJson.compile(document.toString())).isEqualTo(bytes)
+  }
+
+  @Test
+  fun `stock documents keep their previous compilation path`() {
+    val document = source()
+    document.remove("compilerProfile")
+    val buffer =
+      androidx.compose.remote.creation.json.RemoteComposeJsonParser.parseToByteBuffer(
+        document.toString()
+      )
+    val expected = ByteArray(buffer.remaining()).also { buffer.get(it) }
+    assertThat(RemoteComposeJson.compile(document.toString())).isEqualTo(expected)
+  }
+
+  @Test
+  fun `extension requires an explicit profile`() {
+    val document = source(expression("index", "@page + 1"))
+    document.remove("compilerProfile")
+    assertThrows(RemoteComposeJsonException::class.java) {
+      RemoteComposeJson.compile(document.toString())
+    }
+  }
+
+  @Test
+  fun `unknown and malformed profiles are refused even without extended nodes`() {
+    for (profile in listOf("future-v2", "", 1, JSONObject.NULL, JSONObject())) {
+      val document = source().put("compilerProfile", profile)
+      val failure =
+        assertThrows(RemoteComposeJsonException::class.java) {
+          RemoteComposeJson.compile(document.toString())
+        }
+      assertThat(failure).hasMessageThat().contains("Unsupported compilerProfile")
+    }
+  }
+
+  @Test
+  fun `misspelled and forward integer references are refused`() {
+    refuses("unknown integer reference", expression("index", "@missing + 1"))
+    refuses(
+      "unknown integer reference",
+      expression("index", "@later + 1"),
+      expression("later", "2"),
+    )
+  }
+
+  @Test
+  fun `duplicate declarations cannot change a reference silently`() {
+    refuses("duplicate name", expression("page", "1"))
+    refuses("duplicate name", expression("index", "1"), expression("index", "2"))
+  }
+
+  @Test
+  fun `malformed expression stack and unsupported syntax are refused at compilation`() {
+    for (value in
+      listOf(
+        "",
+        "1 +",
+        "min(1)",
+        "1 2",
+        "min(1, 2, 3)",
+        "(1 + 2",
+        "1 + 2)",
+        "1 & 2",
+        "1.5",
+        "sin(1)",
+      )) {
+      refuses("integerExpression 'index'", expression("index", value))
+    }
+  }
+
+  @Test
+  fun `wire operand mask cannot truncate a long expression`() {
+    refuses("1–32 operands/operators", expression("index", (1..17).joinToString(" + ")))
+    val document = source(expression("index", (1..16).joinToString(" + ")))
+    assertThat(RemoteComposeJson.compile(document.toString()).size).isGreaterThan(64)
+  }
+
+  @Test
+  fun `wrong function arities cannot cancel each other in the expression stack`() {
+    refuses("function requires", expression("index", "min(1, 2, 3) + max(4)"))
+    refuses("unexpected comma", expression("index", "(1, 2) + 3"))
+  }
+
+  @Test
+  fun `all supported functions and negative integer extremes compile`() {
+    for (value in
+      listOf(
+        "-2147483648",
+        "2147483647",
+        "abs(-10)",
+        "min(1, 2)",
+        "max(1, 2)",
+        "clamp(1, 2, 3)",
+        "-@page",
+        "@page / 65536",
+      )) {
+      assertThat(RemoteComposeJson.compile(source(expression("index", value)).toString()).size)
+        .isGreaterThan(64)
+    }
+  }
+
+  @Test
+  fun `float references are not coerced to integer ids`() {
+    val document = source(expression("index", "@fraction + 1"))
+    document
+      .getJSONArray("root")
+      .getJSONObject(0)
+      .put("variables", JSONObject().put("fraction", 1.5))
+    val failure =
+      assertThrows(RemoteComposeJsonException::class.java) {
+        RemoteComposeJson.compile(document.toString())
+      }
+    assertThat(failure).hasMessageThat().contains("unknown integer reference")
+  }
+
+  private fun refuses(message: String, vararg expressions: JSONObject) {
+    val failure =
+      assertThrows(RemoteComposeJsonException::class.java) {
+        RemoteComposeJson.compile(source(*expressions).toString())
+      }
+    assertThat(failure).hasMessageThat().contains(message)
+  }
+}


### PR DESCRIPTION
AndroidX authoring JSON can reference an integer state value in `StateLayout.indexId`, but cannot declare the derived integer expressions needed to map authored case values to branch indexes. Add the explicit `compose-preview-integer-expressions-v1` compiler profile to the existing plain-JVM `remotecompose-json` module. Documents without a profile retain the stock parser path; unknown profiles fail compilation.

The internal component-registry adapter compiles named integer expressions with AndroidX’s expression compiler and emits standard Remote Compose operations. It validates integer references, duplicate names, infix syntax, function arity and the 32-slot wire limit before returning bytes. The source profile is documented separately from the binary API level/profile mask, and its name is exposed as an additive API constant with an updated ABI dump. No server, Android runtime, binary patching or replacement parser is introduced.

Validation:

- `:remotecompose-json:check`: 28 JVM tests, formatting, module boundaries and ABI checks pass.
- Locally staged normal Maven publication consumed by compose-preview-server’s real-player proof: all 10 tests pass, including integer limits, adjacent values above Float’s exact range, 13 cases, click/callback behavior and density 2.
- Existing server resolves the local publication and passes all 103 `ServeHttpRoutingTest` cases.

The player proof uses the local empty-Box fix in [rc-players#92](https://github.com/yschimke/rc-players/pull/92). This supplies the shared compiler seam for [compose-preview-server#708](https://github.com/yschimke/compose-preview-server/pull/708); production builder JSON export and live assembly are still separate integration work. The adapter is internal but deliberately shares the AndroidX parser package to reach the package-visible compiler and symbol tables, so dependency upgrades must preserve the profile tests.
