### PR TITLE
docs: correct data product wire examples

### DIFF
--- a/site/reference/focus.md
+++ b/site/reference/focus.md
@@ -46,26 +46,31 @@ bounding box on top of the captured PNG.
 - Dialog focus restoration: verify focus comes back to the trigger button after a dialog dismisses.
 - Form regression: catch a refactor that accidentally makes a `TextField` non-focusable.
 
-## Payload shape
+## Override shape
 
 `Material3FocusProduct.KIND` /  `FocusOverride` and `FocusDirection`
 in [`:data-focus-core`](https://github.com/yschimke/compose-ai-tools/tree/main/data/focus/core)
 and `daemon:core`.
 
+`compose/focus` is an override capability, not a focused-node snapshot payload. A
+`renderNow` request carries the focus instruction under `overrides.focus`:
+
 ```jsonc
-// compose/focus
 {
-  "focused": {
-    "testTag": "submit-button",
-    "role": "Button",
-    "label": "Submit",
-    "boundsInScreen": "48,200,144,232"
-  },
-  "history": [
-    { "direction": "Down", "from": "name-field", "to": "submit-button" }
-  ]
+  "overrides": {
+    "focus": {
+      "tabIndex": 1,
+      "direction": "Down",
+      "step": 1,
+      "overlay": true,
+      "pressed": false
+    }
+  }
 }
 ```
+
+Use [`compose/semantics`](../layout-inspector) to identify the resulting focused node and
+its `boundsInRoot`.
 
 ## Enabling
 

--- a/site/reference/history.md
+++ b/site/reference/history.md
@@ -48,15 +48,14 @@ entries (e.g. base render vs. PR head, or before / after a code edit).
 ```jsonc
 // history/diff/regions
 {
-  "leftEntryId": "compose-preview/main@7a1c…",
-  "rightEntryId": "<head>",
+  "baselineHistoryId": "compose-preview/main@7a1c…",
+  "totalPixelsChanged": 9184,
+  "changedFraction": 0.0085,
   "regions": [
-    { "boundsInScreen": "48,200,144,232",
-      "changedPixels": 412, "totalPixels": 3072,
-      "deltaSummary": "color-shift" }
-  ],
-  "totalChangedPixels": 9184,
-  "totalPixels": 1080000
+    { "bounds": "48,200,144,232",
+      "pixelCount": 412,
+      "avgDelta": { "r": 18.2, "g": 4.1, "b": 2.0, "a": 0.0 } }
+  ]
 }
 ```
 

--- a/site/reference/layout-inspector.md
+++ b/site/reference/layout-inspector.md
@@ -56,7 +56,8 @@ question here is layout structure or stable test selectors.
 // layout/inspector
 {
   "nodes": [
-    { "id": 1, "name": "Column", "boundsInScreen": "0,0,1080,1920",
+    { "nodeId": "1", "component": "Column",
+      "bounds": { "left": 0, "top": 0, "right": 1080, "bottom": 1920 },
       "measuredSize": "1080x1920",
       "constraints": "minW=0, maxW=1080, minH=0, maxH=1920",
       "modifiers": [{ "name": "padding", "args": "16dp" }],
@@ -67,8 +68,8 @@ question here is layout structure or stable test selectors.
 // compose/semantics
 {
   "nodes": [
-    { "testTag": "submit-button", "role": "Button",
-      "mergeMode": "Merged", "boundsInScreen": "48,200,144,232" }
+    { "nodeId": "2", "testTag": "submit-button", "role": "Button",
+      "mergeMode": "mergeDescendants", "boundsInRoot": "48,200,144,232" }
   ]
 }
 ```

--- a/site/reference/strings.md
+++ b/site/reference/strings.md
@@ -15,7 +15,7 @@ locale coverage from `values*/strings.xml` (`i18n/translations`).
 | | |
 |---|---|
 | Kinds | `text/strings`, `i18n/translations` |
-| Schema version | 1 |
+| Schema versions | `text/strings`: 3 · `i18n/translations`: 2 |
 | Modules | `:data-strings-core` (published) · `:data-strings-connector` |
 | Render mode | default |
 | Cost | low |
@@ -50,9 +50,10 @@ locale coverage from `values*/strings.xml` (`i18n/translations`).
 ```jsonc
 // text/strings
 {
-  "entries": [
-    { "text": "Submit", "locale": "en-US", "fontScale": 1.0,
-      "fontSize": 14, "color": "#FFFFFFFF",
+  "texts": [
+    { "text": "Submit", "nodeId": "2", "localeTag": "en-US", "fontScale": 1.0,
+      "fontSize": "14sp", "foregroundColor": "#FFFFFFFF",
+      "boundsInRoot": "48,200,144,232",
       "boundsInScreen": "48,200,144,232",
       "truncated": false, "didOverflowWidth": false, "didOverflowHeight": false,
       "lineCount": 1, "maxLines": 1 }
@@ -61,13 +62,21 @@ locale coverage from `values*/strings.xml` (`i18n/translations`).
 
 // i18n/translations
 {
+  "supportedLocales": ["en-US", "fr", "de", "es"],
+  "renderedLocale": "en-US",
+  "defaultLocale": "en-US",
   "strings": [
-    { "id": "submit", "default": "Submit",
-      "locales": { "en-US": "Submit", "fr": "Envoyer" },
-      "missing": ["de", "es"] }
+    { "nodeId": "2", "boundsInRoot": "48,200,144,232",
+      "boundsInScreen": "48,200,144,232", "rendered": "Submit",
+      "resourceName": "R.string.submit",
+      "translations": { "en-US": "Submit", "fr": "Envoyer" },
+      "untranslatedLocales": ["de", "es"] }
   ]
 }
 ```
+
+Both products retain `boundsInScreen` as a deprecated compatibility alias; those values were
+always root-relative. New consumers should read `boundsInRoot`.
 
 ## Enabling
 

--- a/site/reference/uiautomator.md
+++ b/site/reference/uiautomator.md
@@ -16,7 +16,7 @@ per node to formulate a UIAutomator-style `By.text(...)` /
 | | |
 |---|---|
 | Kind | `uia/hierarchy` |
-| Schema version | 1 |
+| Schema version | 2 |
 | Modules | `:data-uiautomator-core` (published) · `:data-uiautomator-hierarchy-android` (published) · `:data-uiautomator-connector` |
 | Render mode | default |
 | Cost | low |
@@ -28,7 +28,7 @@ per node to formulate a UIAutomator-style `By.text(...)` /
 
 - For each actionable node, what selector inputs are available — `text`, `contentDescription`, `testTag`, `role`?
 - Which `uia.*` actions does it support — `uia.click`, `uia.scrollForward`, `uia.inputText`, …?
-- What is the node's bounds in source-bitmap pixels (same shape as `AccessibilityNode`'s `boundsInScreen`)?
+- What are the node's root-relative bounds in source-bitmap pixels (`boundsInRoot`)?
 - Does the node have testTag ancestors that a `hasParent({testTag: …})` / `hasAncestor` selector chain could resolve?
 
 The default filter keeps only nodes that expose at least one of the
@@ -58,17 +58,21 @@ collapses into one node) or the unmerged tree.
 ```jsonc
 // uia/hierarchy
 {
-  "merged": true,
   "nodes": [
     { "text": "Submit", "contentDescription": null,
       "testTag": "submit-button",
       "testTagAncestors": ["checkout-screen"],
       "role": "Button",
-      "actions": ["uia.click"],
-      "boundsInScreen": "48,200,144,232" }
+      "actions": ["click"],
+      "boundsInRoot": "48,200,144,232",
+      "boundsInScreen": "48,200,144,232",
+      "merged": true }
   ]
 }
 ```
+
+`boundsInScreen` is a deprecated schema-v1 compatibility alias. Its value was always
+root-relative despite the name; schema v2 adds the accurately named `boundsInRoot` field.
 
 ## Enabling
 


### PR DESCRIPTION
## Summary
- correct layout inspector and Compose semantics bounds fields
- document the canonical root-relative UI Automator bounds field while retaining the compatibility alias
- align focus, history, and strings examples with their producer models and schema versions

## Test plan
- `git diff --check`
- audited examples against the current producer model definitions

Companion documentation for #5345. Producer-side schema changes are in [compose-preview-daemon#93](https://github.com/yschimke/compose-preview-daemon/pull/93), which closes the issue when merged.