### PR TITLE
docs(spec): document `display.role`, the catalog's own kind

### DIFF
--- a/scripts/design-artifacts/catalog.spec.schema.json
+++ b/scripts/design-artifacts/catalog.spec.schema.json
@@ -177,6 +177,10 @@
         "hero": {
           "type": "string",
           "description": "The representative preview to feature as the system's hero — a componentId (e.g. \"Template/TimeText\") or a flattened preview id. Absent ⇒ the server picks one (prefer a screen, else a canonical component)."
+        },
+        "role": {
+          "type": "string",
+          "description": "What KIND of catalog this is, and through that what shape its component pages take. `samples` is a catalog of CALL SITES rather than of a design system's own components: the preview server drops every comparison lane (there is no reference a sample is meant to match, so a difference is not a defect) and stands the source beside the render instead of behind a chip. It also names the catalog in a reader's back-links — a component points at \"Samples\" rather than at a catalog title. Declared by the catalog because only it knows; a server that inferred this from a system name would be holding catalog knowledge it must not. Deliberately an open string rather than an enum: a consumer that does not recognise a role must degrade to the ordinary page, and an enum here would instead fail a newer producer's spec at validation."
         }
       }
     },


### PR DESCRIPTION
The preview server reads `display.role` off a published `catalog.json` to decide the shape of that catalog's component pages. `samples` — a catalog of **call sites** rather than of a design system's own components — drops every comparison lane (there is no reference a sample is meant to match, so a difference is not a defect) and stands the source beside the render instead of behind a chip that swaps it out. It also names the catalog in a reader's back-links, so a kit component points at "Samples" rather than at a catalog title.

Server side: [compose-preview-server#757](https://github.com/yschimke/compose-preview-server/pull/757) and [#765](https://github.com/yschimke/compose-preview-server/pull/765).

## This changes no behaviour, and that is the point

The field already reaches `catalog.json`: `generate-design-catalog.mjs` carries `spec.display` through wholesale (`manifest.display = spec.display`). And `validate-catalog-spec.mjs` reads **no schema at all** — nothing in `scripts/design-artifacts/` uses ajv, and I confirmed a spec with a typo'd key under `display` validates clean:

```
$ node scripts/design-artifacts/validate-catalog-spec.mjs --spec probe.json --no-scan   # display: { rle: "samples" }
OK — 0 warning(s), 0 errors.
```

So the `additionalProperties: false` on `display` is documentation of intent rather than an enforced gate. What this PR changes is what a catalog author reads when they ask what `display` may carry — the one place the field was invisible.

## An open string, not an enum

A consumer that does not recognise a role must degrade to the ordinary page. An enum here would instead make a newer producer's spec invalid against an older schema — failing the catalog that is ahead rather than the reader that is behind. The server parses it the same way (`PageRole.of` maps anything unknown to the default), and that is tested there.

## Test plan

- `validate-catalog-spec.mjs` on a spec carrying `display.role: "samples"` — OK, 0 errors.
- The same with `role: "tiles-from-the-future"` — also OK, which is the degradation property this field depends on.
- Schema parses as JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJVnYyuf9kfwEsUPWuZrAq

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJVnYyuf9kfwEsUPWuZrAq)_