### PR TITLE
feat(design-artifacts): let a spec declare where a component's source lives

### DIFF
--- a/scripts/design-artifacts/apply-source-files.mjs
+++ b/scripts/design-artifacts/apply-source-files.mjs
@@ -15,6 +15,29 @@
  * function carried no path (discovery didn't record one, or an older bundle) is left
  * untouched — the server then simply renders no link for it.
  *
+ * ## A spec may declare the path itself, and then it wins
+ *
+ * The join above answers "where is the `@Preview` function?", and for almost every catalog that is
+ * also "where should a reader be sent". A catalog of **call sites** breaks the two apart. The
+ * AndroidX samples catalogs generate one `@Preview` wrapper per sample —
+ * `fun ButtonSamplePreview() = androidx.wear.compose.material3.samples.ButtonSample()` — because
+ * only 34 of 170 Wear samples carry `@Preview` upstream. Discovery is right that the preview lives
+ * in the generated file; a reader opening the Source panel wants the sample, and three lines of
+ * generated delegation is the one thing on that page nobody came for.
+ *
+ * So a spec component may carry its own `sourceFile` (and `bodyLine`), and it takes precedence over
+ * both the discovery join and anything a newer exporter preserved. Precedence rather than fallback
+ * is the whole point: the catalog is not filling a gap the join left, it is overriding an answer the
+ * join got right for a different question. Nothing else changes — the identity fields still describe
+ * the producing module, because that is still where the preview was compiled from.
+ *
+ * Inference was considered and rejected. Discovery's target inference does not fire on these
+ * previews at all (`PreviewTargetInference` filters the sample's own package as library code, since
+ * `androidx.wear.compose.material3.samples` sits under the `androidx.wear.compose.material3.`
+ * wrapper prefix), and widening that heuristic to serve one catalog would change the target of
+ * previews in every other. A catalog that generates its own wrappers knows exactly what each one
+ * delegates to; saying so is cheaper and truer than asking a scorer to guess it back.
+ *
  * Additive and idempotent:
  *  - only components whose spec function resolves to a `sourceFile` are touched;
  *  - a component that already carries a `sourceFile` is left as-is (never clobbered).
@@ -31,8 +54,10 @@
  *
  * @param {{components?: Array<{componentId: string, sourceFile?: string, sourceModule?: string, bodyLine?: number}>}} manifest
  *   The parsed `catalog.json`, mutated in place.
- * @param {{groups?: Array<{components?: Array<{componentId: string, preview?: string}>}>}} spec
- *   The catalog spec the manifest was built from.
+ * @param {{groups?: Array<{components?: Array<{componentId: string, preview?: string,
+ *   sourceFile?: string, bodyLine?: number}>}>}} spec
+ *   The catalog spec the manifest was built from. A component's own `sourceFile` / `bodyLine`, when
+ *   it declares them, override the join for that component.
  * @param {Map<string, {sourceFile?: string, bodyLine?: number, module?: string}>} sourceByFn
  *   Function-name → source lookup (the generator's `sourceByFunction(bundle)`).
  * @returns {number} how many components had a `sourceFile` newly stamped.
@@ -41,10 +66,23 @@ export function applySourceFiles(manifest, spec, sourceByFn) {
   if (!sourceByFn || sourceByFn.size === 0) return 0;
 
   const previewByComponentId = new Map();
+  // What the SPEC says about a component's source, as opposed to what discovery found. Only
+  // components that declare a path are here, so the ordinary catalog's map is empty and the join
+  // below behaves exactly as it did.
+  const declaredByComponentId = new Map();
   for (const group of spec?.groups ?? []) {
     for (const component of group.components ?? []) {
       if (component.preview) {
         previewByComponentId.set(component.componentId, component.preview);
+      }
+      if (typeof component.sourceFile === "string" && component.sourceFile.length > 0) {
+        declaredByComponentId.set(component.componentId, {
+          sourceFile: component.sourceFile,
+          bodyLine:
+            typeof component.bodyLine === "number" && component.bodyLine > 0
+              ? component.bodyLine
+              : undefined,
+        });
       }
     }
   }
@@ -53,6 +91,26 @@ export function applySourceFiles(manifest, spec, sourceByFn) {
   for (const component of manifest?.components ?? []) {
     const fn = previewByComponentId.get(component.componentId);
     const source = fn ? sourceByFn.get(fn) : undefined;
+    const declared = declaredByComponentId.get(component.componentId);
+    if (declared) {
+      // Before every other branch, and unconditionally: a declared path is an override, so it must
+      // win over a value the exporter preserved as surely as over the join. `bodyLine` is cleared
+      // rather than left when the declaration carries none — a line from the OTHER file would slice
+      // the panel at an arbitrary point of this one, which reads as a rendering bug rather than a
+      // missing field.
+      const changed = component.sourceFile !== declared.sourceFile;
+      component.sourceFile = declared.sourceFile;
+      if (declared.bodyLine === undefined) delete component.bodyLine;
+      else component.bodyLine = declared.bodyLine;
+      // The identity fields still describe where the preview was COMPILED from, which the override
+      // does not change — the module and directory are the samples module either way.
+      stampIdentity(component, source);
+      if (typeof source?.module === "string" && source.module.length > 0) {
+        component.sourceModule ??= source.module;
+      }
+      if (changed) stamped += 1;
+      continue;
+    }
     if (component.sourceFile !== undefined) {
       // A newer exporter may already preserve sourceFile. Add the matching module identity without
       // replacing the path; never pair a module with a different pre-existing file.

--- a/scripts/design-artifacts/apply-source-files.test.mjs
+++ b/scripts/design-artifacts/apply-source-files.test.mjs
@@ -323,3 +323,132 @@ test("stamps nothing for a bundle that never recorded a directory", () => {
   assert.equal("sourceDirectory" in manifest.components[0], false);
   assert.equal("sourceFunction" in manifest.components[0], false);
 });
+
+test("a spec-declared sourceFile overrides the discovery join", () => {
+  // The samples-catalog shape: the `@Preview` really does live in the generated wrapper, and the
+  // reader wants the sample it delegates to. Discovery is not wrong here — it is answering a
+  // different question — so this is precedence, not a fallback for a gap.
+  const spec = {
+    groups: [
+      {
+        name: "Button",
+        components: [
+          {
+            componentId: "Button/ButtonSample",
+            preview: "ButtonSamplePreview",
+            sourceFile: "src/main/kotlin/upstream/androidx/.../ButtonSample.kt",
+            bodyLine: 77,
+          },
+        ],
+      },
+    ],
+  };
+  const m = manifest([comp("Button/ButtonSample")]);
+  const sources = byFn([
+    ["ButtonSamplePreview", "src/main/kotlin/generated/SamplePreviews.kt", 62],
+  ]);
+
+  assert.equal(applySourceFiles(m, spec, sources), 1);
+  assert.equal(
+    m.components[0].sourceFile,
+    "src/main/kotlin/upstream/androidx/.../ButtonSample.kt",
+  );
+  assert.equal(m.components[0].bodyLine, 77);
+});
+
+test("a declared path beats one the exporter already preserved", () => {
+  // The branch below this one exists to never clobber an exporter's own value. An override has to
+  // outrank that too, or the fix would silently stop working the day the pinned exporter starts
+  // preserving `sourceFile` — the one change that is otherwise pure improvement.
+  const spec = {
+    groups: [
+      {
+        components: [
+          {
+            componentId: "Button/ButtonSample",
+            preview: "ButtonSamplePreview",
+            sourceFile: "src/main/kotlin/upstream/ButtonSample.kt",
+            bodyLine: 77,
+          },
+        ],
+      },
+    ],
+  };
+  const m = manifest([
+    comp("Button/ButtonSample", {
+      sourceFile: "src/main/kotlin/generated/SamplePreviews.kt",
+      bodyLine: 62,
+    }),
+  ]);
+
+  applySourceFiles(m, spec, byFn([["ButtonSamplePreview", "x.kt", 1]]));
+  assert.equal(m.components[0].sourceFile, "src/main/kotlin/upstream/ButtonSample.kt");
+  assert.equal(m.components[0].bodyLine, 77);
+});
+
+test("a declaration with no line clears a line belonging to the other file", () => {
+  // A `bodyLine` from the generated wrapper would slice the panel at an arbitrary point of the
+  // sample's file — a wrong picture rather than a missing one.
+  const spec = {
+    groups: [
+      {
+        components: [
+          {
+            componentId: "Button/ButtonSample",
+            preview: "ButtonSamplePreview",
+            sourceFile: "src/main/kotlin/upstream/ButtonSample.kt",
+          },
+        ],
+      },
+    ],
+  };
+  const m = manifest([comp("Button/ButtonSample")]);
+
+  applySourceFiles(
+    m,
+    spec,
+    byFn([["ButtonSamplePreview", "src/main/kotlin/generated/SamplePreviews.kt", 62]]),
+  );
+  assert.equal(m.components[0].sourceFile, "src/main/kotlin/upstream/ButtonSample.kt");
+  assert.equal("bodyLine" in m.components[0], false);
+});
+
+test("an empty declared path is not a declaration", () => {
+  // `""` is a spec someone half-filled, not an instruction to blank the link. It falls through to
+  // the ordinary join rather than overriding it with nothing.
+  const spec = {
+    groups: [
+      {
+        components: [
+          { componentId: "C", preview: "P", sourceFile: "" },
+        ],
+      },
+    ],
+  };
+  const m = manifest([comp("C")]);
+  applySourceFiles(m, spec, byFn([["P", "src/main/kotlin/Real.kt", 9]]));
+  assert.equal(m.components[0].sourceFile, "src/main/kotlin/Real.kt");
+  assert.equal(m.components[0].bodyLine, 9);
+});
+
+test("an override is idempotent — a second pass stamps nothing new", () => {
+  const spec = {
+    groups: [
+      {
+        components: [
+          {
+            componentId: "C",
+            preview: "P",
+            sourceFile: "src/main/kotlin/upstream/ButtonSample.kt",
+            bodyLine: 77,
+          },
+        ],
+      },
+    ],
+  };
+  const m = manifest([comp("C")]);
+  const sources = byFn([["P", "src/main/kotlin/generated/SamplePreviews.kt", 62]]);
+  assert.equal(applySourceFiles(m, spec, sources), 1);
+  assert.equal(applySourceFiles(m, spec, sources), 0);
+  assert.equal(m.components[0].bodyLine, 77);
+});

--- a/scripts/design-artifacts/catalog.spec.schema.json
+++ b/scripts/design-artifacts/catalog.spec.schema.json
@@ -318,6 +318,15 @@
           "type": "string",
           "description": "Optional Code Connect override: the source location (path or URL) for `component`."
         },
+        "sourceFile": {
+          "type": "string",
+          "description": "Optional override for where a reader should be sent for this component's source, as a module-relative path. Takes precedence over the path discovery recorded for the `preview` function. For a catalog of call sites whose previews are generated wrappers, the wrapper is where the @Preview is and the thing it delegates to is what a reader came for — and only the catalog knows which. Leave it out on an ordinary catalog, where the two are the same file."
+        },
+        "bodyLine": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Optional line inside `sourceFile` to anchor the source panel on, meaningful only alongside `sourceFile`. Without it the whole file is shown, which is right for a file holding one declaration and poor for a file holding several."
+        },
         "priority": { "$ref": "#/definitions/priority" },
         "variants": {
           "type": "array",


### PR DESCRIPTION
`applySourceFiles` answers *"where is the `@Preview` function?"* by joining the spec's `preview` name to discovery's recorded path. For almost every catalog that is also *"where should a reader be sent"*. A catalog of **call sites** breaks the two apart.

The AndroidX samples catalogs generate one `@Preview` wrapper per sample, because only 34 of 170 Wear samples carry `@Preview` upstream:

```kotlin
fun ButtonSamplePreview() = androidx.wear.compose.material3.samples.ButtonSample()
```

Discovery is right that the preview lives in the generated file. The Source panel then shows three lines of delegation — the one thing on that page nobody came for. **115 of that catalog's 150 pages are in this shape.**

## The change

A spec component may carry its own `sourceFile` and `bodyLine`, and they take precedence over both the join and anything a newer exporter preserved.

**Precedence rather than fallback is the point.** The catalog is not filling a gap the join left; it is overriding an answer the join got *right for a different question*. Making it a fallback would also mean the fix silently stops working the day the pinned exporter starts preserving `sourceFile` — the one change that is otherwise pure improvement. There's a test pinning that.

A declaration with **no line clears** the joined one: a `bodyLine` belonging to the generated file would slice the panel at an arbitrary point of the sample's file, which reads as a rendering bug rather than a missing field. The identity fields (`sourceModule`, `sourceDirectory`, `sourceFunction`) are untouched — the module and directory still describe where the preview was compiled, which the override doesn't change.

## Why not inference

This was my first plan and it does not work. `PreviewTargetInference` **does not fire on these previews at all** — `targets` is `[]` on all 150. `androidx.wear.compose.material3.samples` sits under the `androidx.wear.compose.material3.` prefix in `WRAPPER_FQN_PREFIXES`, so the sample's own call is filtered as library scaffolding before scoring. Widening that heuristic to serve one catalog would change the inferred target of previews in every other catalog that uses it.

A catalog that generates its own wrappers knows exactly what each one delegates to. Saying so is cheaper and truer than asking a scorer to guess it back.

## Compatibility

**No behaviour change for a catalog that declares nothing** — the new map is empty and every existing path runs exactly as before. The consumer side is already in place: the samples catalog's spec is generated, so the declaration can't drift, and the server reads `sourceFile` from `previews/variants.json` as it always has.

## Test plan

- `node --test scripts/design-artifacts/apply-source-files.test.mjs` — 18 tests (was 13). The five new ones cover the override, its precedence over a value the exporter preserved, the line-clearing rule, an empty declared path falling through to the join, and idempotence.
- **Every `*.test.mjs` under `scripts/design-artifacts/` — 100+ files, zero failures.** Scripted the whole sweep rather than spot-checking, since this touches a shared post-process pass.
- Schema addition parses as JSON, and `validate-catalog-spec.mjs` accepts a spec carrying the new fields (0 warnings, 0 errors against the real samples catalog).

Catalog side: [wear-m3-catalog#473](https://github.com/yschimke/wear-m3-catalog/pull/473). The extra spec fields are inert without this, so the merge order doesn't matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJVnYyuf9kfwEsUPWuZrAq

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJVnYyuf9kfwEsUPWuZrAq)_