### PR TITLE
ci: filter -SNAPSHOT out of Gradle candidates, and record why github-actions is off

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,9 +12,8 @@
   "prConcurrentLimit": 10,
   "minimumReleaseAge": "7 days",
   "github-actions": {
-    "description": "Every `uses:` in this repository is SHA-pinned with a `# vX.Y.Z` comment \u2014 183 of them \u2014 and with the manager off not one of those digests could ever move: a fixed or security-patched action never reached CI, and nothing else in the repo bumps them. Renovate rewrites the digest and the version comment together, and `pinDigests` keeps a newly added tag-only `uses:` from staying unpinned. The shared preset batches every action into ONE weekly `github-actions` PR, so this costs a single PR a week rather than one per action; the `yschimke/compose-ai-tools` self-reference moves with it. Same setting as compose-preview-daemon.",
-    "enabled": true,
-    "pinDigests": true
+    "description": "Deliberately OFF, and it must stay off: `.github/dependabot.yml` already runs the `github-actions` ecosystem for this repository, weekly with a 7-day cooldown and minor/patch grouping, and it rewrites the digest and the trailing `# vX.Y.Z` comment together. Turning this manager on gives the same `uses:` lines two weekly updaters that propose overlapping edits on the same Monday. This repository is the only one in the family carrying Dependabot \u2014 compose-preview-daemon, compose-preview-server, m3-catalog, wear-m3-catalog and rc-players have none, which is why Renovate owns their actions and not this one's.\n\nEnabling it would also break the release train: the six tag-based self-references in the composite actions (`.github/actions/apply/action.yml`, `preview-baselines`, `preview-comment`, `notification-previews`, `a11y-report`) are pinned `@vX.Y.Z # x-release-please-version` on purpose, and release-please rewrites that version TEXT. `pinDigests` would replace each with a commit SHA that release-please cannot recompute, so every later release would keep invoking the previous release's helpers.",
+    "enabled": false
   },
   "packageRules": [
     {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,9 @@
   "prConcurrentLimit": 10,
   "minimumReleaseAge": "7 days",
   "github-actions": {
-    "enabled": false
+    "description": "Every `uses:` in this repository is SHA-pinned with a `# vX.Y.Z` comment \u2014 183 of them \u2014 and with the manager off not one of those digests could ever move: a fixed or security-patched action never reached CI, and nothing else in the repo bumps them. Renovate rewrites the digest and the version comment together, and `pinDigests` keeps a newly added tag-only `uses:` from staying unpinned. The shared preset batches every action into ONE weekly `github-actions` PR, so this costs a single PR a week rather than one per action; the `yschimke/compose-ai-tools` self-reference moves with it. Same setting as compose-preview-daemon.",
+    "enabled": true,
+    "pinDigests": true
   },
   "packageRules": [
     {
@@ -31,11 +33,11 @@
       "groupName": "design-parity export toolchain"
     },
     {
-      "description": "Never take a `…-compat` backport artifact. JetBrains publishes compatibility variants of the kotlinx libraries under a `<version>-<oldline>.x-compat` suffix (e.g. `kotlinx-datetime:0.8.0-0.6.x-compat`, the 0.8.0 code recompiled against the 0.6.x API) and Renovate's gradle versioning ranks that suffix ABOVE the plain release, so it proposes a *downgrade of API surface* dressed as an upgrade (#3359). Filtering the suffix out of the candidate list — rather than disabling the update — keeps Renovate offering the next genuine release. Declared before the per-dep pins below so those stricter `allowedVersions` still win for their deps.",
+      "description": "Never take a `…-compat` backport artifact. JetBrains publishes compatibility variants of the kotlinx libraries under a `<version>-<oldline>.x-compat` suffix (e.g. `kotlinx-datetime:0.8.0-0.6.x-compat`, the 0.8.0 code recompiled against the 0.6.x API) and Renovate's gradle versioning ranks that suffix ABOVE the plain release, so it proposes a *downgrade of API surface* dressed as an upgrade (#3359). Filtering the suffix out of the candidate list — rather than disabling the update — keeps Renovate offering the next genuine release. Declared before the per-dep pins below so those stricter `allowedVersions` still win for their deps. Also carries the `-SNAPSHOT` filter the shared preset applies across the gradle manager: both rules set `allowedVersions` and the last match wins, so naming only `-compat` here would hand every Gradle dependency in this repository its snapshots back (Renovate ranks `1.0.0-SNAPSHOT` above `1.0.0-alpha18`).",
       "matchManagers": [
         "gradle"
       ],
-      "allowedVersions": "!/-compat$/"
+      "allowedVersions": "!/(-compat|-SNAPSHOT)$/"
     },
     {
       "description": "eclipse-temurin (cloudrun image): stay on the JDK 17 line. deploy/cloudrun/Dockerfile builds the tool from source inside the image, and the repo's Gradle daemon toolchain is pinned to 17 (gradle/gradle-daemon-jvm.properties) — a newer base JDK means Gradle's auto-detection finds no matching toolchain and the image build fails. Patch bumps inside 17.x are fine; changing the major is a manual decision that has to move the daemon toolchain with it (#3362).",


### PR DESCRIPTION
**Scope changed after review.** This PR originally enabled Renovate's `github-actions` manager. Two review findings showed that was wrong on both of its premises, and the enablement has been reverted — see the second commit. What remains is the `-SNAPSHOT` filter plus a comment that stops the next reader repeating the mistake.

## What this does

The gradle-wide `allowedVersions` rule now filters `-SNAPSHOT` alongside `-compat`. The shared preset gained a `-SNAPSHOT` filter across the Gradle manager ([yschimke/renovate-config#2](https://github.com/yschimke/renovate-config/pull/2), merged) — Renovate ranks `1.0.0-SNAPSHOT` above `1.0.0-alpha18`, and rc-players is currently offered exactly that on seven `androidx.compose.remote` coordinates. Both rules set `allowedVersions` and the last match wins, so leaving this one naming only `-compat` would drop the new filter for every Gradle dependency here.

The `github-actions: { enabled: false }` block keeps its value and gains the rationale it never had.

## Why the enablement was withdrawn

- **`.github/dependabot.yml` already runs this ecosystem** — weekly, 7-day cooldown, minor/patch grouped, rewriting the digest and the `# vX.Y.Z` comment together. My claim that "nothing else in the repository bumps them" was false; I checked the workflows and not the Dependabot config. Enabling Renovate's manager gives the same `uses:` lines two weekly updaters landing on the same Monday. This repository is the **only** one in the family with a `dependabot.yml` — compose-preview-daemon, compose-preview-server, m3-catalog, wear-m3-catalog and rc-players have none — so what I read as an inconsistency across the repos is in fact the correct split.
- **`pinDigests` would have broken the release train.** Six tag-based self-references in the composite actions (`apply`, `preview-baselines`, `preview-comment`, `notification-previews`, `a11y-report`) are pinned `@v2.11.1 # x-release-please-version` deliberately. release-please rewrites that version *text* and cannot compute a SHA, so a digest there would leave each release invoking the previous release's helpers.

Both findings came from the Codex review on `738537d`; verified against `.github/dependabot.yml` and `grep -rn "uses: yschimke/compose-ai-tools" .github/actions/*/action.yml` before reverting.

## Test plan

- `renovate-config-validator .github/renovate.json` — passes.
- `git diff origin/main -- .github/renovate.json` is now exactly two hunks: the `-SNAPSHOT` suffix in the gradle rule, and the `description` on the (unchanged, still `false`) `github-actions` block.
- Config-only; no build files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKmoA3G7s4hyNmgN6d2WvS