### PR TITLE
fix(plugin): let a KMP-Android module pack a bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,6 +371,30 @@ jobs:
       # failed while I was building it, so a gate that cannot see that is no gate.
       - name: Render the KMP-Android Robolectric sample
         run: ./gradlew :samples:cmp-android-robolectric:composePreviewRenderAll
+      # And PACK it, asserting the file exists. `composePreviewBundle` carries an `onlyIf`
+      # renderability gate, and a gate that says no is — to Gradle — a successful build: the task
+      # reports SKIPPED, the invocation exits 0, and nothing in the log names it. So `./gradlew
+      # :…:composePreviewBundle` passing proves nothing; only the bundle on disk does.
+      #
+      # This is not hypothetical. The gate was the desktop path's `isDesktopRenderableConfig`,
+      # which rejects the literal string `androidRuntimeClasspath` — the last-resort fallback
+      # there, but the ORDINARY runtime configuration of every
+      # `com.android.kotlin.multiplatform.library` module. Applied to the Android registration it
+      # skipped the bundle task on every KMP-Android module, and the only symptom was
+      # `compose-preview bundle pack` failing with "Bundle task reported success but bundle.png is
+      # missing" after a render that had just succeeded. wear-m3-catalog's `:catalog` stopped
+      # publishing for weeks on exactly that, because no CI job here ever packed this module shape
+      # — the two bundles CI did pack (`:samples:wear`, `:samples:remotecompose`) are classic AGP.
+      - name: Pack the KMP-Android Robolectric sample into a bundle
+        run: |
+          set -euo pipefail
+          ./gradlew :samples:cmp-android-robolectric:composePreviewBundle
+          out=samples/cmp-android-robolectric/build/compose-previews/bundle.png
+          if [ ! -s "$out" ]; then
+            echo "::error title=KMP-Android bundle missing::composePreviewBundle exited 0 but wrote no $out — the task was almost certainly SKIPPED by its onlyIf gate."
+            exit 1
+          fi
+          echo "packed $out ($(stat -c %s "$out") bytes)"
       # The other side of the same fix: a KMP-Android module WITHOUT the opt-in must still take
       # the Desktop lane it has taken since #248. `:samples:cmp-shared` is that shape.
       - name: Discover previews on the default (Desktop) KMP-Android lane

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -110,6 +110,29 @@ internal object ComposePreviewTasks {
     configName != "androidRuntimeClasspath"
 
   /**
+   * Whether `composePreviewBundle` has something to pack, for the registration identified by
+   * [backendId].
+   *
+   * The renderability question is a DESKTOP question, and asking it on the Android registration is
+   * what broke wear-m3-catalog's catalog: [isDesktopRenderableConfig] rejects exactly the literal
+   * string `androidRuntimeClasspath`, and that is not only the desktop path's last-resort fallback
+   * — it is also the real, correct runtime configuration of every
+   * `com.android.kotlin.multiplatform.library` module (see [AndroidVariantNaming.kmpAndroid], which
+   * derives `<targetName>RuntimeClasspath` from the KMP target, named `android` unless the consumer
+   * renamed it). So a KMP-Android module on the Robolectric lane registered its bundle task with
+   * `backendId = "android"` and then skipped it forever, and `compose-preview bundle pack` failed
+   * with "Bundle task reported success but bundle.png is missing" after a render that had just
+   * succeeded — no error naming the task, because a skipped task is a successful build.
+   *
+   * On the Android registration the module's renderability is not in question: AGP handed us a
+   * variant and the Robolectric lane rendered against it. Only the desktop registration, which can
+   * fall through to `androidRuntimeClasspath` when a module has no JVM-flavoured runtime at all,
+   * needs the gate.
+   */
+  internal fun bundleRenderable(backendId: String, configName: String): Boolean =
+    backendId == "android" || isDesktopRenderableConfig(configName)
+
+  /**
    * The consumer runtime configuration the desktop pipeline resolves against, in preference order.
    * `androidRuntimeClasspath` is the LAST-RESORT KMP-Android fallback — it carries `*-android`
    * Compose AARs the JVM renderer can't load, so anything with a real JVM-flavoured runtime must
@@ -709,14 +732,11 @@ internal object ComposePreviewTasks {
       // though composePreviewRender itself no-ops (Codex review on #1863). Computed lazily at task
       // realization (so a cmp-shared module whose `jvm("desktop")` target configures after
       // registerDesktopTasks isn't mis-skipped) and captured as a Boolean so `onlyIf` doesn't pin
-      // `project` into the configuration cache. `isDesktopRenderableConfig` only trips on the
-      // literal
-      // `androidRuntimeClasspath` fallback, so this is a no-op on the Android bundle path and on
-      // real desktop modules.
+      // `project` into the configuration cache.
       // ONE lazy resolution feeds both the renderability gate and the classpath the bundle carries,
       // so the two can no longer disagree about which consumer runtime config this module has.
       val deps = depBinding()
-      val bundleRenderable = isDesktopRenderableConfig(deps.configName)
+      val bundleRenderable = bundleRenderable(backendId, deps.configName)
       onlyIf { extension.enabled.get() && bundleRenderable }
       previewsJson.set(previewOutputDir.map { it.file("previews.json") })
       moduleClassDirs.from(sourceClassDirs)

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/KmpAndroidDesktopRoutingTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/KmpAndroidDesktopRoutingTest.kt
@@ -143,6 +143,30 @@ class KmpAndroidDesktopRoutingTest {
   }
 
   @Test
+  fun `the bundle renderability gate does not apply to the Android registration`() {
+    // `androidRuntimeClasspath` means two different things depending on who is asking. On the
+    // desktop registration it is the last-resort fallback of `desktopDependencyConfigName`, and a
+    // module that lands there has no JVM runtime to render against — the case above. On the
+    // ANDROID registration it is the ordinary, correct runtime configuration of every
+    // `com.android.kotlin.multiplatform.library` module, because `AndroidVariantNaming.kmpAndroid`
+    // derives it from the KMP target name.
+    //
+    // Reusing the desktop test for both is what made `composePreviewBundle` SKIPPED on every
+    // KMP-Android module: the render succeeded, the bundle task never ran, and `compose-preview
+    // bundle pack` failed with "Bundle task reported success but bundle.png is missing" — a
+    // skipped task being, to Gradle, a successful build. wear-m3-catalog's `:catalog` stopped
+    // publishing the moment it moved to that module shape.
+    assertThat(ComposePreviewTasks.bundleRenderable("android", "androidRuntimeClasspath")).isTrue()
+    assertThat(ComposePreviewTasks.bundleRenderable("android", "debugRuntimeClasspath")).isTrue()
+
+    // The desktop registration keeps the gate exactly as it was.
+    assertThat(ComposePreviewTasks.bundleRenderable("desktop", "androidRuntimeClasspath")).isFalse()
+    assertThat(ComposePreviewTasks.bundleRenderable("desktop", "desktopRuntimeClasspath")).isTrue()
+    assertThat(ComposePreviewTasks.bundleRenderable("desktop", "jvmRuntimeClasspath")).isTrue()
+    assertThat(ComposePreviewTasks.bundleRenderable("desktop", "runtimeClasspath")).isTrue()
+  }
+
+  @Test
   fun `non-renderable module skips only the guard and daemon, never discover or render`() {
     // Issue #1855: the desktop-render classpath guard and the daemon-start task are skipped for a
     // pure KMP-Android module (they'd otherwise hard-fail on its androidRuntimeClasspath), but


### PR DESCRIPTION
## What

`composePreviewBundle` carries an `onlyIf` renderability gate, and that gate was the desktop path's `isDesktopRenderableConfig` — which rejects exactly one literal string, `androidRuntimeClasspath`.

On the **desktop** registration that string means "this module has no JVM-flavoured runtime at all", which is the case the gate exists for (#1852 / #1863). On the **Android** registration it means nothing of the sort: `AndroidVariantNaming.kmpAndroid` derives the runtime config from the KMP target name, so `androidRuntimeClasspath` is the ordinary, correct configuration of every `com.android.kotlin.multiplatform.library` module.

So every KMP-Android module on the Robolectric lane registered its bundle task and then skipped it forever. Nothing failed — a skipped task is, to Gradle, a successful build: the invocation exits 0 and no log line names it. The only symptom was `compose-preview bundle pack` exiting 1 with

```
Bundle task reported success but bundle.png is missing.
```

immediately after a render that had just succeeded, which reads like a render problem and is not one.

## Why it matters now

[yschimke/wear-m3-catalog](https://github.com/yschimke/wear-m3-catalog)'s `:catalog` hit this the moment it moved to one multiplatform source set (yschimke/wear-m3-catalog#437). Its Design Artifacts render has failed at step 34 "Render catalog bundle" on every run since, `design-artifacts/wear-m3` has been stale for weeks, and the catalog cannot republish. The evidence that it is not the render: the failing run's own uploaded JUnit results carry **zero** `<failure>`/`<error>` entries — every preview drew.

Tracked as yschimke/wear-m3-catalog#460.

## The fix

Scope the gate to the registration it belongs to:

```kotlin
internal fun bundleRenderable(backendId: String, configName: String): Boolean =
  backendId == "android" || isDesktopRenderableConfig(configName)
```

On the Android registration the module's renderability is not in question — AGP handed us a variant and Robolectric rendered against it. The desktop registration keeps the gate byte-for-byte.

## Test plan

Measured on `:samples:cmp-android-robolectric`, the fixture that is exactly this module shape (KMP-Android, no desktop target, Android-only previews).

Before:

```
Skipping task ':samples:cmp-android-robolectric:composePreviewBundle'
  as task onlyIf 'Task satisfies onlyIf spec' is false.
```

After:

```
composePreviewBundle — wrote bundle.png (275381 bytes)
  resolution:           coordinates
  previews baked:       3 / 3
  module classes kept:  1 / 1
```

- New unit test in `KmpAndroidDesktopRoutingTest` pins both halves: `("android", "androidRuntimeClasspath")` is renderable, `("desktop", "androidRuntimeClasspath")` is not. `./gradlew :gradle-plugin:test --tests '*KmpAndroidDesktopRoutingTest*'` — green.
- New CI step packs that sample and **asserts the file on disk**. `./gradlew :…:composePreviewBundle` passing proves nothing here, since the failure mode is a silent skip. The two bundles CI already packed (`:samples:wear`, `:samples:remotecompose`) are classic AGP, which is why no job caught this.
- `./gradlew :gradle-plugin:ktfmtFormatMain :gradle-plugin:ktfmtFormatTest` run before committing.

Not UI-affecting — no render output changes; the change is whether a bundle is written at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01297vAqLHxgAc6XQuaQYCSe

---
_Generated by [Claude Code](https://claude.ai/code/session_01297vAqLHxgAc6XQuaQYCSe)_