### PR TITLE
feat(discovery): measure Glimmer stickers against the glasses display

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/DeviceDimensions.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/DeviceDimensions.kt
@@ -151,6 +151,26 @@ object DeviceDimensions {
   val DEFAULT = DeviceSpec(400, 800, DEFAULT_DENSITY)
   val DEFAULT_WEAR = DeviceSpec(227, 227, 2.0f, isRound = true)
 
+  /**
+   * The AI-glasses display `androidx.xr.glimmer` draws for: 960x720 at **density 1.0**.
+   *
+   * The density is the load-bearing half and is not a phone-style guess. Glimmer sizes UI in
+   * **visual angle**, not dp: at ~30 pixels per degree the library's own type and touch targets
+   * land on the angular sizes it is calibrated for (18dp text -> 18px -> 0.6 degrees) and that
+   * identity holds **only at density 1.0**. At 1.5 the same text measures 27px -> 0.9 degrees and
+   * contrast and legibility read optimistically; at the renderer's 2.625 phone default it is worse
+   * again. `samples/xr-glimmer` pinned dpi=160 for exactly this reason and states the arithmetic.
+   *
+   * 960x720 at 30 PPD spans 32 x 24 degrees of field of view — a plausible 4:3 HUD. Re-pin all
+   * three numbers here if Google publishes the AI Glasses AVD's exact resolution, FoV and
+   * densityDpi; the 30-PPD identity is the anchor to preserve.
+   *
+   * Used as a **wrap sandbox** rather than a pinned canvas — see
+   * [PreviewDiscovery.retargetGlimmerStickers], which is where the difference between "measure
+   * against the glasses display" and "occupy the glasses display" is spelled out.
+   */
+  val DEFAULT_GLASSES = DeviceSpec(960, 720, 1.0f)
+
   fun resolve(device: String?, widthDp: Int? = null, heightDp: Int? = null): DeviceSpec {
     // Explicit widthDp/heightDp on the @Preview annotation — no device info,
     // so fall back to the AS default density (xxhdpi-ish, matching Studio's

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -789,10 +789,13 @@ object PreviewDiscovery {
     // Lottie asset previews are appended after normalization with their render outputs already
     // shell-safe, so they bypass the package-prefix stripping (they have no class/package).
     val normalized =
-      retargetWearStickers(
-        input.isWear,
-        pinWearCanvas = input.retargetWearPreviews,
-        normalizeRenderOutputs(deduped),
+      retargetGlimmerStickers(
+        isGlimmerModule(input),
+        retargetWearStickers(
+          input.isWear,
+          pinWearCanvas = input.retargetWearPreviews,
+          normalizeRenderOutputs(deduped),
+        ),
       ) +
         discoverLottieAssets(input) +
         discoverSvgAssets(input) +
@@ -4968,6 +4971,78 @@ object PreviewDiscovery {
           }
         }
       } else {
+        info
+      }
+    }
+  }
+
+  /**
+   * Maven group of the Glimmer UI toolkit, matched against [Input.dependencyJarCoordinates].
+   *
+   * Detection is by DEPENDENCY rather than by manifest, which is the difference from [Input.isWear]
+   * and not an inconsistency: a Wear module announces itself with `<uses-feature
+   * android:name="android.hardware.type.watch">`, and glasses have no such feature to declare. What
+   * makes a module a Glimmer module is that it draws with Glimmer, and the classpath is where that
+   * is written down.
+   *
+   * Group prefix rather than an exact artifact so `glimmer`, `glimmer-google-fonts` and whatever
+   * the line adds next all count, and so an alpha repackaging does not silently stop matching.
+   */
+  private const val GLIMMER_COORDINATE_PREFIX = "androidx.xr.glimmer:"
+
+  /**
+   * True when this module compiles against `androidx.xr.glimmer` — see [GLIMMER_COORDINATE_PREFIX].
+   */
+  internal fun isGlimmerModule(input: Input): Boolean =
+    input.dependencyJarCoordinates.values.any { it.startsWith(GLIMMER_COORDINATE_PREFIX) }
+
+  /**
+   * Measure a Glimmer module's device-less previews against the AI-glasses display
+   * ([DeviceDimensions.DEFAULT_GLASSES], 960x720 @ 1.0x) instead of the renderer's 400dp phone
+   * sandbox at 2.625x. A no-op off Glimmer, and on any preview that pins its own canvas.
+   *
+   * This is [retargetWearStickers]'s argument applied to a second form factor, and the reason is
+   * the same twice over: a module drawing for a screen that is not a phone should measure against
+   * that screen, and export at that screen's density. What is Glimmer-specific is how much the
+   * density matters — Glimmer sizes UI in visual angle, so density 1.0 is a calibration rather than
+   * a scale factor (see [DeviceDimensions.DEFAULT_GLASSES]).
+   *
+   * As with Wear, this sets [PreviewParams.wrapSandboxWidthDp] /
+   * [PreviewParams.wrapSandboxHeightDp] and NOT `widthDp` / `heightDp`. The distinction is the
+   * whole point, and both halves of it were observed in the field before this existed:
+   * - Pinning the axes is what #2373 did on Wear, and yschimke/m3-catalog#367 is the same fault
+   *   arrived at from the other direction: `glimmer-catalog` wrote `device =
+   *   "spec:width=960,height=720,dpi=160"` on all 19 stickers, and every one of them became a
+   *   component adrift in a 691,200-pixel frame — a 118x48 toggle button at 0.8% coverage, 4.1% on
+   *   average across the sheet.
+   * - Leaving the sandbox alone is what gives a fill-width `Card` a 400dp phone bound it has no
+   *   relationship to.
+   *
+   * Sandboxing gets both: `fillMaxWidth` resolves against 960dp so a Card sizes to the display, a
+   * Button still wraps tight, and the renderer crops every sticker to its measured bounds.
+   */
+  internal fun retargetGlimmerStickers(
+    isGlimmer: Boolean,
+    previews: List<PreviewInfo>,
+  ): List<PreviewInfo> {
+    if (!isGlimmer) return previews
+    val glasses = DeviceDimensions.DEFAULT_GLASSES
+    return previews.map { info ->
+      val p = info.params
+      if (
+        p.kind == PreviewKind.COMPOSE && p.device == null && p.widthDp == null && p.heightDp == null
+      ) {
+        info.copy(
+          params =
+            p.copy(
+              wrapSandboxWidthDp = glasses.widthDp,
+              wrapSandboxHeightDp = glasses.heightDp,
+              density = glasses.density,
+            )
+        )
+      } else {
+        // A preview that names its own device or size is asking for exactly that, and a specimen
+        // pinned to a measured width is the usual reason. Left untouched, same as on Wear.
         info
       }
     }

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryGlimmerRetargetTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryGlimmerRetargetTest.kt
@@ -1,0 +1,161 @@
+package ee.schimke.composeai.discovery
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins [PreviewDiscovery.retargetGlimmerStickers] (yschimke/m3-catalog#367): on a module drawing
+ * with `androidx.xr.glimmer`, a device-less component `@Preview` inherits the renderer's 400dp
+ * phone sandbox at 2.625x — the wrong measuring bound, and a density that misstates the angular
+ * size of a UI Glimmer specifies in degrees rather than dp.
+ *
+ * The retarget moves the *wrap sandbox*, not the frame, exactly as the Wear one does:
+ * `widthDp`/`heightDp` MUST stay null so both axes keep wrapping and the renderer crops each
+ * sticker to its measured bounds. Pinning the canvas instead is what #367 looked like — 19 stickers
+ * each adrift in a 960x720 frame, 4.1% mean content coverage.
+ */
+class PreviewDiscoveryGlimmerRetargetTest {
+
+  private fun preview(
+    id: String,
+    device: String? = null,
+    widthDp: Int? = null,
+    heightDp: Int? = null,
+    density: Float? = DeviceDimensions.DEFAULT_DENSITY,
+    kind: PreviewKind = PreviewKind.COMPOSE,
+  ) =
+    PreviewInfo(
+      id = id,
+      functionName = id,
+      className = "ee.schimke.m3catalog.glimmer.ButtonsKt",
+      params =
+        PreviewParams(
+          device = device,
+          widthDp = widthDp,
+          heightDp = heightDp,
+          density = density,
+          kind = kind,
+        ),
+    )
+
+  /**
+   * Only the coordinate map matters here; the rest is the minimum [PreviewDiscovery.Input] needs.
+   */
+  private fun input(vararg coordinates: String) =
+    PreviewDiscovery.Input(
+      classDirs = emptyList(),
+      dependencyJars = emptyList(),
+      sourceFiles = emptyList(),
+      moduleName = "glimmer-catalog",
+      variantName = "debug",
+      projectDirectory = File("."),
+      failOnEmpty = false,
+      dependencyJarCoordinates =
+        coordinates.withIndex().associate { (i, c) -> "/jars/$i.jar" to c },
+    )
+
+  @Test
+  fun `a module without glimmer on the classpath is not a glimmer module`() {
+    assertEquals(
+      false,
+      PreviewDiscovery.isGlimmerModule(
+        input("androidx.compose.material3:material3:1.5.0", "androidx.compose.ui:ui:1.10.0")
+      ),
+    )
+  }
+
+  @Test
+  fun `glimmer is detected by group, so its sibling artifacts count too`() {
+    assertTrue(PreviewDiscovery.isGlimmerModule(input("androidx.xr.glimmer:glimmer:1.0.0-alpha19")))
+    // Matched by GROUP prefix on purpose: the toolkit ships more than one artifact, and a module
+    // that only pulled the fonts one is still drawing with Glimmer.
+    assertTrue(
+      PreviewDiscovery.isGlimmerModule(
+        input("androidx.xr.glimmer:glimmer-google-fonts:1.0.0-alpha19")
+      )
+    )
+  }
+
+  @Test
+  fun `a lookalike group does not match`() {
+    // `androidx.xr.` alone would drag in the XR runtime modules, which are not Glimmer and draw for
+    // a headset rather than glasses.
+    assertEquals(
+      false,
+      PreviewDiscovery.isGlimmerModule(input("androidx.xr.scenecore:scenecore:1.0.0")),
+    )
+  }
+
+  @Test
+  fun `off glimmer, previews are unchanged`() {
+    val previews = listOf(preview("ButtonSticker"))
+    assertEquals(
+      previews,
+      PreviewDiscovery.retargetGlimmerStickers(isGlimmer = false, previews = previews),
+    )
+  }
+
+  @Test
+  fun `a device-less compose preview is measured against the glasses display at density 1`() {
+    val out =
+      PreviewDiscovery.retargetGlimmerStickers(
+          isGlimmer = true,
+          previews = listOf(preview("ButtonSticker")),
+        )
+        .single()
+        .params
+
+    assertEquals(DeviceDimensions.DEFAULT_GLASSES.widthDp, out.wrapSandboxWidthDp)
+    assertEquals(DeviceDimensions.DEFAULT_GLASSES.heightDp, out.wrapSandboxHeightDp)
+    // The calibration, not a scale factor: Glimmer sizes UI in visual angle and the ~30 PPD
+    // identity holds only at density 1.0.
+    assertEquals(1.0f, out.density)
+    // Load-bearing: the axes stay WRAPPED. Pinning them is #367 — a 118x48 toggle button in a
+    // 691,200-pixel frame.
+    assertNull(out.widthDp)
+    assertNull(out.heightDp)
+  }
+
+  @Test
+  fun `the preview id is untouched, so catalog references and filenames stay stable`() {
+    val out =
+      PreviewDiscovery.retargetGlimmerStickers(
+          isGlimmer = true,
+          previews = listOf(preview("ButtonSticker")),
+        )
+        .single()
+    assertEquals("ButtonSticker", out.id)
+  }
+
+  @Test
+  fun `a preview that names its own device is left alone`() {
+    val pinned = preview("EnvironmentSticker", device = "spec:width=960,height=720,dpi=160")
+    val out =
+      PreviewDiscovery.retargetGlimmerStickers(isGlimmer = true, previews = listOf(pinned)).single()
+    assertEquals(pinned, out)
+    assertNull(out.params.wrapSandboxWidthDp)
+  }
+
+  @Test
+  fun `a preview pinned to a measured width is left alone`() {
+    val pinned = preview("ListItemSpecimen", widthDp = 360, heightDp = 200)
+    assertEquals(
+      pinned,
+      PreviewDiscovery.retargetGlimmerStickers(isGlimmer = true, previews = listOf(pinned))
+        .single(),
+    )
+  }
+
+  @Test
+  fun `a non-compose preview is left alone`() {
+    // Lottie and SVG assets carry their own intrinsic size; a glasses sandbox means nothing to one.
+    val asset = preview("LogoAsset", kind = PreviewKind.SVG)
+    assertEquals(
+      asset,
+      PreviewDiscovery.retargetGlimmerStickers(isGlimmer = true, previews = listOf(asset)).single(),
+    )
+  }
+}


### PR DESCRIPTION
A module drawing with `androidx.xr.glimmer` has two options today and neither is right. [yschimke/m3-catalog#367](https://github.com/yschimke/m3-catalog/issues/367) is what picking the first one looks like from the outside.

**Pin the device** — `device = "spec:width=960,height=720,dpi=160"` — and the frame is pinned with it, so the intrinsic crop never runs. A 118×48 toggle button ships adrift in a 691,200-pixel black frame. Measured across that catalog's 19 stickers:

```
component                 canvas    content    coverage
ToggleButton             960x720    118x48       0.82%
VoiceInputIndicator      960x720     24x10       0.03%
Card                     960x720    912x80      10.56%
                                    mean:         4.10%
```

**Leave the device off** and the crop works, but the sticker measures against the renderer's 400dp phone sandbox at density 2.625 — a bound a fill-width `Card` has no relationship to, and a density that misstates the UI's angular size.

## Why the density is not cosmetic

Glimmer sizes UI in **visual angle**, not dp. At ~30 PPD the library's type and touch targets land on the angular sizes it is calibrated for — 18dp text → 18px → 0.6° — and that identity holds **only at density 1.0**. At 1.5 the same text measures 27px → 0.9° and contrast and legibility read optimistically; at the 2.625 phone default it is worse again. `samples/xr-glimmer` pinned `dpi=160` for exactly this reason and works the arithmetic out in a comment; this moves that reasoning somewhere every Glimmer module inherits it.

## The change

The same move `retargetWearStickers` already makes for the watch. A device-less compose preview on a Glimmer module gets the glasses display as its wrap **sandbox** (960×720 @ 1.0×), never as its frame:

- `fillMaxWidth` resolves against 960dp, so a `Card` sizes to the display
- a `Button` still wraps tight
- every sticker still crops to its measured bounds

The sandbox-not-frame distinction is the whole point, and both halves of it have been observed already: pinning the axes is what #2373 did on Wear (*"a FilledButton sticker that used to export 217×179 became a 454×454 watch canvas with the button adrift in the corner"*), and #367 is the same fault reached from the other direction.

Previews that name their own `device`, `widthDp` or `heightDp` are untouched — so `samples/xr-glimmer`'s own pinned previews are unaffected by this, which the tests pin explicitly.

## Detection is by dependency, not manifest

Deliberate, and the one place this departs from `isWear`. A Wear module announces itself with `<uses-feature android:name="android.hardware.type.watch">`; glasses have no such feature to declare. What makes a module a Glimmer module is that it draws with Glimmer, and the classpath is where that is written down.

Matched on the `androidx.xr.glimmer:` **group** so sibling artifacts (`glimmer-google-fonts`) count, and so `androidx.xr.scenecore` — a headset toolkit, not glasses — does not. Both directions are tested.

## Verified

- 9 new tests in `PreviewDiscoveryGlimmerRetargetTest`, covering detection (positive, sibling artifact, lookalike group), the retarget itself, id stability, and all three left-alone cases (device-pinned, size-pinned, non-compose).
- `PreviewDiscoveryWearRetargetTest` 11 and `DeviceDimensionsTest` 46 unchanged — no regression in the mechanism this borrows from.
- Full `:gradle-plugin:preview-discovery:test` suite: **584 tests, 0 failures, 0 errors**.
- `ktfmtFormat` clean.

## Downstream

`yschimke/m3-catalog` has the matching change staged: the 19 stickers are already device-less and the `Sticker` wrapper's `fillMaxSize`/`background`/`padding` are removed (that padding being the mistake `CatalogCaptureGutters.kt` names as #179). Once this releases, those previews pick the glasses sandbox up with no further Kotlin change — device-less is exactly what the retarget keys on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011aLMTJbd7A8fxL1BQyzGn6

---
_Generated by [Claude Code](https://claude.ai/code/session_011aLMTJbd7A8fxL1BQyzGn6)_