### PR TITLE
feat(plugin): render one module's previews on another module's lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,6 +375,20 @@ jobs:
       # the Desktop lane it has taken since #248. `:samples:cmp-shared` is that shape.
       - name: Discover previews on the default (Desktop) KMP-Android lane
         run: ./gradlew :samples:cmp-shared:composePreviewDiscover
+      # `composePreviewSource`: ONE shared module's previews rendered on BOTH lanes.
+      # `:samples:preview-source-shared` applies no preview plugin and registers no lane; the two
+      # samples above name it, and each renders its previews on its own renderer. `RenderAll` on
+      # both, for the same reason as the Robolectric gate above — the bare render task writes a
+      # `.error.json` and still exits 0, so only the aggregate's missing-render gate can see a
+      # shared preview that was discovered and then failed to draw.
+      #
+      # Rendering both is the point: a regression that drops the shared module from one lane's
+      # discovery leaves the other green, and a single-lane gate would report success.
+      - name: Render shared preview sources on both lanes
+        run: >-
+          ./gradlew
+          :samples:cmp-shared:composePreviewRenderAll
+          :samples:cmp-android-robolectric:composePreviewRenderAll
       # Full render for the screenshot-test sample — the interesting behaviour
       # isn't discovery (which `:samples:android` also exercises) but rendering
       # class-member @Previews co-applied with `com.android.compose.screenshot`.

--- a/gradle-plugin/gradle-plugin-config/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
+++ b/gradle-plugin/gradle-plugin-config/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
@@ -6,6 +6,7 @@ import javax.inject.Inject
 import org.gradle.api.Action
 import org.gradle.api.Named
 import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
@@ -378,6 +379,34 @@ abstract class PreviewExtension @Inject constructor(private val objects: ObjectF
    */
   val kmpAndroidRobolectric: Property<Boolean> =
     objects.property(Boolean::class.java).convention(false)
+
+  /**
+   * Source roots of the modules named by the `composePreviewSource` dependency configuration, so
+   * their `@Preview`s are attributed to the file that declares them.
+   *
+   * `composePreviewSource` alone gets the *classes* scanned — enough to find the previews. It is
+   * not enough to place them: a Kotlin file's `@file:` annotations reach the bytecode on the `…Kt`
+   * facade class, but resolving that class back to `sections/Buttons.kt` is done by matching its
+   * package-qualified source name against real files. Without the shared module's sources on that
+   * list every `@file:CatalogGroup` default silently stops applying — a catalog whose previews all
+   * land ungrouped, with a green build.
+   *
+   * Point it at the directory, not the files:
+   * ```
+   * dependencies { composePreviewSource(project(":catalog-shared")) }
+   * composePreview { previewSourceRoots.from(file("../catalog-shared/src")) }
+   * ```
+   *
+   * Paths are reported relative to the *consuming* module, so a sibling module's previews carry a
+   * `../catalog-shared/…` source path. That is the honest answer — the file genuinely is not in
+   * this module — and every consumer that resolves a preview back to its source (the CLI, the VS
+   * Code extension) follows it.
+   *
+   * Two declarations rather than one on purpose. Reading another project's source tree through the
+   * dependency graph would mean a cross-project model lookup, which isolated projects forbids; a
+   * path is just a path, and stays legal in every configuration mode.
+   */
+  val previewSourceRoots: ConfigurableFileCollection = objects.fileCollection()
 
   /** Generic selector for preview extensions that produce data alongside preview PNGs. */
   val previewExtensions: PreviewExtensionsExtension =

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewPlugin.kt
@@ -9,6 +9,12 @@ import org.gradle.api.configuration.BuildFeatures
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 import org.gradle.util.GradleVersion
 
+/**
+ * Name of the dependency configuration a module names its shared preview-source modules in. See the
+ * `configurations.create` call in [ComposePreviewPlugin.apply] for what it is for.
+ */
+const val PREVIEW_SOURCE_CONFIGURATION = "composePreviewSource"
+
 abstract class ComposePreviewPlugin
 @Inject
 constructor(
@@ -32,6 +38,41 @@ constructor(
     // `Property` objects. Convention wiring (`-PcomposePreview.variant=…` etc.) lives in
     // [ComposePreviewDsl.createOrFindExtension].
     val extension = ComposePreviewDsl.createOrFindExtension(project)
+
+    // `composePreviewSource` — the bucket a module names a SHARED SOURCE MODULE in, so that
+    // module's `@Preview`s are discovered here and rendered on this module's lane.
+    //
+    // The plugin registers exactly one render lane per module (Robolectric or CMP Desktop), and
+    // discovery method-walks only the module's OWN classes: a dependency JAR stays on the scan
+    // classpath so a multi-preview annotation still resolves, but its `@Preview` functions are
+    // never walked. Together those two rules mean a catalog that wants to render on more than one
+    // lane has to re-declare its previews once per lane. This configuration is the seam that
+    // removes the duplication: the previews live once, in a plain library module with no preview
+    // plugin, and each lane module points at it.
+    //
+    //     dependencies {
+    //       implementation(project(":catalog-shared"))        // the classes, at runtime
+    //       composePreviewSource(project(":catalog-shared"))  // + discover its @Previews
+    //     }
+    //
+    // Deliberately NOT extended from (or by) `implementation`. What a module renders is a narrower
+    // question than what it compiles against: a catalog depends on a dozen libraries whose
+    // `@Preview`s — the ones a library ships for its own sticker sheet — must not silently become
+    // this module's. Naming the source module is the opt-in.
+    // A plain BUCKET — neither resolvable nor consumable. It carries declarations only; the
+    // resolvable view is derived in [ComposePreviewTasks.registerDiscoverTask], which copies the
+    // attributes of the module's own runtime classpath onto it. That indirection is not optional:
+    // a KMP producer publishes several variants, and a configuration with no attributes cannot
+    // choose between them — it resolves to nothing, silently, and the shared previews simply never
+    // appear. Borrowing the lane's own attributes asks for exactly the variant this module already
+    // renders against (`androidJvm` on the Robolectric lane, `jvm` on Desktop).
+    project.configurations.create(PREVIEW_SOURCE_CONFIGURATION) {
+      isCanBeConsumed = false
+      isCanBeResolved = false
+      description =
+        "Modules whose @Preview functions are discovered and rendered by this module's " +
+          "compose-preview lane. See composePreview.previewSourceRoots for their sources."
+    }
 
     // ToolingModelBuilderRegistry is a build-scoped service — registering
     // from any applying project makes the model available on every

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -6,6 +6,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.repositories.ArtifactRepository
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.file.Directory
@@ -155,6 +156,43 @@ internal object ComposePreviewTasks {
    * ONLY for the `androidRuntimeClasspath` fallback (mirroring discovery) so a strict JVM classpath
    * still surfaces a genuinely missing dependency instead of silently dropping it.
    */
+  /**
+   * Resolvable view of the [PREVIEW_SOURCE_CONFIGURATION] bucket, wearing the attributes of the
+   * module's own runtime classpath ([runtimeConfigName]).
+   *
+   * The bucket itself carries declarations and nothing else. A shared preview-source module is
+   * normally Kotlin Multiplatform, so it publishes several variants; a configuration with no
+   * attributes cannot choose between them and resolves to nothing — no error, no previews, a green
+   * build with a silently shorter sticker sheet. Copying the lane's own attributes asks for exactly
+   * the variant this module already renders against: `androidJvm` on the Robolectric lane, `jvm` on
+   * Desktop. That is also what makes one shared module serve both lanes from one declaration.
+   *
+   * Returns null when nothing was declared, or when the runtime classpath is not resolvable yet —
+   * both meaning "no shared preview sources", which is every module that does not use the feature.
+   */
+  private fun previewSourceClasspath(project: Project, runtimeConfigName: String): Configuration? {
+    val bucket = project.configurations.findByName(PREVIEW_SOURCE_CONFIGURATION) ?: return null
+    if (bucket.dependencies.isEmpty()) return null
+    val runtime = project.configurations.findByName(runtimeConfigName) ?: return null
+    val name = "composePreviewSourceClasspath"
+    project.configurations.findByName(name)?.let {
+      return it
+    }
+    return project.configurations.create(name) {
+      isCanBeConsumed = false
+      isCanBeResolved = true
+      extendsFrom(bucket)
+      description =
+        "Resolvable view of $PREVIEW_SOURCE_CONFIGURATION, carrying the attributes of " +
+          "$runtimeConfigName so a multiplatform preview-source module selects the same variant " +
+          "this module renders against."
+      runtime.attributes.keySet().forEach { key ->
+        @Suppress("UNCHECKED_CAST") val typed = key as org.gradle.api.attributes.Attribute<Any>
+        runtime.attributes.getAttribute(typed)?.let { value -> attributes.attribute(typed, value) }
+      }
+    }
+  }
+
   private fun pinnedConsumerClasspath(
     project: Project,
     configName: String,
@@ -1764,8 +1802,42 @@ internal object ComposePreviewTasks {
       this.catalogRenderSupported.set(catalogRenderSupported)
       classDirs.from(sourceClassDirs)
       activeClassDirs.from(activeSourceClassDirs)
+
+      // Shared preview-source modules (`composePreviewSource(project(":catalog-shared"))`).
+      // Their classes go on `classDirs`, NOT `dependencyJars`: that is the whole point of the
+      // configuration. Discovery keeps the two apart deliberately — a dependency JAR stays on the
+      // ClassGraph classpath so a multi-preview annotation resolves, but is never method-walked,
+      // so its `@Preview` functions are invisible. Putting these on `classDirs` walks them as
+      // project classes, which is what makes the previews this module's to render. The task sorts
+      // dirs from jars: a jar put on `classDirs` is dropped silently, since discovery filters that
+      // list to existing DIRECTORIES.
+      //
+      // Not added to `activeClassDirs`: that set exists for the empty-compile integrity check,
+      // which asks whether THIS module's compilation produced output. A shared module's classes
+      // are not evidence about that, and letting them in would mask exactly the broken cache
+      // restore the check is there to catch.
+      previewSourceClasspath(project, dependencyConfigName())?.let { config ->
+        previewSourceClasses.from(
+          config.incoming.artifactView { attributes.attribute(artifactType, "jar") }.files
+        )
+        previewSourceClasses.from(
+          config.incoming
+            .artifactView { attributes.attribute(artifactType, "android-classes") }
+            .files
+        )
+      }
+
       sourceFiles.from(
         project.fileTree("src") {
+          include("**/*.kt")
+          include("**/*.java")
+        }
+      )
+      // …and their sources, so a shared preview still resolves back to the file that declares it
+      // and its `@file:CatalogGroup` default still applies. Classes alone find the preview; only
+      // the source file places it. See `composePreview.previewSourceRoots`.
+      sourceFiles.from(
+        extension.previewSourceRoots.asFileTree.matching {
           include("**/*.kt")
           include("**/*.java")
         }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -82,6 +82,25 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
   @get:PathSensitive(PathSensitivity.RELATIVE)
   abstract val projectClassJars: ListProperty<RegularFile>
 
+  /**
+   * Compiled output of the modules named in the `composePreviewSource` configuration — shared
+   * preview-source modules whose `@Preview` functions this module renders on its own lane.
+   *
+   * One collection rather than a dirs/jars pair because what a project dependency resolves to is
+   * not the consumer's to predict: a KMP producer hands back a jar, an Android one an extracted
+   * `classes.jar`, an in-place compilation a directory. [discover] sorts them, because the two
+   * halves land in different [PreviewDiscovery.Input] fields — and putting a jar on `classDirs`
+   * fails silently, since discovery filters that list to directories that exist.
+   *
+   * Method-walked as project classes, exactly like the module's own output. That is the whole
+   * point: a dependency JAR stays on the ClassGraph classpath so a multi-preview annotation
+   * resolves, but its previews are never walked.
+   */
+  @get:InputFiles
+  @get:Optional
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract val previewSourceClasses: ConfigurableFileCollection
+
   @get:InputFiles
   @get:PathSensitive(PathSensitivity.NONE)
   abstract val dependencyJars: ConfigurableFileCollection
@@ -305,8 +324,13 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     // which compiler produced them. ClassGraph attributes each FQN to a single
     // element and previews are deduped by id, so any overlap between the two
     // sources is harmless. See issue #1924.
-    val scopedClassDirs = projectClassDirs.getOrElse(emptyList()).map { it.asFile }
-    val scopedClassJars = projectClassJars.getOrElse(emptyList()).map { it.asFile }
+    val sharedPreviewSources = previewSourceClasses.files.filter { it.exists() }
+    val scopedClassDirs =
+      projectClassDirs.getOrElse(emptyList()).map { it.asFile } +
+        sharedPreviewSources.filter { it.isDirectory }
+    val scopedClassJars =
+      projectClassJars.getOrElse(emptyList()).map { it.asFile } +
+        sharedPreviewSources.filter { it.isFile && it.name.lowercase().endsWith(".jar") }
     // A Wear OS module declares `<uses-feature android:name="android.hardware.type.watch">` in its
     // merged manifest. Plain-substring match on the raw XML — enough to distinguish a Wear module
     // from a phone one without pulling in an XML parser; absent manifest → not Wear.

--- a/samples/cmp-android-robolectric/build.gradle.kts
+++ b/samples/cmp-android-robolectric/build.gradle.kts
@@ -70,12 +70,29 @@ kotlin {
       @Suppress("DEPRECATION") implementation(compose.foundation)
       @Suppress("DEPRECATION") implementation(compose.material3)
       implementation("org.jetbrains.compose.ui:ui-tooling-preview:1.10.3")
+
+      // The shared preview-source module, on the runtime classpath so its composables resolve at
+      // render time. Its `android` variant is what an `androidJvm` consumer selects, so what
+      // Robolectric renders is Android-flavoured Compose — the same source, compiled for this
+      // lane.
+      implementation(project(":samples:preview-source-shared"))
     }
   }
+}
+
+dependencies {
+  // The SAME module `:samples:cmp-shared` names, rendered here on the OTHER lane. One set of
+  // preview declarations, two renderers: this is the case `composePreviewSource` exists for, and
+  // having both samples point at one module is what keeps CI honest about it.
+  composePreviewSource(project(":samples:preview-source-shared"))
 }
 
 composePreview {
   // The opt-in. Without it this module takes the Desktop lane like every other KMP-Android
   // module and its previews fail to render at all.
   kmpAndroidRobolectric = true
+
+  // Sources of the shared module above, so its previews resolve back to the file that declares
+  // them and its `@file:CatalogGroup` still applies — on this lane exactly as on Desktop.
+  previewSourceRoots.from(file("../preview-source-shared/src"))
 }

--- a/samples/cmp-shared/build.gradle.kts
+++ b/samples/cmp-shared/build.gradle.kts
@@ -78,6 +78,26 @@ kotlin {
       // multiplatform `preview-annotations` artifact exists for (mirrors meshcore's
       // `:meshcore-components`, whose tokens live in shared code). Exercised by `SharedTokens.kt`.
       implementation(libs.composeai.preview.annotations)
+
+      // The shared preview-source module, on the runtime classpath. Declaring it here is what
+      // makes its composables resolvable at render time; `composePreviewSource` below is what
+      // makes its `@Preview`s DISCOVERABLE. The two are separate on purpose — a module depends on
+      // plenty of libraries whose own sticker-sheet previews must not become this module's.
+      implementation(project(":samples:preview-source-shared"))
     }
   }
+}
+
+dependencies {
+  // Render `:samples:preview-source-shared`'s previews on THIS module's lane (Desktop). The same
+  // module is named by `:samples:cmp-android-robolectric`, which renders the same previews on
+  // Robolectric — one declaration, two lanes, which is the whole point of the configuration.
+  composePreviewSource(project(":samples:preview-source-shared"))
+}
+
+composePreview {
+  // Its sources, so the shared previews resolve back to the file that declares them and the
+  // `@file:CatalogGroup` on it still applies. Classes alone find a preview; only the source file
+  // places it.
+  previewSourceRoots.from(file("../preview-source-shared/src"))
 }

--- a/samples/preview-source-shared/build.gradle.kts
+++ b/samples/preview-source-shared/build.gradle.kts
@@ -1,0 +1,68 @@
+// `:samples:preview-source-shared` — previews declared ONCE, rendered on TWO lanes.
+//
+// The module applies **no** `ee.schimke.composeai.preview` plugin and registers no render lane. It
+// is a plain multiplatform library that happens to contain `@Preview` functions. Two sibling
+// samples name it in their `composePreviewSource` configuration and each renders these same
+// previews on its own lane:
+//
+//   * `:samples:cmp-shared`             — Compose Multiplatform Desktop (`ImageComposeScene`)
+//   * `:samples:cmp-android-robolectric` — Robolectric, against real Android
+//
+// This is the case the `composePreviewSource` configuration exists for. The plugin registers
+// exactly ONE lane per module, and discovery method-walks only the module's own classes — a
+// dependency JAR stays on the ClassGraph classpath so a multi-preview annotation resolves, but its
+// `@Preview` functions are never walked. Before this configuration, a catalog that wanted both
+// lanes had to re-declare every preview once per lane, and the two copies drifted.
+//
+// `@file:CatalogGroup` in `SharedSourcePreviews.kt` is not decoration: it is the half of the
+// feature that classes alone cannot carry. The annotation reaches the bytecode on the `…Kt` facade
+// class, but resolving that class back to `SharedSourcePreviews.kt` is done by matching its
+// package-qualified source name against real files — which is why each consumer also points
+// `composePreview.previewSourceRoots` at this module's `src`. Drop that line and both lanes still
+// render, ungrouped, with a green build. That is the failure this sample is here to catch.
+//
+// Two targets so each consumer resolves its own flavour of the compose runtime: `android` for the
+// Robolectric lane (whose classes call into `compose-runtime-android`) and `jvm("desktop")` for the
+// Desktop one. A jvm-only producer would resolve for both — an `androidJvm` consumer takes a `jvm`
+// producer — but the Android lane would then render classes compiled against desktop Compose.
+plugins {
+  id("composeai.base-conventions")
+  id("composeai.jvm-conventions")
+  // Same buildscript-classpath bundle story as `:samples:cmp-shared` — apply by id without a
+  // version, or AGP 9's bundled copies error with "already on the classpath with an unknown
+  // version, so compatibility cannot be checked".
+  id("org.jetbrains.kotlin.multiplatform")
+  id("com.android.kotlin.multiplatform.library")
+  alias(libs.plugins.compose.multiplatform)
+  id("org.jetbrains.kotlin.plugin.compose")
+}
+
+kotlin {
+  android {
+    namespace = "com.example.previewsourceshared"
+    compileSdk = 36
+    minSdk = 24
+
+    compilations.configureEach {
+      compileTaskProvider.configure {
+        compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) }
+      }
+    }
+  }
+
+  jvm("desktop")
+
+  sourceSets {
+    commonMain.dependencies {
+      @Suppress("DEPRECATION") implementation(compose.runtime)
+      @Suppress("DEPRECATION") implementation(compose.foundation)
+      @Suppress("DEPRECATION") implementation(compose.material3)
+      // The JetBrains-relocated androidx artifact, which ships
+      // `androidx.compose.ui.tooling.preview.Preview` on every target — the FQN discovery scans
+      // for. See the same note in `:samples:cmp-shared`.
+      implementation("org.jetbrains.compose.ui:ui-tooling-preview:1.10.3")
+      // `@file:CatalogGroup`, from `commonMain` — the multiplatform half of `preview-annotations`.
+      implementation(libs.composeai.preview.annotations)
+    }
+  }
+}

--- a/samples/preview-source-shared/src/commonMain/kotlin/com/example/previewsourceshared/SharedSourcePreviews.kt
+++ b/samples/preview-source-shared/src/commonMain/kotlin/com/example/previewsourceshared/SharedSourcePreviews.kt
@@ -1,0 +1,39 @@
+@file:CatalogGroup(name = "Shared source", section = "Samples")
+
+package com.example.previewsourceshared
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import ee.schimke.composeai.preview.CatalogComponent
+import ee.schimke.composeai.preview.CatalogGroup
+
+/**
+ * Declared once here; rendered by `:samples:cmp-shared` on the Desktop lane AND by
+ * `:samples:cmp-android-robolectric` on the Robolectric lane, because both name this module in
+ * `composePreviewSource`. Neither re-declares it.
+ */
+@CatalogComponent(id = "shared-green", caption = "Rendered on both lanes from one declaration")
+@Preview
+@Composable
+fun SharedSourceGreenBoxPreview() {
+  Box(modifier = Modifier.size(120.dp).background(Color.Green)) { Text("shared source") }
+}
+
+/**
+ * A second preview so the two lanes have to agree on a SET rather than on one file. The
+ * `@file:CatalogGroup` above applies to both, and only does so because each consumer points
+ * `previewSourceRoots` at this module's sources.
+ */
+@CatalogComponent(id = "shared-magenta", caption = "Second preview, same file, same group")
+@Preview(name = "Magenta", showBackground = true, backgroundColor = 0xFFFFFFFF)
+@Composable
+fun SharedSourceMagentaBoxPreview() {
+  Box(modifier = Modifier.size(120.dp).background(Color.Magenta)) { Text("shared source 2") }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -307,6 +307,9 @@ include(":samples:xr-glimmer")
 include(":samples:cmp")
 
 include(":samples:cmp-shared")
+// Previews declared once and rendered on BOTH lanes by the two samples above/below it, through
+// the `composePreviewSource` configuration. Applies no preview plugin itself.
+include(":samples:preview-source-shared")
 
 // In-browser CMP tier — a `wasmJs` Compose app rendering the M3 catalog in the
 // browser sandbox (a `wasmJs` Compose app). wasmJs-only, no


### PR DESCRIPTION
## Why

The plugin registers exactly **one** render lane per module — Robolectric or CMP Desktop, decided once — and discovery method-walks only the module's **own** classes. A dependency JAR stays on the ClassGraph classpath so a multi-preview annotation still resolves, but its `@Preview` functions are never walked.

Together those two rules mean a catalog that wants to render on more than one lane has to re-declare every preview once per lane, and the copies drift. Found from wear-m3-catalog, whose 32-file Wear catalog compiles unchanged from a KMP `commonMain` but could only ever have rendered on one of its two targets.

## What

`composePreviewSource` is the seam. The previews live once, in a plain library that applies no preview plugin and registers no lane; each lane module names it:

```kotlin
dependencies {
  implementation(project(":catalog-shared"))        // classes, at runtime
  composePreviewSource(project(":catalog-shared"))  // + discover its previews
}
composePreview { previewSourceRoots.from(file("../catalog-shared/src")) }
```

Deliberately **not** extended from `implementation`. What a module renders is a narrower question than what it compiles against: a catalog depends on libraries that ship `@Preview`s for their own sticker sheets, and those must not silently become its own. Naming the module is the opt-in.

## Three things that fail silently, and how each is handled

- **The bucket is unresolvable; the resolvable view copies the attributes of the module's own runtime classpath.** A shared module is normally KMP and publishes several variants; a configuration with no attributes cannot choose between them and resolves to nothing — no error, green build, shorter sticker sheet. Borrowing the lane's attributes is also what makes one shared module serve both lanes from one declaration: `androidJvm` selects the android variant, `jvm` the desktop one.
- **Resolved artifacts go to a new `previewSourceClasses` input, which the task sorts into dirs and jars.** What a project dependency resolves to is not the consumer's to predict, and a jar placed on `classDirs` is dropped without a word — discovery filters that list to existing *directories*. This was the bug the first cut had: 4 previews discovered, then 4 again.
- **`previewSourceRoots` carries the shared module's sources.** `@file:CatalogGroup` reaches the bytecode on the `…Kt` facade class, but resolving that class back to its file is done by matching the package-qualified source name against real files. Without it both lanes render, ungrouped, green.

Shared classes stay **out** of `activeClassDirs`: that set backs the empty-compile integrity check, which asks whether *this* module's compilation produced output. A shared module's classes are not evidence about that, and admitting them would mask exactly the broken cache restore the check exists to catch.

## The proof

`:samples:preview-source-shared` — one module, named by two **existing** samples on two different lanes rather than a pair of new ones, so CI cannot go green with the feature working on only one:

| sample | lane | previews |
| --- | --- | --- |
| `:samples:cmp-shared` | CMP Desktop | 4 → 6 |
| `:samples:cmp-android-robolectric` | Robolectric | 1 → 3 |

Both render the **same two PNGs** from one declaration — `SharedSourceGreenBoxPreview-7a08db87.png` and `SharedSourceMagentaBoxPreview_Magenta-1ff13d35.png` — and the `@file:CatalogGroup` resolves to `"group": "Shared source"` on both.

## Test plan

- `:samples:cmp-shared:composePreviewRenderAll` and `:samples:cmp-android-robolectric:composePreviewRenderAll` — green, PNG sets above. `RenderAll`, not `composePreviewRender`: only the aggregate carries the missing-render gate, and the bare task writes `.error.json` and exits 0.
- Source attribution verified in `previews.json` — the shared previews carry `../preview-source-shared/src/commonMain/.../SharedSourcePreviews.kt`.
- `ktfmtFormatAll`, `:gradle-plugin:test`, `:gradle-plugin:gradle-plugin-config:test` — green.
- CI gains a gate rendering both lanes in one step.

No functional test beside the samples: the samples *are* the coverage here, the same way `:samples:cmp-android-robolectric` covers the lane it was added for, and a stubbed build would not exercise variant selection across two real renderers.

Plugin/infrastructure change — the new sample's PNGs are the evidence and are produced by the CI gate rather than committed, so no embedded before/after images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkKpVkVtMQkHK78wJkh1Pe

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkKpVkVtMQkHK78wJkh1Pe)_