### PR TITLE
feat(design-artifacts): publish a generic `related` list on catalog components

### DIFF
--- a/scripts/design-artifacts/apply-related.mjs
+++ b/scripts/design-artifacts/apply-related.mjs
@@ -1,0 +1,97 @@
+/**
+ * Stamp each spec component's `related` links — its counterparts in OTHER catalogs — onto
+ * the built catalog manifest.
+ *
+ * Same post-write stamp, and the same reason, as {@link file://./apply-parallels.mjs}: the pinned
+ * `@design-parity/catalog-export`'s `toCatalogManifest` allow-lists the component fields it knows
+ * and drops the rest with no error anywhere, so a field it predates never reaches the published
+ * `catalog.json` and nothing says otherwise.
+ *
+ * What it carries is deliberately NOT a second `parallel`:
+ *
+ *   - `parallel` (with the manifest's `compareWith`) says two renders are pictures of ONE CELL and
+ *     should be diffed. It is one handle, because a parity comparison has one counterpart.
+ *   - `related` says only that ANOTHER CATALOG is worth looking at from here. It is a LIST, and
+ *     carries no parity semantics — nothing scores, diffs or gates on it.
+ *
+ * A list rather than a second scalar because the case that needs it has three catalogs, not two.
+ * The AndroidX samples import (see `docs/design/ANDROIDX_SAMPLES.md` in yschimke/m3-catalog and
+ * yschimke/wear-m3-catalog) publishes an `m3-samples` / `wear-m3-samples` catalog beside each kit
+ * catalog, and `remote-m3` has already spent its single `compareWith` on `wear-m3-catalog` —
+ * so no pairwise mechanism could also point it at the samples. Issue #5398.
+ *
+ * Additive and idempotent, exactly like `applyParallels`:
+ *  - only components whose spec entry declares a non-empty `related` are touched;
+ *  - a component that already carries one (a future `toCatalogManifest` that learns the field) is
+ *    left as-is, so bumping the pin makes this a no-op rather than a conflict.
+ *
+ * Like `parallel`, this carries the declaration verbatim and does NOT check that the named system
+ * exists or has such a component. The consumer is the only party that can: a preview server knows
+ * which catalogs it serves, and one that does not serve the named system renders no link. Dropping
+ * an unresolvable entry here would hide a spec typo behind an absent field instead of surfacing it
+ * where the inventory is actually readable.
+ */
+
+/** A link is worth publishing only if it names where it points. */
+function normaliseLink(link) {
+  const system = typeof link?.system === "string" ? link.system.trim() : "";
+  if (!system) return null;
+  const componentId =
+    typeof link?.componentId === "string" ? link.componentId.trim() : "";
+  const label = typeof link?.label === "string" ? link.label.trim() : "";
+  return {
+    system,
+    // Omitted rather than emitted blank: an absent `componentId` MEANS "same id as mine" (the
+    // id-parity case), and an empty string would read as a declared id that matches nothing.
+    ...(componentId ? { componentId } : {}),
+    ...(label ? { label } : {}),
+  };
+}
+
+/**
+ * `componentId -> related[]`, for every spec component that declares at least one usable link.
+ *
+ * Exported for the same reason `parallelIndex` is: the manifest is stamped in two places — over
+ * `manifest.components` here, and over the DEFERRED records at their own construction in
+ * `generate-design-catalog.mjs`, which are built after this call and so cannot be reached from it.
+ * One reader, so the two cannot come to disagree about which links are dropped.
+ *
+ * @param {{groups?: Array<{components?: Array<{componentId: string, related?: unknown}>}>}} spec
+ * @returns {Map<string, Array<{system: string, componentId?: string, label?: string}>>}
+ */
+export function relatedIndex(spec) {
+  const relatedByComponentId = new Map();
+  for (const group of spec?.groups ?? []) {
+    for (const component of group.components ?? []) {
+      if (!Array.isArray(component?.related)) continue;
+      const links = component.related.map(normaliseLink).filter(Boolean);
+      // An empty list is not published: "declared, and empty" and "not declared" mean the same
+      // thing to every consumer, and the shorter one does not make an absent link look declared.
+      if (links.length > 0)
+        relatedByComponentId.set(component.componentId, links);
+    }
+  }
+  return relatedByComponentId;
+}
+
+/**
+ * @param {{components?: Array<{componentId: string, related?: unknown}>}} manifest
+ *   The parsed `catalog.json`, mutated in place.
+ * @param {{groups?: Array<{components?: Array<{componentId: string, related?: unknown}>}>}} spec
+ *   The catalog spec the manifest was built from.
+ * @returns {number} how many components had `related` newly stamped.
+ */
+export function applyRelated(manifest, spec) {
+  const relatedByComponentId = relatedIndex(spec);
+
+  let stamped = 0;
+  for (const component of manifest?.components ?? []) {
+    if (component.related !== undefined) continue; // never clobber an exporter that carries it
+    const related = relatedByComponentId.get(component.componentId);
+    if (related !== undefined) {
+      component.related = related;
+      stamped += 1;
+    }
+  }
+  return stamped;
+}

--- a/scripts/design-artifacts/apply-related.test.mjs
+++ b/scripts/design-artifacts/apply-related.test.mjs
@@ -1,0 +1,186 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { applyRelated, relatedIndex } from "./apply-related.mjs";
+
+const comp = (componentId, extra = {}) => ({
+  componentId,
+  images: [],
+  ...extra,
+});
+const manifest = (components) => ({
+  schema: "design-parity-catalog/v1",
+  system: "s",
+  components,
+});
+const specOf = (components) => ({ groups: [{ name: "Buttons", components }] });
+
+test("stamps each spec component's related links onto the matching manifest component", () => {
+  const spec = specOf([
+    {
+      componentId: "Button/Filled",
+      related: [{ system: "m3-samples", label: "Samples" }],
+    },
+    {
+      componentId: "Button/Outlined",
+      related: [{ system: "m3-samples", componentId: "Button/Outlined" }],
+    },
+  ]);
+  const m = manifest([comp("Button/Filled"), comp("Button/Outlined")]);
+
+  assert.equal(applyRelated(m, spec), 2);
+  assert.deepEqual(m.components[0].related, [
+    { system: "m3-samples", label: "Samples" },
+  ]);
+  assert.deepEqual(m.components[1].related, [
+    { system: "m3-samples", componentId: "Button/Outlined" },
+  ]);
+});
+
+test("carries several links for one component — what a scalar `parallel` cannot express", () => {
+  const spec = specOf([
+    {
+      componentId: "Button/Filled",
+      related: [
+        { system: "wear-m3-catalog", label: "Wear" },
+        { system: "wear-m3-samples", label: "Wear samples" },
+      ],
+    },
+  ]);
+  const m = manifest([comp("Button/Filled")]);
+
+  assert.equal(applyRelated(m, spec), 1);
+  assert.equal(m.components[0].related.length, 2);
+});
+
+test("is a no-op for a catalog that declares no related links", () => {
+  const spec = specOf([{ componentId: "Button/Filled" }]);
+  const m = manifest([comp("Button/Filled")]);
+
+  assert.equal(applyRelated(m, spec), 0);
+  assert.equal("related" in m.components[0], false);
+});
+
+test("never clobbers an exporter that already carries the field", () => {
+  const spec = specOf([
+    { componentId: "Button/Filled", related: [{ system: "m3-samples" }] },
+  ]);
+  const m = manifest([
+    comp("Button/Filled", { related: [{ system: "from-exporter" }] }),
+  ]);
+
+  assert.equal(applyRelated(m, spec), 0);
+  assert.deepEqual(m.components[0].related, [{ system: "from-exporter" }]);
+});
+
+test("is idempotent — a second pass stamps nothing and changes nothing", () => {
+  const spec = specOf([
+    { componentId: "Button/Filled", related: [{ system: "m3-samples" }] },
+  ]);
+  const m = manifest([comp("Button/Filled")]);
+
+  assert.equal(applyRelated(m, spec), 1);
+  const after = JSON.stringify(m);
+  assert.equal(applyRelated(m, spec), 0);
+  assert.equal(JSON.stringify(m), after);
+});
+
+test("leaves a manifest component the spec does not mention alone", () => {
+  const spec = specOf([
+    { componentId: "Button/Filled", related: [{ system: "m3-samples" }] },
+  ]);
+  const m = manifest([comp("Button/Filled"), comp("Card/Elevated")]);
+
+  assert.equal(applyRelated(m, spec), 1);
+  assert.equal("related" in m.components[1], false);
+});
+
+test("drops a link that names no system rather than publishing half of one", () => {
+  const spec = specOf([
+    {
+      componentId: "Button/Filled",
+      related: [{ label: "Samples" }, { system: "  " }, { system: "m3-samples" }],
+    },
+  ]);
+  const m = manifest([comp("Button/Filled")]);
+
+  assert.equal(applyRelated(m, spec), 1);
+  assert.deepEqual(m.components[0].related, [{ system: "m3-samples" }]);
+});
+
+test("publishes nothing when every declared link is unusable", () => {
+  const spec = specOf([{ componentId: "Button/Filled", related: [{ label: "x" }] }]);
+  const m = manifest([comp("Button/Filled")]);
+
+  assert.equal(applyRelated(m, spec), 0);
+  assert.equal("related" in m.components[0], false);
+});
+
+test("omits a blank componentId rather than emitting an id that matches nothing", () => {
+  // An ABSENT componentId means "the same id as mine" — the id-parity case. An empty string would
+  // read as a declared id, and resolve against no component in the other catalog.
+  const spec = specOf([
+    {
+      componentId: "Button/Filled",
+      related: [{ system: "m3-samples", componentId: "", label: "" }],
+    },
+  ]);
+  const m = manifest([comp("Button/Filled")]);
+
+  assert.equal(applyRelated(m, spec), 1);
+  assert.deepEqual(m.components[0].related, [{ system: "m3-samples" }]);
+});
+
+test("trims the declared values", () => {
+  const spec = specOf([
+    {
+      componentId: "Button/Filled",
+      related: [
+        { system: " m3-samples ", componentId: " Button/Filled ", label: " Samples " },
+      ],
+    },
+  ]);
+  const m = manifest([comp("Button/Filled")]);
+
+  applyRelated(m, spec);
+  assert.deepEqual(m.components[0].related, [
+    { system: "m3-samples", componentId: "Button/Filled", label: "Samples" },
+  ]);
+});
+
+test("ignores a `related` that is not an array (the spec validator is what reports it)", () => {
+  const spec = specOf([{ componentId: "Button/Filled", related: "m3-samples" }]);
+  const m = manifest([comp("Button/Filled")]);
+
+  assert.equal(applyRelated(m, spec), 0);
+  assert.equal("related" in m.components[0], false);
+});
+
+test("survives a manifest or spec with no components at all", () => {
+  assert.equal(applyRelated({}, {}), 0);
+  assert.equal(applyRelated(undefined, undefined), 0);
+  assert.equal(relatedIndex(undefined).size, 0);
+});
+
+test("relatedIndex is keyed by componentId across groups, for the deferred stamp to read", () => {
+  const spec = {
+    groups: [
+      {
+        name: "Buttons",
+        components: [
+          { componentId: "Button/Filled", related: [{ system: "m3-samples" }] },
+        ],
+      },
+      {
+        name: "Cards",
+        components: [
+          { componentId: "Card/Elevated", related: [{ system: "m3-samples" }] },
+          { componentId: "Card/Outlined" },
+        ],
+      },
+    ],
+  };
+
+  const index = relatedIndex(spec);
+  assert.deepEqual([...index.keys()], ["Button/Filled", "Card/Elevated"]);
+});

--- a/scripts/design-artifacts/catalog-spec.mjs
+++ b/scripts/design-artifacts/catalog-spec.mjs
@@ -620,6 +620,7 @@ export function validateSpec(spec, opts = {}) {
         }
       }
       errors.push(...priorityErrors(comp, cp));
+      errors.push(...relatedErrors(comp, cp));
       const variants = comp?.variants;
       if (variants !== undefined) {
         if (!Array.isArray(variants)) {
@@ -830,6 +831,57 @@ function priorityErrors(entry, path) {
     `${path}.priority must be one of ${PRIORITIES.map((p) => `"${p}"`).join(", ")} ` +
       `(got ${JSON.stringify(value)})`,
   ];
+}
+
+/**
+ * Reject a malformed `related` — a component's links into OTHER catalogs (issue #5398).
+ *
+ * Typed here rather than left to `catalog.spec.schema.json`, for the reason the variant key checks
+ * already state: the schema is a `$schema` hint for editors and no build step enforces it, so this
+ * function is the only gate a malformed spec actually meets.
+ *
+ * An ERROR rather than a lenient drop, on the same reasoning as `capture` and `priority`: a link
+ * whose `system` is misspelled or mistyped is silently unpublishable (`applyRelated` drops it), so
+ * a typo would present as the affordance simply never appearing, with nothing pointing back at the
+ * spec. That is exactly the failure this repository has already paid for once with `parallel`,
+ * where 51 components published zero pairings and nothing said so.
+ */
+function relatedErrors(entry, path) {
+  const value = entry?.related;
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) {
+    return [`${path}.related must be an array when present`];
+  }
+  const errors = [];
+  const allowedKeys = new Set(["system", "componentId", "label"]);
+  value.forEach((link, li) => {
+    const lp = `${path}.related[${li}]`;
+    if (typeof link !== "object" || link === null || Array.isArray(link)) {
+      errors.push(`${lp} must be an object`);
+      return;
+    }
+    for (const key of Object.keys(link)) {
+      if (!allowedKeys.has(key)) {
+        errors.push(
+          `${lp}.${key} is not supported; expected only ${[...allowedKeys]
+            .map((k) => `\`${k}\``)
+            .join(", ")}`,
+        );
+      }
+    }
+    if (typeof link.system !== "string" || link.system.trim().length === 0) {
+      errors.push(`${lp}.system is required (the other catalog's system slug)`);
+    }
+    // `componentId` and `label` are both optional, and both MEAN something by their absence —
+    // "same id as mine" and "use the other catalog's title". Present-but-empty says neither, so it
+    // is rejected rather than treated as absent.
+    for (const key of ["componentId", "label"]) {
+      if (link[key] !== undefined && (typeof link[key] !== "string" || link[key].trim() === "")) {
+        errors.push(`${lp}.${key} must be a non-empty string when present`);
+      }
+    }
+  });
+  return errors;
 }
 
 /**

--- a/scripts/design-artifacts/catalog-spec.test.mjs
+++ b/scripts/design-artifacts/catalog-spec.test.mjs
@@ -1164,3 +1164,86 @@ test("validateSpec still rejects a hero that matches nothing at all", () => {
   );
   assert.ok(errors.some((e) => e.includes('display.hero "Nope/Missing" matches no componentId')));
 });
+
+// --- related links into other catalogs (issue #5398) -------------------------------------------
+
+/** A minimal, otherwise-valid spec whose single component carries the given `related`. */
+function relatedSpec(related) {
+  return {
+    system: "demo",
+    title: "Demo",
+    groups: [
+      {
+        name: "Components",
+        components: [{ componentId: "A", preview: "Alpha", related }],
+      },
+    ],
+  };
+}
+
+test("validateSpec accepts related links, with and without the optional fields", () => {
+  const { errors } = validateSpec(
+    relatedSpec([
+      { system: "m3-samples" },
+      { system: "m3-samples", componentId: "Button/Filled" },
+      { system: "wear-m3-samples", componentId: "Button/Filled", label: "Wear samples" },
+    ]),
+  );
+  assert.deepEqual(errors, []);
+});
+
+test("validateSpec rejects a related link that names no system", () => {
+  // `applyRelated` drops it, so without this the affordance would simply never appear and nothing
+  // would point back at the spec — the failure `parallel` already cost this repo once.
+  const { errors } = validateSpec(relatedSpec([{ label: "Samples" }]));
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /related\[0\]\.system is required/);
+});
+
+test("validateSpec rejects a blank system", () => {
+  const { errors } = validateSpec(relatedSpec([{ system: "   " }]));
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /related\[0\]\.system is required/);
+});
+
+test("validateSpec rejects a related that is not an array", () => {
+  const { errors } = validateSpec(relatedSpec("m3-samples"));
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /\.related must be an array when present/);
+});
+
+test("validateSpec rejects a non-object entry in related", () => {
+  const { errors } = validateSpec(relatedSpec(["m3-samples"]));
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /related\[0\] must be an object/);
+});
+
+test("validateSpec rejects an unknown key on a related link", () => {
+  const { errors } = validateSpec(
+    relatedSpec([{ system: "m3-samples", repo: "yschimke/m3-catalog" }]),
+  );
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /related\[0\]\.repo is not supported/);
+});
+
+test("validateSpec rejects a present-but-empty componentId or label", () => {
+  // Both MEAN something by their absence — "same id as mine", "use the other catalog's title" —
+  // so an empty string says neither and is a mistake rather than a shorthand.
+  assert.match(
+    validateSpec(relatedSpec([{ system: "m3-samples", componentId: "" }])).errors[0],
+    /related\[0\]\.componentId must be a non-empty string when present/,
+  );
+  assert.match(
+    validateSpec(relatedSpec([{ system: "m3-samples", label: "  " }])).errors[0],
+    /related\[0\]\.label must be a non-empty string when present/,
+  );
+});
+
+test("validateSpec is silent about a component that declares no related links", () => {
+  const { errors } = validateSpec({
+    system: "demo",
+    title: "Demo",
+    groups: [{ name: "Components", components: [{ componentId: "A", preview: "Alpha" }] }],
+  });
+  assert.deepEqual(errors, []);
+});

--- a/scripts/design-artifacts/catalog.spec.schema.json
+++ b/scripts/design-artifacts/catalog.spec.schema.json
@@ -271,6 +271,32 @@
           "type": "string",
           "description": "Optional componentId of the counterpart in the `compareWith` sibling system, paired side-by-side on the cross-system compare page."
         },
+        "related": {
+          "type": "array",
+          "description": "Optional links to this component's counterparts in OTHER catalogs — a samples catalog demonstrating how it is called, a sibling platform's rendition. Unlike `parallel` this is a LIST and carries no parity semantics: `parallel` says two renders are pictures of one cell and should be diffed, `related` says only that another catalog is worth looking at from here. A list because a component can have more than one such neighbour and `compareWith` names exactly one sibling system — `remote-m3` spends its `compareWith` on the Wear kit catalog, so a second pairwise handle could never reach the samples. Presentation only: nothing scores, diffs or gates on it.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["system"],
+            "properties": {
+              "system": {
+                "type": "string",
+                "minLength": 1,
+                "description": "The other catalog's system slug, as it is served (e.g. \"m3-samples\"). Resolution is the consumer's: a preview server serving both catalogs already knows where it is, and one that does not serve it simply renders no link."
+              },
+              "componentId": {
+                "type": "string",
+                "minLength": 1,
+                "description": "The counterpart's componentId in that system. Omit when it is the same as this component's — the id-parity case, which is most of them."
+              },
+              "label": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Display text for the link (e.g. \"Samples\"). Omit to let the consumer fall back to the other catalog's own title."
+              }
+            }
+          }
+        },
         "component": {
           "type": "string",
           "description": "Optional Code Connect override: the production composable name the sticker maps to (takes priority over the inferred target when building code-connect.json)."

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -177,6 +177,7 @@ import {
   unbridgeableFunctions,
 } from "./extra-render-fold.mjs";
 import { applyParallels, parallelIndex } from "./apply-parallels.mjs";
+import { applyRelated, relatedIndex } from "./apply-related.mjs";
 import { applyVariantParity } from "./apply-variant-parity.mjs";
 import { applySpecSections } from "./apply-spec-sections.mjs";
 import { applySourceFiles } from "./apply-source-files.mjs";
@@ -1857,6 +1858,17 @@ if (uiBuilderCatalog) {
       `[${spec.system}] stamped parallel on ${stampedParallels} component(s) from spec components`,
     );
   }
+  // Links into OTHER catalogs, dropped by the same allow-list as `parallel` and stamped the same
+  // way. Not a second `parallel`: that one names the counterpart a render is DIFFED against, in the
+  // single `compareWith` sibling, while this is a presentation-only LIST with no parity semantics —
+  // which is what lets `remote-m3`, whose `compareWith` is already spent on the Wear kit catalog,
+  // point at a samples catalog as well (issue #5398).
+  const stampedRelated = applyRelated(manifest, spec);
+  if (stampedRelated > 0) {
+    console.log(
+      `[${spec.system}] stamped related on ${stampedRelated} component(s) from spec components`,
+    );
+  }
   // The same gap, one level down: a variant's pixels reach the manifest (folded onto the parent's
   // `images[]`) but its identity does not, so the compare page cannot tell that one of those tagged
   // images is a distinct render with a counterpart of its own. Only variants declaring kit
@@ -1923,9 +1935,14 @@ if (uiBuilderCatalog) {
     // even though the catalog publishes `compareWith`. Read from one index rather than a second
     // reader, so the two cannot disagree about the blank-means-none rule.
     const deferredParallels = parallelIndex(spec);
+    // And its `related` links, for exactly the same reason: a wholly deferred component never
+    // reaches `manifest.components`, so stamping only there would drop the links a server needs to
+    // reconstruct the card.
+    const deferredRelated = relatedIndex(spec);
     manifest.deferred = records.map((record) => {
       const ids = idsByFunction.get(record.preview) ?? [];
       const parallel = deferredParallels.get(record.componentId);
+      const related = deferredRelated.get(record.componentId);
       return {
         ...record,
         ...(mismatches.length === 0
@@ -1935,6 +1952,10 @@ if (uiBuilderCatalog) {
         // Never clobber a record that already carries one, matching `applyParallels`.
         ...(parallel !== undefined && record.parallel === undefined
           ? { parallel }
+          : {}),
+        // Never clobber a record that already carries them, matching `applyRelated`.
+        ...(related !== undefined && record.related === undefined
+          ? { related }
           : {}),
       };
     });


### PR DESCRIPTION
Closes #5398 (the spec + emit half of it; the annotation and the server affordance follow separately — see below).

## Why

A published component can point at exactly one other catalog: `compareWith` names the sibling system, `parallel` names the counterpart component. That is enough while a catalog has one sibling, and stops working the moment it has two.

The AndroidX samples import — merged as `docs/design/ANDROIDX_SAMPLES.md` in [yschimke/m3-catalog](https://github.com/yschimke/m3-catalog/blob/main/docs/design/ANDROIDX_SAMPLES.md) and [yschimke/wear-m3-catalog](https://github.com/yschimke/wear-m3-catalog/blob/main/docs/design/ANDROIDX_SAMPLES.md) — puts a samples catalog beside each kit catalog. Two of its three links already work (id parity; samples → kit through `compareWith` + `parallel`, pairing on `CANONICAL`, which reads correctly). The third cannot: **`remote-m3` has already spent its single `compareWith` on `wear-m3-catalog`**, so no pairwise handle can also reach `wear-m3-samples`, and the kit catalogs have no way to offer a back-link into the samples at all.

So the requirement is not a second `parallel`. It is a list.

## What this adds

```json
{
  "componentId": "Button/Filled",
  "related": [{ "system": "m3-samples", "componentId": "Button/Filled", "label": "Samples" }]
}
```

Deliberately **not** `compareWith`-shaped — no design column, no pairing basis, no parity semantics:

- `parallel` says two renders are pictures of one cell and should be **diffed**;
- `related` says only that another catalog is worth **looking at** from here.

Conflating them would drag a samples catalog into a comparison it should never be scored by. `componentId` is optional and means "the same id as mine" when absent (the id-parity case, which will be most of them); `label` is optional and falls back to the other catalog's title.

## How

- **`apply-related.mjs`** — a post-write stamp onto `catalog.json`, the same shape and for the same reason as `apply-parallels.mjs`: the pinned `toCatalogManifest` allow-lists the component fields it knows and drops the rest with no error anywhere. Additive, idempotent, and never clobbering an exporter that learns the field later, so bumping the pin makes it a no-op rather than a conflict.
- **Deferred records stamped from the same index** (`relatedIndex`), because a wholly deferred component never reaches `manifest.components` — the gap `parallelIndex` was extracted to close.
- **Validated in `catalog-spec.mjs`, not in the JSON schema.** The schema is a `$schema` editor hint that no build step enforces, so the validator is the only gate a malformed spec actually meets. A link with no `system` is unpublishable, so it is an error rather than an affordance that silently never appears — the failure this repo already paid for once with `parallel`, when `remote-m3` published 51 components and zero pairings and nothing said so.
- Carried verbatim: no check that the named system exists or has such a component. Only the consumer can resolve that, and a silent drop here would hide a spec typo behind an absent field.

## Not in this PR

- **The annotation.** `@CatalogComponent(related = [...])` lives in the daemon's `:preview-annotations`, consumed here at the `composeai-preview-daemon` pin, so it cannot land in the same change. The spec path is useful on its own: it unblocks both catalog repos now, and the annotation becomes the nicer spelling rather than a prerequisite.
- **The server affordance** in `yschimke/compose-preview-server`. That one is UI and needs visual evidence.

## Test plan

New `apply-related.test.mjs` (13 tests): stamping, multi-link (the case a scalar cannot express), no-op, never-clobber, idempotence, unmentioned components left alone, dropping a link with no `system`, blank `componentId`/`label` omitted rather than emitted, trimming, non-array tolerated, empty inputs, and `relatedIndex` keying across groups.

New validator tests in `catalog-spec.test.mjs` (8): accepts the three shapes, rejects a missing/blank `system`, a non-array `related`, a non-object entry, an unknown key, and a present-but-empty `componentId`/`label`.

```
node --test apply-related.test.mjs        13 pass, 0 fail
node --test catalog-spec.test.mjs         79 pass, 0 fail
npm test (whole driver suite)           1494 pass, 0 fail, 30 skipped
```

The generator was also loaded with deps installed, to confirm the new import resolves. Non-visual change — no Kotlin touched, so no `ktfmtCheckAll` impact and no render evidence applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJVnYyuf9kfwEsUPWuZrAq

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJVnYyuf9kfwEsUPWuZrAq)_