### PR TITLE
chore: drop the catalog entries and Renovate pins the daemon split orphaned

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -70,28 +70,6 @@
       "allowedVersions": "/^2025\\.11\\./"
     },
     {
-      "description": "material-kolor: pin to the 4.0.x line. `:data-wallpaper-connector` is published against the renderer-android Compose floor (`compose-bom-compat`, Compose 1.9.5); 4.1.0 rebuilt against Compose Multiplatform 1.10.0 + Kotlin 2.3.0 and migrated to a Multiplatform Android library, raising the transitive floor above our published surface. See gradle/libs.versions.toml for the full rationale — bumping the floor is a manual decision.",
-      "matchManagers": [
-        "gradle"
-      ],
-      "matchDepNames": [
-        "com.materialkolor:material-kolor"
-      ],
-      "matchCurrentValue": "/^4\\.0\\./",
-      "allowedVersions": "/^4\\.0\\./"
-    },
-    {
-      "description": "androidx.core:core: pin to the 1.13.x line. `:data-keyboard-connector` declares this as a `compileOnly` compat floor so the published AAR's bytecode stays binary-backward-compatible with consumers on older `androidx.core` lines (same rationale as `compose-foundation` via `compose-bom-compat`). Raising the floor is a manual decision.",
-      "matchManagers": [
-        "gradle"
-      ],
-      "matchDepNames": [
-        "androidx.core:core"
-      ],
-      "matchCurrentValue": "/^1\\.13\\./",
-      "allowedVersions": "/^1\\.13\\./"
-    },
-    {
       "description": "compose-multiplatform: pin to the 1.11.x line. `:data-render-compose` exposes `org.jetbrains.compose.{runtime,ui}` as `api` on a published artifact, so the Compose Multiplatform version is part of the supported-minimum floor for consumers, and the ref is also a CEILING on every catalog the serve host renders live (docs/RENDERER_COMPATIBILITY.md). 1.12.0 needs a coordinated move, not a minor/patch bump: its `androidx.compose.*` AARs declare `minCompileSdk = 37` (the repo default is 36), skiko 0.150.1 deletes the mutating `org.jetbrains.skia.Path` API our `conicTo` seams call, and `compose-multiplatform-material3` + `compottie` have to move with it. See gradle/libs.versions.toml — raising the floor is a manual decision. `matchCurrentValue` scopes this to the refs that are actually on 1.11.x; the explicit `ui-tooling-preview:1.10.3` coords in the cmp samples are held on their own line by the rule below.",
       "matchManagers": [
         "gradle"
@@ -124,17 +102,6 @@
       ],
       "matchCurrentValue": "/^2\\.0\\.17$/",
       "allowedVersions": "/^2\\.0\\.17$/"
-    },
-    {
-      "description": "compottie: pin to the 2.2.x line. `:lottie-preview-runtime` is built against JetBrains Compose foundation 1.11.0 (matching `compose-multiplatform = 1.11.x`); a compottie line built against a newer foundation drags a newer Compose onto the renderer classpath — the skew `docs/RENDERER_COMPATIBILITY.md` warns about. Bump only in lockstep with `compose-multiplatform`; see gradle/libs.versions.toml.",
-      "matchManagers": [
-        "gradle"
-      ],
-      "matchDepNames": [
-        "io.github.alexzhirkevich:compottie"
-      ],
-      "matchCurrentValue": "/^2\\.2\\./",
-      "allowedVersions": "/^2\\.2\\./"
     },
     {
       "description": "coil3: pin to the 3.5.x line. 3.6.0 depends on `org.jetbrains.compose.foundation:foundation-android:1.12.0`, which resolves `androidx.compose.foundation`/`ui` 1.12.0 — the Compose line this repo deliberately does not sit on (see the compose-multiplatform rule above). coil3 is `compileOnly` in `:renderer-android` but `testImplementation` for that module's own unit tests, so the upgrade lands on a test classpath compiled against `compose-bom-compat` and `FigmaSvgRasterizedTextFieldRenderTest` fails with `AbstractMethodError` (#4503). 3.5.0 resolves foundation 1.11.2 and is green. Bump in lockstep with the Compose floor, not on its own.",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -123,12 +123,6 @@ compose-multiplatform-material3 = "1.11.0-alpha07"
 # would pass while covering nothing. `m3-catalog` pins this exact version.
 compose-multiplatform-material3-forward = "1.12.0-alpha03"
 graphics-shapes = "1.1.0"
-# Compottie — the KMP Lottie runtime that powers `:lottie-preview-runtime`. Tracks the same Compose
-# minor as `compose-multiplatform`: 2.2.x is built against JetBrains Compose foundation 1.11.0, which
-# is what the 1.11 line above now ships. (On the old 1.10.3 floor this was held at 2.1.0 precisely so
-# it could not drag a *newer* Compose onto the renderer classpath — the failure direction
-# `docs/RENDERER_COMPATIBILITY.md` warns about. Bump only in lockstep with `compose-multiplatform`.)
-compottie = "2.2.4"
 activity-compose = "1.13.0"
 # `androidx.navigation:navigation-compose` — used only by the
 # `:samples:android` NavHost preview that exercises the daemon's
@@ -310,20 +304,6 @@ android-compose-screenshot = "0.0.1-alpha16"
 # warning without exporting the annotation to consumers (it's marker-only;
 # zero runtime impact).
 checker-qual = "4.2.3"
-# KMP port of Google's Material Color Utilities. Powers the wallpaper data
-# extension's seed → ColorScheme derivation (HCT tonal palettes, palette
-# styles, contrast level) so the result matches what Android's wallpaper-
-# derived dynamic theming actually produces.
-# Pinned to the 4.0.x line: `:data-wallpaper-connector` is a published
-# module and its consumers live on the renderer-android Compose floor
-# (`compose-bom-compat`, Compose 1.9.5). 4.1.0 rebuilt against Compose
-# Multiplatform 1.10.0 + Kotlin 2.3.0 and switched from an Android library
-# to a "Multiplatform Android library" — both move the transitive floor
-# above what our published surface targets. Renovate is constrained to
-# 4.0.x in `.github/renovate.json`; bumping the supported floor is a
-# manual decision (re-check `:data-wallpaper-connector:compileKotlin`
-# against `compose-bom-compat` when raising it).
-material-kolor = "4.0.5"
 # Metro — Zac Sweers' compile-time DI framework, used only by the JDK 21+
 # `:samples:sdk21:android-metro-viewmodel` module to demonstrate that
 # constructor-injected ViewModels render under the renderer's @Preview
@@ -601,7 +581,6 @@ jetbrains-forward-compose-material3 = { module = "org.jetbrains.compose.material
 graphics-shapes = { module = "androidx.graphics:graphics-shapes", version.ref = "graphics-shapes" }
 jetbrains-compose-components-ui-tooling-preview = { module = "org.jetbrains.compose.components:components-ui-tooling-preview", version.ref = "compose-multiplatform" }
 jetbrains-compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "compose-multiplatform" }
-compottie = { module = "io.github.alexzhirkevich:compottie", version.ref = "compottie" }
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
 navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation-compose" }
 glance-appwidget = { module = "androidx.glance:glance-appwidget", version.ref = "glance-appwidget" }
@@ -697,7 +676,6 @@ truth = { module = "com.google.truth:truth", version.ref = "truth" }
 # files the test can't differentiate "stale" from "fresh".
 asm = { module = "org.ow2.asm:asm", version = "9.10.1" }
 asm-commons = { module = "org.ow2.asm:asm-commons", version = "9.10.1" }
-material-kolor = { module = "com.materialkolor:material-kolor", version.ref = "material-kolor" }
 # `metroViewModel()` + `LocalMetroViewModelFactory` + the `MetroViewModelFactory` /
 # `ViewModelGraph` base types live here. Used by `:samples:android-metro-viewmodel`.
 metro-viewmodel-compose = { module = "dev.zacsweers.metro:metrox-viewmodel-compose", version.ref = "metro" }


### PR DESCRIPTION
Three floor pins in `.github/renovate.json` guard modules that no longer live here. `:data-wallpaper-connector` (material-kolor 4.0.x), `:lottie-preview-runtime` (compottie 2.2.x) and `:data-keyboard-connector` (androidx.core 1.13.x) all moved to [yschimke/compose-preview-daemon](https://github.com/yschimke/compose-preview-daemon) at its 3.0.0 (#5336), and that repository carries live copies of the same three rules.

Here they are inert:

- **androidx.core:core** — `matchCurrentValue: /^1\.13\./` has matched nothing since the `compileOnly("androidx.core:core:1.13.1")` literal left with the module. The catalog's own `androidx-core` is 1.19.0 and is deliberately free to move, so the rule reads as a floor it does not hold.
- **material-kolor** and **compottie** — nothing in this build resolves either coordinate any more.

The last two go from `gradle/libs.versions.toml` as well, comments included: no build file references `libs.material.kolor` or `libs.compottie`, and the comments document the moved modules by name (`:data-wallpaper-connector:compileKotlin`, `:lottie-preview-runtime`). The docs mentioning the libraries in prose — `site/reference/wallpaper.md`, `docs/LOTTIE_PREVIEWS.md` — describe the features rather than the catalog keys, so they are unaffected.

`androidx-core` stays in the catalog: the Gradle plugin resolves it (`RenderClasspathDuplicates`, `CompatRules`). Only its dead Renovate rule goes.

## Test plan

- Every removal checked against every tracked file, for both the catalog entry name and its `libs.` accessor form.
- Catalog parses (`tomllib`) and no surviving library or plugin loses a `version.ref` — verified by resolving every `version.ref` against the remaining `[versions]` block.
- `renovate-config-validator .github/renovate.json` — passes; 17 package rules to 14.
- No `.kt` / `.kts` touched, so `ktfmtCheckAll` is unaffected.

Context: this was the open item from the version-catalog audit whose earlier PRs were #5425 here, plus [renovate-config#2](https://github.com/yschimke/renovate-config/pull/2), [compose-preview-daemon#95](https://github.com/yschimke/compose-preview-daemon/pull/95), [compose-preview-server#763](https://github.com/yschimke/compose-preview-server/pull/763), [wear-m3-catalog#465](https://github.com/yschimke/wear-m3-catalog/pull/465) and [m3-catalog#349](https://github.com/yschimke/m3-catalog/pull/349).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKmoA3G7s4hyNmgN6d2WvS

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKmoA3G7s4hyNmgN6d2WvS)_