### PR TITLE
feat(remote-json): compile exact decimal comparisons

### DIFF
--- a/remotecompose/json/README.md
+++ b/remotecompose/json/README.md
@@ -77,3 +77,17 @@ The unextended parser and the existing integer-expression profile keep their beh
 particular, stock `variable` declarations of `vtype:string` still intern equal text; use the new
 declaration when independent mutable identity is required. The profile emits ordinary
 `NamedVariable` and `TextData` operations, with no binary rewriting or custom player opcode.
+
+## Exact decimal comparisons
+
+The state profile also accepts `{"type":"floatEquals","name":"match","left":"@page","right":1.25}`.
+Each operand is a finite Float literal or a previously declared scalar Float reference; integer,
+text, collection, forward and expression-string operands are rejected. The output is an integer
+0/1 usable by subsequent `integerExpression` declarations and StateLayout index calculations.
+Only `type`, `name`, `left` and `right` are accepted, and output names must be unique identifiers.
+
+The compiler emits creation-compose's exact Float equality sequence followed by an integer
+expression reading its result. It does not use an epsilon or approximate equality, so adjacent
+finite Floats remain distinct. Literal values use Float precision. The player must publish the
+integer view of Float results as AndroidX does; older CMP player builds need rc-players#94.
+Host-supplied non-finite values are outside this finite-selector contract.

--- a/remotecompose/json/src/main/kotlin/androidx/compose/remote/creation/json/ComposePreviewFloatEquals.kt
+++ b/remotecompose/json/src/main/kotlin/androidx/compose/remote/creation/json/ComposePreviewFloatEquals.kt
@@ -1,0 +1,67 @@
+package androidx.compose.remote.creation.json
+
+import androidx.compose.remote.core.operations.Utils
+import androidx.compose.remote.core.operations.utilities.AnimatedFloatExpression
+import org.json.JSONException
+
+/** Exact finite Float equality, lowered identically to creation-compose's RemoteFloat.isEqualTo. */
+internal object ComposePreviewFloatEquals {
+  fun install(parser: RemoteComposeJsonParser) {
+    parser.registerComponentParser("floatEquals") { component, _, writer, current ->
+      val name = component.getString("name")
+      try {
+        require(Regex("[A-Za-z_][A-Za-z0-9_]*").matches(name)) { "name must be an identifier" }
+        require(component.keySet().all { it in setOf("type", "name", "left", "right") }) {
+          "only type, name, left and right are supported"
+        }
+        require(
+          name !in current.mIntegerVariables &&
+            name !in current.mVariables &&
+            name !in current.mDeferredVariables
+        ) {
+          "duplicate name '$name'"
+        }
+        fun operand(key: String): Float {
+          val value = component.get(key)
+          if (value is Number)
+            return value.toFloat().also {
+              require(it.isFinite()) { "$key must fit a finite Float" }
+            }
+          require(value is String && Regex("@[A-Za-z_][A-Za-z0-9_]*").matches(value)) {
+            "$key must be a finite number or @float reference"
+          }
+          val variable = value.drop(1)
+          val encoded = current.mVariables[variable]
+          require(
+            variable !in current.mIntegerVariables &&
+              encoded != null &&
+              encoded.isNaN() &&
+              Utils.idFromNan(encoded) in 1 until 0x10000
+          ) {
+            "$key: unknown scalar float reference '$value'"
+          }
+          return encoded
+        }
+        val left = operand("left")
+        val right = operand("right")
+        // Do not approximate equality with 1-min(1, abs(a-b)): that aliases adjacent Floats.
+        val match =
+          writer.floatExpression(
+            1f,
+            0f,
+            right,
+            left,
+            AnimatedFloatExpression.SUB,
+            AnimatedFloatExpression.ABS,
+            AnimatedFloatExpression.IFELSE,
+          )
+        val encoded = writer.integerExpression(0x100000000L + Utils.idFromNan(match))
+        current.mIntegerVariables[name] = encoded
+        current.mVariables[name] = Utils.asNan(encoded.toInt())
+        current.recordVariable(name, encoded.toInt())
+      } catch (e: RuntimeException) {
+        throw JSONException("${current.contextPathString}: floatEquals '$name': ${e.message}", e)
+      }
+    }
+  }
+}

--- a/remotecompose/json/src/main/kotlin/ee/schimke/composeai/remotecompose/json/RemoteComposeJson.kt
+++ b/remotecompose/json/src/main/kotlin/ee/schimke/composeai/remotecompose/json/RemoteComposeJson.kt
@@ -4,6 +4,7 @@ import androidx.compose.remote.core.CoreDocument
 import androidx.compose.remote.core.RemoteComposeBuffer
 import androidx.compose.remote.core.operations.Header
 import androidx.compose.remote.creation.RemoteComposeWriter
+import androidx.compose.remote.creation.json.ComposePreviewFloatEquals
 import androidx.compose.remote.creation.json.ComposePreviewIntegerExpressions
 import androidx.compose.remote.creation.json.ComposePreviewMutableStrings
 import androidx.compose.remote.creation.json.RemoteComposeJsonParser
@@ -92,7 +93,9 @@ public object RemoteComposeJson {
    */
   public const val INTEGER_EXPRESSIONS_PROFILE: String = "compose-preview-integer-expressions-v1"
 
-  /** Named integer expressions and independent mutable string declarations. */
+  /**
+   * Named integer expressions, exact Float equality and independent mutable string declarations.
+   */
   public const val STATE_PROFILE: String = "compose-preview-state-v1"
 
   /**
@@ -124,7 +127,10 @@ public object RemoteComposeJson {
           )
         val parser = RemoteComposeJsonParser(writer)
         ComposePreviewIntegerExpressions.install(parser)
-        if (profile.content == STATE_PROFILE) ComposePreviewMutableStrings.install(parser)
+        if (profile.content == STATE_PROFILE) {
+          ComposePreviewMutableStrings.install(parser)
+          ComposePreviewFloatEquals.install(parser)
+        }
         parser.parse(json)
         return writer.encodeToByteArray()
       }

--- a/remotecompose/json/src/test/kotlin/ee/schimke/composeai/remotecompose/json/FloatEqualsProfileTest.kt
+++ b/remotecompose/json/src/test/kotlin/ee/schimke/composeai/remotecompose/json/FloatEqualsProfileTest.kt
@@ -1,0 +1,99 @@
+package ee.schimke.composeai.remotecompose.json
+
+import com.google.common.truth.Truth.assertThat
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class FloatEqualsProfileTest {
+  private fun comparison(left: Any = "@page", right: Any = 1.25) =
+    JSONObject()
+      .put("type", "floatEquals")
+      .put("name", "match")
+      .put("left", left)
+      .put("right", right)
+
+  private fun source(vararg nodes: JSONObject): JSONObject {
+    val resources =
+      JSONObject()
+        .put("type", "resources")
+        .put(
+          "variables",
+          JSONObject().put("page", JSONObject().put("value", 1.25).put("export", true)),
+        )
+    val root = JSONObject().put("type", "box").put("children", JSONArray(nodes.toList()))
+    return JSONObject()
+      .put("compilerProfile", RemoteComposeJson.STATE_PROFILE)
+      .put("header", JSONObject().put("width", 100).put("height", 100))
+      .put("root", JSONArray().put(resources).put(root))
+  }
+
+  @Test
+  fun `comparison emits standard float and integer expressions deterministically`() {
+    val source =
+      source(
+        comparison(),
+        JSONObject()
+          .put("type", "integerExpression")
+          .put("name", "index")
+          .put("value", "1 - @match"),
+      )
+    val bytes = RemoteComposeJson.compile(source.toString())
+    assertThat(RemoteComposeJson.compile(source.toString())).isEqualTo(bytes)
+    val dump = RemoteComposeJson.dump(bytes)
+    assertThat(dump).contains("FloatExpression")
+    assertThat(dump).contains("IntegerExpression")
+  }
+
+  @Test
+  fun `unextended profiles refuse float comparison`() {
+    for (profile in listOf<String?>(null, RemoteComposeJson.INTEGER_EXPRESSIONS_PROFILE)) {
+      val source = source(comparison())
+      if (profile == null) source.remove("compilerProfile")
+      else source.put("compilerProfile", profile)
+      assertThrows(RemoteComposeJsonException::class.java) {
+        RemoteComposeJson.compile(source.toString())
+      }
+    }
+  }
+
+  @Test
+  fun `invalid operands and names are located refusals`() {
+    val invalid =
+      listOf(
+        comparison("@missing"),
+        comparison("@page + 1"),
+        comparison(true),
+        comparison(JSONObject.NULL),
+        comparison(1e100),
+        comparison().put("name", "page"),
+        comparison().put("name", "not a name"),
+        comparison().put("extra", 1),
+      )
+    for (node in invalid) {
+      val error =
+        assertThrows(RemoteComposeJsonException::class.java) {
+          RemoteComposeJson.compile(source(node).toString())
+        }
+      assertThat(error).hasMessageThat().contains("floatEquals")
+      assertThat(error).hasMessageThat().contains("ContextPath")
+    }
+    assertThrows(RemoteComposeJsonException::class.java) {
+      RemoteComposeJson.compile(source(comparison(), comparison()).toString())
+    }
+  }
+
+  @Test
+  fun `integer and text references cannot masquerade as floats`() {
+    for (declaration in
+      listOf(
+        JSONObject().put("type", "integerExpression").put("name", "other").put("value", "1"),
+        JSONObject().put("type", "mutableString").put("name", "other").put("value", "1.25"),
+      )) {
+      assertThrows(RemoteComposeJsonException::class.java) {
+        RemoteComposeJson.compile(source(declaration, comparison("@other")).toString())
+      }
+    }
+  }
+}


### PR DESCRIPTION
The state compiler profile now accepts exact decimal equality for StateLayout selection. `floatEquals` lowers finite literals and declared scalar Float references into the same FloatExpression → IntegerExpression sequence that creation-compose uses, so adjacent Float values stay distinct.

The output is a named integer 0/1 that existing integer expressions can combine into case ordinals. Invalid operands, integer/text references, duplicate names, unknown fields and unavailable profiles produce located refusals. The unextended and integer-only profiles retain their behavior; no custom wire operation or public API is added.

Validation: all 35 module tests, formatting, ABI and layer checks pass on current main. The UI-builder consumer's exact production JSON passes 18 real-player scenarios (nine cases at two densities), including ordered actions, fallback, adjacent values, subnormals and finite extremes. The CMP player needs the AndroidX numeric-storage correction in [rc-players #94](https://github.com/yschimke/rc-players/pull/94).

This branch starts from main after the independent text-state PR #5406 merged. Local publications are staged into the existing UI-builder build without a release. Integration is tracked in [compose-preview-server #708](https://github.com/yschimke/compose-preview-server/pull/708).

The final committed publication also passes the existing WASM app proof: real decimal clicks cycle through both cases and fallback; editing the initial value from 2.5 to 3.75 produces JSON, RC and PNG downloads identical to hosted MCP. No browser errors or saved server designs occur.

Before the click, the live document selects case 2.5:

![Decimal case before click](https://raw.githubusercontent.com/yschimke/compose-preview-server/9f5445d6a65324d380a42384a54022d7eb369cb8/docs/design/evidence/ui-builder-decimal-selection/decimal-preview-second.png)

After the click changes state to 3.75, it selects the fallback:

![Decimal fallback after click](https://raw.githubusercontent.com/yschimke/compose-preview-server/9f5445d6a65324d380a42384a54022d7eb369cb8/docs/design/evidence/ui-builder-decimal-selection/decimal-preview-fallback.png)

These are interaction captures of the existing ui-builder WASM app. [Source, all six exported artifacts and reproduction](https://github.com/yschimke/compose-preview-server/blob/9f5445d6a65324d380a42384a54022d7eb369cb8/docs/design/evidence/ui-builder-decimal-selection/README.md).
