### PR TITLE
feat(ui-builder): let a builtin slot state how many children it admits

### DIFF
--- a/scripts/design-artifacts/ui-builder.policy.schema.json
+++ b/scripts/design-artifacts/ui-builder.policy.schema.json
@@ -220,6 +220,11 @@
                 "acceptedRoles": { "type": "array", "items": { "type": "string" } },
                 "acceptedTraits": { "type": "array", "items": { "type": "string" } },
                 "required": { "type": "boolean" },
+                "max": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "description": "The most children this slot admits. Absent is unbounded, which is what every builtin slot was before this field and what most of them still are. Present for a host that draws exactly one thing: `remote-m3`'s widget containers are `max: 1` on `content`, and with no way to say so the published shelf offered a container a design could put three children into while the launcher drew one. `required` sets the other end."
+                },
                 "role": {
                   "enum": ["screen-root", "list", "list-item", "overlay", "controlled", "decoration"],
                   "description": "The structural role each child of this slot is written with, when it is not the child's own. The same closed set the containing builtin's `role` uses, and closed for the same reason: a role the engine does not know selects no template, and a typo caught here is caught before a render rather than during an export."


### PR DESCRIPTION
One field on the builtin slot schema: `max`.

A builtin is the only way a catalog offers a component the record cannot carry, so what it declares is all there is — and its slots could say *what* they accept but not *how many*.

## The case it is for

`remote-m3`'s two `WidgetContainer` components are `max: 1` on their `content` slot; a widget hosts one thing. With no way to write the bound they compose unbounded, so the published shelf offers a widget host a design can put three children into while the launcher draws one.

They are also why builtins exist at all: `WidgetContainerPreviews.kt` draws them through `CapturingWearWidgetPreview`, a preview harness, so there is no library composable behind them and no record entry is possible. Everything else the frozen containers declare — `screen-root`, their traits, the `background` slot — a builtin already carried. `max` is the last piece, and it is what keeps the two containers on the shelf when `remote-m3` stops being synthesised (compose-preview-server#674's first blocker).

## Shape

```json
"max": { "type": "integer", "minimum": 1 }
```

- **Absent stays unbounded**, which is what every builtin slot is today — no existing policy changes meaning, and no slot silently acquires a bound of one.
- **`minimum: 1`** because a slot admitting no children is one the catalog should not declare. `required` already sets the other end, so the pair spans the cardinality.

The validator in `ui-builder-policy.mjs` needs nothing. It exists for what the schema states poorly or not at all — the closed structural-role set — and `max` is fully described by `type` and `minimum`. No contradiction is reachable: `required: true` with `max: 1` is exactly the widget container.

## Test plan

`npm --prefix scripts/design-artifacts test` — **1462 pass, 8 fail, all pre-existing**: `bundle-strip-figma-svg`, `catalog-themes`, `figma-rest-raster`, `live-bundle-namespace`, `rc-compare-pixels`, `rc-font-axis-order`, `rc-size-modifier`, and one catalog-export version test. Confirmed by stashing this diff and re-running on pristine `main` — byte-identical failure list, and none of them reads this schema.

The behavioural assertion lives with the reader, in compose-preview-server's `PublishedUiBuilderCatalogTest` — a builtin declaring `max: 1` composes to a bounded slot, and one declaring nothing stays unbounded. Falsified there by reverting the reader to `max = null`.

Schema-only: no generated artifact changes until a catalog declares the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01297vAqLHxgAc6XQuaQYCSe

---
_Generated by [Claude Code](https://claude.ai/code/session_01297vAqLHxgAc6XQuaQYCSe)_