### PR TITLE
fix(deps): take the daemon line to 3.4.3 so `related` is readable

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -371,7 +371,7 @@ composeai-contracts = "2.17.0"
 # for the same reason as the contracts above. The Gradle plugin bakes this value in as
 # `PreviewDaemonVersion` and resolves `renderer-*` / `daemon-*` for external consumers at it, and
 # the CLI fetches that release's sidecar archives (`DaemonSidecarProvision`) at it.
-composeai-preview-daemon = "3.3.0"
+composeai-preview-daemon = "3.4.3"
 
 # The preview server, published from yschimke/compose-preview-server since its 2.0.0 — the
 # extraction #4732 planned. This repository no longer owns `cli/serve`: `compose-preview serve`,


### PR DESCRIPTION
`@CatalogComponent(related = …)` was added to `preview-annotations` in the daemon repository's **3.4.0** ([yschimke/compose-preview-daemon#62](https://github.com/yschimke/compose-preview-daemon/pull/62)). This repository's pin has been at 3.3.0, which predates it.

Discovery has read `related` here since #5401 and nothing failed, because it reads the member reflectively by name. That is also exactly why the gap was invisible: the annotation is unusable **from a consumer**. A catalog declaring `related` compiles against whatever `preview-annotations` the plugin resolves, and at 3.3.0 there is no such member to compile against — so the producer half of the lane has been shipped and unreachable.

## Verified per coordinate, not from the tag

The sibling catalogs' own version comments exist because a release tag is not evidence that the artifacts behind it were published — `v2.2.1` had a tag, a GitHub release and a green release run, and a version line that resolved nowhere. So:

```
preview-annotations:3.4.3           → 200 on Central
daemon-core:3.4.3                   → 200 on Central
javap preview-annotations-jvm-3.4.3 → public abstract java.lang.String[] related();
```

The third line is the one that matters here: it is the published artifact carrying the member, not the source at a tag.

## Test plan

- `./gradlew compileKotlin compileTestKotlin` — green against 3.4.3.
- `./gradlew :gradle-plugin:test --tests '*PreviewData*' --tests '*Discovery*'` — green; these are the tests that read the annotation into the catalog inventory.
- No dependency locking in this repository, so nothing to regenerate.

## Why now

It unblocks the catalog repositories: they already pin the daemon line at 3.4.1+, so they can declare `related` today, but nothing downstream could read it into a published `catalog.json` until this pin moved. The server side is already in place — [compose-preview-server#754](https://github.com/yschimke/compose-preview-server/pull/754) reads `related`, and [#755](https://github.com/yschimke/compose-preview-server/pull/755) surfaces it as a directory in the viewer's drawer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJVnYyuf9kfwEsUPWuZrAq

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJVnYyuf9kfwEsUPWuZrAq)_