### PR TITLE
fix(ci): retry the CLI download on connection resets, not just refusals

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -136,7 +136,16 @@ runs:
         # for `version: latest`). With a literal version we can still be
         # pointed at an in-progress release; without timeouts the curl can
         # hang for minutes per retry instead of failing fast.
-        curl -fL --retry 3 --retry-connrefused \
+        # `--retry-all-errors`, not `--retry-connrefused`: curl retries only its
+        # *transient* set by default — timeouts and 408/429/5xx — and
+        # `--retry-connrefused` widens that by exactly one errno. A connection
+        # reset during the TLS handshake is `curl: (35)`, which is in neither,
+        # so `--retry 3` sat here doing nothing while a single reset failed the
+        # whole job in under 400ms (wear-m3-catalog#474, #476; issue #5432).
+        # `--retry-all-errors` covers 35 and the rest of the non-transient
+        # family, and subsumes `--retry-connrefused`. `--max-time` still bounds
+        # each attempt, so the incomplete-release race above is unaffected.
+        curl -fL --retry 3 --retry-all-errors \
           --connect-timeout 30 --max-time 300 \
           -o "$tmp/$asset" "$url"
 


### PR DESCRIPTION
Closes #5432.

## The failure

The `apply` action failed twice on wear-m3-catalog today, in under two seconds each time, **with the retry flags present and inert**:

```
Downloading .../releases/download/v2.11.1/compose-preview-2.11.1.tar.gz
curl: (35) Recv failure: Connection reset by peer
Process completed with exit code 35.
```

## Why `--retry 3` did nothing

`--retry` covers only curl's **transient** set — timeouts and 408/429/5xx — and `--retry-connrefused` widens it by exactly one errno, `ECONNREFUSED`. Exit **35** (`CURLE_SSL_CONNECT_ERROR`, a reset during the TLS handshake) is in neither, so all three retries were skipped and a single reset failed the job in **384 ms**.

```diff
-        curl -fL --retry 3 --retry-connrefused \
+        curl -fL --retry 3 --retry-all-errors \
           --connect-timeout 30 --max-time 300 \
           -o "$tmp/$asset" "$url"
```

`--retry-all-errors` covers 35 and the rest of the non-transient family, and **subsumes** `--retry-connrefused`, so the latter goes rather than sitting alongside it.

`--connect-timeout` and `--max-time` are untouched and still bound each attempt, so the incomplete-release race the comment above defends against behaves exactly as before. The change adds retries for a class of failure; it does not lengthen the worst case for the class already covered.

## Why this is worth fixing rather than shrugging at

The Compose Preview check is **not required**, so both affected PRs were merged over the red. An intermittent, unexplained failure on a non-blocking check is how people learn to merge past that check — and that erosion is the same shape as the silent-publish problems this tooling exists to catch.

## Deliberately not widened

Four sibling `curl --retry 3` invocations share the identical gap:

| file | line |
| --- | --- |
| `.github/workflows/ci.yml` | 666, 902, 1116 |
| `.github/workflows/design-artifacts-reusable.yml` | 4301 |

Left alone here. This one is the **proven** failure with a log behind it; the others are the same class but unobserved, and folding them in would turn a one-flag fix with evidence into a speculative sweep. Recorded on #5432 so they are not lost — happy to do them as a follow-up.

## Test plan

- The file parses as YAML.
- `--retry-all-errors` is accepted and documented by the runner's curl — `--retry-all-errors  Retry all errors (use with --retry)`. It needs curl ≥ 7.71; `ubuntu-latest` ships 8.5.
- No behaviour change on the success path: same URL, same output path, same timeouts.

The failure is transient by nature, so this cannot be proven green by one CI run — the evidence is the flag semantics and the exit code, both checked rather than recalled.

## One note on how this was found

I could not reach the job log from my sandbox (it redirects to a blob host the egress proxy refuses) and reasoned from the action source instead. That produced four hypotheses, **all wrong** — they are recorded in #5432 so nobody re-derives them. The log settled it in seconds once supplied. The lesson, written down there: a 2-second failure was read as "bailed in early validation" and the source was searched only for `exit 1` paths, so a fast failure in a *network* step was never in the search space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01297vAqLHxgAc6XQuaQYCSe

---
_Generated by [Claude Code](https://claude.ai/code/session_01297vAqLHxgAc6XQuaQYCSe)_